### PR TITLE
feat: `crew setup repos` to clone every missing knownRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    gh repo clone owner/repo ~/dev/groundcrew-workspaces/owner/repo
    ```
 
+   Or let `crew` clone every missing `owner/repo` entry for you using your `gh` login:
+
+   ```bash
+   crew setup repos              # clone all missing entries
+   crew setup repos --dry-run    # preview what would be cloned
+   crew setup repos owner/repo   # restrict to one entry
+   ```
+
+   `crew setup repos` is idempotent — already-cloned repos are reported `[exists]` and untouched. Bare-name entries (no `owner/`) are skipped with an instruction to clone manually, since groundcrew can't safely guess the org. The command fails fast with an install hint when `gh` is not on `PATH`.
+
    `crew` resolves the config path as: `GROUNDCREW_CONFIG` if set → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` if it exists → a `config.ts` sitting next to `crew`'s own source files (only useful from a local checkout; see [Hacking on groundcrew](#hacking-on-groundcrew)). Set `GROUNDCREW_CONFIG` only when you want to override the XDG location.
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
@@ -187,6 +197,7 @@ crew remote attach <session-id-or-command> --runner crew-claude-1
 crew remote ps crew-claude-1
 crew remote interrupt <process-group-id> --runner crew-claude-1
 crew run --ticket <TICKET>
+crew setup repos [--dry-run] [<repo>...]
 crew cleanup <TICKET>
 ```
 
@@ -211,6 +222,7 @@ crew cleanup <TICKET>
 - **Doctor checks every enabled model, including shipped defaults you didn't disable.** `models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and don't have `codex` installed, set `models.definitions.codex: { disabled: true }` (see "Disabling a shipped default" under "Config reference"). Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
+- **`crew setup repos` only auto-clones `owner/repo` entries.** Bare-name entries in `workspace.knownRepositories` (e.g. `"api"` rather than `"clipboardhealth/api"`) are skipped with a hint to clone manually — the command refuses to guess the owner. After a partial setup, the exit code is non-zero so CI gates notice; rerun is idempotent once you clone the bare ones into `<projectDir>/<name>` yourself. Adding a new repo to `knownRepositories` later? Just rerun `crew setup repos`; already-present entries report `[exists]` and are untouched.
 
 ## Hacking on groundcrew
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,6 +5,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
   captureConsoleError,
@@ -24,6 +25,9 @@ vi.mock(import("./commands/orchestrator.ts"), () => ({
 vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
 }));
+vi.mock(import("./commands/setupRepos.ts"), () => ({
+  setupReposCli: vi.fn<typeof setupReposCli>(),
+}));
 vi.mock(import("./commands/remoteSetup.ts"), () => ({
   remoteCli: vi.fn<typeof remoteCli>(),
 }));
