### PR TITLE
feat: add cli version flag

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+
 import { run } from "./cli.ts";
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
@@ -31,6 +33,25 @@ const doctorMock = vi.mocked(doctor);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const remoteMock = vi.mocked(remoteCli);
+const requireFromTest = createRequire(import.meta.url);
+const PACKAGE_VERSION = readPackageVersion();
+
+function packageMetadataHasVersion(value: unknown): value is { version: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "version" in value &&
+    typeof value.version === "string"
+  );
+}
+
+function readPackageVersion(): string {
+  const packageMetadata: unknown = requireFromTest("../package.json");
+  if (!packageMetadataHasVersion(packageMetadata)) {
+    throw new Error("Unable to read package version");
+  }
+  return packageMetadata.version;
+}
 
 describe(run, () => {
   let consoleLog: ConsoleCapture;
@@ -60,6 +81,7 @@ describe(run, () => {
     expect(consoleLog.calls.length).toBeGreaterThan(0);
     const helpOutput = consoleLog.output();
     expect(helpOutput).toContain("Usage: crew <command>");
+    expect(helpOutput).toContain("-v, --version");
     expect(helpOutput).toContain("run");
     expect(helpOutput).not.toContain("sandbox");
     expect(process.exitCode).toBe(1);
@@ -77,6 +99,22 @@ describe(run, () => {
 
     expect(consoleLog.calls.length).toBeGreaterThan(0);
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints the package version on -v without setting exit code", async () => {
+    await run(["-v"]);
+
+    expect(consoleLog.output()).toBe(PACKAGE_VERSION);
+    expect(process.exitCode).toBeUndefined();
+    expect(orchestrateMock).not.toHaveBeenCalled();
+  });
+
+  it("prints the package version on --version without setting exit code", async () => {
+    await run(["--version"]);
+
+    expect(consoleLog.output()).toBe(PACKAGE_VERSION);
+    expect(process.exitCode).toBeUndefined();
+    expect(orchestrateMock).not.toHaveBeenCalled();
   });
 
   it("reports unknown subcommands and exits with code 1", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
@@ -5,11 +7,17 @@ import { remoteCli } from "./commands/remoteSetup.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { errorMessage, writeError, writeOutput } from "./lib/util.ts";
 
+interface PackageMetadata {
+  version: string;
+}
+
 interface Subcommand {
   summary: string;
   usage?: string;
   invoke: (argv: string[]) => Promise<void>;
 }
+
+const requireFromCli = createRequire(import.meta.url);
 
 async function runCli(argv: string[]): Promise<void> {
   let watch = false;
@@ -85,6 +93,10 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
 function printHelp(): void {
   const width = Math.max(...Object.keys(SUBCOMMANDS).map((key) => key.length));
   writeOutput("Usage: crew <command> [...args]\n");
+  writeOutput("Options:");
+  writeOutput("  -h, --help     Show help");
+  writeOutput("  -v, --version  Print version");
+  writeOutput("");
   writeOutput("Commands:");
   for (const [name, command] of Object.entries(SUBCOMMANDS)) {
     writeOutput(`  ${name.padEnd(width)}  ${command.summary}`);
@@ -95,6 +107,12 @@ function printHelp(): void {
   writeOutput("\nSee README.md for full configuration and behavior.");
 }
 
+function packageVersion(): string {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment -- package.json is shipped with this package and is the version source of truth.
+  const packageMetadata: PackageMetadata = requireFromCli("../package.json");
+  return packageMetadata.version;
+}
+
 export async function run(argv: string[]): Promise<void> {
   const [subcommand, ...rest] = argv;
 
@@ -103,6 +121,11 @@ export async function run(argv: string[]): Promise<void> {
     if (subcommand === undefined) {
       process.exitCode = 1;
     }
+    return;
+  }
+
+  if (subcommand === "-v" || subcommand === "--version") {
+    writeOutput(packageVersion());
     return;
   }
 


### PR DESCRIPTION
## Summary

Add a top-level Groundcrew CLI version flag so users can run `crew -v` or `crew --version` to see the installed package version. The CLI now reads the version from its own `package.json`, includes the flag in help output, and covers both aliases in CLI tests.

## Validation

- `npm exec vitest run src/cli.test.ts`
- `node --run verify`
- `node ./bin/run.js --version` -> `1.8.0`
- `node ./bin/run.js -v` -> `1.8.0`

Agent session: codex resume 019e38b3-3a4e-77b0-903d-0ff7e5f0aad3

<!-- commit-push-pr:created v1 core@3.4.0 -->