### PR TITLE
feat: add datadog setup to remote runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Alphabetical directories
 .cache/
+.clawpatch/
 .nx/cache
 .nx/tsbuildinfo
 .nx/workspace-data

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
      --claude \
      --codex \
      --copy-local-codex-auth \
+     --datadog \
      --github \
      --git-name "Your Name" \
      --git-email "you@users.noreply.github.com" \
@@ -89,7 +90,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
      --checkpoint
    ```
 
-   Known MCP aliases are `linear`, `slack`, and `notion`. For another HTTP MCP server, pass `--mcp name=https://example.com/mcp`. The command creates the remote runner if needed, prepares `~/dev`, configures Git, runs selected auth flows, adds selected MCP servers to Claude Code, and then opens Claude so you can run `/mcp` and authenticate only those selected servers. With the Sprite provider, `--copy-local-codex-auth` copies `${CODEX_HOME:-$HOME/.codex}/auth.json` into `/home/sprite/.codex/auth.json` and then verifies `codex login status`; it never prints the file contents. Use `--skip-mcp-auth` when you only want to add MCP definitions, and run the `/mcp` step later.
+   Known MCP aliases are `linear`, `slack`, and `notion`. For another HTTP MCP server, pass `--mcp name=https://example.com/mcp`. The command creates the remote runner if needed, prepares `~/dev`, configures Git, runs selected auth flows, adds selected MCP servers to Claude Code, and then opens Claude so you can run `/mcp` and authenticate only those selected servers. With the Sprite provider, `--copy-local-codex-auth` copies `${CODEX_HOME:-$HOME/.codex}/auth.json` into `/home/sprite/.codex/auth.json` and then verifies `codex login status`; it never prints the file contents. `--datadog` installs a pinned `pup` release in the remote runner, verifies its checksum, installs the `dd-pup` guidance for Claude and Codex, verifies `pup auth status`, and when auth is missing temporarily runs `sprite proxy` for the OAuth callback while `pup auth login --read-only` runs in the remote runner. Open the Datadog URL printed by `pup` if your terminal does not open it automatically. Use `--skip-mcp-auth` when you only want to add MCP definitions, and run the `/mcp` step later.
 
    Repo setup is separate from runner setup and should run after the ticket branch exists, immediately before launching an agent. It clones/fetches the repo in the remote runner, checks out the requested branch (creating it from the base branch when it does not exist on origin), forwards only build-time secrets for the dependency install, removes the temporary secret file, clears those env vars, and then exits. It uses groundcrew's remote setup command.
 
