### PR TITLE
feat: crew setup discover-repos to populate knownRepositories from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
    gh repo clone owner/repo ~/dev/groundcrew-workspaces/owner/repo
    ```
 
+   Or let `crew` clone every missing `owner/repo` entry for you using your `gh` login:
+
+   ```bash
+   crew setup repos              # clone all missing entries
+   crew setup repos --dry-run    # preview what would be cloned
+   crew setup repos owner/repo   # restrict to one entry
+   ```
+
+   `crew setup repos` is idempotent — already-cloned repos are reported `[exists]` and untouched. Bare-name entries (no `owner/`) are skipped with an instruction to clone manually, since groundcrew can't safely guess the org. The command fails fast with an install hint when `gh` is not on `PATH`.
+
    `crew` resolves the config path as: `GROUNDCREW_CONFIG` if set → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` if it exists → a `config.ts` sitting next to `crew`'s own source files (only useful from a local checkout; see [Hacking on groundcrew](#hacking-on-groundcrew)). Set `GROUNDCREW_CONFIG` only when you want to override the XDG location.
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
@@ -187,6 +197,7 @@ crew remote attach <session-id-or-command> --runner crew-claude-1
 crew remote ps crew-claude-1
 crew remote interrupt <process-group-id> --runner crew-claude-1
 crew run --ticket <TICKET>
+crew setup repos [--dry-run] [<repo>...]
 crew cleanup <TICKET>
 ```
 
@@ -211,6 +222,7 @@ crew cleanup <TICKET>
 - **Doctor checks every enabled model, including shipped defaults you didn't disable.** `models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and don't have `codex` installed, set `models.definitions.codex: { disabled: true }` (see "Disabling a shipped default" under "Config reference"). Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
+- **`crew setup repos` only auto-clones `owner/repo` entries.** Bare-name entries in `workspace.knownRepositories` (e.g. `"api"` rather than `"clipboardhealth/api"`) are skipped with a hint to clone manually — the command refuses to guess the owner. After a partial setup, the exit code is non-zero so CI gates notice; rerun is idempotent once you clone the bare ones into `<projectDir>/<name>` yourself. Adding a new repo to `knownRepositories` later? Just rerun `crew setup repos`; already-present entries report `[exists]` and are untouched.
 
 ## Hacking on groundcrew
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
    `crew setup repos` is idempotent — already-cloned repos are reported `[exists]` and untouched. Bare-name entries (no `owner/`) are skipped with an instruction to clone manually, since groundcrew can't safely guess the org. The command fails fast with an install hint when `gh` is not on `PATH`.
 
+   Or let `crew` discover them for you:
+
+   ```bash
+   crew setup discover-repos your-org           # add every active repo to knownRepositories
+   crew setup discover-repos --dry-run your-org # preview without writing
+   ```
+
+   `discover-repos` adds entries shaped `your-org/<repo>` to `workspace.knownRepositories` in your `config.ts`, skipping archived/fork/disabled repos. Pair with `crew setup repos` to actually clone them.
+
    `crew` resolves the config path as: `GROUNDCREW_CONFIG` if set → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` if it exists → a `config.ts` sitting next to `crew`'s own source files (only useful from a local checkout; see [Hacking on groundcrew](#hacking-on-groundcrew)). Set `GROUNDCREW_CONFIG` only when you want to override the XDG location.
 
 4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
@@ -198,6 +207,7 @@ crew remote ps crew-claude-1
 crew remote interrupt <process-group-id> --runner crew-claude-1
 crew run --ticket <TICKET>
 crew setup repos [--dry-run] [<repo>...]
+crew setup discover-repos [--dry-run] <org>
 crew cleanup <TICKET>
 ```
 
@@ -222,6 +232,7 @@ crew cleanup <TICKET>
 - **Doctor checks every enabled model, including shipped defaults you didn't disable.** `models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and don't have `codex` installed, set `models.definitions.codex: { disabled: true }` (see "Disabling a shipped default" under "Config reference"). Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
 - **Switch to tmux if cmux is misbehaving.** Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and vertical-tab sidebar.
 - **Agent CLI must accept a positional prompt.** The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
+- **`crew setup discover-repos` rewrites your `config.ts`.** It edits the `knownRepositories` array literal in-place; back up the file or use `--dry-run` first if your config has unusual structure. The writer aborts cleanly if the literal isn't a single, simple `knownRepositories: [...]` declaration.
 - **`crew setup repos` only auto-clones `owner/repo` entries.** Bare-name entries in `workspace.knownRepositories` (e.g. `"api"` rather than `"clipboardhealth/api"`) are skipped with a hint to clone manually — the command refuses to guess the owner. After a partial setup, the exit code is non-zero so CI gates notice; rerun is idempotent once you clone the bare ones into `<projectDir>/<name>` yourself. Adding a new repo to `knownRepositories` later? Just rerun `crew setup repos`; already-present entries report `[exists]` and are untouched.
 
 ## Hacking on groundcrew

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
     "maxtimeout",
     "Metabase",
     "mintimeout",
+    "myorg",
     "noproxy",
     "nrwl",
     "npmjs",
@@ -59,6 +60,7 @@
     "unstub",
     "vitest",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "writeback"
   ]
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,6 +5,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
   captureConsoleError,
@@ -24,6 +25,9 @@ vi.mock(import("./commands/orchestrator.ts"), () => ({
 vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
 }));
+vi.mock(import("./commands/setupRepos.ts"), () => ({
+  setupReposCli: vi.fn<typeof setupReposCli>(),
+}));
 vi.mock(import("./commands/remoteSetup.ts"), () => ({
   remoteCli: vi.fn<typeof remoteCli>(),
 }));
