### PR TITLE
fix: create setup repo clone parents

### DIFF
--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -24,7 +24,6 @@ const loadConfigMock = vi.hoisted(() => vi.fn<() => Promise<Readonly<ResolvedCon
 const connectMock = vi.hoisted(() => vi.fn<ConnectMock>());
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
 
-// oxlint-disable-next-line jest/no-untyped-mock-factory -- typed dynamic imports conflict with Node builtin module typings.
 vi.mock("node:net", () => ({ connect: connectMock }));
 
 vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -111,6 +111,21 @@ describe(setupRepos, () => {
     );
     expect(result.cloned).toStrictEqual(["owner/repo"]);
     expect(result.existing).toStrictEqual([]);
+    expect(result.failed).toStrictEqual([]);
+  });
+
+  it("creates the owner parent directory before cloning into an owner/repo target", async () => {
+    runCommandMock.mockImplementationOnce((_command, arguments_) => {
+      const { 3: target = "" } = arguments_;
+      expect(target).toBe(join(projectDir, "owner/repo"));
+      expect(existsSync(dirname(target))).toBe(true);
+      return "";
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+
+    const result = await setupRepos(config, {});
+
+    expect(result.cloned).toStrictEqual(["owner/repo"]);
     expect(result.failed).toStrictEqual([]);
   });
 

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -6,8 +6,8 @@
  * we can guess at without involving the user's gh login. Idempotent.
  */
 
-import { opendirSync, statSync } from "node:fs";
-import { isAbsolute, relative, resolve } from "node:path";
+import { mkdirSync, opendirSync, statSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 
 import { runCommandAsync } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -249,6 +249,7 @@ export async function setupRepos(
     const target = resolve(projectDir, entry);
     log(`[clone] ${entry} → ${target}`);
     try {
+      mkdirSync(dirname(target), { recursive: true });
       // oxlint-disable-next-line no-await-in-loop -- see comment above
       await runCommandAsync("gh", ["repo", "clone", entry, target], {
         stdio: "inherit",


### PR DESCRIPTION
## Summary

Fixes `crew setup repos` for owner-qualified `knownRepositories` entries by creating the clone target parent directory before invoking `gh repo clone`, so a fresh workspace can clone into `<projectDir>/owner/repo`. Also removes a stale oxlint suppression that fails with the clean-install lint version.

## Validation

- `npx vitest run src/commands/setupRepos.test.ts`
- `node --run verify`

## Notes

Reported bug id: `fnd_sig-feat-cli-command-5e71c53ad1-_9bde7eb65e`

Agent session: codex resume 019e3c5c-ad36-7a40-85ea-c9d58def8091
<!-- commit-push-pr:created v1 core@3.4.0 -->