@@ -180,7 +181,7 @@ Rules:
 ## Manual commands
 
 ```bash
-crew remote setup crew-claude-1 --claude --codex --copy-local-codex-auth --github --mcp linear --checkpoint
+crew remote setup crew-claude-1 --claude --codex --copy-local-codex-auth --datadog --github --mcp linear --checkpoint
 crew remote bootstrap crew-claude-1 core-utils --branch rocky-team-123
 crew remote sessions
 crew remote attach <session-id-or-command> --runner crew-claude-1

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "maxtimeout",
     "Metabase",
     "mintimeout",
+    "mktemp",
     "noproxy",
     "nrwl",
     "npmjs",

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "cdkw",
     "cleanupworkspace",
     "clipboardhealth",
+    "clawpatch",
     "cmux",
     "codexbar",
     "commandrunner",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   remote: {
     summary: "Create, authenticate, bootstrap, and inspect a remote runner",
     usage:
-      "setup <runner-name> [--claude] [--github] [--mcp <alias|name=url>] [--checkpoint]\n" +
+      "setup <runner-name> [--claude] [--codex] [--datadog] [--github] [--mcp <alias|name=url>] [--checkpoint]\n" +
       "           → crew remote bootstrap <runner-name> <repo> [--branch <branch>]\n" +
       "           → crew remote sessions [<runner-name>]\n" +
       "           → crew remote attach <session-id-or-command> [--runner <runner-name>]\n" +

--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -155,11 +155,43 @@ function mockSpriteListWithCodexStatus(options: {
   return () => codexStatusCalls;
 }
 
+function mockSpriteListWithDatadogStatus(options: {
+  failuresBeforeSuccess?: number;
+  alwaysFail?: boolean;
+}): () => number {
+  let datadogStatusCalls = 0;
+  runCommandMock.mockImplementation(async (command, arguments_) => {
+    if (command === "sprite" && arguments_[0] === "list") {
+      return "NAME STATUS\ncrew-claude-1 running";
+    }
+    if (hasRemoteCommand([command, arguments_], ["pup", "auth", "status"])) {
+      datadogStatusCalls += 1;
+      if (
+        options.alwaysFail === true ||
+        datadogStatusCalls <= (options.failuresBeforeSuccess ?? 0)
+      ) {
+        throw new Error("datadog missing");
+      }
+    }
+    return "";
+  });
+  return () => datadogStatusCalls;
+}
+
 function isInteractiveCodexLoginCall(call: readonly unknown[]): boolean {
   const [, arguments_] = call;
   return (
     Array.isArray(arguments_) &&
     hasRemoteCommand(call, ["codex", "login"]) &&
+    !arguments_.includes("status")
+  );
+}
+
+function isInteractiveDatadogLoginCall(call: readonly unknown[]): boolean {
+  const [, arguments_] = call;
+  return (
+    Array.isArray(arguments_) &&
+    hasRemoteCommand(call, ["pup", "auth", "login"]) &&
     !arguments_.includes("status")
   );
 }
@@ -226,6 +258,9 @@ describe(remoteCli, () => {
       remoteCli(["setup", "crew-claude-1", "--mcp", "bad$name=https://example.com/mcp"]),
     ).rejects.toThrow(/Invalid MCP server name/);
     await expect(remoteCli(["setup", "crew-claude-1", "--bogus"])).rejects.toThrow(
+      /Unknown remote setup argument/,
+    );
+    await expect(remoteCli(["setup", "crew-claude-1", "--pup"])).rejects.toThrow(
       /Unknown remote setup argument/,
     );
   });
@@ -585,6 +620,64 @@ describe(setupRemoteRunner, () => {
     });
 
     expect(runCommandMock.mock.calls.some(isInteractiveCodexLoginCall)).toBe(false);
+  });
+
+  it("sets up Datadog pup and authenticates through a temporary Sprite port proxy", async () => {
+    const datadogStatusCalls = mockSpriteListWithDatadogStatus({ failuresBeforeSuccess: 1 });
+
+    await remoteCli(["setup", "crew-claude-1", "--datadog", "--no-create"]);
+
+    const installCall = runCommandMock.mock.calls.find((call) =>
+      String(call[1].at(-1)).includes("version='0.63.0'"),
+    );
+    expect(installCall?.[1]?.at(-1)).toStrictEqual(expect.stringContaining("version='0.63.0'"));
+    expect(installCall?.[1]?.at(-1)).toStrictEqual(expect.stringContaining("sha256sum -c"));
+    expectRemoteCommand(["pup", "skills", "install", "claude-code", "--name", "dd-pup", "--yes"]);
+    expectRemoteCommand(["pup", "skills", "install", "codex", "--name", "dd-pup", "--yes"]);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sprite",
+      ["proxy", "-s", "crew-claude-1", "8000"],
+      expect.objectContaining({ timeoutMs: 0 }),
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sprite",
+      [
+        "exec",
+        "--tty",
+        "-s",
+        "crew-claude-1",
+        "--",
+        "pup",
+        "auth",
+        "login",
+        "--read-only",
+        "--callback-port",
+        "8000",
+      ],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
+    expect(datadogStatusCalls()).toBe(2);
+  });
+
+  it("skips Datadog OAuth when pup auth is already valid", async () => {
+    mockSpriteListWithDatadogStatus({});
+
+    await remoteCli(["setup", "crew-claude-1", "--datadog", "--no-create"]);
+
+    expect(runCommandMock.mock.calls.some(isInteractiveDatadogLoginCall)).toBe(false);
+    expect(
+      runCommandMock.mock.calls.some((call) => hasRemoteCommand(call, ["proxy", "8000"])),
+    ).toBe(false);
+  });
+
+  it("fails with Datadog auth guidance when pup login still does not validate", async () => {
+    mockSpriteListWithDatadogStatus({ alwaysFail: true });
+
+    await expect(remoteCli(["setup", "crew-claude-1", "--datadog", "--no-create"])).rejects.toThrow(
+      /Datadog auth/,
+    );
+
+    expect(runCommandMock.mock.calls.some(isInteractiveDatadogLoginCall)).toBe(true);
   });
 
   it("copies local codex auth when requested and validates it", async () => {

--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -11,10 +11,21 @@ type RunCommandAsyncMock = (
   arguments_: readonly string[],
   options?: RunCommandOptions,
 ) => Promise<string | undefined>;
+interface FakeSocket {
+  destroy(): FakeSocket;
+  once(eventName: string, listener: () => void): FakeSocket;
+  setTimeout(timeoutMilliseconds: number): FakeSocket;
+}
+
+type ConnectMock = (options: { host: string; port: number }) => FakeSocket;
 
 const runCommandMock = vi.hoisted(() => vi.fn<RunCommandAsyncMock>());
 const loadConfigMock = vi.hoisted(() => vi.fn<() => Promise<Readonly<ResolvedConfig>>>());
+const connectMock = vi.hoisted(() => vi.fn<ConnectMock>());
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
+
+// oxlint-disable-next-line jest/no-untyped-mock-factory -- typed dynamic imports conflict with Node builtin module typings.
+vi.mock("node:net", () => ({ connect: connectMock }));
 
 vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -90,6 +101,30 @@ function expectRemoteCommand(remoteCommand: readonly string[]): void {
   );
 }
 
+function mockProxyPortReady(): void {
+  connectMock.mockImplementation(() => {
+    const socket: FakeSocket = {
+      destroy: () => socket,
+      once(eventName, listener) {
+        if (eventName === "connect") {
+          queueMicrotask(listener);
+        }
+        return socket;
+      },
+      setTimeout: () => socket,
+    };
+    return socket;
+  });
+}
+
+async function waitForProxyAbort(options: RunCommandOptions | undefined): Promise<string> {
+  return await new Promise<string>((_resolve, reject) => {
+    options?.signal?.addEventListener("abort", () => {
+      reject(Object.assign(new Error("aborted"), { signal: "SIGINT" }));
+    });
+  });
+}
+
 function mockSpriteList(output: string): void {
   runCommandMock.mockImplementation(async (command, arguments_) => {
     if (command === "sprite" && arguments_[0] === "list") {
@@ -160,9 +195,12 @@ function mockSpriteListWithDatadogStatus(options: {
   alwaysFail?: boolean;
 }): () => number {
   let datadogStatusCalls = 0;
-  runCommandMock.mockImplementation(async (command, arguments_) => {
+  runCommandMock.mockImplementation(async (command, arguments_, commandOptions) => {
     if (command === "sprite" && arguments_[0] === "list") {
       return "NAME STATUS\ncrew-claude-1 running";
+    }
+    if (command === "sprite" && arguments_[0] === "proxy") {
+      return await waitForProxyAbort(commandOptions);
     }
     if (hasRemoteCommand([command, arguments_], ["pup", "auth", "status"])) {
       datadogStatusCalls += 1;
@@ -196,8 +234,14 @@ function isInteractiveDatadogLoginCall(call: readonly unknown[]): boolean {
   );
 }
 
+function resetProxyPortReadyMock(): void {
+  connectMock.mockReset();
+  mockProxyPortReady();
+}
+
 describe(remoteCli, () => {
   beforeEach(() => {
+    resetProxyPortReadyMock();
     loadConfigMock.mockResolvedValue(makeConfig());
     mockSpriteList("NAME STATUS\ncrew-claude-1 running");
   });
@@ -502,6 +546,10 @@ describe(remoteCli, () => {
 });
 
 describe(setupRemoteRunner, () => {
+  beforeEach(() => {
+    resetProxyPortReadyMock();
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -630,8 +678,27 @@ describe(setupRemoteRunner, () => {
     const installCall = runCommandMock.mock.calls.find((call) =>
       String(call[1].at(-1)).includes("version='0.63.0'"),
     );
-    expect(installCall?.[1]?.at(-1)).toStrictEqual(expect.stringContaining("version='0.63.0'"));
-    expect(installCall?.[1]?.at(-1)).toStrictEqual(expect.stringContaining("sha256sum -c"));
+    const installScript = String(installCall?.[1]?.at(-1));
+    expect(installScript).toStrictEqual(expect.stringContaining("version='0.63.0'"));
+    expect(installScript).toStrictEqual(expect.stringContaining("sha256sum -c"));
+    expect(installScript).toStrictEqual(expect.stringContaining('install_dir="$(mktemp -d)"'));
+    expect(installScript).toStrictEqual(
+      expect.stringContaining("trap 'rm -rf \"$install_dir\"' EXIT"),
+    );
+    const shellVariable = "$";
+    const installDirectoryVariable = `${shellVariable}{install_dir}`;
+    const assetVariable = `${shellVariable}{asset}`;
+    const versionVariable = `${shellVariable}{version}`;
+    expect(installScript).toStrictEqual(
+      expect.stringContaining(`archive="${installDirectoryVariable}/${assetVariable}"`),
+    );
+    expect(installScript).toStrictEqual(
+      expect.stringContaining(
+        `checksums="${installDirectoryVariable}/pup_${versionVariable}_checksums.txt"`,
+      ),
+    );
+    expect(installScript).not.toStrictEqual(expect.stringContaining('archive="/tmp/'));
+    expect(installScript).not.toStrictEqual(expect.stringContaining('checksums="/tmp/'));
     expectRemoteCommand(["pup", "skills", "install", "claude-code", "--name", "dd-pup", "--yes"]);
     expectRemoteCommand(["pup", "skills", "install", "codex", "--name", "dd-pup", "--yes"]);
     expect(runCommandMock).toHaveBeenCalledWith(
@@ -659,6 +726,14 @@ describe(setupRemoteRunner, () => {
     expect(datadogStatusCalls()).toBe(2);
   });
 
+  it("retries Datadog auth status briefly after OAuth", async () => {
+    const datadogStatusCalls = mockSpriteListWithDatadogStatus({ failuresBeforeSuccess: 2 });
+
+    await remoteCli(["setup", "crew-claude-1", "--datadog", "--no-create"]);
+
+    expect(datadogStatusCalls()).toBe(3);
+  });
+
   it("skips Datadog OAuth when pup auth is already valid", async () => {
     mockSpriteListWithDatadogStatus({});
 
@@ -671,13 +746,14 @@ describe(setupRemoteRunner, () => {
   });
 
   it("fails with Datadog auth guidance when pup login still does not validate", async () => {
-    mockSpriteListWithDatadogStatus({ alwaysFail: true });
+    const datadogStatusCalls = mockSpriteListWithDatadogStatus({ alwaysFail: true });
 
     await expect(remoteCli(["setup", "crew-claude-1", "--datadog", "--no-create"])).rejects.toThrow(
       /Datadog auth/,
     );
 
     expect(runCommandMock.mock.calls.some(isInteractiveDatadogLoginCall)).toBe(true);
+    expect(datadogStatusCalls()).toBe(6);
   });
 
   it("copies local codex auth when requested and validates it", async () => {
@@ -766,6 +842,10 @@ describe(setupRemoteRunner, () => {
 });
 
 describe(bootstrapRemoteRepository, () => {
+  beforeEach(() => {
+    resetProxyPortReadyMock();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();

--- a/src/commands/remoteSetup.ts
+++ b/src/commands/remoteSetup.ts
@@ -33,6 +33,7 @@ export interface RemoteSetupOptions {
   shouldAuthenticateClaude: boolean;
   shouldAuthenticateCodex: boolean;
   shouldCopyLocalCodexAuth?: boolean;
+  shouldSetupDatadog?: boolean;
   shouldAuthenticateGithub: boolean;
   shouldAuthenticateMcp: boolean;
   shouldCheckpoint: boolean;
@@ -76,6 +77,8 @@ const DEFAULT_CHECKPOINT_COMMENT =
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
 const DEFAULT_REPOSITORY_OWNER = "ClipboardHealth";
 const DEFAULT_BASE_BRANCH = "main";
+const DATADOG_PUP_VERSION = "0.63.0";
+const DATADOG_OAUTH_CALLBACK_PORT = 8000;
 const REMOTE_SECRETS_FILE = "/tmp/groundcrew-build-secrets.env";
 const REMOTE_CODEX_AUTH_UPLOAD_FILE = "/tmp/groundcrew-codex-auth.json";
 const REMOTE_CODEX_AUTH_FILE = "/home/sprite/.codex/auth.json";
@@ -94,6 +97,7 @@ function usage(): string {
     "  --claude                    Authenticate Claude Code with a Claude subscription",
     "  --codex                     Authenticate Codex CLI",
     "  --copy-local-codex-auth     With --codex, copy local CODEX_HOME auth.json into the remote runner",
+    "  --datadog                   Install pup, add dd-pup skills, and authenticate Datadog",
     "  --github                    Authenticate gh for GitHub PRs",
     "  --mcp <alias|name=url>      Add/authenticate one MCP server; repeat for multiple",
     "                              Known aliases: linear, slack, notion",
@@ -209,6 +213,7 @@ function parseArguments(argv: readonly string[]): RemoteSetupOptions {
   let shouldAuthenticateClaude = false;
   let shouldAuthenticateCodex = false;
   let shouldCopyLocalCodexAuth = false;
+  let shouldSetupDatadog = false;
   let shouldAuthenticateGithub = false;
   let shouldAuthenticateMcp = true;
   let shouldCheckpoint = false;
@@ -230,6 +235,10 @@ function parseArguments(argv: readonly string[]): RemoteSetupOptions {
     if (argument === "--copy-local-codex-auth") {
       shouldAuthenticateCodex = true;
       shouldCopyLocalCodexAuth = true;
+      continue;
+    }
+    if (argument === "--datadog") {
+      shouldSetupDatadog = true;
       continue;
     }
     if (argument === "--github") {
@@ -279,6 +288,7 @@ function parseArguments(argv: readonly string[]): RemoteSetupOptions {
     shouldAuthenticateClaude,
     shouldAuthenticateCodex,
     shouldCopyLocalCodexAuth,
+    shouldSetupDatadog,
     shouldAuthenticateGithub,
     shouldAuthenticateMcp,
     shouldCheckpoint,
@@ -602,6 +612,118 @@ async function authenticateCodex(arguments_: {
   );
 }
 
+function datadogPupInstallCommand(): string {
+  const shellVariable = "$";
+  return [
+    "set -euo pipefail",
+    `version=${shellSingleQuote(DATADOG_PUP_VERSION)}`,
+    'case "$(uname -m)" in',
+    "  x86_64|amd64) arch=x86_64 ;;",
+    "  aarch64|arm64) arch=arm64 ;;",
+    '  *) echo "Unsupported Linux architecture: $(uname -m)" >&2; exit 1 ;;',
+    "esac",
+    `asset="pup_${shellVariable}{version}_Linux_${shellVariable}{arch}.tar.gz"`,
+    `base_url="https://github.com/DataDog/pup/releases/download/v${shellVariable}{version}"`,
+    'binary="$HOME/.local/bin/pup"',
+    'mkdir -p "$HOME/.local/bin"',
+    `if [ -x "$binary" ] && "$binary" version | grep -q "Pup ${shellVariable}{version} "; then "$binary" version; exit 0; fi`,
+    `archive="/tmp/${shellVariable}{asset}"`,
+    `checksums="/tmp/pup_${shellVariable}{version}_checksums.txt"`,
+    'curl -fsSL -o "$archive" "$base_url/$asset"',
+    `curl -fsSL -o "$checksums" "$base_url/pup_${shellVariable}{version}_checksums.txt"`,
+    `(cd /tmp && grep " ${shellVariable}{asset}$" "$checksums" | sha256sum -c -)`,
+    'tar -xzf "$archive" -C "$HOME/.local/bin" pup',
+    'chmod 755 "$binary"',
+    'rm -f "$archive" "$checksums"',
+    '"$binary" version',
+  ].join("\n");
+}
+
+async function installDatadogPup(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<void> {
+  log(`Installing Datadog pup ${DATADOG_PUP_VERSION} inside the remote runner`);
+  await provider.runCommand({
+    config,
+    remoteArguments: ["bash", "-lc", datadogPupInstallCommand()],
+  });
+}
+
+async function installDatadogPupSkills(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<void> {
+  for (const platform of ["claude-code", "codex"] as const) {
+    // oxlint-disable-next-line no-await-in-loop -- installs are quick and ordered so logs stay readable.
+    await provider.runCommand({
+      config,
+      remoteArguments: ["pup", "skills", "install", platform, "--name", "dd-pup", "--yes"],
+    });
+  }
+}
+
+async function validateDatadogLogin(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<boolean> {
+  return await commandSucceeds({
+    provider,
+    config,
+    remoteArguments: ["pup", "auth", "status"],
+  });
+}
+
+async function authenticateDatadog(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<void> {
+  if (await validateDatadogLogin(provider, config)) {
+    return;
+  }
+
+  writeOutput();
+  writeOutput("Datadog OAuth will run inside the remote runner.");
+  writeOutput(
+    `Groundcrew is forwarding local port ${DATADOG_OAUTH_CALLBACK_PORT} to the remote callback server while login runs.`,
+  );
+  writeOutput("Open the Datadog URL printed by pup if your terminal does not open it for you.");
+  writeOutput();
+
+  const proxy = await provider.startPortProxy(config, DATADOG_OAUTH_CALLBACK_PORT);
+  try {
+    await provider.runTtyCommand({
+      config,
+      remoteArguments: [
+        "pup",
+        "auth",
+        "login",
+        "--read-only",
+        "--callback-port",
+        String(DATADOG_OAUTH_CALLBACK_PORT),
+      ],
+    });
+  } finally {
+    await proxy.close();
+  }
+
+  if (await validateDatadogLogin(provider, config)) {
+    return;
+  }
+  throw new Error(
+    "Datadog auth finished, but `pup auth status` still reports not logged in inside the remote runner.",
+  );
+}
+
+async function setupDatadog(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<void> {
+  await installDatadogPup(provider, config);
+  await installDatadogPupSkills(provider, config);
+  await authenticateDatadog(provider, config);
+}
+
 async function addMcpServer(arguments_: {
   provider: RemoteRunnerProvider;
   config: RemoteRunnerConfig;
@@ -859,6 +981,9 @@ export async function setupRemoteRunner(options: RemoteSetupOptions): Promise<vo
       config,
       shouldCopyLocalAuth: options.shouldCopyLocalCodexAuth === true,
     });
+  }
+  if (options.shouldSetupDatadog === true) {
+    await setupDatadog(provider, config);
   }
 
   for (const server of options.mcpServers) {

--- a/src/commands/remoteSetup.ts
+++ b/src/commands/remoteSetup.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 
 import {
   BUILD_SECRET_NAMES,
@@ -79,6 +80,8 @@ const DEFAULT_REPOSITORY_OWNER = "ClipboardHealth";
 const DEFAULT_BASE_BRANCH = "main";
 const DATADOG_PUP_VERSION = "0.63.0";
 const DATADOG_OAUTH_CALLBACK_PORT = 8000;
+const DATADOG_AUTH_STATUS_RETRY_ATTEMPTS = 5;
+const DATADOG_AUTH_STATUS_RETRY_DELAY_MS = 250;
 const REMOTE_SECRETS_FILE = "/tmp/groundcrew-build-secrets.env";
 const REMOTE_CODEX_AUTH_UPLOAD_FILE = "/tmp/groundcrew-codex-auth.json";
 const REMOTE_CODEX_AUTH_FILE = "/home/sprite/.codex/auth.json";
@@ -627,14 +630,15 @@ function datadogPupInstallCommand(): string {
     'binary="$HOME/.local/bin/pup"',
     'mkdir -p "$HOME/.local/bin"',
     `if [ -x "$binary" ] && "$binary" version | grep -q "Pup ${shellVariable}{version} "; then "$binary" version; exit 0; fi`,
-    `archive="/tmp/${shellVariable}{asset}"`,
-    `checksums="/tmp/pup_${shellVariable}{version}_checksums.txt"`,
+    'install_dir="$(mktemp -d)"',
+    "trap 'rm -rf \"$install_dir\"' EXIT",
+    `archive="${shellVariable}{install_dir}/${shellVariable}{asset}"`,
+    `checksums="${shellVariable}{install_dir}/pup_${shellVariable}{version}_checksums.txt"`,
     'curl -fsSL -o "$archive" "$base_url/$asset"',
     `curl -fsSL -o "$checksums" "$base_url/pup_${shellVariable}{version}_checksums.txt"`,
-    `(cd /tmp && grep " ${shellVariable}{asset}$" "$checksums" | sha256sum -c -)`,
+    `(cd "$install_dir" && grep " ${shellVariable}{asset}$" "$checksums" | sha256sum -c -)`,
     'tar -xzf "$archive" -C "$HOME/.local/bin" pup',
     'chmod 755 "$binary"',
-    'rm -f "$archive" "$checksums"',
     '"$binary" version',
   ].join("\n");
 }
@@ -674,6 +678,23 @@ async function validateDatadogLogin(
   });
 }
 
+async function waitForDatadogLogin(
+  provider: RemoteRunnerProvider,
+  config: RemoteRunnerConfig,
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= DATADOG_AUTH_STATUS_RETRY_ATTEMPTS; attempt += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- bounded polling smooths over Datadog OAuth propagation delay.
+    if (await validateDatadogLogin(provider, config)) {
+      return true;
+    }
+    if (attempt < DATADOG_AUTH_STATUS_RETRY_ATTEMPTS) {
+      // oxlint-disable-next-line no-await-in-loop -- retries are intentionally spaced.
+      await sleep(DATADOG_AUTH_STATUS_RETRY_DELAY_MS);
+    }
+  }
+  return false;
+}
+
 async function authenticateDatadog(
   provider: RemoteRunnerProvider,
   config: RemoteRunnerConfig,
@@ -707,7 +728,7 @@ async function authenticateDatadog(
     await proxy.close();
   }
 
-  if (await validateDatadogLogin(provider, config)) {
+  if (await waitForDatadogLogin(provider, config)) {
     return;
   }
   throw new Error(

--- a/src/lib/spriteRemoteRunnerProvider.test.ts
+++ b/src/lib/spriteRemoteRunnerProvider.test.ts
@@ -73,6 +73,69 @@ describe("Sprite remote runner provider", () => {
     );
   });
 
+  it("starts and closes Sprite port proxies", async () => {
+    const config = remoteConfig();
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { signal: "SIGINT" }));
+          });
+        }),
+    );
+
+    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+    await proxy.close();
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sprite",
+      ["proxy", "-s", "crew-special", "8000"],
+      expect.objectContaining({ stdio: "inherit", timeoutMs: 0 }),
+    );
+    expect(runCommandMock.mock.calls[0]?.[2]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("surfaces Sprite port proxy startup failures on close", async () => {
+    const config = remoteConfig();
+    runCommandMock.mockRejectedValue(new Error("missing sprite auth"));
+
+    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+
+    await expect(proxy.close()).rejects.toThrow(/missing sprite auth/);
+  });
+
+  it("surfaces Sprite port proxy failures that are not caused by close", async () => {
+    const config = remoteConfig();
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new Error("proxy failed", { cause: { signal: "SIGTERM" } }));
+          });
+        }),
+    );
+
+    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+
+    await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+  });
+
+  it("surfaces Sprite port proxy failures with empty causes", async () => {
+    const config = remoteConfig();
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new Error("proxy failed", { cause: null }));
+          });
+        }),
+    );
+
+    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+
+    await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+  });
+
   it("runs captured remote commands with files, working directory, and caller options", async () => {
     const config = remoteConfig();
     runCommandMock.mockResolvedValue("ok");

--- a/src/lib/spriteRemoteRunnerProvider.test.ts
+++ b/src/lib/spriteRemoteRunnerProvider.test.ts
@@ -1,3 +1,5 @@
+import { createServer, type AddressInfo, type Server } from "node:net";
+
 import type { RunCommandOptions } from "./commandRunner.ts";
 import type { RemoteRunnerConfig } from "./config.ts";
 import {
@@ -34,8 +36,37 @@ function remoteConfig(overrides: Partial<RemoteRunnerConfig> = {}): RemoteRunner
   };
 }
 
+async function listenOnLoopback(port = 0): Promise<{ port: number; server: Server }> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return { port: portFromAddress(server.address()), server };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function portFromAddress(address: AddressInfo | string | null): number {
+  if (typeof address === "object" && address !== null) {
+    return address.port;
+  }
+  throw new Error(`Expected TCP server address, got ${String(address)}.`);
+}
+
 describe("Sprite remote runner provider", () => {
   afterEach(() => {
+    vi.useRealTimers();
     runCommandMock.mockReset();
   });
 
@@ -75,6 +106,7 @@ describe("Sprite remote runner provider", () => {
 
   it("starts and closes Sprite port proxies", async () => {
     const config = remoteConfig();
+    const listener = await listenOnLoopback();
     runCommandMock.mockImplementation(
       async (_command, _arguments, options) =>
         await new Promise<string>((_resolve, reject) => {
@@ -84,28 +116,120 @@ describe("Sprite remote runner provider", () => {
         }),
     );
 
-    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
-    await proxy.close();
+    try {
+      const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, listener.port);
+      await proxy.close();
+    } finally {
+      await closeServer(listener.server);
+    }
 
     expect(runCommandMock).toHaveBeenCalledWith(
       "sprite",
-      ["proxy", "-s", "crew-special", "8000"],
+      ["proxy", "-s", "crew-special", String(listener.port)],
       expect.objectContaining({ stdio: "inherit", timeoutMs: 0 }),
     );
     expect(runCommandMock.mock.calls[0]?.[2]?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it("surfaces Sprite port proxy startup failures on close", async () => {
+  it("allows Sprite port proxy commands to exit cleanly during close", async () => {
     const config = remoteConfig();
+    const listener = await listenOnLoopback();
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((resolve) => {
+          options?.signal?.addEventListener("abort", () => {
+            resolve("");
+          });
+        }),
+    );
+
+    try {
+      const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, listener.port);
+
+      await expect(proxy.close()).resolves.toBeUndefined();
+    } finally {
+      await closeServer(listener.server);
+    }
+  });
+
+  it("waits for Sprite port proxies to accept connections before resolving", async () => {
+    const config = remoteConfig();
+    const { port, server: reservedServer } = await listenOnLoopback();
+    await closeServer(reservedServer);
+    let didResolve = false;
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { signal: "SIGINT" }));
+          });
+        }),
+    );
+
+    const proxyPromise = spriteRemoteRunnerProvider.startPortProxy(config, port).then((proxy) => {
+      didResolve = true;
+      return proxy;
+    });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    const listener = await listenOnLoopback(port);
+
+    try {
+      expect(didResolve).toBe(false);
+      const proxy = await proxyPromise;
+      expect(didResolve).toBe(true);
+      await proxy.close();
+    } finally {
+      await closeServer(listener.server);
+    }
+  });
+
+  it("surfaces Sprite port proxy startup failures before readiness", async () => {
+    const config = remoteConfig();
+    const { port, server: reservedServer } = await listenOnLoopback();
+    await closeServer(reservedServer);
     runCommandMock.mockRejectedValue(new Error("missing sprite auth"));
 
-    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+    await expect(spriteRemoteRunnerProvider.startPortProxy(config, port)).rejects.toThrow(
+      /missing sprite auth/,
+    );
+  });
 
-    await expect(proxy.close()).rejects.toThrow(/missing sprite auth/);
+  it("surfaces Sprite port proxy exits before readiness", async () => {
+    const config = remoteConfig();
+    const { port, server: reservedServer } = await listenOnLoopback();
+    await closeServer(reservedServer);
+    runCommandMock.mockResolvedValue("");
+
+    await expect(spriteRemoteRunnerProvider.startPortProxy(config, port)).rejects.toThrow(
+      /Sprite proxy exited before it was closed/,
+    );
+  });
+
+  it("times out when Sprite port proxies never accept connections", async () => {
+    const config = remoteConfig();
+    const { port, server: reservedServer } = await listenOnLoopback();
+    await closeServer(reservedServer);
+    vi.useFakeTimers();
+    runCommandMock.mockImplementation(
+      async (_command, _arguments, options) =>
+        await new Promise<string>((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { signal: "SIGINT" }));
+          });
+        }),
+    );
+
+    const proxyPromise = spriteRemoteRunnerProvider.startPortProxy(config, port);
+    await vi.advanceTimersByTimeAsync(6000);
+
+    await expect(proxyPromise).rejects.toThrow(/Timed out waiting for Sprite proxy/);
   });
 
   it("surfaces Sprite port proxy failures that are not caused by close", async () => {
     const config = remoteConfig();
+    const listener = await listenOnLoopback();
     runCommandMock.mockImplementation(
       async (_command, _arguments, options) =>
         await new Promise<string>((_resolve, reject) => {
@@ -115,13 +239,18 @@ describe("Sprite remote runner provider", () => {
         }),
     );
 
-    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+    try {
+      const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, listener.port);
 
-    await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+      await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+    } finally {
+      await closeServer(listener.server);
+    }
   });
 
   it("surfaces Sprite port proxy failures with empty causes", async () => {
     const config = remoteConfig();
+    const listener = await listenOnLoopback();
     runCommandMock.mockImplementation(
       async (_command, _arguments, options) =>
         await new Promise<string>((_resolve, reject) => {
@@ -131,9 +260,13 @@ describe("Sprite remote runner provider", () => {
         }),
     );
 
-    const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, 8000);
+    try {
+      const proxy = await spriteRemoteRunnerProvider.startPortProxy(config, listener.port);
 
-    await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+      await expect(proxy.close()).rejects.toThrow(/proxy failed/);
+    } finally {
+      await closeServer(listener.server);
+    }
   });
 
   it("runs captured remote commands with files, working directory, and caller options", async () => {

--- a/src/lib/spriteRemoteRunnerProvider.ts
+++ b/src/lib/spriteRemoteRunnerProvider.ts
@@ -3,6 +3,7 @@ import type { RemoteRunnerConfig, RemoteRunnerProviderName } from "./config.ts";
 import { shellSingleQuote } from "./shell.ts";
 
 const LONG_RUNNING_COMMAND_OPTIONS = { stdio: "inherit", timeoutMs: 0 } as const;
+const PROXY_CLOSE_SIGNAL = "SIGINT";
 
 export const SPRITE_REMOTE_PROVIDER_DEFAULTS = {
   provider: "sprite",
@@ -65,6 +66,7 @@ export interface RemoteRunnerProvider {
   runCommand(arguments_: RemoteRunArguments): Promise<string | undefined>;
   runTtyCommand(arguments_: RemoteRunArguments): Promise<void>;
   buildTtyCommand(arguments_: RemoteTtyCommandArguments): string;
+  startPortProxy(config: RemoteRunnerConfig, port: number): Promise<{ close(): Promise<void> }>;
   listSessions(config: RemoteRunnerConfig): Promise<string>;
   attachSession(config: RemoteRunnerConfig, target: string): Promise<void>;
   listProcesses(config: RemoteRunnerConfig): Promise<string>;
@@ -260,6 +262,51 @@ async function createSpriteRunner(config: RemoteRunnerConfig): Promise<void> {
   });
 }
 
+async function startSpritePortProxy(
+  config: RemoteRunnerConfig,
+  port: number,
+): Promise<{ close(): Promise<void> }> {
+  const controller = new AbortController();
+  let closeWasRequested = false;
+  let proxyError: Error | undefined;
+  const proxy = runCommandAsync("sprite", ["proxy", "-s", config.runnerName, String(port)], {
+    signal: controller.signal,
+    stdio: "inherit",
+    timeoutMs: 0,
+  }).catch((error: unknown) => {
+    if (closeWasRequested && errorHasSignal(error, PROXY_CLOSE_SIGNAL)) {
+      return;
+    }
+    proxyError = new Error(`Sprite proxy exited before it was closed: ${String(error)}`, {
+      cause: error,
+    });
+  });
+
+  return {
+    async close() {
+      closeWasRequested = true;
+      controller.abort();
+      await proxy;
+      if (proxyError !== undefined) {
+        throw new Error(proxyError.message, { cause: proxyError });
+      }
+    },
+  };
+}
+
+function errorHasSignal(error: unknown, signal: string): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  if ("signal" in error && error.signal === signal) {
+    return true;
+  }
+  if (error instanceof Error && error.cause !== undefined) {
+    return errorHasSignal(error.cause, signal);
+  }
+  return false;
+}
+
 export const spriteRemoteRunnerProvider: RemoteRunnerProvider = {
   name: "sprite",
   async runnerExists(config) {
@@ -279,6 +326,9 @@ export const spriteRemoteRunnerProvider: RemoteRunnerProvider = {
     });
   },
   buildTtyCommand: buildSpriteTtyCommand,
+  async startPortProxy(config, port) {
+    return await startSpritePortProxy(config, port);
+  },
   async listSessions(config) {
     const output = await runCommandAsync("sprite", ["sessions", "list", "-s", config.runnerName], {
       trim: false,

--- a/src/lib/spriteRemoteRunnerProvider.ts
+++ b/src/lib/spriteRemoteRunnerProvider.ts
@@ -1,9 +1,15 @@
+import { connect } from "node:net";
+import { setTimeout as sleep } from "node:timers/promises";
+
 import { runCommandAsync, type RunCommandOptions } from "./commandRunner.ts";
 import type { RemoteRunnerConfig, RemoteRunnerProviderName } from "./config.ts";
 import { shellSingleQuote } from "./shell.ts";
 
 const LONG_RUNNING_COMMAND_OPTIONS = { stdio: "inherit", timeoutMs: 0 } as const;
 const PROXY_CLOSE_SIGNAL = "SIGINT";
+const PROXY_READY_HOST = "127.0.0.1";
+const PROXY_READY_TIMEOUT_MS = 5000;
+const PROXY_READY_RETRY_DELAY_MS = 25;
 
 export const SPRITE_REMOTE_PROVIDER_DEFAULTS = {
   provider: "sprite",
@@ -269,18 +275,34 @@ async function startSpritePortProxy(
   const controller = new AbortController();
   let closeWasRequested = false;
   let proxyError: Error | undefined;
-  const proxy = runCommandAsync("sprite", ["proxy", "-s", config.runnerName, String(port)], {
-    signal: controller.signal,
-    stdio: "inherit",
-    timeoutMs: 0,
-  }).catch((error: unknown) => {
-    if (closeWasRequested && errorHasSignal(error, PROXY_CLOSE_SIGNAL)) {
-      return;
+  const proxy = (async () => {
+    try {
+      await runCommandAsync("sprite", ["proxy", "-s", config.runnerName, String(port)], {
+        signal: controller.signal,
+        stdio: "inherit",
+        timeoutMs: 0,
+      });
+      if (!closeWasRequested) {
+        proxyError = new Error("Sprite proxy exited before it was closed.");
+      }
+    } catch (error) {
+      if (closeWasRequested && errorHasSignal(error, PROXY_CLOSE_SIGNAL)) {
+        return;
+      }
+      proxyError = new Error(`Sprite proxy exited before it was closed: ${String(error)}`, {
+        cause: error,
+      });
     }
-    proxyError = new Error(`Sprite proxy exited before it was closed: ${String(error)}`, {
-      cause: error,
-    });
-  });
+  })();
+
+  try {
+    await waitForSpritePortProxy({ port, proxy, proxyError: () => proxyError });
+  } catch (error) {
+    closeWasRequested = true;
+    controller.abort();
+    await proxy;
+    throw error;
+  }
 
   return {
     async close() {
@@ -292,6 +314,49 @@ async function startSpritePortProxy(
       }
     },
   };
+}
+
+async function waitForSpritePortProxy(arguments_: {
+  port: number;
+  proxy: Promise<void>;
+  proxyError: () => Error | undefined;
+}): Promise<void> {
+  const deadline = Date.now() + PROXY_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    throwIfProxyExited(arguments_.proxyError());
+    // eslint-disable-next-line no-await-in-loop -- readiness polling must observe attempts sequentially.
+    if (await canConnectToLocalPort(arguments_.port)) {
+      throwIfProxyExited(arguments_.proxyError());
+      return;
+    }
+    throwIfProxyExited(arguments_.proxyError());
+    // eslint-disable-next-line no-await-in-loop -- retry delay is bounded and stops early if the proxy exits.
+    await Promise.race([sleep(PROXY_READY_RETRY_DELAY_MS), arguments_.proxy]);
+  }
+  throwIfProxyExited(arguments_.proxyError());
+  throw new Error(
+    `Timed out waiting for Sprite proxy on ${PROXY_READY_HOST}:${arguments_.port} to accept connections.`,
+  );
+}
+
+function throwIfProxyExited(error: Error | undefined): void {
+  if (error !== undefined) {
+    throw new Error(error.message, { cause: error });
+  }
+}
+
+async function canConnectToLocalPort(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const socket = connect({ host: PROXY_READY_HOST, port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
 }
 
 function errorHasSignal(error: unknown, signal: string): boolean {


### PR DESCRIPTION
## Summary

Adds deterministic Datadog setup to `crew remote setup --datadog` so remote Sprite runners install the pinned `pup` release with checksum verification, install the `dd-pup` guidance for Claude and Codex, and validate Datadog auth before launching OAuth through a temporary Sprite port proxy.

## Validation

- `node --run verify`

Agent session: codex resume 019e3bb6-7293-7b42-bc2b-dfa7eba047b9

<!-- commit-push-pr:created v1 core@3.4.0 -->