@@ -31,6 +35,7 @@ vi.mock(import("./commands/remoteSetup.ts"), () => ({
 const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
 const setupMock = vi.mocked(setupWorkspaceCli);
+const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const remoteMock = vi.mocked(remoteCli);
 const requireFromTest = createRequire(import.meta.url);
@@ -64,6 +69,7 @@ describe(run, () => {
     orchestrateMock.mockResolvedValue();
     doctorMock.mockResolvedValue(true);
     setupMock.mockResolvedValue();
+    setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
     remoteMock.mockResolvedValue();
   });
@@ -241,6 +247,34 @@ describe(run, () => {
     await run(["cleanup", "--force", "TEAM-1"]);
 
     expect(cleanupMock).toHaveBeenCalledWith(["--force", "TEAM-1"]);
+  });
+
+  it("dispatches `setup repos` to setupReposCli with the remaining argv", async () => {
+    await run(["setup", "repos", "--dry-run", "owner/repo"]);
+
+    expect(setupReposMock).toHaveBeenCalledWith(["--dry-run", "owner/repo"]);
+  });
+
+  it("dispatches bare `setup repos` (no args) to setupReposCli", async () => {
+    await run(["setup", "repos"]);
+
+    expect(setupReposMock).toHaveBeenCalledWith([]);
+  });
+
+  it("reports an unknown `setup` verb instead of routing it", async () => {
+    await run(["setup", "bogus"]);
+
+    expect(setupReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints the setup usage when no verb is given", async () => {
+    await run(["setup"]);
+
+    expect(setupReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(process.exitCode).toBe(1);
   });
 
   it("dispatches remote to remoteCli with the remaining argv", async () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 
 import { run } from "./cli.ts";
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
+import { discoverReposCli } from "./commands/discoverRepos.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
@@ -28,6 +29,9 @@ vi.mock(import("./commands/setupWorkspace.ts"), () => ({
 vi.mock(import("./commands/setupRepos.ts"), () => ({
   setupReposCli: vi.fn<typeof setupReposCli>(),
 }));
+vi.mock(import("./commands/discoverRepos.ts"), () => ({
+  discoverReposCli: vi.fn<typeof discoverReposCli>(),
+}));
 vi.mock(import("./commands/remoteSetup.ts"), () => ({
   remoteCli: vi.fn<typeof remoteCli>(),
 }));
@@ -36,6 +40,7 @@ const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const setupReposMock = vi.mocked(setupReposCli);
+const discoverReposMock = vi.mocked(discoverReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const remoteMock = vi.mocked(remoteCli);
 const requireFromTest = createRequire(import.meta.url);
@@ -70,6 +75,7 @@ describe(run, () => {
     doctorMock.mockResolvedValue(true);
     setupMock.mockResolvedValue();
     setupReposMock.mockResolvedValue();
+    discoverReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
     remoteMock.mockResolvedValue();
   });
@@ -265,7 +271,9 @@ describe(run, () => {
     await run(["setup", "bogus"]);
 
     expect(setupReposMock).not.toHaveBeenCalled();
-    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(discoverReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("crew setup repos");
+    expect(consoleError.output()).toContain("crew setup discover-repos");
     expect(process.exitCode).toBe(1);
   });
 
@@ -273,8 +281,23 @@ describe(run, () => {
     await run(["setup"]);
 
     expect(setupReposMock).not.toHaveBeenCalled();
-    expect(consoleError.output()).toContain("Usage: crew setup repos");
+    expect(discoverReposMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("crew setup repos");
+    expect(consoleError.output()).toContain("crew setup discover-repos");
     expect(process.exitCode).toBe(1);
+  });
+
+  it("dispatches `setup discover-repos` to discoverReposCli with the remaining argv", async () => {
+    await run(["setup", "discover-repos", "myorg"]);
+
+    expect(discoverReposMock).toHaveBeenCalledWith(["myorg"]);
+    expect(setupReposMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards --dry-run to discoverReposCli", async () => {
+    await run(["setup", "discover-repos", "--dry-run", "myorg"]);
+
+    expect(discoverReposMock).toHaveBeenCalledWith(["--dry-run", "myorg"]);
   });
 
   it("dispatches remote to remoteCli with the remaining argv", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { errorMessage, writeError, writeOutput } from "./lib/util.ts";
 
@@ -18,6 +19,19 @@ interface Subcommand {
 }
 
 const requireFromCli = createRequire(import.meta.url);
+
+function setupUsage(): string {
+  return "Usage: crew setup repos [--dry-run] [<repo>...]";
+}
+
+async function setupCli(argv: string[]): Promise<void> {
+  const [verb, ...rest] = argv;
+  if (verb === "repos") {
+    await setupReposCli(rest);
+    return;
+  }
+  throw new Error(setupUsage());
+}
 
 async function runCli(argv: string[]): Promise<void> {
   let watch = false;
@@ -76,6 +90,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Tear down a worktree",
     usage: "[--force] <ticket>",
     invoke: cleanupWorkspaceCli,
+  },
+  setup: {
+    summary: "Project-level setup commands (currently: repos)",
+    usage: "repos [--dry-run] [<repo>...]",
+    invoke: setupCli,
   },
   remote: {
     summary: "Create, authenticate, bootstrap, and inspect a remote runner",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
+import { discoverReposCli } from "./commands/discoverRepos.ts";
 import { doctor } from "./commands/doctor.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { remoteCli } from "./commands/remoteSetup.ts";
@@ -21,13 +22,21 @@ interface Subcommand {
 const requireFromCli = createRequire(import.meta.url);
 
 function setupUsage(): string {
-  return "Usage: crew setup repos [--dry-run] [<repo>...]";
+  return [
+    "Usage:",
+    "  crew setup repos [--dry-run] [<repo>...]",
+    "  crew setup discover-repos [--dry-run] <org>",
+  ].join("\n");
 }
 
 async function setupCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
   if (verb === "repos") {
     await setupReposCli(rest);
+    return;
+  }
+  if (verb === "discover-repos") {
+    await discoverReposCli(rest);
     return;
   }
   throw new Error(setupUsage());
@@ -92,8 +101,10 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: cleanupWorkspaceCli,
   },
   setup: {
-    summary: "Project-level setup commands (currently: repos)",
-    usage: "repos [--dry-run] [<repo>...]",
+    summary: "Project-level setup commands (repos, discover-repos)",
+    usage:
+      "repos [--dry-run] [<repo>...]\n" +
+      "           → crew setup discover-repos [--dry-run] <org>",
     invoke: setupCli,
   },
   remote: {

--- a/src/commands/discoverRepos.test.ts
+++ b/src/commands/discoverRepos.test.ts
@@ -272,6 +272,24 @@ describe(discoverRepos, () => {
 
     await expect(discoverRepos(config, "myorg", {})).rejects.toThrow(/did not return an array/);
   });
+
+  it("warns to stderr when gh returns exactly the page-size limit", async () => {
+    const PAGE = 1000;
+    const entries = Array.from({ length: PAGE }, (_, i) => ({
+      name: `repo-${i}`,
+      isArchived: false,
+      isFork: false,
+      isDisabled: false,
+    }));
+    runCommandMock.mockReturnValue(JSON.stringify(entries));
+    const config = makeConfig({ knownRepositories: [] });
+
+    await discoverRepos(config, "myorg", { dryRun: true });
+
+    expect(consoleError.output()).toContain("warning");
+    expect(consoleError.output()).toContain("1000");
+    expect(consoleError.output()).toContain("myorg");
+  });
 });
 
 describe(discoverReposCli, () => {

--- a/src/commands/discoverRepos.test.ts
+++ b/src/commands/discoverRepos.test.ts
@@ -1,0 +1,359 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, resolveConfigPath, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import {
+  captureConsoleError,
+  captureConsoleLog,
+  type ConsoleCapture,
+} from "../testHelpers/consoleCapture.ts";
+import { discoverRepos, discoverReposCli } from "./discoverRepos.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shared sync/async mock recorder for test only.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, which: vi.fn<typeof actual.which>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    loadConfig: vi.fn<typeof loadConfig>(),
+    resolveConfigPath: vi.fn<typeof resolveConfigPath>(),
+  };
+});
+
+const whichMock = vi.mocked(which);
+const loadConfigMock = vi.mocked(loadConfig);
+const resolveConfigPathMock = vi.mocked(resolveConfigPath);
+
+const CONFIG_TEMPLATE = [
+  "export const config = {",
+  "  workspace: {",
+  "    projectDir: '/tmp/groundcrew-workspaces',",
+  "    knownRepositories: [",
+  '      "owner/existing", // first entry',
+  "    ],",
+  "  },",
+  "};",
+  "",
+].join("\n");
+
+function makeConfig(overrides: { knownRepositories: string[] }): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: "/tmp/groundcrew-workspaces",
+      knownRepositories: overrides.knownRepositories,
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
+    remote: {
+      provider: "sprite",
+      runnerName: "crew-claude-1",
+      owner: "ClipboardHealth",
+      repoRoot: "/home/sprite/dev",
+      worktreeRoot: "/home/sprite/groundcrew/worktrees",
+      secretNames: ["NPM_TOKEN", "BUF_TOKEN"],
+    },
+  };
+}
+
+const GH_FOUR_REPOS = JSON.stringify([
+  { name: "active", isArchived: false, isFork: false, isDisabled: false },
+  { name: "old", isArchived: true, isFork: false, isDisabled: false },
+  { name: "mirror", isArchived: false, isFork: true, isDisabled: false },
+  { name: "broken", isArchived: false, isFork: false, isDisabled: true },
+]);
+
+let dir: string;
+let configPath: string;
+
+describe(discoverRepos, () => {
+  let consoleLog: ConsoleCapture;
+  let consoleError: ConsoleCapture;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "groundcrew-discover-repos-"));
+    configPath = join(dir, "config.ts");
+    writeFileSync(configPath, CONFIG_TEMPLATE);
+    consoleLog = captureConsoleLog();
+    consoleError = captureConsoleError();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue(GH_FOUR_REPOS);
+    resolveConfigPathMock.mockReturnValue(configPath);
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    consoleError.restore();
+    rmSync(dir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("adds only active repos and filters archived/fork/disabled with reasons", async () => {
+    const config = makeConfig({ knownRepositories: ["owner/existing"] });
+
+    const result = await discoverRepos(config, "myorg", {});
+
+    expect(result.added).toStrictEqual(["myorg/active"]);
+    expect(result.alreadyKnown).toStrictEqual([]);
+    expect(result.filtered.map((f) => f.repo)).toStrictEqual([
+      "myorg/old",
+      "myorg/mirror",
+      "myorg/broken",
+    ]);
+    const [archived, fork, disabled] = result.filtered;
+    expect(archived?.reasons).toContain("archived");
+    expect(fork?.reasons).toContain("fork");
+    expect(disabled?.reasons).toContain("disabled");
+    expect(readFileSync(configPath, "utf8")).toContain('"myorg/active",');
+    expect(readFileSync(configPath, "utf8")).toContain("// first entry");
+  });
+
+  it("invokes gh with the documented flags and --json projection", async () => {
+    const config = makeConfig({ knownRepositories: [] });
+
+    await discoverRepos(config, "myorg", {});
+
+    expect(runCommandMock).toHaveBeenCalledWith("gh", [
+      "repo",
+      "list",
+      "myorg",
+      "--no-archived",
+      "--source",
+      "--limit",
+      "1000",
+      "--json",
+      "name,isArchived,isFork,isDisabled",
+    ]);
+  });
+
+  it("is a no-op when every active repo is already in knownRepositories", async () => {
+    const original = readFileSync(configPath);
+    const originalMtime = statSync(configPath).mtimeMs;
+    const config = makeConfig({ knownRepositories: ["owner/existing", "myorg/active"] });
+
+    const result = await discoverRepos(config, "myorg", {});
+
+    expect(result.added).toStrictEqual([]);
+    expect(result.alreadyKnown).toStrictEqual(["myorg/active"]);
+    expect(readFileSync(configPath)).toStrictEqual(original);
+    expect(statSync(configPath).mtimeMs).toBe(originalMtime);
+  });
+
+  it("does not write config.ts in --dry-run mode but reports the would-be diff", async () => {
+    const original = readFileSync(configPath, "utf8");
+    const config = makeConfig({ knownRepositories: ["owner/existing", "myorg/old"] });
+
+    const result = await discoverRepos(config, "myorg", { dryRun: true });
+
+    expect(result.added).toStrictEqual(["myorg/active"]);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(consoleLog.output()).toContain("dry-run");
+    expect(consoleLog.output()).toContain("+ myorg/active");
+  });
+
+  it("marks already-known repos with a space (not `+`) in the dry-run diff", async () => {
+    runCommandMock.mockReturnValue(
+      JSON.stringify([
+        { name: "active", isArchived: false, isFork: false, isDisabled: false },
+        { name: "known", isArchived: false, isFork: false, isDisabled: false },
+      ]),
+    );
+    const config = makeConfig({ knownRepositories: ["myorg/known"] });
+
+    await discoverRepos(config, "myorg", { dryRun: true });
+
+    expect(consoleLog.output()).toContain("+ myorg/active");
+    expect(consoleLog.output()).toContain("  myorg/known");
+  });
+
+  it("reports gh missing without calling runCommand or touching config.ts", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- which returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+    const original = readFileSync(configPath, "utf8");
+    const config = makeConfig({ knownRepositories: ["owner/existing"] });
+
+    const result = await discoverRepos(config, "myorg", {});
+
+    expect(result.ghMissing).toBe(true);
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(consoleError.output()).toContain("cli.github.com");
+    expect(consoleError.output()).not.toContain("brew install");
+  });
+
+  it("surfaces errors from gh repo list and leaves config.ts untouched", async () => {
+    runCommandMock.mockImplementation(() => {
+      throw new Error("gh: HTTP 401");
+    });
+    const original = readFileSync(configPath, "utf8");
+    const config = makeConfig({ knownRepositories: ["owner/existing"] });
+
+    await expect(discoverRepos(config, "myorg", {})).rejects.toThrow(/HTTP 401/);
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+  });
+
+  it("preserves the inline comment on an existing entry after writeback", async () => {
+    const config = makeConfig({ knownRepositories: ["owner/existing"] });
+
+    await discoverRepos(config, "myorg", {});
+
+    const after = readFileSync(configPath, "utf8");
+    expect(after).toContain('"owner/existing", // first entry');
+    expect(after).toContain('"myorg/active",');
+  });
+
+  it("drops gh entries that are null or have missing/wrong-typed fields", async () => {
+    runCommandMock.mockReturnValue(
+      JSON.stringify([
+        null,
+        "string-entry",
+        { name: 42, isArchived: false, isFork: false, isDisabled: false },
+        { isArchived: false, isFork: false, isDisabled: false },
+        { name: "noArchived", isFork: false, isDisabled: false },
+        { name: "badFork", isArchived: false, isFork: "no", isDisabled: false },
+        { name: "badDisabled", isArchived: false, isFork: false, isDisabled: 0 },
+        { name: "good", isArchived: false, isFork: false, isDisabled: false },
+      ]),
+    );
+    const config = makeConfig({ knownRepositories: [] });
+
+    const result = await discoverRepos(config, "myorg", { dryRun: true });
+
+    expect(result.added).toStrictEqual(["myorg/good"]);
+  });
+
+  it("throws with a clear message when gh stdout is not JSON", async () => {
+    runCommandMock.mockReturnValue("not-json");
+    const config = makeConfig({ knownRepositories: [] });
+
+    await expect(discoverRepos(config, "myorg", {})).rejects.toThrow(/non-JSON output/);
+  });
+
+  it("throws when gh stdout is JSON but not an array", async () => {
+    runCommandMock.mockReturnValue('{"total":3}');
+    const config = makeConfig({ knownRepositories: [] });
+
+    await expect(discoverRepos(config, "myorg", {})).rejects.toThrow(/did not return an array/);
+  });
+});
+
+describe(discoverReposCli, () => {
+  let consoleLog: ConsoleCapture;
+  let consoleError: ConsoleCapture;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "groundcrew-discover-cli-"));
+    configPath = join(dir, "config.ts");
+    writeFileSync(configPath, CONFIG_TEMPLATE);
+    consoleLog = captureConsoleLog();
+    consoleError = captureConsoleError();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("[]");
+    loadConfigMock.mockResolvedValue(makeConfig({ knownRepositories: ["owner/existing"] }));
+    resolveConfigPathMock.mockReturnValue(configPath);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    consoleError.restore();
+    rmSync(dir, { recursive: true, force: true });
+    process.exitCode = undefined;
+    vi.resetAllMocks();
+  });
+
+  it("requires a positional <org>", async () => {
+    await expect(discoverReposCli([])).rejects.toThrow(/<org> is required/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty-string <org>", async () => {
+    await expect(discoverReposCli([""])).rejects.toThrow(/<org> is required/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown flags instead of treating them as the org name", async () => {
+    await expect(discoverReposCli(["--bogus", "myorg"])).rejects.toThrow(/Unknown option: --bogus/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects extra positional args after <org>", async () => {
+    await expect(discoverReposCli(["myorg", "extra"])).rejects.toThrow(/Too many positional/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches discoverRepos with the parsed positional org", async () => {
+    runCommandMock.mockReturnValue(GH_FOUR_REPOS);
+
+    await discoverReposCli(["myorg"]);
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["repo", "list", "myorg"]),
+    );
+  });
+
+  it("forwards --dry-run without writing the config", async () => {
+    runCommandMock.mockReturnValue(GH_FOUR_REPOS);
+    const original = readFileSync(configPath, "utf8");
+
+    await discoverReposCli(["--dry-run", "myorg"]);
+
+    expect(readFileSync(configPath, "utf8")).toBe(original);
+    expect(consoleLog.output()).toContain("dry-run");
+  });
+
+  it("sets process.exitCode = 1 when gh is missing", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- which returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+
+    await discoverReposCli(["myorg"]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves process.exitCode unset on a successful no-op", async () => {
+    runCommandMock.mockReturnValue("[]");
+
+    await discoverReposCli(["myorg"]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/commands/discoverRepos.ts
+++ b/src/commands/discoverRepos.ts
@@ -41,6 +41,7 @@ interface GhRepoEntry {
 const USAGE = "Usage: crew setup discover-repos [--dry-run] <org>";
 const GH_INSTALL_HINT =
   "gh CLI not found — install from https://cli.github.com/ (or add entries to workspace.knownRepositories manually).";
+const GH_REPO_LIST_LIMIT = 1000;
 
 function emptyResult(org: string): DiscoverReposResult {
   return {
@@ -122,11 +123,16 @@ export async function discoverRepos(
     "--no-archived",
     "--source",
     "--limit",
-    "1000",
+    String(GH_REPO_LIST_LIMIT),
     "--json",
     "name,isArchived,isFork,isDisabled",
   ]);
   const entries = parseGhRepoList(stdout);
+  if (entries.length === GH_REPO_LIST_LIMIT) {
+    writeError(
+      `discover-repos: warning — gh returned exactly ${GH_REPO_LIST_LIMIT} repos for ${org}; the org may have more. Results may be incomplete.`,
+    );
+  }
 
   const active: string[] = [];
   for (const entry of entries) {

--- a/src/commands/discoverRepos.ts
+++ b/src/commands/discoverRepos.ts
@@ -1,0 +1,206 @@
+/**
+ * `crew setup discover-repos <org>` — query GitHub for every active
+ * (non-archived, non-fork, non-disabled) repository in `<org>` and add
+ * the resulting `<org>/<repo>` entries to `workspace.knownRepositories`
+ * in the user's `config.ts`. Idempotent: re-runs add nothing when every
+ * active repo is already tracked. Pair with `crew setup repos` to clone
+ * the new entries.
+ */
+import { runCommand } from "../lib/commandRunner.ts";
+import { loadConfig, resolveConfigPath, type ResolvedConfig } from "../lib/config.ts";
+import { updateKnownRepositoriesInConfigFile } from "../lib/configFileWriter.ts";
+import { which } from "../lib/host.ts";
+import { errorMessage, log, writeError, writeOutput } from "../lib/util.ts";
+
+export interface DiscoverReposOptions {
+  /** Print the planned changes without modifying `config.ts`. */
+  dryRun?: boolean;
+}
+
+export interface FilteredRepo {
+  repo: string;
+  reasons: string[];
+}
+
+export interface DiscoverReposResult {
+  org: string;
+  active: string[];
+  alreadyKnown: string[];
+  added: string[];
+  filtered: FilteredRepo[];
+  ghMissing: boolean;
+}
+
+interface GhRepoEntry {
+  name: string;
+  isArchived: boolean;
+  isFork: boolean;
+  isDisabled: boolean;
+}
+
+const USAGE = "Usage: crew setup discover-repos [--dry-run] <org>";
+const GH_INSTALL_HINT =
+  "gh CLI not found — install from https://cli.github.com/ (or add entries to workspace.knownRepositories manually).";
+
+function emptyResult(org: string): DiscoverReposResult {
+  return {
+    org,
+    active: [],
+    alreadyKnown: [],
+    added: [],
+    filtered: [],
+    ghMissing: false,
+  };
+}
+
+function isGhRepoEntry(value: unknown): value is GhRepoEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("name" in value) || typeof value.name !== "string") {
+    return false;
+  }
+  if (!("isArchived" in value) || typeof value.isArchived !== "boolean") {
+    return false;
+  }
+  if (!("isFork" in value) || typeof value.isFork !== "boolean") {
+    return false;
+  }
+  if (!("isDisabled" in value) || typeof value.isDisabled !== "boolean") {
+    return false;
+  }
+  return true;
+}
+
+function parseGhRepoList(stdout: string): GhRepoEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`gh repo list returned non-JSON output: ${errorMessage(error)}`, {
+      cause: error,
+    });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new TypeError("gh repo list did not return an array");
+  }
+  return parsed.filter(isGhRepoEntry);
+}
+
+function dropReasons(entry: GhRepoEntry): string[] {
+  const reasons: string[] = [];
+  if (entry.isArchived) {
+    reasons.push("archived");
+  }
+  if (entry.isFork) {
+    reasons.push("fork");
+  }
+  if (entry.isDisabled) {
+    reasons.push("disabled");
+  }
+  return reasons;
+}
+
+export async function discoverRepos(
+  config: ResolvedConfig,
+  org: string,
+  options: DiscoverReposOptions,
+): Promise<DiscoverReposResult> {
+  const result = emptyResult(org);
+
+  const ghPath = await which("gh");
+  if (ghPath === undefined) {
+    result.ghMissing = true;
+    writeError(GH_INSTALL_HINT);
+    return result;
+  }
+
+  const stdout = runCommand("gh", [
+    "repo",
+    "list",
+    org,
+    "--no-archived",
+    "--source",
+    "--limit",
+    "1000",
+    "--json",
+    "name,isArchived,isFork,isDisabled",
+  ]);
+  const entries = parseGhRepoList(stdout);
+
+  const active: string[] = [];
+  for (const entry of entries) {
+    const reasons = dropReasons(entry);
+    if (reasons.length > 0) {
+      result.filtered.push({ repo: `${org}/${entry.name}`, reasons });
+      continue;
+    }
+    active.push(`${org}/${entry.name}`);
+  }
+  result.active = active;
+
+  const known = new Set(config.workspace.knownRepositories);
+  for (const repo of active) {
+    if (known.has(repo)) {
+      result.alreadyKnown.push(repo);
+    } else {
+      result.added.push(repo);
+    }
+  }
+
+  if (result.added.length === 0) {
+    log(
+      `discover-repos: nothing new (${active.length} active, ${result.alreadyKnown.length} already known, ${result.filtered.length} filtered)`,
+    );
+    return result;
+  }
+
+  if (options.dryRun === true) {
+    writeOutput(`discover-repos (dry-run): ${result.added.length} would be added to ${org}`);
+    for (const repo of active) {
+      writeOutput(`  ${known.has(repo) ? " " : "+"} ${repo}`);
+    }
+    return result;
+  }
+
+  const configPath = resolveConfigPath();
+  updateKnownRepositoriesInConfigFile({ configPath, toAdd: result.added });
+  writeOutput(
+    `discover-repos: added ${result.added.length} entries to workspace.knownRepositories (${result.alreadyKnown.length} already known, ${result.filtered.length} filtered)`,
+  );
+  for (const repo of result.added) {
+    writeOutput(`  + ${repo}`);
+  }
+  return result;
+}
+
+interface ParsedArguments {
+  org: string;
+  dryRun: boolean;
+}
+
+function parseArguments(argv: string[]): ParsedArguments {
+  const dryRun = argv.includes("--dry-run");
+  const positionals = argv.filter((argument) => argument !== "--dry-run");
+  const stray = positionals.find((argument) => argument.startsWith("-"));
+  if (stray !== undefined) {
+    throw new Error(`Unknown option: ${stray}\n${USAGE}`);
+  }
+  const [first, ...rest] = positionals;
+  if (first === undefined || first.length === 0) {
+    throw new Error(`<org> is required\n${USAGE}`);
+  }
+  if (rest.length > 0) {
+    throw new Error(`Too many positional arguments\n${USAGE}`);
+  }
+  return { org: first, dryRun };
+}
+
+export async function discoverReposCli(argv: string[]): Promise<void> {
+  const { org, dryRun } = parseArguments(argv);
+  const config = await loadConfig();
+  const result = await discoverRepos(config, org, { dryRun });
+  if (result.ghMissing) {
+    process.exitCode = 1;
+  }
+}

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -1,0 +1,357 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { setupRepos, setupReposCli } from "./setupRepos.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test mock intentionally shares one recorder across sync and async command APIs.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, which: vi.fn<typeof actual.which>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+
+const whichMock = vi.mocked(which);
+const loadConfigMock = vi.mocked(loadConfig);
+
+function makeConfig(overrides: {
+  projectDir: string;
+  knownRepositories: string[];
+}): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: overrides.projectDir,
+      knownRepositories: overrides.knownRepositories,
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    logging: { file: "/tmp/groundcrew-test.log" },
+    remote: {
+      provider: "sprite",
+      runnerName: "crew-claude-1",
+      owner: "ClipboardHealth",
+      repoRoot: "/home/sprite/dev",
+      worktreeRoot: "/home/sprite/groundcrew/worktrees",
+      secretNames: ["NPM_TOKEN", "BUF_TOKEN"],
+    },
+  };
+}
+
+let projectDir: string;
+
+describe(setupRepos, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-"));
+    consoleLog = captureConsoleLog();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("clones a missing repo via `gh repo clone <entry> <target>`", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.existing).toStrictEqual([]);
+    expect(result.failed).toStrictEqual([]);
+  });
+
+  it("skips a repo whose target directory already exists", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.existing).toStrictEqual(["owner/repo"]);
+    expect(result.cloned).toStrictEqual([]);
+  });
+
+  it("clones only the missing entries when some already exist", async () => {
+    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/have", "owner/missing"],
+    });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/missing", join(projectDir, "owner/missing")],
+      expect.anything(),
+    );
+    expect(result.existing).toStrictEqual(["owner/have"]);
+    expect(result.cloned).toStrictEqual(["owner/missing"]);
+  });
+
+  it("does not invoke gh in dry-run mode and reports what would be cloned", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, { dryRun: true });
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.cloned).toStrictEqual([]);
+    expect(result.planned).toStrictEqual(["owner/repo"]);
+    expect(consoleLog.output()).toContain("[dry-run]");
+    expect(consoleLog.output()).toContain("owner/repo");
+  });
+
+  it("filters cloning to the `only` subset when provided", async () => {
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/a", "owner/b"],
+    });
+
+    const result = await setupRepos(config, { only: ["owner/b"] });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/b", join(projectDir, "owner/b")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/b"]);
+  });
+
+  it("deduplicates entries so a single repo is cloned at most once", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, { only: ["owner/repo", "owner/repo"] });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.failed).toStrictEqual([]);
+  });
+
+  it("throws when `only` contains an entry not in knownRepositories", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/a"] });
+
+    await expect(setupRepos(config, { only: ["owner/missing"] })).rejects.toThrow(
+      /not in workspace\.knownRepositories.*owner\/missing/,
+    );
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("skips bare-name entries with a warning and marks the result skipped", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo", "bare"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.repo).toBe("bare");
+    expect(result.skipped[0]?.reason).toContain("owner/");
+    expect(consoleLog.output()).toContain("[skip] bare");
+  });
+
+  it("fails fast with an install hint when gh is not on PATH", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- `which` returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(result.ghMissing).toBe(true);
+    expect(result.cloned).toStrictEqual([]);
+    expect(consoleLog.output()).toMatch(/gh.*not found.*brew install gh/);
+  });
+
+  it("does not probe for gh when there is nothing to clone", async () => {
+    mkdirSync(join(projectDir, "owner", "have"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/have"] });
+
+    await setupRepos(config, {});
+
+    expect(whichMock).not.toHaveBeenCalled();
+  });
+
+  it("captures failures and continues with remaining repos", async () => {
+    runCommandMock
+      .mockImplementationOnce(() => {
+        throw new Error("auth failed");
+      })
+      .mockReturnValueOnce("");
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/broken", "owner/ok"],
+    });
+
+    const result = await setupRepos(config, {});
+
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+    expect(result.cloned).toStrictEqual(["owner/ok"]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.repo).toBe("owner/broken");
+    expect(result.failed[0]?.error.message).toMatch(/auth failed/);
+  });
+
+  it("wraps a non-Error throw from gh into an Error carrying the message", async () => {
+    runCommandMock.mockImplementationOnce(() => {
+      // oxlint-disable-next-line no-throw-literal, typescript/only-throw-error -- intentionally throws a non-Error to exercise the catch branch
+      throw "gh died spectacularly";
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.error).toBeInstanceOf(Error);
+    expect(result.failed[0]?.error.message).toBe("gh died spectacularly");
+  });
+});
+
+describe(setupReposCli, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-cli-"));
+    consoleLog = captureConsoleLog();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+    loadConfigMock.mockResolvedValue(makeConfig({ projectDir, knownRepositories: ["owner/repo"] }));
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+    process.exitCode = undefined;
+    vi.resetAllMocks();
+  });
+
+  it("clones every missing knownRepositories entry with no args", async () => {
+    await setupReposCli([]);
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/repo", join(projectDir, "owner/repo")],
+      expect.anything(),
+    );
+  });
+
+  it("parses --dry-run", async () => {
+    await setupReposCli(["--dry-run"]);
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("[dry-run]");
+  });
+
+  it("treats positional args as the `only` subset", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({ projectDir, knownRepositories: ["owner/a", "owner/b"] }),
+    );
+
+    await setupReposCli(["owner/b"]);
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "owner/b", join(projectDir, "owner/b")],
+      expect.anything(),
+    );
+  });
+
+  it("rejects unknown options instead of treating them as repo names", async () => {
+    await expect(setupReposCli(["--bogus"])).rejects.toThrow(/Unknown option: --bogus/);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("sets process.exitCode = 1 when gh is missing", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- `which` returns Promise<string | undefined>; passing nothing is a TS error
+    whichMock.mockResolvedValue(undefined);
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets process.exitCode = 1 when any clone fails", async () => {
+    runCommandMock.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets process.exitCode = 1 when bare-name entries are skipped", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+    loadConfigMock.mockResolvedValue(
+      makeConfig({ projectDir, knownRepositories: ["owner/repo", "bare"] }),
+    );
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves process.exitCode unset when every repo is already present", async () => {
+    mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
+
+    await setupReposCli([]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -1,0 +1,208 @@
+/**
+ * `crew setup repos` — clone every entry of `workspace.knownRepositories`
+ * that does not already exist under `workspace.projectDir`. Entries
+ * shaped `<owner>/<repo>` are cloned via `gh repo clone`; bare-name
+ * entries are skipped with a hint, because they have no canonical URL
+ * we can guess at without involving the user's gh login. Idempotent.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { runCommandAsync } from "../lib/commandRunner.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { errorMessage, log, writeOutput } from "../lib/util.ts";
+
+export interface SetupReposOptions {
+  /** Print the plan without running any clone. */
+  dryRun?: boolean;
+  /**
+   * Restrict the action to this subset of `knownRepositories`. Each entry
+   * must match an entry in the config or the call rejects before any side
+   * effect.
+   */
+  only?: readonly string[];
+}
+
+export interface SetupReposResult {
+  /** Entries already present under `projectDir`. */
+  existing: string[];
+  /** Entries that would be cloned in dry-run mode. */
+  planned: string[];
+  /** Entries successfully cloned this run. */
+  cloned: string[];
+  /** Entries skipped with a reason (e.g. bare names, dry-run). */
+  skipped: { repo: string; reason: string }[];
+  /** Entries that failed during clone. */
+  failed: { repo: string; error: Error }[];
+  /** True when `gh` is missing and at least one clone was needed. */
+  ghMissing: boolean;
+}
+
+interface ClonePlan {
+  toClone: string[];
+  existing: string[];
+  skipped: { repo: string; reason: string }[];
+}
+
+function emptyResult(): SetupReposResult {
+  return {
+    existing: [],
+    planned: [],
+    cloned: [],
+    skipped: [],
+    failed: [],
+    ghMissing: false,
+  };
+}
+
+function selectRepositories(
+  config: ResolvedConfig,
+  only: readonly string[] | undefined,
+): readonly string[] {
+  if (only === undefined) {
+    return config.workspace.knownRepositories;
+  }
+  const known = new Set(config.workspace.knownRepositories);
+  const unknown = only.filter((entry) => !known.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Repositories not in workspace.knownRepositories: ${unknown.join(", ")}. Known: ${config.workspace.knownRepositories.join(", ")}`,
+    );
+  }
+  return only;
+}
+
+function planClones(config: ResolvedConfig, repositories: readonly string[]): ClonePlan {
+  const projectDir = resolve(config.workspace.projectDir);
+  const toClone: string[] = [];
+  const existing: string[] = [];
+  const skipped: { repo: string; reason: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of repositories) {
+    if (seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    const target = resolve(projectDir, entry);
+    if (existsSync(target)) {
+      existing.push(entry);
+      continue;
+    }
+    if (!entry.includes("/")) {
+      skipped.push({
+        repo: entry,
+        reason: `bare name needs owner/ prefix to auto-clone; clone manually into ${target}`,
+      });
+      continue;
+    }
+    toClone.push(entry);
+  }
+
+  return { toClone, existing, skipped };
+}
+
+export async function setupRepos(
+  config: ResolvedConfig,
+  options: SetupReposOptions,
+): Promise<SetupReposResult> {
+  const repositories = selectRepositories(config, options.only);
+  const plan = planClones(config, repositories);
+  const result = emptyResult();
+  result.existing = plan.existing;
+  result.skipped = plan.skipped;
+
+  for (const entry of plan.existing) {
+    log(`[exists] ${entry}`);
+  }
+  for (const { repo, reason } of plan.skipped) {
+    log(`[skip] ${repo} — ${reason}`);
+  }
+
+  if (options.dryRun === true) {
+    result.planned = plan.toClone;
+    for (const entry of plan.toClone) {
+      log(`[dry-run] would clone ${entry}`);
+    }
+    return result;
+  }
+
+  if (plan.toClone.length === 0) {
+    return result;
+  }
+
+  const ghPath = await which("gh");
+  if (ghPath === undefined) {
+    result.ghMissing = true;
+    writeOutput(
+      "gh CLI not found — install with 'brew install gh' (or clone the missing repos manually).",
+    );
+    for (const entry of plan.toClone) {
+      result.skipped.push({ repo: entry, reason: "gh CLI not installed" });
+    }
+    return result;
+  }
+
+  const projectDir = resolve(config.workspace.projectDir);
+  // Sequential on purpose: each `gh repo clone` inherits stdio for progress
+  // bars and auth prompts. Parallel clones would interleave output and make
+  // any interactive 2FA prompt unanswerable.
+  for (const entry of plan.toClone) {
+    const target = resolve(projectDir, entry);
+    log(`[clone] ${entry} → ${target}`);
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- see comment above
+      await runCommandAsync("gh", ["repo", "clone", entry, target], {
+        stdio: "inherit",
+        timeoutMs: 0,
+      });
+      result.cloned.push(entry);
+    } catch (error) {
+      const wrapped = error instanceof Error ? error : new Error(errorMessage(error));
+      log(`[fail]  ${entry}: ${wrapped.message}`);
+      result.failed.push({ repo: entry, error: wrapped });
+    }
+  }
+
+  return result;
+}
+
+function parseArguments(argv: string[]): SetupReposOptions {
+  let dryRun = false;
+  const positionals: string[] = [];
+  for (const argument of argv) {
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(
+        `Unknown option: ${argument}\nUsage: crew setup repos [--dry-run] [<repo>...]`,
+      );
+    }
+    positionals.push(argument);
+  }
+  const options: SetupReposOptions = { dryRun };
+  if (positionals.length > 0) {
+    options.only = positionals;
+  }
+  return options;
+}
+
+export async function setupReposCli(argv: string[]): Promise<void> {
+  const options = parseArguments(argv);
+  const config = await loadConfig();
+  const result = await setupRepos(config, options);
+
+  if (result.ghMissing || result.failed.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+  // Bare-name skips mean setup is incomplete — signal that to CI gates.
+  const bareSkips = result.skipped.filter(({ reason }) => reason.includes("bare name"));
+  if (bareSkips.length > 0) {
+    process.exitCode = 1;
+  }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -289,7 +289,7 @@ function defaultLogFile(): string {
   return xdgStatePath("groundcrew", "groundcrew.log");
 }
 
-function resolveConfigPath(): string {
+export function resolveConfigPath(): string {
   const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
   if (override !== undefined && override.length > 0) {
     return resolve(override);

--- a/src/lib/configFileWriter.test.ts
+++ b/src/lib/configFileWriter.test.ts
@@ -1,0 +1,501 @@
+import { mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { updateKnownRepositoriesInConfigFile } from "./configFileWriter.ts";
+
+vi.mock(import("node:fs"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    renameSync: vi.fn<typeof actual.renameSync>(actual.renameSync),
+  };
+});
+
+const renameSyncMock = vi.mocked(renameSync);
+
+let dir: string;
+let configPath: string;
+
+function write(content: string): void {
+  writeFileSync(configPath, content);
+}
+
+function read(): string {
+  return readFileSync(configPath, "utf8");
+}
+
+describe(updateKnownRepositoriesInConfigFile, () => {
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "groundcrew-config-writer-"));
+    configPath = join(dir, "config.ts");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("appends a new entry to a multi-line array with a trailing comma", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const result = updateKnownRepositoriesInConfigFile({
+      configPath,
+      toAdd: ["owner/b"],
+    });
+
+    expect(result).toStrictEqual({ added: ["owner/b"], alreadyPresent: [] });
+    expect(read()).toBe(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        '      "owner/b",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("inserts a trailing comma when the previous last entry lacked one", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a"',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toBe(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        '      "owner/b",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("uses the dominant entry indent from existing entries", () => {
+    write(
+      [
+        "export const config = {",
+        "\tworkspace: {",
+        "\t\tknownRepositories: [",
+        '\t\t\t"owner/a",',
+        "\t\t],",
+        "\t},",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('\t\t\t"owner/b",\n');
+  });
+
+  it("preserves interleaved // and /* */ comments inside the array", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        "      // top",
+        '      "owner/a",',
+        "      /* mid */",
+        '      "owner/b",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/c"] });
+
+    const after = read();
+    expect(after).toContain("// top");
+    expect(after).toContain("/* mid */");
+    expect(after).toContain('"owner/a",');
+    expect(after).toContain('"owner/b",');
+    expect(after).toContain('"owner/c",');
+  });
+
+  it("expands an empty array to multi-line shape when adding several entries", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({
+      configPath,
+      toAdd: ["owner/a", "owner/b"],
+    });
+
+    expect(read()).toBe(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        '      "owner/b",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps an empty array inline when adding a single entry", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/a"] });
+
+    expect(read()).toContain('knownRepositories: ["owner/a"],');
+  });
+
+  it("inserts into a single-line non-empty array with a trailing comma", () => {
+    write(
+      [
+        "export const config = {",
+        '  workspace: { knownRepositories: ["owner/a",] },',
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('knownRepositories: ["owner/a", "owner/b",]');
+  });
+
+  it("preserves CRLF line endings when adding entries", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\r\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('"owner/b",\r\n');
+  });
+
+  it("handles a config file ending with a line comment and no trailing newline", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        "    ],",
+        "  },",
+        "};",
+        "// trailing comment without newline",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('"owner/b",');
+    expect(read()).toContain("// trailing comment without newline");
+  });
+
+  it("inserts into a single-line non-empty array preserving the same shape", () => {
+    write(
+      [
+        "export const config = {",
+        '  workspace: { knownRepositories: ["owner/a"] },',
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('knownRepositories: ["owner/a", "owner/b"]');
+  });
+
+  it("does not rewrite the file when every entry to add is already present", () => {
+    const original = [
+      "export const config = {",
+      "  workspace: {",
+      "    knownRepositories: [",
+      '      "owner/a",',
+      "    ],",
+      "  },",
+      "};",
+      "",
+    ].join("\n");
+    write(original);
+
+    const result = updateKnownRepositoriesInConfigFile({
+      configPath,
+      toAdd: ["owner/a"],
+    });
+
+    expect(result).toStrictEqual({ added: [], alreadyPresent: ["owner/a"] });
+    expect(read()).toBe(original);
+  });
+
+  it("throws when the `knownRepositories` array literal cannot be found", () => {
+    write(["export const config = {", "  workspace: { projectDir: '/tmp' },", "};", ""].join("\n"));
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/a"] })).toThrow(
+      /couldn't find/,
+    );
+  });
+
+  it("ignores `knownRepositories` mentions that appear inside comments and strings", () => {
+    write(
+      [
+        "// knownRepositories: [bogus]",
+        '/* knownRepositories: ["nope"] */',
+        String.raw`const fakeDoc = "knownRepositories: [\"x\"]";`,
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/real",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/added"] });
+
+    const after = read();
+    expect(after).toContain('"owner/real",');
+    expect(after).toContain('"owner/added",');
+    expect(after).toContain("// knownRepositories: [bogus]");
+  });
+
+  it("throws when two real `knownRepositories` array literals exist", () => {
+    write(
+      [
+        "export const a = { knownRepositories: ['x'] };",
+        "export const b = { knownRepositories: ['y'] };",
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/a"] })).toThrow(
+      /multiple .*knownRepositories/,
+    );
+  });
+
+  it("reads single-quoted entries and writes back as double-quoted", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        "      'owner/a',",
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const result = updateKnownRepositoriesInConfigFile({
+      configPath,
+      toAdd: ["owner/a", "owner/b"],
+    });
+
+    expect(result).toStrictEqual({ added: ["owner/b"], alreadyPresent: ["owner/a"] });
+    expect(read()).toContain('"owner/b",');
+  });
+
+  it("reads backtick-quoted entries with no interpolation", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        "      `owner/a`,",
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const result = updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/a"] });
+
+    expect(result).toStrictEqual({ added: [], alreadyPresent: ["owner/a"] });
+  });
+
+  it("rejects template literals with interpolation in knownRepositories", () => {
+    write(
+      [
+        "const owner = 'foo';",
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        // oxlint-disable-next-line no-template-curly-in-string -- intentional: the test fixture contains a template-literal interpolation as a string for the writer to reject.
+        "      `${owner}/a`,",
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] })).toThrow(
+      /template literals with interpolation/,
+    );
+  });
+
+  it("rejects non-string-literal entries (e.g. `null`)", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        "      null,",
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/a"] })).toThrow(
+      /unexpected token .* only string literals/,
+    );
+  });
+
+  it("treats a nested `[...]` inside the array body as part of the same literal", () => {
+    write(
+      [
+        "export const config = {",
+        "  workspace: {",
+        '    knownRepositories: ["owner/a", ["nested"], "owner/b"],',
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/c"] })).toThrow(
+      /unexpected token .* only string literals/,
+    );
+  });
+
+  it("skips `knownRepositories` identifiers used in non-array-assignment positions", () => {
+    write(
+      [
+        "let knownRepositories;",
+        "function readKnownRepositories(): string[] { return []; }",
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('"owner/a",');
+    expect(read()).toContain('"owner/b",');
+  });
+
+  it("skips `knownRepositories:` followed by a non-array value", () => {
+    write(
+      [
+        "const fakeType = { knownRepositories: 0 };",
+        "export const config = {",
+        "  workspace: {",
+        "    knownRepositories: [",
+        '      "owner/a",',
+        "    ],",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] });
+
+    expect(read()).toContain('"owner/b",');
+  });
+
+  it("leaves the original file unmodified when the atomic rename fails", () => {
+    const original = [
+      "export const config = {",
+      "  workspace: {",
+      "    knownRepositories: [",
+      '      "owner/a",',
+      "    ],",
+      "  },",
+      "};",
+      "",
+    ].join("\n");
+    write(original);
+
+    renameSyncMock.mockImplementationOnce(() => {
+      throw new Error("rename failed");
+    });
+
+    expect(() => updateKnownRepositoriesInConfigFile({ configPath, toAdd: ["owner/b"] })).toThrow(
+      /rename failed/,
+    );
+    expect(read()).toBe(original);
+  });
+});

--- a/src/lib/configFileWriter.ts
+++ b/src/lib/configFileWriter.ts
@@ -1,0 +1,432 @@
+/**
+ * Textual rewriter for the workspace.knownRepositories array literal in
+ * the user's resolved config.ts. We scan rather than parse so we keep
+ * zero new dependencies; anything we cannot reason about (multiple
+ * occurrences, non-string entries, missing literal) aborts cleanly so the
+ * user can edit the file by hand.
+ */
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+
+const KEY = "knownRepositories";
+
+interface UpdateKnownRepositoriesInput {
+  configPath: string;
+  toAdd: readonly string[];
+}
+
+interface UpdateKnownRepositoriesResult {
+  added: string[];
+  alreadyPresent: string[];
+}
+
+interface ArrayLiteral {
+  open: number;
+  close: number;
+}
+
+interface Entry {
+  value: string;
+  start: number;
+  end: number;
+}
+
+interface KeyMatch {
+  literal: ArrayLiteral | undefined;
+  next: number;
+}
+
+const LEADING_WHITESPACE = /^[\t ]*/;
+const ONLY_WHITESPACE = /^[\t ]*$/;
+const IDENTIFIER_START = /[A-Za-z_$]/;
+const IDENTIFIER_PART = /[A-Za-z0-9_$]/;
+const WHITESPACE = /\s/;
+const ANY_NON_WHITESPACE = /\S/;
+const TEMPLATE_INTERPOLATION_TOKEN = String.fromCodePoint(36, 123);
+const BACKSLASH_APOSTROPHE = String.fromCodePoint(92, 39);
+const BACKSLASH_DOUBLE_QUOTE = String.fromCodePoint(92, 34);
+const DOUBLE_QUOTE = String.fromCodePoint(34);
+
+export function updateKnownRepositoriesInConfigFile(
+  input: UpdateKnownRepositoriesInput,
+): UpdateKnownRepositoriesResult {
+  const source = readFileSync(input.configPath, "utf8");
+  const literal = findKnownRepositoriesArray(source);
+  const entries = parseEntries(source, literal);
+
+  const present = new Set(entries.map((entry) => entry.value));
+  const added: string[] = [];
+  const alreadyPresent: string[] = [];
+  for (const value of input.toAdd) {
+    if (present.has(value)) {
+      alreadyPresent.push(value);
+      continue;
+    }
+    added.push(value);
+    present.add(value);
+  }
+
+  if (added.length === 0) {
+    return { added, alreadyPresent };
+  }
+
+  const next = rewrite({ source, literal, entries, added });
+  writeAtomically(input.configPath, next);
+
+  return { added, alreadyPresent };
+}
+
+function findKnownRepositoriesArray(source: string): ArrayLiteral {
+  const candidates: ArrayLiteral[] = [];
+  let index = 0;
+  while (index < source.length) {
+    const skipped = skipNonCode(source, index);
+    if (skipped !== index) {
+      index = skipped;
+      continue;
+    }
+    const matched = tryMatchKeyAt(source, index);
+    if (matched.literal !== undefined) {
+      candidates.push(matched.literal);
+    }
+    index = matched.next;
+  }
+  return assertSoleCandidate(candidates);
+}
+
+function assertSoleCandidate(candidates: readonly ArrayLiteral[]): ArrayLiteral {
+  if (candidates.length === 0) {
+    throw new Error(
+      "groundcrew config: couldn't find a `knownRepositories: [...]` array literal — please add entries manually",
+    );
+  }
+  if (candidates.length > 1) {
+    throw new Error(
+      "groundcrew config: multiple `knownRepositories` array literals found — please resolve manually",
+    );
+  }
+  // oxlint-disable-next-line typescript/no-non-null-assertion -- length === 1 guarantees the entry exists.
+  return candidates[0]!;
+}
+
+/** Returns end index after any comment/string starting at the given index, or the index itself when none. */
+function skipNonCode(source: string, index: number): number {
+  const ch = source.charAt(index);
+  if (ch === '"' || ch === "'" || ch === "`") {
+    return skipString(source, index);
+  }
+  return skipComment(source, index);
+}
+
+function tryMatchKeyAt(source: string, index: number): KeyMatch {
+  const ch = source.charAt(index);
+  const prev = source.charAt(index - 1);
+  if (!IDENTIFIER_START.test(ch) || IDENTIFIER_PART.test(prev)) {
+    return { literal: undefined, next: index + 1 };
+  }
+  let end = index + 1;
+  while (end < source.length && IDENTIFIER_PART.test(source.charAt(end))) {
+    end += 1;
+  }
+  const ident = source.slice(index, end);
+  if (ident !== KEY || prev === ".") {
+    return { literal: undefined, next: end };
+  }
+  const literal = tryReadArrayAssignment(source, end);
+  if (literal === undefined) {
+    return { literal: undefined, next: end };
+  }
+  return { literal, next: literal.close + 1 };
+}
+
+function tryReadArrayAssignment(source: string, after: number): ArrayLiteral | undefined {
+  let index = skipWhitespace(source, after);
+  if (source.charAt(index) !== ":") {
+    return undefined;
+  }
+  index = skipWhitespace(source, index + 1);
+  if (source.charAt(index) !== "[") {
+    return undefined;
+  }
+  return scanArrayClose(source, index);
+}
+
+function scanArrayClose(source: string, open: number): ArrayLiteral {
+  let depth = 1;
+  let index = open + 1;
+  while (index < source.length) {
+    const skipped = skipNonCode(source, index);
+    if (skipped !== index) {
+      /* v8 ignore next 3 @preserve -- skipNonCode returning source.length means a line comment ran to EOF inside the literal; defensive guard, configs always close the array before EOF. */
+      if (skipped === source.length) {
+        throw new Error("groundcrew config: unterminated knownRepositories array literal");
+      }
+      index = skipped;
+      continue;
+    }
+    const ch = source.charAt(index);
+    if (ch === "[") {
+      depth += 1;
+    } else if (ch === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return { open, close: index };
+      }
+    }
+    index += 1;
+  }
+  /* v8 ignore next 2 @preserve -- reached only when the array literal extends past EOF; configs always close the array. */
+  throw new Error("groundcrew config: unterminated knownRepositories array literal");
+}
+
+function skipWhitespace(source: string, start: number): number {
+  let index = start;
+  while (index < source.length && WHITESPACE.test(source.charAt(index))) {
+    index += 1;
+  }
+  return index;
+}
+
+function skipString(source: string, start: number): number {
+  const quote = source.charAt(start);
+  let index = start + 1;
+  while (index < source.length) {
+    const ch = source.charAt(index);
+    if (ch === "\\") {
+      index += 2;
+      continue;
+    }
+    if (ch === quote) {
+      return index + 1;
+    }
+    /* v8 ignore next 3 @preserve -- TS source files never embed raw newlines in single/double-quoted strings; defensive guard. */
+    if (ch === "\n" && quote !== "`") {
+      throw new Error("groundcrew config: unterminated string literal in config");
+    }
+    index += 1;
+  }
+  /* v8 ignore next 2 @preserve -- string extending past EOF means a malformed source file. */
+  throw new Error("groundcrew config: unterminated string literal in config");
+}
+
+function parseEntries(source: string, literal: ArrayLiteral): Entry[] {
+  const entries: Entry[] = [];
+  let index = literal.open + 1;
+  while (index < literal.close) {
+    const ch = source.charAt(index);
+    if (WHITESPACE.test(ch) || ch === ",") {
+      index += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const start = index;
+      const end = skipString(source, index);
+      const raw = source.slice(start, end);
+      entries.push({ value: unquote(raw), start, end });
+      index = end;
+      continue;
+    }
+    const skipped = skipComment(source, index);
+    if (skipped !== index) {
+      index = Math.min(skipped, literal.close);
+      continue;
+    }
+    throw new TypeError(
+      `groundcrew config: unexpected token ${ch} in knownRepositories — only string literals are supported`,
+    );
+  }
+  return entries;
+}
+
+function skipComment(source: string, index: number): number {
+  const ch = source.charAt(index);
+  const next = source.charAt(index + 1);
+  if (ch === "/" && next === "/") {
+    const nl = source.indexOf("\n", index);
+    return nl === -1 ? source.length : nl + 1;
+  }
+  if (ch === "/" && next === "*") {
+    const end = source.indexOf("*/", index + 2);
+    /* v8 ignore next 3 @preserve -- malformed source with an unterminated block comment is a malformed .ts file; the user fixes it before retrying. */
+    if (end === -1) {
+      throw new Error("groundcrew config: unterminated block comment");
+    }
+    return end + 2;
+  }
+  return index;
+}
+
+function unquote(raw: string): string {
+  const head = raw.charAt(0);
+  if (head === '"') {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- raw is a verbatim "…" JSON string literal from the source.
+    return JSON.parse(raw) as string;
+  }
+  if (head === "'") {
+    const body = raw
+      .slice(1, -1)
+      .replaceAll(BACKSLASH_APOSTROPHE, "'")
+      .replaceAll(DOUBLE_QUOTE, BACKSLASH_DOUBLE_QUOTE);
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- body comes from a single-quoted source string; the wrap-and-parse fixes escapes.
+    return JSON.parse(DOUBLE_QUOTE + body + DOUBLE_QUOTE) as string;
+  }
+  if (raw.includes(TEMPLATE_INTERPOLATION_TOKEN)) {
+    throw new TypeError(
+      "groundcrew config: template literals with interpolation are not supported in knownRepositories",
+    );
+  }
+  return raw.slice(1, -1);
+}
+
+interface RewriteInput {
+  source: string;
+  literal: ArrayLiteral;
+  entries: Entry[];
+  added: readonly string[];
+}
+
+function rewrite(input: RewriteInput): string {
+  const { source, literal, entries, added } = input;
+  const lineEnd = source.includes("\r\n") ? "\r\n" : "\n";
+  const body = source.slice(literal.open + 1, literal.close);
+  const isMultiLine = body.includes("\n");
+
+  if (entries.length === 0) {
+    return rewriteEmpty({ source, literal, added, lineEnd, isMultiLine });
+  }
+
+  // oxlint-disable typescript/no-non-null-assertion -- entries.length > 0 guarantees both elements exist.
+  const firstEntry = entries[0]!;
+  const lastEntry = entries.at(-1)!;
+  // oxlint-enable typescript/no-non-null-assertion
+
+  if (!isMultiLine) {
+    return rewriteInline({ source, literal, added, lastEntry });
+  }
+
+  return rewriteMultiLine({ source, literal, added, firstEntry, lastEntry, lineEnd });
+}
+
+interface RewriteEmptyInput {
+  source: string;
+  literal: ArrayLiteral;
+  added: readonly string[];
+  lineEnd: string;
+  isMultiLine: boolean;
+}
+
+function rewriteEmpty(input: RewriteEmptyInput): string {
+  const { source, literal, added, lineEnd, isMultiLine } = input;
+  const outerIndent = detectOuterIndent(source, literal);
+  const head = source.slice(0, literal.open + 1);
+  const tail = source.slice(literal.close);
+  if (added.length === 1 && !isMultiLine) {
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- length === 1 guarantees the entry.
+    return [head, wrapInQuotes(added[0]!), tail].join("");
+  }
+  const entryIndent = [outerIndent, "  "].join("");
+  const lines = added
+    .map((value) => [entryIndent, wrapInQuotes(value), ","].join(""))
+    .join(lineEnd);
+  return [head, lineEnd, lines, lineEnd, outerIndent, tail].join("");
+}
+
+interface RewriteInlineInput {
+  source: string;
+  literal: ArrayLiteral;
+  added: readonly string[];
+  lastEntry: Entry;
+}
+
+function rewriteInline(input: RewriteInlineInput): string {
+  const { source, literal, added, lastEntry } = input;
+  const tail = source.slice(lastEntry.end, literal.close);
+  const hasTrailingComma = findTrailingCommaIndex(tail) !== -1;
+  const inserts = added.map((value) => wrapInQuotes(value)).join(", ");
+  const insertion = hasTrailingComma ? [" ", inserts, ","].join("") : [", ", inserts].join("");
+  return [source.slice(0, literal.close), insertion, source.slice(literal.close)].join("");
+}
+
+interface RewriteMultiLineInput {
+  source: string;
+  literal: ArrayLiteral;
+  added: readonly string[];
+  firstEntry: Entry;
+  lastEntry: Entry;
+  lineEnd: string;
+}
+
+function rewriteMultiLine(input: RewriteMultiLineInput): string {
+  const { source, literal, added, firstEntry, lastEntry, lineEnd } = input;
+  const tail = source.slice(lastEntry.end, literal.close);
+  const hasTrailingComma = findTrailingCommaIndex(tail) !== -1;
+  const entryIndent = detectEntryIndent(source, firstEntry);
+
+  let mutated = source;
+  let closeIndex = literal.close;
+  if (!hasTrailingComma) {
+    mutated = [mutated.slice(0, lastEntry.end), ",", mutated.slice(lastEntry.end)].join("");
+    closeIndex += 1;
+  }
+
+  const closeLineStart = mutated.lastIndexOf("\n", closeIndex - 1) + 1;
+  const insertion = added
+    .map((value) => [entryIndent, wrapInQuotes(value), ",", lineEnd].join(""))
+    .join("");
+  return [mutated.slice(0, closeLineStart), insertion, mutated.slice(closeLineStart)].join("");
+}
+
+function detectOuterIndent(source: string, literal: ArrayLiteral): string {
+  const lineStart = source.lastIndexOf("\n", literal.open - 1) + 1;
+  const match = LEADING_WHITESPACE.exec(source.slice(lineStart));
+  /* v8 ignore next @preserve -- LEADING_WHITESPACE matches the empty string, so exec never returns null here; the fallback exists for type-narrowing only. */
+  return match?.[0] ?? "";
+}
+
+function detectEntryIndent(source: string, firstEntry: Entry): string {
+  const lineStart = source.lastIndexOf("\n", firstEntry.start - 1) + 1;
+  const leading = source.slice(lineStart, firstEntry.start);
+  /* v8 ignore else @preserve -- the else branch handles the unusual case where the first entry shares a line with the open bracket; the writer otherwise routes through rewriteInline. */
+  if (ONLY_WHITESPACE.test(leading)) {
+    return leading;
+  }
+  // companion to the v8-ignored else branch above.
+  /* v8 ignore start @preserve */
+  const outerLine = source.lastIndexOf("\n", lineStart - 2) + 1;
+  const outerLeading = LEADING_WHITESPACE.exec(source.slice(outerLine));
+  const outerIndent = outerLeading === null ? "" : outerLeading[0];
+  return [outerIndent, "  "].join("");
+  /* v8 ignore stop */
+}
+
+function findTrailingCommaIndex(tail: string): number {
+  for (let index = 0; index < tail.length; index += 1) {
+    const ch = tail.charAt(index);
+    if (ch === ",") {
+      return index;
+    }
+    /* v8 ignore next 3 @preserve -- tail spans lastEntry.end to the close bracket, so non-comma non-whitespace would require malformed source we don't try to repair. */
+    if (ANY_NON_WHITESPACE.test(ch)) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
+function wrapInQuotes(value: string): string {
+  return JSON.stringify(value);
+}
+
+function writeAtomically(path: string, content: string): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, content);
+  try {
+    renameSync(tmp, path);
+  } catch (error) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a companion verb to `crew setup repos` that auto-populates `workspace.knownRepositories` instead of requiring hand-curation.

`crew setup discover-repos <org>` queries `gh repo list` for every active (non-archived, non-fork, non-disabled) repository in an org and merges the resulting `<org>/<repo>` entries into the user's resolved `config.ts`. Idempotent, supports `--dry-run`, and aborts cleanly when the array literal isn't a single simple `knownRepositories: [...]` declaration. After running it the user runs `crew setup repos` to actually clone the new entries — clean separation between "what should we track?" and "what should we put on disk?".

## Dependency

Builds on PR #11 (`feat: crew setup repos`) which introduces the `crew setup` namespace and the `repos` verb. This branch is stacked on top of that PR. **Merge #11 first**, then rebase this onto `main`.

<!-- commit-push-pr:created v1 core@3.4.0 -->