### PR TITLE
fix: roll back remote worktree on state write failure

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeOs from "node:os";
 import { tmpdir, userInfo } from "node:os";
 import { join, sep } from "node:path";
@@ -417,6 +417,78 @@ describe(create, () => {
       remoteRepoDir: "/home/sprite/dev/ClipboardHealth--repo-a",
     });
     expect(readRemoteStateEntries()).toStrictEqual([actual]);
+  });
+
+  it("rolls back the remote worktree when local state persistence fails", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    writeFileSync(join(projectDir, "state"), "not a directory");
+    const config = makeConfig({ projectDir });
+
+    await expect(
+      create(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        model: "claude",
+        runner: "remote",
+      }),
+    ).rejects.toThrow(/ENOTDIR|not a directory/);
+
+    const spriteCalls = runCommandMock.mock.calls.filter(([command]) => command === "sprite");
+    expect(spriteCalls).toHaveLength(2);
+    const removeCommand = spriteCalls[1]?.[1].at(-1);
+    expect(removeCommand).toStrictEqual(
+      expect.stringContaining(
+        "git -C '/home/sprite/dev/ClipboardHealth--repo-a' worktree remove --force '/home/sprite/groundcrew/worktrees/ClipboardHealth--repo-a-team-1'",
+      ),
+    );
+    expect(removeCommand).toStrictEqual(
+      expect.stringContaining(
+        "git -C '/home/sprite/dev/ClipboardHealth--repo-a' branch -D 'rocky-team-1' || true",
+      ),
+    );
+  });
+
+  it("removes the temporary state file when an atomic state replace fails", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "state", "groundcrew"), { recursive: true });
+    mkdirSync(remoteStatePath());
+    const config = makeConfig({ projectDir });
+
+    await expect(
+      create(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        model: "claude",
+        runner: "remote",
+      }),
+    ).rejects.toThrow(/EISDIR|directory|remote-worktrees\.json/);
+
+    expect(readdirSync(join(projectDir, "state", "groundcrew"))).toStrictEqual([
+      "remote-worktrees.json",
+    ]);
+    const spriteCalls = runCommandMock.mock.calls.filter(([command]) => command === "sprite");
+    expect(spriteCalls).toHaveLength(2);
+  });
+
+  it("rethrows the state persistence error when remote rollback fails", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    writeFileSync(join(projectDir, "state"), "not a directory");
+    const config = makeConfig({ projectDir });
+    runCommandMock.mockReturnValueOnce("").mockImplementationOnce(() => {
+      throw new Error("rollback failed");
+    });
+
+    await expect(
+      create(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        model: "claude",
+        runner: "remote",
+      }),
+    ).rejects.toThrow(/ENOTDIR|not a directory/);
+
+    const spriteCalls = runCommandMock.mock.calls.filter(([command]) => command === "sprite");
+    expect(spriteCalls).toHaveLength(2);
   });
 
   it("creates remote worktrees for owner-qualified repositories without double-prefixing the owner", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -17,8 +17,11 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { homedir, userInfo } from "node:os";
 import { dirname, resolve } from "node:path";
 
@@ -326,12 +329,33 @@ function readRemoteEntries(): WorktreeEntry[] {
 
 function writeRemoteEntries(entries: readonly WorktreeEntry[]): void {
   const path = remoteStateFilePath();
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify({ entries }, undefined, 2)}\n`);
+  const directory = dirname(path);
+  mkdirSync(directory, { recursive: true });
+  const temporaryPath = resolve(directory, `.remote-worktrees-${process.pid}-${randomUUID()}.tmp`);
+  let didReplaceStateFile = false;
+
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify({ entries }, undefined, 2)}\n`);
+    renameSync(temporaryPath, path);
+    didReplaceStateFile = true;
+  } finally {
+    if (!didReplaceStateFile) {
+      removeTemporaryRemoteStateFileBestEffort(temporaryPath);
+    }
+  }
 }
 
 function upsertRemoteEntry(entry: WorktreeEntry): void {
   writeRemoteEntries([...readRemoteEntries(), entry]);
+}
+
+function removeTemporaryRemoteStateFileBestEffort(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch (error) {
+    /* v8 ignore next @preserve -- only external filesystem races can make best-effort temp cleanup fail */
+    log(`Temporary remote state file cleanup skipped: ${errorMessage(error)}`);
+  }
 }
 
 function deleteRemoteEntry(entry: WorktreeEntry): void {
@@ -350,6 +374,29 @@ function deleteRemoteEntry(entry: WorktreeEntry): void {
 
 function remoteProviderFor(config: ResolvedConfig, entry?: WorktreeEntry): RemoteRunnerProvider {
   return getRemoteRunnerProvider(entry?.remoteProvider ?? config.remote.provider);
+}
+
+async function removeCreatedRemoteWorktreeBestEffort(arguments_: {
+  config: ResolvedConfig;
+  provider: RemoteRunnerProvider;
+  entry: WorktreeEntry;
+  signal?: AbortSignal;
+}): Promise<void> {
+  try {
+    log(
+      `Rolling back remote worktree ${arguments_.entry.dir} after local state persistence failed...`,
+    );
+    await arguments_.provider.removeWorktree({
+      config: arguments_.config.remote,
+      entry: arguments_.entry,
+      force: true,
+      ...signalProperty(arguments_.signal),
+    });
+  } catch (error) {
+    log(
+      `Remote worktree rollback skipped after local state persistence failed: ${errorMessage(error)}`,
+    );
+  }
 }
 
 const remoteWorktreeAdapter: WorktreeAdapter = {
@@ -378,7 +425,17 @@ const remoteWorktreeAdapter: WorktreeAdapter = {
       remoteRunnerName: config.remote.runnerName,
       remoteRepoDir,
     };
-    upsertRemoteEntry(entry);
+    try {
+      upsertRemoteEntry(entry);
+    } catch (error) {
+      await removeCreatedRemoteWorktreeBestEffort({
+        config,
+        provider,
+        entry,
+        ...signalProperty(signal),
+      });
+      throw error;
+    }
     return entry;
   },
   list(config) {


### PR DESCRIPTION
## Summary

Investigates and fixes the remote create failure mode where provider worktree creation succeeded but local tracking state persistence failed. Remote state writes are now atomic, and create rolls back the just-created remote worktree and branch if the local state entry cannot be saved.

## Validation

- `./node_modules/.bin/vitest run src/lib/worktrees.test.ts`
- `node --run verify`
- `git push -u origin fix/remote-create-state-rollback` (pre-push hook ran `node --run verify` and passed)

<!-- commit-push-pr:created v1 core@3.4.0 -->