### PR TITLE
fix: support cmux workspaces on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img alt="Groundcrew logo." height="250px" src="./static/groundcrew.svg">
 </p>
 
-Watch a Linear project and farm out ready tickets to coding-agent CLIs running in workspaces backed by git worktrees. Workspaces are [`cmux`](https://github.com/clayton-cole/cmux) panes on macOS or `tmux` windows on Linux/macOS.
+Watch a Linear project and farm out ready tickets to coding-agent CLIs running in workspaces backed by git worktrees. Workspaces are [`cmux`](https://github.com/clayton-cole/cmux) panes or `tmux` windows.
 
 ## Install
 
@@ -64,7 +64,7 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 5. **Prepare the runner and agent auth.** Groundcrew supports one local runner and one remote runner:
    - macOS local: `cmux` or `tmux` workspace, Safehouse on `PATH`, `clearance`, and locally authenticated agent CLIs.
    - macOS remote: local `cmux` or `tmux` workspace that launches the configured remote runner.
-   - Linux/WSL remote: `tmux` workspace that launches the configured remote runner. Label tickets `agent-remote`; local execution is not supported.
+   - Linux/WSL remote: `cmux` or `tmux` workspace that launches the configured remote runner. Label tickets `agent-remote`; local execution is not supported.
 
    Local setup fails before creating a worktree when the host is not macOS or `safehouse` is missing. `models.isolation`, per-model `isolation`, and per-model `sandbox` are legacy keys and now fail config validation.
 

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -404,7 +404,7 @@ describe(doctor, () => {
     expect(checked).toContain("alpha");
   });
 
-  it("reports non-macOS hosts as unsupported for local runs", async () => {
+  it("reports non-macOS local-runner guidance while accepting cmux workspaces", async () => {
     detectHostMock.mockResolvedValue({
       hasSafehouse: false,
       hasCmux: true,
@@ -416,10 +416,13 @@ describe(doctor, () => {
 
     const actual = await doctor();
 
-    expect(actual).toBe(false);
+    expect(actual).toBe(true);
     const lines = consoleLog.output();
     expect(lines).toContain("Local runner");
     expect(lines).toContain("use agent-remote with the remote runner");
+    expect(lines).toMatch(/requested=auto, resolved=cmux/);
+    expect(checkedCommands()).toContain("cmux");
+    expect(checkedCommands()).not.toContain("tmux");
     expect(lines).not.toContain("sbx diagnose");
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -35,8 +35,7 @@ export function isRemoteRunnerProviderName(value: unknown): value is RemoteRunne
 /**
  * Which terminal session manager hosts the agent process:
  *
- * - `auto`: pick the first available — cmux on macOS when installed,
- *   else tmux.
+ * - `auto`: pick the first available — cmux when installed, else tmux.
  * - `cmux`: require the cmux binary; fail loudly if missing.
  * - `tmux`: require the tmux binary; fail loudly if missing.
  */
@@ -200,7 +199,7 @@ export interface ResolvedConfig {
   };
   /**
    * Terminal session manager. Always present — defaults to `"auto"`.
-   * `auto` resolves to cmux on macOS when installed, else tmux.
+   * `auto` resolves to cmux when installed, else tmux.
    */
   workspaceKind: WorkspaceKindSetting;
   remote: RemoteRunnerConfig;

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -15,7 +15,7 @@ export interface HostCapabilities {
   hasCmux: boolean;
   /** True when the `tmux` binary is on PATH. */
   hasTmux: boolean;
-  /** True when the host platform is macOS. cmux and safehouse are macOS-only. */
+  /** True when the host platform is macOS. Safehouse is macOS-only. */
   isMacOS: boolean;
   /**
    * True when the host platform is one Safehouse supports. Safehouse is

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -792,13 +792,14 @@ describe(resolveWorkspaceKind, () => {
     }).toThrow(/cmux binary is not on PATH/);
   });
 
-  it("rejects explicit cmux on non-macOS hosts even when the binary is present", () => {
-    expect(() => {
-      resolveWorkspaceKind({
-        config: makeConfig("cmux"),
-        host: makeHost({ isMacOS: false, hasCmux: true }),
-      });
-    }).toThrow(/only supported on macOS/);
+  it("returns cmux when explicitly set on non-macOS hosts and cmux is on PATH", () => {
+    const result = resolveWorkspaceKind({
+      config: makeConfig("cmux"),
+      host: makeHost({ isMacOS: false, hasCmux: true }),
+    });
+
+    expect(result.resolved).toBe("cmux");
+    expect(result.requested).toBe("cmux");
   });
 
   it("returns tmux when explicitly set and tmux is on PATH", () => {
@@ -818,22 +819,22 @@ describe(resolveWorkspaceKind, () => {
     }).toThrow(/tmux binary is not on PATH/);
   });
 
-  it("auto prefers cmux when present on macOS", () => {
+  it("auto prefers cmux when present", () => {
     const result = resolveWorkspaceKind({
       config: makeConfig("auto"),
       host: makeHost({ isMacOS: true, hasCmux: true, hasTmux: true }),
     });
     expect(result.resolved).toBe("cmux");
-    expect(result.reason).toMatch(/macOS with cmux/);
+    expect(result.reason).toMatch(/cmux available/);
   });
 
-  it("auto skips cmux on non-macOS even when the binary is on PATH", () => {
+  it("auto prefers cmux on non-macOS when the binary is on PATH", () => {
     const result = resolveWorkspaceKind({
       config: makeConfig("auto"),
       host: makeHost({ isMacOS: false, hasCmux: true, hasTmux: true }),
     });
-    expect(result.resolved).toBe("tmux");
-    expect(result.reason).toMatch(/non-macOS/);
+    expect(result.resolved).toBe("cmux");
+    expect(result.reason).toMatch(/cmux available/);
   });
 
   it("auto falls back to tmux when cmux is missing", () => {

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -249,17 +249,14 @@ function resolveAuto(arguments_: {
   host: HostCapabilities;
 }): WorkspaceResolution {
   const { requested, host } = arguments_;
-  // cmux is macOS-only; non-macOS hosts with cmux on PATH (e.g. a stale
-  // build artifact) still resolve to tmux so `auto` matches the documented
-  // default and behaves correctly cross-platform.
-  if (host.isMacOS && host.hasCmux) {
-    return { requested, resolved: "cmux", reason: "auto: macOS with cmux available" };
+  if (host.hasCmux) {
+    return { requested, resolved: "cmux", reason: "auto: cmux available" };
   }
   if (host.hasTmux) {
     return {
       requested,
       resolved: "tmux",
-      reason: "auto: cmux unavailable or non-macOS, falling back to tmux",
+      reason: "auto: cmux unavailable, falling back to tmux",
     };
   }
   throw new Error(
@@ -273,11 +270,6 @@ const HOST_CAPABILITY_BY_KIND: Record<WorkspaceKind, "hasCmux" | "hasTmux"> = {
 };
 
 function failIfBinaryUnavailable(kind: WorkspaceKind, host: HostCapabilities): void {
-  if (kind === "cmux" && !host.isMacOS) {
-    throw new Error(
-      "workspaceKind 'cmux' is only supported on macOS. Switch to 'tmux' or 'auto' on this platform.",
-    );
-  }
   if (!host[HOST_CAPABILITY_BY_KIND[kind]]) {
     throw new Error(
       `workspaceKind '${kind}' is set but the ${kind} binary is not on PATH. Install ${kind} or change the setting.`,


### PR DESCRIPTION
## Summary

Allow Groundcrew to use cmux as the workspace backend on Linux when cmux is available on PATH. This supports running Groundcrew from a Linux host reached through a cmux SSH workflow, for example connecting with `cmux ssh myhost`, while still keeping local agent execution gated by the existing macOS/Safehouse requirements.

## Validation

- `node --run crew -- doctor` resolves `requested=auto, resolved=cmux` and reports all required checks passed in the Linux SSH session.
- `npx vitest run src/lib/workspaces.test.ts src/commands/doctor.test.ts`
- `env -u NPM_TOKEN -u BUF_TOKEN node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->