### PR TITLE
feat: disable shipped model defaults via per-model flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Required fields are marked **required**; everything else has a default and can b
 | `models.definitions.<name>.cmd`         | —                                     | Shell command launched for the model. Local macOS runs execute in the worktree through Safehouse/clearance; remote runs execute inside the remote worktree. `{{worktree}}` is replaced before launch and legacy `{{sandbox}}` expands to an empty string.       |
 | `models.definitions.<name>.color`       | —                                     | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                                        |
 | `models.definitions.<name>.usage`       | optional                              | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Omit to never gate. When `usage.codexbar.source` is omitted, groundcrew uses `auto` on macOS and `cli` elsewhere.                                                       |
+| `models.definitions.<name>.disabled`    | optional                              | When set to exactly `true`, drops the named shipped default (`claude` or `codex`). Doctor skips probing it; `agent-<name>` labels fall back to `models.default` with a warning. See "Disabling a shipped default" below.                                        |
 | `prompts.initial`                       | (template)                            | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`.                                                                                                                                                    |
 | `workspaceKind`                         | `"auto"`                              | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing. tmux windows live in a dedicated `groundcrew` session.                                                |
 | `remote.provider`                       | `"sprite"`                            | Remote runner provider used for tickets labeled `agent-remote`. Sprite is currently the only provider.                                                                                                                                                          |
@@ -145,6 +146,36 @@ Required fields are marked **required**; everything else has a default and can b
 | `logging.file`                          | XDG state path                        | Append-mode log file destination. `log()` / `logEvent()` tee here in addition to stdout, so a vanished workspace doesn't take the evidence with it. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                              |
 
 The branch prefix (`<prefix>-<TICKET>`) is derived from your OS username (`os.userInfo().username`), not configured. Agent selection looks for a top-level Linear label named `agent-<model>` (e.g. `agent-claude`, `agent-codex`). Add `agent-remote` to run that ticket in the configured remote runner instead of locally; `agent-remote` is a modifier label, not a model. **`crew run` only fetches tickets with an `agent-*` label** — the GraphQL query filters them server-side, so unlabeled tickets are never returned by Linear's API and do not appear in the rendered board. Use `crew setup <TICKET>` to provision an unlabeled ticket on demand (manual setup falls back to `models.default`). The reserved label `agent-any` routes the ticket to the configured model with the most available session capacity (lowest codexbar session-used percent), skipping any model already over `sessionLimitPercentage`. With no usage data, `agent-any` resolves to `models.default`. The name `any` cannot be used in `models.definitions`. Todo tickets blocked by Linear issues that are not in `linear.statuses.terminal` are skipped until their blockers reach a terminal status.
+
+### Disabling a shipped default
+
+Groundcrew ships `claude` and `codex` as default model definitions, additively merged into every resolved config. If you only ever route work through one of them, set `disabled: true` on the other so doctor stops probing for the unused CLI:
+
+```ts
+// config.ts
+export const config = {
+  // …
+  models: {
+    default: "claude",
+    definitions: {
+      codex: { disabled: true },
+    },
+  },
+};
+```
+
+Effects:
+
+- `crew doctor` does not probe the disabled model's CLI. `crew doctor || exit 1` becomes viable as a CI gate when you only have one agent installed.
+- `agent-any` only resolves to enabled models.
+- An `agent-<disabled>` label on a ticket (e.g. `agent-codex` after disabling codex) falls back to `models.default` with a warning in the log, so the ticket still runs and you can see the mismatch.
+
+Rules:
+
+- `disabled` only accepts shipped-default keys (`claude`, `codex`). A typo on the key fails loudly at config load instead of silently disabling nothing.
+- `disabled` must be exactly the boolean `true`.
+- It cannot be combined with `cmd`, `color`, or `usage` in the same entry — disable a model or override its fields, not both.
+- `models.default` must point at an enabled model.
 
 ## Manual commands
 
@@ -177,7 +208,7 @@ crew cleanup <TICKET>
 - **Project must be on a single Linear team in practice.** Cross-team projects work — the orchestrator caches the in-progress state ID per team — but every team in the project must use the same status name for `linear.statuses.inProgress`.
 - **Claude launches in bypass-permissions mode by default.** Groundcrew creates isolated per-ticket worktrees and unattended remote sessions, so the shipped `claude` command is `claude --permission-mode bypassPermissions` to avoid workspace-trust and tool-permission prompts blocking automation. Override `models.definitions.claude.cmd` if you want a stricter mode.
 - **Doctor's command introspection is shallow.** Doctor reports whether the host can run local tickets with macOS plus Safehouse, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH (so `safehouse claude --foo` checks both `safehouse` and `claude`). Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. In particular, `npx -y claude` and `env FOO=1 claude` only check the wrapper, not the wrapped CLI.
-- **Doctor checks every configured model, including shipped defaults you don't use.** `models.definitions` always contains `claude` and `codex` (additive merge with the shipped defaults). If you only intend to label tickets `agent-claude`, doctor will still fail on a missing `codex` binary and exit non-zero. `crew run` itself only routes to the model named in a ticket's `agent-*` label, so a doctor failure for an unused model does not block actual ticket dispatch.
+- **Doctor checks every enabled model, including shipped defaults you didn't disable.** `models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and don't have `codex` installed, set `models.definitions.codex: { disabled: true }` (see "Disabling a shipped default" under "Config reference"). Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
 

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -268,6 +268,20 @@ describe(doctor, () => {
     expect(checked).not.toContain("script.ts");
   });
 