@@ -31,6 +35,7 @@ vi.mock(import("./commands/remoteSetup.ts"), () => ({
 const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
 const setupMock = vi.mocked(setupWorkspaceCli);
+const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const remoteMock = vi.mocked(remoteCli);
 const requireFromTest = createRequire(import.meta.url);
@@ -64,6 +69,7 @@ describe(run, () => {
     orchestrateMock.mockResolvedValue();
     doctorMock.mockResolvedValue(true);
     setupMock.mockResolvedValue();
+    setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
     remoteMock.mockResolvedValue();
   });
@@ -241,6 +247,34 @@ describe(run, () => {
     await run(["cleanup", "--force", "TEAM-1"]);
 
     expect(cleanupMock).toHaveBeenCalledWith(["--force", "TEAM-1"]);
+  });
+
+  it("dispatches `setup repos` to setupReposCli with the remaining argv", async () => {
+    await run(["setup", "repos", "--dry-run", "owner/repo"]);
+
+    expect(setupReposMock).toHaveBeenCalledWith(["--dry-run", "owner/repo"]);
+  });
+
+  it("dispatches bare `setup repos` (no args) to setupReposCli", async () => {
+    await run(["setup", "repos"]);
+
+    expect(setupReposMock).toHaveBeenCalledWith([]);
+  });
+
+  it("reports an unknown `setup` verb instead of routing it", async () => {
+    await run(["setup", "bogus"]);
+
+    expect(setupReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints the setup usage when no verb is given", async () => {
+    await run(["setup"]);
+
+    expect(setupReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(process.exitCode).toBe(1);
   });
 
   it("dispatches remote to remoteCli with the remaining argv", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { errorMessage, writeError, writeOutput } from "./lib/util.ts";
 
@@ -18,6 +19,19 @@ interface Subcommand {
 }
 
 const requireFromCli = createRequire(import.meta.url);
+
+function setupUsage(): string {
+  return "Usage: crew setup repos [--dry-run] [<repo>...]";
+}
+
+async function setupCli(argv: string[]): Promise<void> {
+  const [verb, ...rest] = argv;
+  if (verb === "repos") {
+    await setupReposCli(rest);
+    return;
+  }
+  throw new Error(setupUsage());
+}
 
 async function runCli(argv: string[]): Promise<void> {
   let watch = false;
@@ -76,6 +90,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Tear down a worktree",
     usage: "[--force] <ticket>",
     invoke: cleanupWorkspaceCli,
+  },
+  setup: {
+    summary: "Project-level setup commands (currently: repos)",
+    usage: "repos [--dry-run] [<repo>...]",
+    invoke: setupCli,
   },
   remote: {
     summary: "Create, authenticate, bootstrap, and inspect a remote runner",

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -1,0 +1,357 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { setupRepos, setupReposCli } from "./setupRepos.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test mock intentionally shares one recorder across sync and async command APIs.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, which: vi.fn<typeof actual.which>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+
+const whichMock = vi.mocked(which);
+const loadConfigMock = vi.mocked(loadConfig);
+
+function makeConfig(overrides: {
+  projectDir: string;
+  knownRepositories: string[];
+}): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: overrides.projectDir,
+      knownRepositories: overrides.knownRepositories,
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
+    remote: {
+      provider: "sprite",
+      runnerName: "crew-claude-1",
+      owner: "ClipboardHealth",
+      repoRoot: "/home/sprite/dev",
+      worktreeRoot: "/home/sprite/groundcrew/worktrees",
+      secretNames: ["NPM_TOKEN", "BUF_TOKEN"],
+    },
+  };
+}
+
+let projectDir: string;
+
+describe(setupRepos, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-"));
+    consoleLog = captureConsoleLog();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("clones a missing repo via `gh repo clone <entry> <target>`", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.existing).toStrictEqual([]);
+    expect(result.failed).toStrictEqual([]);
+  });
+
+  it("skips a repo whose target directory already exists", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.existing).toStrictEqual(["owner/repo"]);
+    expect(result.cloned).toStrictEqual([]);
+  });
+
+  it("clones only the missing entries when some already exist", async () => {
+    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/have", "owner/missing"],
+    });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/missing", join(projectDir, "owner/missing")],
+      expect.anything(),
+    );
+    expect(result.existing).toStrictEqual(["owner/have"]);
+    expect(result.cloned).toStrictEqual(["owner/missing"]);
+  });
+
+  it("does not invoke gh in dry-run mode and reports what would be cloned", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, { dryRun: true });
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.cloned).toStrictEqual([]);
+    expect(result.planned).toStrictEqual(["owner/repo"]);
+    expect(consoleLog.output()).toContain("[dry-run]");
+    expect(consoleLog.output()).toContain("owner/repo");
+  });
+
+  it("filters cloning to the `only` subset when provided", async () => {
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/a", "owner/b"],
+    });
+
+    const result = await setupRepos(config, { only: ["owner/b"] });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/b", join(projectDir, "owner/b")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/b"]);
+  });
+
+  it("deduplicates entries so a single repo is cloned at most once", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, { only: ["owner/repo", "owner/repo"] });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.failed).toStrictEqual([]);
+  });
+
+  it("throws when `only` contains an entry not in knownRepositories", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/a"] });
+
+    await expect(setupRepos(config, { only: ["owner/missing"] })).rejects.toThrow(
+      /not in workspace\.knownRepositories.*owner\/missing/,
+    );
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("skips bare-name entries with a warning and marks the result skipped", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo", "bare"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("bare");
+    expect(result.skipped[0]?.reason).toContain("owner/");
+    expect(consoleLog.output()).toContain("[skip] bare");
+  });
+
+  it("fails fast with an install hint when gh is not on PATH", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- `which` returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.ghMissing).toBe(true);
+    expect(result.cloned).toStrictEqual([]);
+    expect(consoleLog.output()).toMatch(/gh.*not found.*brew install gh/);
+  });
+
+  it("does not probe for gh when there is nothing to clone", async () => {
+    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/have"] });
+
+    await setupRepos(config, {});
+
+    expect(whichMock).not.toHaveBeenCalled();
+  });
+
+  it("captures failures and continues with remaining repos", async () => {
+    runCommandMock
+      .mockImplementationOnce(() => {
+        throw new Error("auth failed");
+      })
+      .mockReturnValueOnce("");
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/broken", "owner/ok"],
+    });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+    expect(result.cloned).toStrictEqual(["owner/ok"]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.repo).toBe("owner/broken");
+    expect(result.failed[0]?.error.message).toMatch(/auth failed/);
+  });
+
+  it("wraps a non-Error throw from gh into an Error carrying the message", async () => {
+    runCommandMock.mockImplementationOnce(() => {
+      // oxlint-disable-next-line no-throw-literal, typescript/only-throw-error -- intentionally throws a non-Error to exercise the catch branch
+      throw "gh died spectacularly";
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.error).toBeInstanceOf(Error);
+    expect(result.failed[0]?.error.message).toBe("gh died spectacularly");
+  });
+});
+
+describe(setupReposCli, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-cli-"));
+    consoleLog = captureConsoleLog();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+    loadConfigMock.mockResolvedValue(makeConfig({ projectDir, knownRepositories: ["owner/repo"] }));
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+    process.exitCode = undefined;
+    vi.resetAllMocks();
+  });
+
+  it("clones every missing knownRepositories entry with no args", async () => {
+    await setupReposCli([]);
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+  });
+
+  it("parses --dry-run", async () => {
+    await setupReposCli(["--dry-run"]);
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("[dry-run]");
+  });
+
+  it("treats positional args as the `only` subset", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({ projectDir, knownRepositories: ["owner/a", "owner/b"] }),
+    );
+
+    await setupReposCli(["owner/b"]);
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/b", join(projectDir, "owner/b")],
+      expect.anything(),
+    );
+  });
+
+  it("rejects unknown options instead of treating them as repo names", async () => {
+    await expect(setupReposCli(["--bogus"])).rejects.toThrow(/Unknown option: --bogus/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("sets process.exitCode = 1 when gh is missing", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- `which` returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets process.exitCode = 1 when any clone fails", async () => {
+    runCommandMock.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets process.exitCode = 1 when bare-name entries are skipped", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    loadConfigMock.mockResolvedValue(
+      makeConfig({ projectDir, knownRepositories: ["owner/repo", "bare"] }),
+    );
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves process.exitCode unset when every repo is already present", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -77,6 +77,12 @@ function makeConfig(overrides: {
 
 let projectDir: string;
 
+function makeGitRepositoryTarget(...segments: string[]): string {
+  const target = join(projectDir, ...segments);
+  mkdirSync(join(target, ".git"), { recursive: true });
+  return target;
+}
+
 describe(setupRepos, () => {
   let consoleLog: ConsoleCapture;
 
@@ -108,8 +114,8 @@ describe(setupRepos, () => {
     expect(result.failed).toStrictEqual([]);
   });
 
-  it("skips a repo whose target directory already exists", async () => {
-    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+  it("skips a repo whose target is already a git repository", async () => {
+    makeGitRepositoryTarget("owner", "repo");
     const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
 
     const result = await setupRepos(config, {});
@@ -119,8 +125,51 @@ describe(setupRepos, () => {
     expect(result.cloned).toStrictEqual([]);
   });
 
+  it("clones into an existing empty target directory", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.existing).toStrictEqual([]);
+  });
+
+  it("skips a non-git directory target instead of reporting it as existing", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    writeFileSync(join(projectDir, "owner", "repo", "README.md"), "not a clone");
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.existing).toStrictEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("owner/repo");
+    expect(result.skipped[0]?.kind).toBe("invalid-target");
+    expect(result.skipped[0]?.reason).toContain("not a git repository");
+  });
+
+  it("skips a file target instead of reporting it as existing", async () => {
+    mkdirSync(join(projectDir, "owner"), { recursive: true });
+    writeFileSync(join(projectDir, "owner", "repo"), "not a directory");
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("owner/repo");
+    expect(result.skipped[0]?.kind).toBe("invalid-target");
+  });
+
   it("clones only the missing entries when some already exist", async () => {
-    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    makeGitRepositoryTarget("owner", "have");
     const config = makeConfig({
       projectDir,
       knownRepositories: ["owner/have", "owner/missing"],
@@ -200,8 +249,22 @@ describe(setupRepos, () => {
     expect(result.cloned).toStrictEqual(["owner/repo"]);
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0]?.repo).toBe("bare");
+    expect(result.skipped[0]?.kind).toBe("bare-name");
     expect(result.skipped[0]?.reason).toContain("owner/");
     expect(consoleLog.output()).toContain("[skip] bare");
+  });
+
+  it("skips malformed owner/repo entries instead of passing them to gh", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo/extra"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.cloned).toStrictEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("owner/repo/extra");
+    expect(result.skipped[0]?.kind).toBe("invalid-repository");
+    expect(result.skipped[0]?.reason).toContain("owner/repo");
   });
 
   it("fails fast with an install hint when gh is not on PATH", async () => {
@@ -214,11 +277,12 @@ describe(setupRepos, () => {
     expect(runCommandMock).not.toHaveBeenCalled();
     expect(result.ghMissing).toBe(true);
     expect(result.cloned).toStrictEqual([]);
-    expect(consoleLog.output()).toMatch(/gh.*not found.*brew install gh/);
+    expect(result.skipped).toStrictEqual([]);
+    expect(consoleLog.output()).toMatch(/gh.*not found.*cli\.github\.com/);
   });
 
   it("does not probe for gh when there is nothing to clone", async () => {
-    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    makeGitRepositoryTarget("owner", "have");
     const config = makeConfig({ projectDir, knownRepositories: ["owner/have"] });
 
     await setupRepos(config, {});
@@ -337,7 +401,7 @@ describe(setupReposCli, () => {
   });
 
   it("sets process.exitCode = 1 when bare-name entries are skipped", async () => {
-    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    makeGitRepositoryTarget("owner", "repo");
     loadConfigMock.mockResolvedValue(
       makeConfig({ projectDir, knownRepositories: ["owner/repo", "bare"] }),
     );
@@ -347,8 +411,17 @@ describe(setupReposCli, () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("leaves process.exitCode unset when every repo is already present", async () => {
+  it("sets process.exitCode = 1 when an existing target is invalid", async () => {
     mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    writeFileSync(join(projectDir, "owner", "repo", "README.md"), "not a clone");
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves process.exitCode unset when every repo is already present", async () => {
+    makeGitRepositoryTarget("owner", "repo");
 
     await setupReposCli([]);
 

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -267,6 +267,19 @@ describe(setupRepos, () => {
     expect(result.skipped[0]?.reason).toContain("owner/repo");
   });
 
+  it("skips repository entries whose target would escape projectDir", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["../outside"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.cloned).toStrictEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("../outside");
+    expect(result.skipped[0]?.kind).toBe("invalid-repository");
+    expect(result.skipped[0]?.reason).toContain("outside workspace.projectDir");
+  });
+
   it("fails fast with an install hint when gh is not on PATH", async () => {
     // oxlint-disable-next-line unicorn/no-useless-undefined -- `which` returns Promise<string | undefined>; passing nothing is a TS error
     whichMock.mockResolvedValue(undefined);

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -1,0 +1,208 @@
+/**
+ * `crew setup repos` — clone every entry of `workspace.knownRepositories`
+ * that does not already exist under `workspace.projectDir`. Entries
+ * shaped `<owner>/<repo>` are cloned via `gh repo clone`; bare-name
+ * entries are skipped with a hint, because they have no canonical URL
+ * we can guess at without involving the user's gh login. Idempotent.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runCommandAsync } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { errorMessage, log, writeOutput } from "../lib/util.ts";
+
+export interface SetupReposOptions {
+  /** Print the plan without running any clone. */
+  dryRun?: boolean;
+  /**
+   * Restrict the action to this subset of `knownRepositories`. Each entry
+   * must match an entry in the config or the call rejects before any side
+   * effect.
+   */
+  only?: readonly string[];
+}
+
+export interface SetupReposResult {
+  /** Entries already present under `projectDir`. */
+  existing: string[];
+  /** Entries that would be cloned in dry-run mode. */
+  planned: string[];
+  /** Entries successfully cloned this run. */
+  cloned: string[];
+  /** Entries skipped with a reason (e.g. bare names, dry-run). */
+  skipped: { repo: string; reason: string }[];
+  /** Entries that failed during clone. */
+  failed: { repo: string; error: Error }[];
+  /** True when `gh` is missing and at least one clone was needed. */
+  ghMissing: boolean;
+}
+
+interface ClonePlan {
+  toClone: string[];
+  existing: string[];
+  skipped: { repo: string; reason: string }[];
+}
+
+function emptyResult(): SetupReposResult {
+  return {
+    existing: [],
+    planned: [],
+    cloned: [],
+    skipped: [],
+    failed: [],
+    ghMissing: false,
+  };
+}
+
+function selectRepositories(
+  config: ResolvedConfig,
+  only: readonly string[] | undefined,
+): readonly string[] {
+  if (only === undefined) {
+    return config.workspace.knownRepositories;
+  }
+  const known = new Set(config.workspace.knownRepositories);
+  const unknown = only.filter((entry) => !known.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Repositories not in workspace.knownRepositories: ${unknown.join(", ")}. Known: ${config.workspace.knownRepositories.join(", ")}`,
+    );
+  }
+  return only;
+}
+
+function planClones(config: ResolvedConfig, repositories: readonly string[]): ClonePlan {
+  const projectDir = resolve(config.workspace.projectDir);
+  const toClone: string[] = [];
+  const existing: string[] = [];
+  const skipped: { repo: string; reason: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of repositories) {
+    if (seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    const target = resolve(projectDir, entry);
+    if (existsSync(target)) {
+      existing.push(entry);
+      continue;
+    }
+    if (!entry.includes("/")) {
+      skipped.push({
+        repo: entry,
+        reason: `bare name needs owner/ prefix to auto-clone; clone manually into ${target}`,
+      });
+      continue;
+    }
+    toClone.push(entry);
+  }
+
+  return { toClone, existing, skipped };
+}
+
+export async function setupRepos(
+  config: ResolvedConfig,
+  options: SetupReposOptions,
+): Promise<SetupReposResult> {
+  const repositories = selectRepositories(config, options.only);
+  const plan = planClones(config, repositories);
+  const result = emptyResult();
+  result.existing = plan.existing;
+  result.skipped = plan.skipped;
+
+  for (const entry of plan.existing) {
+    log(`[exists] ${entry}`);
+  }
+  for (const { repo, reason } of plan.skipped) {
+    log(`[skip] ${repo} — ${reason}`);
+  }
+
+  if (options.dryRun === true) {
+    result.planned = plan.toClone;
+    for (const entry of plan.toClone) {
+      log(`[dry-run] would clone ${entry}`);
+    }
+    return result;
+  }
+
+  if (plan.toClone.length === 0) {
+    return result;
+  }
+
+  const ghPath = await which("gh");
+  if (ghPath === undefined) {
+    result.ghMissing = true;
+    writeOutput(
+      "gh CLI not found — install with 'brew install gh' (or clone the missing repos manually).",
+    );
+    for (const entry of plan.toClone) {
+      result.skipped.push({ repo: entry, reason: "gh CLI not installed" });
+    }
+    return result;
+  }
+
+  const projectDir = resolve(config.workspace.projectDir);
+  // Sequential on purpose: each `gh repo clone` inherits stdio for progress
+  // bars and auth prompts. Parallel clones would interleave output and make
+  // any interactive 2FA prompt unanswerable.
+  for (const entry of plan.toClone) {
+    const target = resolve(projectDir, entry);
+    log(`[clone] ${entry} → ${target}`);
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- see comment above
+      await runCommandAsync("gh", ["repo", "clone", entry, target], {
+        stdio: "inherit",
+        timeoutMs: 0,
+      });
+      result.cloned.push(entry);
+    } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(errorMessage(error));
+      log(`[fail]  ${entry}: ${wrapped.message}`);
+      result.failed.push({ repo: entry, error: wrapped });
+    }
+  }
+
+  return result;
+}
+
+function parseArguments(argv: string[]): SetupReposOptions {
+  let dryRun = false;
+  const positionals: string[] = [];
+  for (const argument of argv) {
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(
+        `Unknown option: ${argument}\nUsage: crew setup repos [--dry-run] [<repo>...]`,
+      );
+    }
+    positionals.push(argument);
+  }
+  const options: SetupReposOptions = { dryRun };
+  if (positionals.length > 0) {
+    options.only = positionals;
+  }
+  return options;
+}
+
+export async function setupReposCli(argv: string[]): Promise<void> {
+  const options = parseArguments(argv);
+  const config = await loadConfig();
+  const result = await setupRepos(config, options);
+
+  if (result.ghMissing || result.failed.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+  // Bare-name skips mean setup is incomplete — signal that to CI gates.
+  const bareSkips = result.skipped.filter(({ reason }) => reason.includes("bare name"));
+  if (bareSkips.length > 0) {
+    process.exitCode = 1;
+  }
+}

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -6,7 +6,7 @@
  * we can guess at without involving the user's gh login. Idempotent.
  */
 
-import { existsSync } from "node:fs";
+import { opendirSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { runCommandAsync } from "../lib/commandRunner.ts";
@@ -25,6 +25,14 @@ export interface SetupReposOptions {
   only?: readonly string[];
 }
 
+export type SetupReposSkipKind = "bare-name" | "invalid-repository" | "invalid-target";
+
+export interface SetupReposSkip {
+  repo: string;
+  kind: SetupReposSkipKind;
+  reason: string;
+}
+
 export interface SetupReposResult {
   /** Entries already present under `projectDir`. */
   existing: string[];
@@ -32,8 +40,8 @@ export interface SetupReposResult {
   planned: string[];
   /** Entries successfully cloned this run. */
   cloned: string[];
-  /** Entries skipped with a reason (e.g. bare names, dry-run). */
-  skipped: { repo: string; reason: string }[];
+  /** Entries skipped with a reason (e.g. bare names, invalid targets). */
+  skipped: SetupReposSkip[];
   /** Entries that failed during clone. */
   failed: { repo: string; error: Error }[];
   /** True when `gh` is missing and at least one clone was needed. */
@@ -43,8 +51,11 @@ export interface SetupReposResult {
 interface ClonePlan {
   toClone: string[];
   existing: string[];
-  skipped: { repo: string; reason: string }[];
+  skipped: SetupReposSkip[];
 }
+
+type ExistingTargetPlan = "clone" | "existing" | "skip-invalid";
+type RepositoryEntryPlan = "clone" | "bare-name" | "invalid-repository";
 
 function emptyResult(): SetupReposResult {
   return {
@@ -74,11 +85,73 @@ function selectRepositories(
   return only;
 }
 
+function pathExists(path: string): boolean {
+  return statSync(path, { throwIfNoEntry: false }) !== undefined;
+}
+
+function isDirectoryEmpty(path: string): boolean {
+  const directory = opendirSync(path);
+  try {
+    return directory.readSync() === null;
+  } finally {
+    directory.closeSync();
+  }
+}
+
+function existingTargetPlan(target: string): ExistingTargetPlan {
+  const stats = statSync(target, { throwIfNoEntry: false });
+  if (stats === undefined) {
+    return "clone";
+  }
+  if (!stats.isDirectory()) {
+    return "skip-invalid";
+  }
+  if (pathExists(resolve(target, ".git"))) {
+    return "existing";
+  }
+  return isDirectoryEmpty(target) ? "clone" : "skip-invalid";
+}
+
+function repositoryEntryPlan(repo: string): RepositoryEntryPlan {
+  const parts = repo.split("/");
+  if (parts.length === 1) {
+    return "bare-name";
+  }
+  if (parts.length === 2 && parts.every((part) => part.length > 0)) {
+    return "clone";
+  }
+  return "invalid-repository";
+}
+
+function bareNameSkip(repo: string, target: string): SetupReposSkip {
+  return {
+    repo,
+    kind: "bare-name",
+    reason: `bare name needs owner/ prefix to auto-clone; clone manually into ${target}`,
+  };
+}
+
+function invalidTargetSkip(repo: string, target: string): SetupReposSkip {
+  return {
+    repo,
+    kind: "invalid-target",
+    reason: `target exists but is not a git repository or empty directory: ${target}`,
+  };
+}
+
+function invalidRepositorySkip(repo: string, target: string): SetupReposSkip {
+  return {
+    repo,
+    kind: "invalid-repository",
+    reason: `repository must be owner/repo to auto-clone; clone manually into ${target}`,
+  };
+}
+
 function planClones(config: ResolvedConfig, repositories: readonly string[]): ClonePlan {
   const projectDir = resolve(config.workspace.projectDir);
   const toClone: string[] = [];
   const existing: string[] = [];
-  const skipped: { repo: string; reason: string }[] = [];
+  const skipped: SetupReposSkip[] = [];
   const seen = new Set<string>();
 
   for (const entry of repositories) {
@@ -87,15 +160,22 @@ function planClones(config: ResolvedConfig, repositories: readonly string[]): Cl
     }
     seen.add(entry);
     const target = resolve(projectDir, entry);
-    if (existsSync(target)) {
+    const targetPlan = existingTargetPlan(target);
+    if (targetPlan === "existing") {
       existing.push(entry);
       continue;
     }
-    if (!entry.includes("/")) {
-      skipped.push({
-        repo: entry,
-        reason: `bare name needs owner/ prefix to auto-clone; clone manually into ${target}`,
-      });
+    if (targetPlan === "skip-invalid") {
+      skipped.push(invalidTargetSkip(entry, target));
+      continue;
+    }
+    const repositoryPlan = repositoryEntryPlan(entry);
+    if (repositoryPlan === "bare-name") {
+      skipped.push(bareNameSkip(entry, target));
+      continue;
+    }
+    if (repositoryPlan === "invalid-repository") {
+      skipped.push(invalidRepositorySkip(entry, target));
       continue;
     }
     toClone.push(entry);
@@ -137,11 +217,8 @@ export async function setupRepos(
   if (ghPath === undefined) {
     result.ghMissing = true;
     writeOutput(
-      "gh CLI not found — install with 'brew install gh' (or clone the missing repos manually).",
+      "gh CLI not found - install GitHub CLI from https://cli.github.com/ (or clone the missing repos manually).",
     );
-    for (const entry of plan.toClone) {
-      result.skipped.push({ repo: entry, reason: "gh CLI not installed" });
-    }
     return result;
   }
 
@@ -200,9 +277,8 @@ export async function setupReposCli(argv: string[]): Promise<void> {
     process.exitCode = 1;
     return;
   }
-  // Bare-name skips mean setup is incomplete — signal that to CI gates.
-  const bareSkips = result.skipped.filter(({ reason }) => reason.includes("bare name"));
-  if (bareSkips.length > 0) {
+  // Remaining skips mean setup is incomplete — signal that to CI gates.
+  if (result.skipped.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -7,7 +7,7 @@
  */
 
 import { opendirSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 import { runCommandAsync } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -112,6 +112,13 @@ function existingTargetPlan(target: string): ExistingTargetPlan {
   return isDirectoryEmpty(target) ? "clone" : "skip-invalid";
 }
 
+function isInsideProjectDir(projectDir: string, target: string): boolean {
+  const relativeTarget = relative(projectDir, target);
+  return (
+    relativeTarget.length > 0 && !relativeTarget.startsWith("..") && !isAbsolute(relativeTarget)
+  );
+}
+
 function repositoryEntryPlan(repo: string): RepositoryEntryPlan {
   const parts = repo.split("/");
   if (parts.length === 1) {
@@ -147,6 +154,14 @@ function invalidRepositorySkip(repo: string, target: string): SetupReposSkip {
   };
 }
 
+function escapingTargetSkip(repo: string, projectDir: string, target: string): SetupReposSkip {
+  return {
+    repo,
+    kind: "invalid-repository",
+    reason: `repository resolves outside workspace.projectDir (${projectDir}): ${target}`,
+  };
+}
+
 function planClones(config: ResolvedConfig, repositories: readonly string[]): ClonePlan {
   const projectDir = resolve(config.workspace.projectDir);
   const toClone: string[] = [];
@@ -160,6 +175,10 @@ function planClones(config: ResolvedConfig, repositories: readonly string[]): Cl
     }
     seen.add(entry);
     const target = resolve(projectDir, entry);
+    if (!isInsideProjectDir(projectDir, target)) {
+      skipped.push(escapingTargetSkip(entry, projectDir, target));
+      continue;
+    }
     const targetPlan = existingTargetPlan(target);
     if (targetPlan === "existing") {
       existing.push(entry);


### PR DESCRIPTION
## Summary

- Adds `crew setup repos` to clone missing exact `<owner>/<repo>` entries from `workspace.knownRepositories` into `<workspace.projectDir>/<repo>` via `gh repo clone`.
- Keeps reruns idempotent by reporting `[exists]` only for targets that are already git repositories.
- Allows cloning into existing empty target directories, while file targets and non-git non-empty directories are skipped as invalid setup targets.
- Skips bare-name and malformed repository entries with actionable manual-clone hints; partial setup leaves a non-zero CLI exit code.
- Supports `--dry-run` previews and positional args for restricting setup to known repository entries.
- Fails fast with a cross-platform GitHub CLI install hint when `gh` is not on `PATH`.

## Validation

- `./node_modules/.bin/vitest run src/commands/setupRepos.test.ts src/cli.test.ts` — 53 tests passed.
- `node --run verify` — architecture, build, cpd, format, knip, lint, markdown:lint, spell, syncpack, and test passed; full suite was 612 tests with 100% statement/branch/function/line coverage.
- Not run: manual smoke against a real config.

## Notes

- Sequential cloning is intentional: each `gh repo clone` inherits stdio for progress and auth prompts, so parallel clones would interleave interactive output.
- `which("gh")` is deferred until at least one repository actually needs cloning, so a fully set up rerun starts no `gh` subprocess.
- This started as a port from [ClipboardHealth/core-utils#666](https://github.com/ClipboardHealth/core-utils/pull/666), with repo-local lint adjustments and review fixes for existing target validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- commit-push-pr:created v1 core@3.4.0 -->
