### PR TITLE
fix: honor remote bootstrap config

### DIFF
--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -24,7 +24,6 @@ const loadConfigMock = vi.hoisted(() => vi.fn<() => Promise<Readonly<ResolvedCon
 const connectMock = vi.hoisted(() => vi.fn<ConnectMock>());
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
 
-// oxlint-disable-next-line jest/no-untyped-mock-factory -- typed dynamic imports conflict with Node builtin module typings.
 vi.mock("node:net", () => ({ connect: connectMock }));
 
 vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
@@ -532,7 +531,9 @@ describe(remoteCli, () => {
     expect(command).toStrictEqual(
       expect.stringContaining("gh repo clone 'ClipboardHealth/core-utils' \"$repo_dir\""),
     );
-    expect(command).toStrictEqual(expect.stringContaining(`repo_dir="$HOME/dev"/'core-utils'`));
+    expect(command).toStrictEqual(
+      expect.stringContaining("repo_dir='/home/sprite/dev/ClipboardHealth--core-utils'"),
+    );
     expect(command).toStrictEqual(expect.stringContaining("git_remote='origin'"));
     expect(command).toStrictEqual(expect.stringContaining('git fetch "$git_remote" --prune'));
     expect(command).toStrictEqual(
@@ -997,6 +998,35 @@ describe(bootstrapRemoteRepository, () => {
     );
   });
 
+  it("defaults bootstrap owner, repo root, and secrets from remote config", async () => {
+    mockExistingSpriteForBootstrap();
+    const config = makeConfig();
+    config.remote.owner = "Acme";
+    config.remote.repoRoot = "/srv/repos";
+    config.remote.secretNames = ["CUSTOM_TOKEN", "OTHER_TOKEN"];
+    loadConfigMock.mockResolvedValue(config);
+    vi.stubEnv("CUSTOM_TOKEN", "custom-token");
+    vi.stubEnv("OTHER_TOKEN", "other-token");
+
+    await remoteCli(["bootstrap", "crew-claude-1", "core-utils"]);
+
+    const bootstrapCall = runCommandMock.mock.calls.find((call) =>
+      hasRemoteCommand(call, ["bash", "-lc"]),
+    );
+    expect(bootstrapCall?.[1]).toStrictEqual(
+      expect.arrayContaining(["--file", expect.stringMatching(/secrets\.env:/)]),
+    );
+    expect(bootstrapCall?.[1]?.at(-1)).toStrictEqual(
+      expect.stringContaining("gh repo clone 'Acme/core-utils'"),
+    );
+    expect(bootstrapCall?.[1]?.at(-1)).toStrictEqual(
+      expect.stringContaining("repo_dir='/srv/repos/Acme--core-utils'"),
+    );
+    expect(bootstrapCall?.[1]?.at(-1)).toStrictEqual(
+      expect.stringContaining("unset CUSTOM_TOKEN OTHER_TOKEN"),
+    );
+  });
+
   it("strips .git suffixes when choosing the remote repository directory", async () => {
     mockExistingSpriteForBootstrap();
 
@@ -1015,7 +1045,7 @@ describe(bootstrapRemoteRepository, () => {
       hasRemoteCommand(call, ["bash", "-lc"]),
     );
     expect(bootstrapCall?.[1]?.at(-1)).toStrictEqual(
-      expect.stringContaining(`repo_dir="$HOME/dev"/'core-utils'`),
+      expect.stringContaining("repo_dir='/home/sprite/dev/ClipboardHealth--core-utils'"),
     );
   });
 

--- a/src/commands/remoteSetup.test.ts
+++ b/src/commands/remoteSetup.test.ts
@@ -1064,6 +1064,26 @@ describe(bootstrapRemoteRepository, () => {
       remoteCli(["bootstrap", "crew-claude-1", "core-utils", "--secret", "bad-secret"]),
     ).rejects.toThrow(/Invalid secret name/);
     await expect(
+      remoteCli([
+        "bootstrap",
+        "crew-claude-1",
+        "core-utils",
+        "--secret",
+        "NPM_TOKEN",
+        "--no-secrets",
+      ]),
+    ).rejects.toThrow(/--secret and --no-secrets are mutually exclusive/);
+    await expect(
+      remoteCli([
+        "bootstrap",
+        "crew-claude-1",
+        "core-utils",
+        "--no-secrets",
+        "--secret",
+        "NPM_TOKEN",
+      ]),
+    ).rejects.toThrow(/--secret and --no-secrets are mutually exclusive/);
+    await expect(
       remoteCli(["bootstrap", "crew-claude-1", "core-utils", "--bogus"]),
     ).rejects.toThrow(/Unknown remote bootstrap argument/);
   });

--- a/src/commands/remoteSetup.ts
+++ b/src/commands/remoteSetup.ts
@@ -97,6 +97,8 @@ const DEFAULT_CHECKPOINT_COMMENT =
   "groundcrew remote runner baseline: selected agent auth, git identity, and MCP config";
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
 const DEFAULT_GIT_REMOTE = "origin";
+const BOOTSTRAP_SECRET_FLAGS_CONFLICT_MESSAGE =
+  "--secret and --no-secrets are mutually exclusive. Use --secret to forward selected build secrets or --no-secrets to disable secret forwarding.";
 const DATADOG_PUP_VERSION = "0.63.0";
 const DATADOG_OAUTH_CALLBACK_PORT = 8000;
 const DATADOG_AUTH_STATUS_RETRY_ATTEMPTS = 5;
@@ -361,6 +363,9 @@ function parseBootstrapArguments(argv: readonly string[]): ParsedRemoteBootstrap
       continue;
     }
     if (argument === "--secret") {
+      if (!shouldUseSecrets) {
+        throw new Error(BOOTSTRAP_SECRET_FLAGS_CONFLICT_MESSAGE);
+      }
       const secretName = requireValue(argv, index, "--secret");
       validateSecretName(secretName);
       selectedSecretNames.push(secretName);
@@ -369,6 +374,9 @@ function parseBootstrapArguments(argv: readonly string[]): ParsedRemoteBootstrap
       continue;
     }
     if (argument === "--no-secrets") {
+      if (selectedSecretNames.length > 0 || shouldRequireSelectedSecrets) {
+        throw new Error(BOOTSTRAP_SECRET_FLAGS_CONFLICT_MESSAGE);
+      }
       shouldUseSecrets = false;
       continue;
     }

--- a/src/commands/remoteSetup.ts
+++ b/src/commands/remoteSetup.ts
@@ -4,7 +4,6 @@ import { join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import {
-  BUILD_SECRET_NAMES,
   DEFAULT_REMOTE_SETUP_COMMAND,
   loadConfig,
   type RemoteRunnerConfig,
@@ -12,7 +11,10 @@ import {
 import { shellSingleQuote } from "../lib/shell.ts";
 import {
   getRemoteRunnerProvider,
+  remotePathJoin,
   remoteConfigWithRunnerName,
+  remoteRepositoryDirectoryName,
+  remoteRepositorySlug,
   type RemoteRunnerProvider,
 } from "../lib/spriteRemoteRunnerProvider.ts";
 import { log, readEnvironmentVariable, writeOutput } from "../lib/util.ts";
@@ -50,6 +52,8 @@ export interface RemoteBootstrapOptions {
   owner: string;
   baseBranch: string;
   gitRemote?: string;
+  repoRoot?: string;
+  remoteConfig?: RemoteRunnerConfig;
   secretNames: string[];
   shouldRequireSelectedSecrets: boolean;
   shouldUseSecrets: boolean;
@@ -58,13 +62,17 @@ export interface RemoteBootstrapOptions {
 
 interface ResolvedRemoteBootstrapOptions extends RemoteBootstrapOptions {
   gitRemote: string;
+  repoRoot: string;
+  remoteConfig: RemoteRunnerConfig;
 }
 
 interface ParsedRemoteBootstrapOptions extends Omit<
   RemoteBootstrapOptions,
-  "baseBranch" | "gitRemote"
+  "baseBranch" | "gitRemote" | "owner" | "remoteConfig" | "repoRoot" | "secretNames"
 > {
+  owner?: string;
   baseBranch?: string;
+  secretNames?: string[];
 }
 
 export interface RemoteSessionsOptions {
@@ -88,7 +96,6 @@ export interface RemoteInterruptOptions {
 const DEFAULT_CHECKPOINT_COMMENT =
   "groundcrew remote runner baseline: selected agent auth, git identity, and MCP config";
 const CLAUDE_SUBSCRIPTION_LOGIN_FLAG = ["--claude", "ai"].join("");
-const DEFAULT_REPOSITORY_OWNER = "ClipboardHealth";
 const DEFAULT_GIT_REMOTE = "origin";
 const DATADOG_PUP_VERSION = "0.63.0";
 const DATADOG_OAUTH_CALLBACK_PORT = 8000;
@@ -129,9 +136,9 @@ function usage(): string {
     "Bootstrap options:",
     "  --branch <branch>           Checkout/create a ticket branch before installing deps",
     "  --base <branch>             Base branch used when creating a missing branch (default: git.defaultBranch)",
-    "  --owner <owner>             GitHub owner for bare repo names (default: ClipboardHealth)",
+    "  --owner <owner>             GitHub owner for bare repo names (default: remote.owner)",
     "  --secret <env-name>         Forward one required build secret; repeat for multiple",
-    "  --no-secrets                Do not forward NPM_TOKEN/BUF_TOKEN even if present",
+    "  --no-secrets                Do not forward configured build secrets even if present",
     "",
     "Bootstrap example:",
     "  crew remote bootstrap crew-claude-1 core-utils --branch rocky-team-123",
@@ -326,7 +333,7 @@ function parseBootstrapArguments(argv: readonly string[]): ParsedRemoteBootstrap
   }
   validateRepository(repository);
 
-  let owner = DEFAULT_REPOSITORY_OWNER;
+  let owner: string | undefined;
   let baseBranch: string | undefined;
   let branchName: string | undefined;
   let shouldUseSecrets = true;
@@ -371,10 +378,10 @@ function parseBootstrapArguments(argv: readonly string[]): ParsedRemoteBootstrap
   return {
     runnerName,
     repository,
-    owner,
-    secretNames: selectedSecretNames.length > 0 ? selectedSecretNames : [...BUILD_SECRET_NAMES],
     shouldRequireSelectedSecrets,
     shouldUseSecrets,
+    ...(owner === undefined ? {} : { owner }),
+    ...(selectedSecretNames.length > 0 ? { secretNames: selectedSecretNames } : {}),
     ...(baseBranch === undefined ? {} : { baseBranch }),
     ...(branchName === undefined ? {} : { branchName }),
   };
@@ -832,19 +839,6 @@ async function checkpoint(arguments_: {
   await provider.checkpoint(config, options.checkpointComment);
 }
 
-function repositorySlug(options: Pick<RemoteBootstrapOptions, "owner" | "repository">): string {
-  return options.repository.includes("/")
-    ? options.repository
-    : `${options.owner}/${options.repository}`;
-}
-
-function repositoryDirectoryName(repository: string): string {
-  const name = repository.includes("/")
-    ? repository.slice(repository.lastIndexOf("/") + 1)
-    : repository;
-  return name.endsWith(".git") ? name.slice(0, -4) : name;
-}
-
 function validateRemoteBootstrapOptions(options: ResolvedRemoteBootstrapOptions): void {
   validateRepository(options.repository);
   validateRepositoryOwner(options.owner);
@@ -859,8 +853,9 @@ function validateRemoteBootstrapOptions(options: ResolvedRemoteBootstrapOptions)
 }
 
 function remoteBootstrapCommand(options: ResolvedRemoteBootstrapOptions): string {
-  const slug = repositorySlug(options);
-  const directoryName = repositoryDirectoryName(options.repository);
+  const slug = remoteRepositorySlug(options.owner, options.repository);
+  const directoryName = remoteRepositoryDirectoryName(options.owner, options.repository);
+  const repoDir = remotePathJoin(options.repoRoot, directoryName);
   const baseRef = `${options.gitRemote}/${options.baseBranch}`;
   const unsetSecretsLine =
     options.secretNames.length === 0 ? ":" : `unset ${options.secretNames.join(" ")}`;
@@ -879,9 +874,10 @@ function remoteBootstrapCommand(options: ResolvedRemoteBootstrapOptions): string
     "set -euo pipefail",
     `cleanup() { rm -f ${shellSingleQuote(REMOTE_SECRETS_FILE)}; ${unsetSecretsLine}; }`,
     "trap cleanup EXIT",
+    `repo_root=${shellSingleQuote(options.repoRoot)}`,
+    `repo_dir=${shellSingleQuote(repoDir)}`,
     `git_remote=${shellSingleQuote(options.gitRemote)}`,
-    'mkdir -p "$HOME/dev"',
-    `repo_dir="$HOME/dev"/${shellSingleQuote(directoryName)}`,
+    'mkdir -p "$repo_root"',
     'if [ ! -d "$repo_dir/.git" ]; then',
     `  gh repo clone ${shellSingleQuote(slug)} "$repo_dir"`,
     "fi",
@@ -901,10 +897,19 @@ async function resolveBootstrapOptions(
   options: ParsedRemoteBootstrapOptions,
 ): Promise<ResolvedRemoteBootstrapOptions> {
   const config = await loadConfig();
+  const remoteConfig: RemoteRunnerConfig = {
+    ...config.remote,
+    runnerName: options.runnerName,
+    secretNames: [...config.remote.secretNames],
+  };
   return {
     ...options,
+    owner: options.owner ?? remoteConfig.owner,
     baseBranch: options.baseBranch ?? config.git.defaultBranch,
     gitRemote: config.git.remote,
+    repoRoot: remoteConfig.repoRoot,
+    remoteConfig,
+    secretNames: options.secretNames ?? [...remoteConfig.secretNames],
   };
 }
 
@@ -953,12 +958,14 @@ function stageBuildSecrets(options: RemoteBootstrapOptions): StagedSecrets {
 }
 
 export async function bootstrapRemoteRepository(options: RemoteBootstrapOptions): Promise<void> {
+  const config = options.remoteConfig ?? remoteConfigWithRunnerName(options.runnerName);
   const bootstrapOptions: ResolvedRemoteBootstrapOptions = {
     ...options,
     gitRemote: options.gitRemote ?? DEFAULT_GIT_REMOTE,
+    repoRoot: options.repoRoot ?? config.repoRoot,
+    remoteConfig: config,
   };
   validateRemoteBootstrapOptions(bootstrapOptions);
-  const config = remoteConfigWithRunnerName(options.runnerName);
   const provider = providerFor(config);
   if (!(await provider.runnerExists(config))) {
     throw new Error(
@@ -976,7 +983,9 @@ export async function bootstrapRemoteRepository(options: RemoteBootstrapOptions)
         ? []
         : [{ localPath: stagedSecrets.filePath, remotePath: REMOTE_SECRETS_FILE }];
 
-    log(`Bootstrapping ${repositorySlug(bootstrapOptions)} in ${options.runnerName}`);
+    log(
+      `Bootstrapping ${remoteRepositorySlug(bootstrapOptions.owner, bootstrapOptions.repository)} in ${options.runnerName}`,
+    );
     await provider.runCommand({
       config,
       files,

--- a/src/lib/spriteRemoteRunnerProvider.ts
+++ b/src/lib/spriteRemoteRunnerProvider.ts
@@ -170,7 +170,7 @@ function buildSpriteTtyCommand(arguments_: RemoteTtyCommandArguments): string {
   ].join(" ");
 }
 
-function remotePathJoin(root: string, leaf: string): string {
+export function remotePathJoin(root: string, leaf: string): string {
   let end = root.length;
   while (end > 0 && root[end - 1] === "/") {
     end -= 1;
@@ -178,12 +178,12 @@ function remotePathJoin(root: string, leaf: string): string {
   return `${root.slice(0, end)}/${leaf}`;
 }
 
-function repositorySlug(owner: string, repository: string): string {
+export function remoteRepositorySlug(owner: string, repository: string): string {
   return repository.includes("/") ? repository : `${owner}/${repository}`;
 }
 
-function repositoryDirectoryName(owner: string, repository: string): string {
-  const slug = repositorySlug(owner, repository);
+export function remoteRepositoryDirectoryName(owner: string, repository: string): string {
+  const slug = remoteRepositorySlug(owner, repository);
   const normalizedSlug = slug.endsWith(".git") ? slug.slice(0, -4) : slug;
   return normalizedSlug.replaceAll("/", "--");
 }
@@ -206,7 +206,7 @@ function spriteCreateWorktreeCommand(arguments_: {
   repoRoot: string;
   worktreeRoot: string;
 }): string {
-  const slug = repositorySlug(arguments_.owner, arguments_.repository);
+  const slug = remoteRepositorySlug(arguments_.owner, arguments_.repository);
   const branchRemoteRef = `refs/remotes/${arguments_.gitRemote}/${arguments_.branchName}`;
   const branchRef = `${arguments_.gitRemote}/${arguments_.branchName}`;
   const baseRef = `${arguments_.gitRemote}/${arguments_.baseBranch}`;
@@ -452,7 +452,7 @@ export const spriteRemoteRunnerProvider: RemoteRunnerProvider = {
   },
   async createWorktree(arguments_) {
     const { config, repository, ticket, branchName, baseBranch, gitRemote, signal } = arguments_;
-    const remoteRepositoryName = repositoryDirectoryName(config.owner, repository);
+    const remoteRepositoryName = remoteRepositoryDirectoryName(config.owner, repository);
     const remoteRepoDir = remotePathJoin(config.repoRoot, remoteRepositoryName);
     const remoteWorktreeDir = remotePathJoin(
       config.worktreeRoot,


### PR DESCRIPTION
## Summary

Fixes remote bootstrap so `crew remote bootstrap` resolves the configured remote runner settings instead of falling back to hard-coded Sprite defaults. Bootstrap now uses `remote.owner`, `remote.repoRoot`, configured secret names, and the same owner-qualified repository directory naming as remote worktree creation.

Also rejects mutually exclusive `--secret` and `--no-secrets` bootstrap flags during parsing so explicitly selected build secrets cannot be silently dropped.

## Validation

- `npx vitest run src/commands/remoteSetup.test.ts`
- `node --run verify`
- Pre-push hook: `node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->