+  it("does not probe a disabled shipped default's CLI binary", async () => {
+    // The default makeConfig fixture has only `claude` in `definitions` — the
+    // same shape `mergeDefinitions` produces for `codex: { disabled: true }`.
+    // `gatherToolTokens` iterates `Object.values(definitions)`, so codex is
+    // never gathered.
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    await doctor();
+
+    const checked = checkedCommands();
+    expect(checked).not.toContain("codex");
+    expect(checked).toContain("claude");
+  });
+
   it("reports missing Safehouse as a local runner warning", async () => {
     detectHostMock.mockResolvedValue({
       hasSafehouse: false,

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -394,6 +394,57 @@ describe(createBoardSource, () => {
       expect(first?.runner).toBe("local");
     });
 
+    it("falls back to models.default with a warning when an agent-<model> label refers to a disabled shipped default", async () => {
+      // Simulates the post-filter state of a config with codex disabled: codex
+      // is absent from `definitions` but present in `disabledShippedDefaults`.
+      // The ticket explicitly opted into codex, so silently rerouting it to
+      // claude would be surprising — the warning gives observability without
+      // blocking the ticket.
+      const configWithCodexDisabled = makeConfig({
+        models: {
+          default: "claude",
+          definitions: {
+            claude: { cmd: "claude", color: "#fff" },
+          },
+        },
+      });
+
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [issueNode({ identifier: "STAFF-1", labels: { nodes: [{ name: "agent-codex" }] } })],
+          ],
+        }),
+        configWithCodexDisabled,
+      );
+      const state = await source.fetch();
+      const [first] = state.issues;
+
+      expect(first?.model).toBe("claude");
+      expect(first?.runner).toBe("local");
+      expect(consoleLog.output()).toMatch(
+        /staff-1: agent-codex label refers to a disabled model; falling back to models\.default \(claude\)/,
+      );
+    });
+
+    it("falls back silently to models.default for an unknown (not disabled) agent label", async () => {
+      // Unknown labels (e.g. typos, removed-but-not-disabled models) keep the
+      // existing silent fallback — only explicitly-disabled labels warn, since
+      // those are the cases where the user opted in to a model they themselves
+      // disabled and would want to know about.
+      const { source } = makeBoardSource(
+        makeClient({
+          // cspell:disable-next-line
+          pages: [[issueNode({ labels: { nodes: [{ name: "agent-mystery" }] } })]],
+        }),
+      );
+      const state = await source.fetch();
+      const [first] = state.issues;
+
+      expect(first?.model).toBe("claude");
+      expect(consoleLog.output()).not.toMatch(/falling back to models\.default/);
+    });
+
     it("defaults the local runner for labeled tickets without agent-remote", async () => {
       const { source } = makeBoardSource(
         makeClient({

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -6,7 +6,12 @@
 
 import type { LinearClient } from "@linear/sdk";
 
-import { AGENT_ANY_MODEL, type ResolvedConfig, type WorkspaceRunner } from "./config.ts";
+import {
+  AGENT_ANY_MODEL,
+  isShippedDefaultDisabled,
+  type ResolvedConfig,
+  type WorkspaceRunner,
+} from "./config.ts";
 import { log } from "./util.ts";
 
 const AGENT_LABEL_PREFIX = "agent-";
@@ -243,6 +248,7 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
     .filter((node) => node.children.nodes.length === 0)
     .map((node) => {
       const parsedAgentLabels = parseAgentLabels(node.labels.nodes, config);
+      warnIfDisabledFallback(node.identifier, parsedAgentLabels, config);
       const repository =
         parsedAgentLabels === undefined
           ? undefined
@@ -342,6 +348,7 @@ export async function fetchResolvedIssue(arguments_: {
   // unlabeled ticket still resolves to `models.default` — different from
   // the auto-pickup path, where unlabeled tickets are ignored.
   const parsed = parseAgentLabels(issue.labels.nodes, config);
+  warnIfDisabledFallback(ticket, parsed, config);
   const model =
     parsed === undefined || parsed.model === AGENT_ANY_MODEL ? config.models.default : parsed.model;
   const runner = parsed?.runner ?? "local";
@@ -378,10 +385,17 @@ function parseRepository(arguments_: ParseRepositoryArguments): string {
  * ticket has no `agent-*` label — those tickets are not groundcrew's concern
  * and downstream code skips them. An explicit `agent-<unknown>` label still
  * falls back to `models.default` because the user opted in by labeling.
+ *
+ * `disabledFallback` is set when the label matched a shipped default the user
+ * explicitly disabled (e.g. `agent-codex` against `codex: { disabled: true }`).
+ * Callers warn on this so the user can spot the config/labeling mismatch; we
+ * still fall back rather than skip because skipping would block the ticket
+ * indefinitely. Unknown labels stay silent — those are likelier to be typos.
  */
 interface ParsedAgentLabels {
   model: string;
   runner: WorkspaceRunner;
+  disabledFallback?: string;
 }
 
 function parseAgentLabels(
@@ -393,6 +407,7 @@ function parseAgentLabels(
     return undefined;
   }
   const runner = agentLabels.some((label) => label.name === "agent-remote") ? "remote" : "local";
+  let disabledFallback: string | undefined;
   for (const label of agentLabels) {
     if (label.name === "agent-remote") {
       continue;
@@ -407,8 +422,28 @@ function parseAgentLabels(
     if (Object.hasOwn(config.models.definitions, name)) {
       return { model: name, runner };
     }
+    if (disabledFallback === undefined && isShippedDefaultDisabled(config, name)) {
+      disabledFallback = name;
+    }
   }
-  return { model: config.models.default, runner };
+  const fallback: ParsedAgentLabels = { model: config.models.default, runner };
+  if (disabledFallback !== undefined) {
+    fallback.disabledFallback = disabledFallback;
+  }
+  return fallback;
+}
+
+function warnIfDisabledFallback(
+  ticket: string,
+  parsed: ParsedAgentLabels | undefined,
+  config: ResolvedConfig,
+): void {
+  if (parsed?.disabledFallback === undefined) {
+    return;
+  }
+  log(
+    `${ticket.toLowerCase()}: agent-${parsed.disabledFallback} label refers to a disabled model; falling back to models.default (${config.models.default})`,
+  );
 }
 
 function blockersFromRelations(relations: IssueRelationNode[]): Blocker[] {

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -460,6 +460,129 @@ describe("loadConfig", () => {
     );
   });
 
+  it("rejects `disabled: false` on a model definition", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { definitions: { codex: { disabled: false } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex\.disabled must be exactly `true` when set/,
+    );
+  });
+
+  it('rejects a non-boolean `disabled` value (e.g. the string "true")', async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        '  models: { definitions: { codex: { disabled: "true" } } },',
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex\.disabled must be exactly `true` when set/,
+    );
+  });
+
+  it("rejects `disabled: true` combined with other fields (cmd / color / usage)", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { definitions: { codex: { disabled: true, cmd: 'override' } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.definitions\.codex: cannot combine `disabled: true` with other fields \(cmd\)/,
+    );
+  });
+
+  it("drops a shipped default when `disabled: true` is set", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { definitions: { codex: { disabled: true } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(Object.keys(actual.models.definitions).toSorted()).toStrictEqual(["claude"]);
+    expect(actual.models.definitions["codex"]).toBeUndefined();
+    expect(actual.models.default).toBe("claude");
+  });
+
+  it("rejects `disabled: true` on a key that isn't a shipped default", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        // cspell:disable-next-line
+        "  models: { definitions: { codexx: { disabled: true } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      // cspell:disable-next-line
+      /models\.definitions\.codexx: `disabled: true` is only valid for shipped defaults \(claude, codex\)\. Remove the entry instead\./,
+    );
+  });
+
+  it("rejects disabling the model used as `models.default`", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export const config = {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  models: { default: 'codex', definitions: { codex: { disabled: true } } },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /models\.default \("codex"\) is disabled\. Either re-enable it or set models\.default to an enabled model\./,
+    );
+  });
+
   it("defaults workspaceKind to auto when omitted", async () => {
     const path = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -74,7 +74,17 @@ export interface RemoteRunnerConfig {
   secretNames: string[];
 }
 
-type UserModelDefinition = Partial<ModelDefinition>;
+/**
+ * User-facing model entry shape. Discriminated union so the type system
+ * mirrors the runtime contract: an entry is either a pure overlay
+ * (every concrete field optional, no `disabled` key) or a pure
+ * disable directive (`{ disabled: true }` and nothing else).
+ */
+type EnabledUserModelDefinition = Partial<ModelDefinition> & { disabled?: never };
+interface DisabledUserModelDefinition {
+  disabled: true;
+}
+type UserModelDefinition = EnabledUserModelDefinition | DisabledUserModelDefinition;
 
 /**
  * Setup command run inside sibling worktrees on the host. The host is
@@ -478,6 +488,37 @@ function failIfLegacyModelKeys(
       `models.definitions.${name}.sandbox is no longer supported: Docker Sandboxes are no longer supported`,
     );
   }
+  if (Object.hasOwn(override, "disabled")) {
+    if (override["disabled"] !== true) {
+      fail(
+        `models.definitions.${name}.disabled must be exactly \`true\` when set (got ${JSON.stringify(override["disabled"])})`,
+      );
+    }
+    const conflicting = (["cmd", "color", "usage"] as const).filter((key) =>
+      Object.hasOwn(override, key),
+    );
+    if (conflicting.length > 0) {
+      fail(
+        `models.definitions.${name}: cannot combine \`disabled: true\` with other fields (${conflicting.join(", ")}). Either disable the model or override its fields, not both.`,
+      );
+    }
+  }
+}
+
+/**
+ * True when `name` is a shipped default the user removed via `disabled: true`.
+ * Derived from absence in `definitions` — that's the only path that removes a
+ * shipped default, codified in `failIfLegacyModelKeys` + `mergeDefinitions`.
+ * Consumers needing to distinguish disabled-by-user from unknown-label use this.
+ */
+export function isShippedDefaultDisabled(
+  config: Pick<ResolvedConfig, "models">,
+  name: string,
+): boolean {
+  return (
+    Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, name) &&
+    !Object.hasOwn(config.models.definitions, name)
+  );
 }
 
 function mergeDefinitions(
@@ -494,6 +535,21 @@ function mergeDefinitions(
   );
   for (const [name, override] of Object.entries(user ?? {})) {
     failIfLegacyModelKeys(name, override);
+
+    if (override.disabled === true) {
+      if (!Object.hasOwn(DEFAULT_MODEL_DEFINITIONS, name)) {
+        fail(
+          `models.definitions.${name}: \`disabled: true\` is only valid for shipped defaults (${Object.keys(DEFAULT_MODEL_DEFINITIONS).join(", ")}). Remove the entry instead.`,
+        );
+      }
+      // Drop the key so downstream iterators (doctor, eligibility, usage) ignore
+      // the model automatically; `isShippedDefaultDisabled` lets the few consumers
+      // that need to distinguish disabled from unknown re-derive the set.
+      // oxlint-disable-next-line typescript/no-dynamic-delete -- `merged` is a fresh function-local clone of DEFAULT_MODEL_DEFINITIONS; no V8 dictionary-mode/pollution concerns
+      delete merged[name];
+      continue;
+    }
+
     const base: Partial<ModelDefinition> =
       merged[name] === undefined ? {} : cloneModelDefinition(merged[name]);
     // Per-key spread so overriding `cmd` alone preserves the default
@@ -658,6 +714,14 @@ function validate(config: ResolvedConfig): void {
     }
   }
 
+  // Disabled-default check must run before the generic "not a key" check so
+  // the user gets the specific "is disabled" message instead of a stale-list
+  // message they can't act on without realizing they need to re-enable.
+  if (isShippedDefaultDisabled(config, config.models.default)) {
+    fail(
+      `models.default ("${config.models.default}") is disabled. Either re-enable it or set models.default to an enabled model.`,
+    );
+  }
   if (!(config.models.default in definitions)) {
     fail(
       `models.default ("${config.models.default}") is not a key in models.definitions (have: ${Object.keys(definitions).join(", ")})`,


### PR DESCRIPTION
## Summary

Adds a per-model `disabled: true` knob to `models.definitions` so a user who only routes work through one shipped model (typically `claude`) can suppress the other from doctor, dispatch, label resolution, and usage gating.

```ts
// config.ts
models: {
  default: "claude",
  definitions: {
    codex: { disabled: true },
  },
}
```

After this lands, `crew doctor` no longer probes for the codex binary when codex is disabled, making `crew doctor || exit 1` viable as a CI gate for single-model setups.

**Design — filter, don't flag.** Disabled entries are stripped at the merge boundary in `mergeDefinitions`, so they're absent from `ResolvedConfig.models.definitions`. The five downstream consumers (`doctor`, `eligibility`, `boardSource`, `setupWorkspace`, `usage`) need no code changes — they already tolerate missing keys. `isShippedDefaultDisabled(config, name)` derives the disabled set on demand for the two consumers that need to distinguish disabled from unknown (validate's default-points-at-disabled check, and `parseAgentLabels` warning when an `agent-<disabled>` label degrades to default).

**Loud failures.** Three validation cases at config load:
- `disabled` combined with other fields → `cannot combine \`disabled: true\` with other fields (cmd)`
- `disabled` on a non-shipped key (typo guard) → ``\`disabled: true\` is only valid for shipped defaults (claude, codex)``
- `models.default` points at a disabled model → `models.default ("codex") is disabled. Either re-enable it or set models.default to an enabled model.`

`disabled`, when present, must be exactly `true` — modeled in TS as a discriminated union (`Partial<ModelDefinition> & { disabled?: never }` | `{ disabled: true }`) so the type system mirrors the runtime contract.

**Disabled labels degrade with a warning, not silently.** When a ticket carries an `agent-<disabled>` label, the resolved model falls back to `models.default` and a log line names the ticket and the disabled label. Skipping would block the ticket; the warning gives observability without halting work. Unknown labels keep the existing silent fallback because those are likelier to be typos.

## Validation

- [x] `node --run verify` fully green (architecture:check, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint, test) at 100% statement/branch/line/function coverage.
- [x] 8 new tests covering the four validation paths, the happy path, the doctor regression, and both boardSource fallback paths (disabled-with-warning, unknown-silent).

## Notes

- README "Config reference" gains a `models.definitions.<name>.disabled` row and a new "Disabling a shipped default" subsection; the corresponding Gotcha is rewritten to point at the new knob.
- Filed against the rebased `groundcrew` repo (post-extraction from `core-utils`).

<!-- commit-push-pr:created v1 core@3.4.0 -->