### PR TITLE
fix: mark manual ticket runs in progress

### DIFF
--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -9,13 +9,9 @@
 
 import type { LinearClient } from "@linear/sdk";
 
-import {
-  type BoardState,
-  type GroundcrewIssue,
-  isGroundcrewIssue,
-  type Issue,
-} from "../lib/boardSource.ts";
+import { type BoardState, type GroundcrewIssue, isGroundcrewIssue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import type { UsageByModel } from "../lib/usage.ts";
 import { errorMessage, log, logEvent } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
@@ -51,8 +47,7 @@ export interface Dispatcher {
 
 export function createDispatcher(deps: DispatcherDeps): Dispatcher {
   const { config, client } = deps;
-  const inProgressStateByTeam = new Map<string, string>();
-  let teamsMissingInProgress = new Set<string>();
+  const issueStatusUpdater = createLinearIssueStatusUpdater({ config, client });
 
   function buildExhaustedSet(usage: UsageByModel): Set<string> {
     const exhausted = new Set<string>();
@@ -89,49 +84,6 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       }
     }
     return exhausted;
-  }
-
-  async function getInProgressStateId(teamId: string): Promise<string | undefined> {
-    if (teamId.length === 0) {
-      return undefined;
-    }
-    const cached = inProgressStateByTeam.get(teamId);
-    if (cached !== undefined) {
-      return cached;
-    }
-    // Negative cache is per-iteration so a team that's fixed in Linear during
-    // a `crew watch` session auto-recovers next tick. Within one iteration,
-    // every eligible ticket in a misconfigured team would otherwise re-fetch.
-    if (teamsMissingInProgress.has(teamId)) {
-      return undefined;
-    }
-
-    const team = await client.team(teamId);
-    const states = await team.states();
-    const inProgress = states.nodes.find(
-      (state) => state.name === config.linear.statuses.inProgress,
-    );
-    if (inProgress?.id === undefined) {
-      teamsMissingInProgress.add(teamId);
-      return undefined;
-    }
-    inProgressStateByTeam.set(teamId, inProgress.id);
-    return inProgress.id;
-  }
-
-  async function markInProgress(issue: Issue): Promise<void> {
-    const stateId = await getInProgressStateId(issue.teamId);
-    if (stateId === undefined) {
-      // Throw rather than log+return: if we silently swallowed this, the
-      // ticket would stay Todo forever while the workspace runs, which means
-      // every iteration re-enters the recovery path and the agent never
-      // counts toward maximumInProgress.
-      throw new Error(
-        `Could not find "${config.linear.statuses.inProgress}" state for ${issue.id} (team ${issue.teamId.length > 0 ? issue.teamId : "?"}). Verify the status name in linear.statuses.inProgress matches the team's workflow.`,
-      );
-    }
-    await client.updateIssue(issue.uuid, { stateId });
-    log(`Marked ${issue.id} as ${config.linear.statuses.inProgress}`);
   }
 
   function logSkip(verdict: SkipVerdict): void {
@@ -186,7 +138,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
           ? setupWorkspace(config, setupOptions)
           : setupWorkspace(config, setupOptions, { signal }));
       }
