### PR TITLE
fix: remove Clipboard-specific clearance hosts

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -68,7 +68,5 @@ formulae.brew.sh
 hub.docker.com
 index.docker.io
 nx.dev
-sourcegraph.clipboardhealth.com
-sourcegraph.clipboardhealth.io
 sourcegraph.com
 vitest.dev


### PR DESCRIPTION
## Summary

Removes the Clipboard-specific Sourcegraph hosts from the shipped clearance allowlist so the public package defaults only include generic developer tooling hosts.

## Validation

- `node --run verify`
- Pre-push hook: `node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->