### PR TITLE
fix: harden remote bootstrap inputs

### DIFF
--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -532,7 +532,7 @@ describe(remoteCli, () => {
     expect(command).toStrictEqual(
       expect.stringContaining("gh repo clone 'ClipboardHealth/core-utils' \"$repo_dir\""),
     );
-    expect(command).toStrictEqual(expect.stringContaining('repo_dir="$HOME/dev/core-utils"'));
+    expect(command).toStrictEqual(expect.stringContaining(`repo_dir="$HOME/dev"/'core-utils'`));
     expect(command).toStrictEqual(expect.stringContaining("git_remote='origin'"));
     expect(command).toStrictEqual(expect.stringContaining('git fetch "$git_remote" --prune'));
     expect(command).toStrictEqual(
@@ -886,6 +886,23 @@ describe(bootstrapRemoteRepository, () => {
     vi.clearAllMocks();
   });
 
+  it("rejects unsafe direct repository values before running the provider", async () => {
+    await expect(
+      bootstrapRemoteRepository({
+        runnerName: "crew-claude-1",
+        repository: "ClipboardHealth/core-utils$(touch /tmp/pwn)",
+        owner: "ClipboardHealth",
+        baseBranch: "main",
+        gitRemote: "origin",
+        secretNames: [],
+        shouldRequireSelectedSecrets: false,
+        shouldUseSecrets: false,
+      }),
+    ).rejects.toThrow(/Invalid repository/);
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
   it("does not upload a secrets file when secrets are disabled", async () => {
     mockExistingSpriteForBootstrap();
 
@@ -998,7 +1015,7 @@ describe(bootstrapRemoteRepository, () => {
       hasRemoteCommand(call, ["bash", "-lc"]),
     );
     expect(bootstrapCall?.[1]?.at(-1)).toStrictEqual(
-      expect.stringContaining('repo_dir="$HOME/dev/core-utils"'),
+      expect.stringContaining(`repo_dir="$HOME/dev"/'core-utils'`),
     );
   });
 

--- a/src/commands/remoteSetup.ts
+++ b/src/commands/remoteSetup.ts
@@ -845,6 +845,19 @@ function repositoryDirectoryName(repository: string): string {
   return name.endsWith(".git") ? name.slice(0, -4) : name;
 }
 
+function validateRemoteBootstrapOptions(options: ResolvedRemoteBootstrapOptions): void {
+  validateRepository(options.repository);
+  validateRepositoryOwner(options.owner);
+  validateGitRef(options.baseBranch, "base branch");
+  validateGitRef(options.gitRemote, "git remote");
+  if (options.branchName !== undefined) {
+    validateGitRef(options.branchName, "branch");
+  }
+  for (const name of options.secretNames) {
+    validateSecretName(name);
+  }
+}
+
 function remoteBootstrapCommand(options: ResolvedRemoteBootstrapOptions): string {
   const slug = repositorySlug(options);
   const directoryName = repositoryDirectoryName(options.repository);
@@ -868,7 +881,7 @@ function remoteBootstrapCommand(options: ResolvedRemoteBootstrapOptions): string
     "trap cleanup EXIT",
     `git_remote=${shellSingleQuote(options.gitRemote)}`,
     'mkdir -p "$HOME/dev"',
-    `repo_dir="$HOME/dev/${directoryName}"`,
+    `repo_dir="$HOME/dev"/${shellSingleQuote(directoryName)}`,
     'if [ ! -d "$repo_dir/.git" ]; then',
     `  gh repo clone ${shellSingleQuote(slug)} "$repo_dir"`,
     "fi",
@@ -944,6 +957,7 @@ export async function bootstrapRemoteRepository(options: RemoteBootstrapOptions)
     ...options,
     gitRemote: options.gitRemote ?? DEFAULT_GIT_REMOTE,
   };
+  validateRemoteBootstrapOptions(bootstrapOptions);
   const config = remoteConfigWithRunnerName(options.runnerName);
   const provider = providerFor(config);
   if (!(await provider.runnerExists(config))) {


### PR DESCRIPTION
## Summary

Harden remote bootstrap so direct calls validate repository, owner, refs, and secret names before contacting the provider, and quote the derived repository directory leaf in the remote shell command. This prevents unsafe repository values from shaping bootstrap shell execution.

## Validation

- `node --run verify`
- Pre-push hook: `node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->