-      await markInProgress(issue);
+      await issueStatusUpdater.markInProgress(issue);
       logEvent("dispatch", {
         outcome: recovery ? "resumed" : "started",
         ticket: issue.id,
@@ -215,7 +167,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     signal?: AbortSignal;
   }): Promise<void> {
     const { state, worktreeEntries, usage, dryRun, signal } = arguments_;
-    teamsMissingInProgress = new Set();
+    issueStatusUpdater.resetMissingInProgressCache();
 
     const activeCount = state.issues.filter(
       (issue) => issue.status === config.linear.statuses.inProgress,

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -93,6 +93,13 @@ interface MockedIssue {
 const issueResolver = vi.fn<(id: string) => Promise<MockedIssue>>();
 const rawRequestMock =
   vi.fn<(query: string, variables?: Record<string, unknown>) => Promise<unknown>>();
+const teamStatesMock = vi.fn<() => Promise<{ nodes: { id: string; name: string }[] }>>();
+const teamMock =
+  vi.fn<
+    (id: string) => Promise<{ states: () => Promise<{ nodes: { id: string; name: string }[] }> }>
+  >();
+const updateIssueMock =
+  vi.fn<(id: string, input: { stateId: string }) => Promise<Record<string, never>>>();
 
 function buildMockedIssue(overrides: {
   title?: string;
@@ -105,6 +112,8 @@ function buildMockedIssue(overrides: {
 }
 
 function buildResolveIssueResponse(overrides: {
+  uuid?: string;
+  teamId?: string;
   title?: string;
   description?: string | null | undefined;
   labels?: MockedLabel[];
@@ -112,9 +121,11 @@ function buildResolveIssueResponse(overrides: {
   return {
     data: {
       issue: {
+        id: overrides.uuid ?? "uuid-1",
         title: overrides.title ?? "Title",
         description: "description" in overrides ? overrides.description : "Body for repo-a",
         labels: { nodes: overrides.labels ?? [] },
+        team: { id: overrides.teamId ?? "team-1" },
       },
     },
   };
@@ -185,7 +196,15 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
 }
 
 function mockLinearClient(): void {
-  const linearClient = { issue: issueResolver, client: { rawRequest: rawRequestMock } };
+  teamStatesMock.mockResolvedValue({ nodes: [{ id: "state-in-progress", name: "In Progress" }] });
+  teamMock.mockResolvedValue({ states: teamStatesMock });
+  updateIssueMock.mockResolvedValue({});
+  const linearClient = {
+    issue: issueResolver,
+    team: teamMock,
+    updateIssue: updateIssueMock,
+    client: { rawRequest: rawRequestMock },
+  };
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests stub only the surfaces touched by setupWorkspace + fetchResolvedIssue
   const typedLinearClient = linearClient as unknown as ReturnType<typeof getLinearClient>;
   linearClientMock.mockReturnValue(typedLinearClient);
@@ -1008,6 +1027,47 @@ describe(setupWorkspaceCli, () => {
       "cmux",
       expect.arrayContaining(["set-status", "model", "claude"]),
     );
+  });
+
+  it("marks the ticket In Progress after launching the workspace", async () => {
+    rawRequestMock.mockResolvedValue(
+      buildResolveIssueResponse({ uuid: "issue-uuid-1", teamId: "linear-team-1" }),
+    );
+
+    await setupWorkspaceCli("team-1");
+
+    expect(teamMock).toHaveBeenCalledWith("linear-team-1");
+    expect(updateIssueMock).toHaveBeenCalledWith("issue-uuid-1", {
+      stateId: "state-in-progress",
+    });
+    expect(firstInvocationOrder(runCommandMock)).toBeLessThan(
+      firstInvocationOrder(updateIssueMock),
+    );
+  });
+
+  it("does not mark the ticket In Progress in dry-run mode", async () => {
+    await setupWorkspaceCli("team-1", { dryRun: true });
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(teamMock).not.toHaveBeenCalled();
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it("fails clearly when the configured In Progress status is missing", async () => {
+    teamStatesMock.mockResolvedValue({ nodes: [{ id: "state-other", name: "Other" }] });
+
+    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(
+      /Could not find "In Progress" state for team-1/,
+    );
+    expect(updateIssueMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark the ticket In Progress when workspace setup fails", async () => {
+    createMock.mockRejectedValue(new Error("worktree failed"));
+
+    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(/worktree failed/);
+    expect(teamMock).not.toHaveBeenCalled();
+    expect(updateIssueMock).not.toHaveBeenCalled();
   });
 
   it("rejects when the ticket description has no known repository", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -17,6 +17,7 @@ import {
   buildRemoteLaunchCommand,
   shellSingleQuote,
 } from "../lib/launchCommand.ts";
+import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import { assertLocalRunnerRequirements } from "../lib/localRunner.ts";
 import { getRemoteRunnerProvider } from "../lib/spriteRemoteRunnerProvider.ts";
 import { errorMessage, getLinearClient, log, readEnvironmentVariable } from "../lib/util.ts";
@@ -346,5 +347,10 @@ export async function setupWorkspaceCli(
     model: resolved.model,
     runner: resolved.runner,
     details: { title: resolved.title, description: resolved.description },
+  });
+  await createLinearIssueStatusUpdater({ config, client }).markInProgress({
+    id: ticket.toLowerCase(),
+    uuid: resolved.uuid,
+    teamId: resolved.teamId,
   });
 }

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -140,8 +140,10 @@ function makeClient(options: { projectFound?: boolean; pages?: IssueNodeStub[][]
       return {
         data: {
           issue: {
+            id: "uuid-1",
             title: "Title",
             description: "Touches repo-a.",
+            team: { id: "team-default" },
             labels: { nodes: [] },
           },
         },
@@ -679,8 +681,10 @@ describe(fetchResolvedIssue, () => {
     client.client.rawRequest.mockResolvedValueOnce({
       data: {
         issue: {
+          id: "uuid-1",
           title: "Title",
           description: "Touches repo-a.",
+          team: { id: "team-default" },
           labels: { nodes: [{ name: "agent-remote" }, { name: "agent-codex" }] },
         },
       },
@@ -693,7 +697,37 @@ describe(fetchResolvedIssue, () => {
       ticket: "team-1",
     });
 
-    expect(actual).toMatchObject({ repository: "repo-a", model: "codex", runner: "remote" });
+    expect(actual).toMatchObject({
+      uuid: "uuid-1",
+      repository: "repo-a",
+      model: "codex",
+      runner: "remote",
+      teamId: "team-default",
+    });
+  });
+
+  it("returns an empty team id when Linear omits the issue team", async () => {
+    const client = makeClient({ pages: [[]] });
+    client.client.rawRequest.mockResolvedValueOnce({
+      data: {
+        issue: {
+          id: "uuid-1",
+          title: "Title",
+          description: "Touches repo-a.",
+          team: null,
+          labels: { nodes: [] },
+        },
+      },
+    });
+
+    const actual = await fetchResolvedIssue({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests use the LinearClient surface consumed by boardSource
+      client: client as unknown as LinearClient,
+      config: makeConfig(),
+      ticket: "team-1",
+    });
+
+    expect(actual.teamId).toBe("");
   });
 });
 

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -294,11 +294,13 @@ function buildRepositoryRegex(config: ResolvedConfig): RegExp {
 }
 
 interface ResolvedIssue {
+  uuid: string;
   title: string;
   description: string;
   repository: string;
   model: string;
   runner: WorkspaceRunner;
+  teamId: string;
 }
 
 const ISSUE_LABEL_PAGE_SIZE = 50;
@@ -317,8 +319,10 @@ export async function fetchResolvedIssue(arguments_: {
   const response: { data?: unknown } = await client.client.rawRequest(
     `query ResolveIssue($id: String!) {
       issue(id: $id) {
+        id
         title
         description
+        team { id }
         labels(first: ${ISSUE_LABEL_PAGE_SIZE}) {
           nodes { name }
         }
@@ -329,8 +333,10 @@ export async function fetchResolvedIssue(arguments_: {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shape is fixed by our GraphQL query above
   const { issue } = response.data as {
     issue: {
+      id: string;
       title: string;
       description?: string | null;
+      team?: { id: string } | null;
       labels: { nodes: { name: string }[] };
     } | null;
   };
@@ -352,7 +358,15 @@ export async function fetchResolvedIssue(arguments_: {
   const model =
     parsed === undefined || parsed.model === AGENT_ANY_MODEL ? config.models.default : parsed.model;
   const runner = parsed?.runner ?? "local";
-  return { title: issue.title, description, repository, model, runner };
+  return {
+    uuid: issue.id,
+    title: issue.title,
+    description,
+    repository,
+    model,
+    runner,
+    teamId: issue.team?.id ?? "",
+  };
 }
 
 interface ParseRepositoryArguments {

--- a/src/lib/linearIssueStatus.ts
+++ b/src/lib/linearIssueStatus.ts
@@ -1,0 +1,68 @@
+import type { LinearClient } from "@linear/sdk";
+
+import type { ResolvedConfig } from "./config.ts";
+import { log } from "./util.ts";
+
+interface LinearIssueReference {
+  id: string;
+  uuid: string;
+  teamId: string;
+}
+
+interface LinearIssueStatusUpdater {
+  markInProgress(issue: LinearIssueReference): Promise<void>;
+  resetMissingInProgressCache(): void;
+}
+
+export function createLinearIssueStatusUpdater(arguments_: {
+  config: ResolvedConfig;
+  client: LinearClient;
+}): LinearIssueStatusUpdater {
+  const { config, client } = arguments_;
+  const inProgressStateByTeam = new Map<string, string>();
+  let teamsMissingInProgress = new Set<string>();
+
+  async function getInProgressStateId(teamId: string): Promise<string | undefined> {
+    if (teamId.length === 0) {
+      return undefined;
+    }
+    const cached = inProgressStateByTeam.get(teamId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    // Negative cache is reset by dispatcher each iteration so a team that's
+    // fixed in Linear during a watch session auto-recovers on the next tick.
+    if (teamsMissingInProgress.has(teamId)) {
+      return undefined;
+    }
+
+    const team = await client.team(teamId);
+    const states = await team.states();
+    const inProgress = states.nodes.find(
+      (state) => state.name === config.linear.statuses.inProgress,
+    );
+    if (inProgress?.id === undefined) {
+      teamsMissingInProgress.add(teamId);
+      return undefined;
+    }
+    inProgressStateByTeam.set(teamId, inProgress.id);
+    return inProgress.id;
+  }
+
+  async function markInProgress(issue: LinearIssueReference): Promise<void> {
+    const stateId = await getInProgressStateId(issue.teamId);
+    if (stateId === undefined) {
+      throw new Error(
+        `Could not find "${config.linear.statuses.inProgress}" state for ${issue.id} (team ${issue.teamId.length > 0 ? issue.teamId : "?"}). Verify the status name in linear.statuses.inProgress matches the team's workflow.`,
+      );
+    }
+    await client.updateIssue(issue.uuid, { stateId });
+    log(`Marked ${issue.id} as ${config.linear.statuses.inProgress}`);
+  }
+
+  function resetMissingInProgressCache(): void {
+    teamsMissingInProgress = new Set();
+  }
+
+  return { markInProgress, resetMissingInProgressCache };
+}


### PR DESCRIPTION
## Summary

`crew run --ticket <TICKET>` now marks the resolved Linear issue as the configured In Progress status after the workspace launches, matching the orchestrator pickup path. The shared Linear status updater keeps dispatcher caching behavior while giving manual setup the same update behavior and clear errors when status config is missing.

## Validation

- `./node_modules/.bin/vitest run src/commands/setupWorkspace.test.ts`
- `./node_modules/.bin/vitest run src/commands/dispatcher.test.ts`
- `./node_modules/.bin/vitest run src/lib/boardSource.test.ts`
- `node --run verify`
- Pre-push `node --run verify` hook

Agent session: codex resume 019e38e2-72e8-7701-ad91-6397a6c761d4
<!-- commit-push-pr:created v1 core@3.4.0 -->
