### PR TITLE
feat: support GROUNDCREW_LINEAR_API_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,19 @@ This installs the `crew` binary. `@clipboard-health/clearance` is pulled in tran
 
    `crew` resolves the config path as: `GROUNDCREW_CONFIG` if set → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/config.ts` if it exists → a `config.ts` sitting next to `crew`'s own source files (only useful from a local checkout; see [Hacking on groundcrew](#hacking-on-groundcrew)). Set `GROUNDCREW_CONFIG` only when you want to override the XDG location.
 
-4. **Provide a Linear API key.** `crew` expects `LINEAR_API_KEY` in its environment. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
+4. **Provide a Linear API key.** `crew` reads the key from `GROUNDCREW_LINEAR_API_KEY` first, then falls back to `LINEAR_API_KEY`. Prefer `GROUNDCREW_LINEAR_API_KEY` so the value does not clash with other tools that consume `LINEAR_API_KEY`. Any mechanism works — shell export, [direnv](https://direnv.net/), a `.env` file you `source`, or piping through `op run` if you store the credential in 1Password:
 
    ```bash
    # Direct
-   export LINEAR_API_KEY="lin_api_..."
+   export GROUNDCREW_LINEAR_API_KEY="lin_api_..."
    crew doctor
 
    # Via 1Password CLI (`op`), if you keep the key in a vault
-   echo "LINEAR_API_KEY='op://<vault>/LINEAR_API_KEY/credential'" > .env.1password
+   echo "GROUNDCREW_LINEAR_API_KEY='op://<vault>/LINEAR_API_KEY/credential'" > .env.1password
    op run --env-file .env.1password -- crew doctor
    ```
+
+   `LINEAR_API_KEY` continues to work for existing setups; if both variables are set, `GROUNDCREW_LINEAR_API_KEY` wins.
 
 5. **Prepare the runner and agent auth.** Groundcrew supports one runner: a `cmux` or `tmux` workspace on macOS, with Safehouse on `PATH`, `clearance`, and locally authenticated agent CLIs.
 
@@ -185,7 +187,7 @@ For developers working on the package itself, clone this repo, run `npm install`
 cd ~/dev/c/groundcrew
 node --run crew -- doctor
 
-# With 1Password for LINEAR_API_KEY:
+# With 1Password for GROUNDCREW_LINEAR_API_KEY:
 node --run crew:op -- run --watch
 ```
 

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -122,10 +122,12 @@ function mockMissingPath(missingPath: string): void {
 
 describe(doctor, () => {
   let consoleLog: ConsoleCapture;
-  const originalEnvironment = readEnvironmentVariable("LINEAR_API_KEY");
+  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
 
   beforeEach(() => {
     consoleLog = captureConsoleLog();
+    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
     setEnvironmentVariable("LINEAR_API_KEY", "lin_api_test");
     existsMock.mockReturnValue(true);
     statMock.mockReturnValue(statsWithDirectoryValue(true));
@@ -144,10 +146,15 @@ describe(doctor, () => {
 
   afterEach(() => {
     consoleLog.restore();
-    if (originalEnvironment === undefined) {
+    if (originalGroundcrewKey === undefined) {
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
+    }
+    if (originalLinearKey === undefined) {
       deleteEnvironmentVariable("LINEAR_API_KEY");
     } else {
-      setEnvironmentVariable("LINEAR_API_KEY", originalEnvironment);
+      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
     }
     vi.resetAllMocks();
   });
@@ -180,15 +187,43 @@ describe(doctor, () => {
     expect(consoleLog.output()).toContain("All required checks passed");
   });
 
-  it("returns false and reports a missing LINEAR_API_KEY", async () => {
+  it("returns false and reports both env var names when neither key is set", async () => {
     deleteEnvironmentVariable("LINEAR_API_KEY");
     loadConfigMock.mockResolvedValue(makeConfig());
 
     const actual = await doctor();
 
     expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain("$LINEAR_API_KEY");
-    expect(consoleLog.output()).toContain("export the variable");
+    const output = consoleLog.output();
+    expect(output).toContain("linear api key");
+    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
+    expect(output).toContain("$LINEAR_API_KEY");
+  });
+
+  it("reports the resolved env var when only GROUNDCREW_LINEAR_API_KEY is set", async () => {
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+    setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const output = consoleLog.output();
+    expect(output).toContain("linear api key");
+    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
+  });
+
+  it("prefers GROUNDCREW_LINEAR_API_KEY in doctor output when both env vars are set", async () => {
+    setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+    setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const output = consoleLog.output();
+    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
+    expect(output).not.toMatch(/set via \$LINEAR_API_KEY/);
   });
 
   it("returns false when a required CLI tool is missing", async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7,7 +7,7 @@ import { existsSync, statSync } from "node:fs";
 
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
-import { errorMessage, readEnvironmentVariable, writeOutput } from "../lib/util.ts";
+import { errorMessage, resolveLinearApiKey, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
 
 // Tokenization stops after this many non-flag tokens. Two is enough to
@@ -35,14 +35,21 @@ async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<
   return result;
 }
 
-function checkEnvironment(name: string): Check {
-  const value = readEnvironmentVariable(name);
-  const set = value !== undefined && value.length > 0;
+function checkLinearApiKey(): Check {
+  const resolved = resolveLinearApiKey();
+  if (resolved !== undefined) {
+    return {
+      name: "linear api key",
+      ok: true,
+      required: true,
+      hint: `set via $${resolved.source}`,
+    };
+  }
   return {
-    name: `$${name}`,
-    ok: set,
+    name: "linear api key",
+    ok: false,
     required: true,
-    hint: set ? "set" : "export the variable in your shell",
+    hint: "export $GROUNDCREW_LINEAR_API_KEY or $LINEAR_API_KEY",
   };
 }
 
@@ -157,7 +164,7 @@ export async function doctor(): Promise<boolean> {
   reportWorkspaceKind(config, workspaceOutcome);
 
   const checks: Check[] = [
-    checkEnvironment("LINEAR_API_KEY"),
+    checkLinearApiKey(),
     await checkCmd("git", true, "https://git-scm.com/"),
     ...(await workspaceChecks(workspaceOutcome)),
     checkDir(config.workspace.projectDir, "workspace.projectDir"),

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -142,7 +142,7 @@ async function verifyProject(client: LinearClient, config: ResolvedConfig): Prom
   const [project] = projects.nodes;
   if (!project) {
     throw new Error(
-      `No Linear project found with slugId "${config.linear.slugId}" (linear.projectSlug = "${config.linear.projectSlug}"). Confirm the slug matches the trailing segment of your project's URL and that LINEAR_API_KEY can access this workspace.`,
+      `No Linear project found with slugId "${config.linear.slugId}" (linear.projectSlug = "${config.linear.projectSlug}"). Confirm the slug matches the trailing segment of your project's URL and that your Linear API key can access this workspace.`,
     );
   }
   log(`Resolved Linear project: ${project.name} (slugId ${project.slugId})`);

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -12,6 +12,7 @@ import {
   log,
   logEvent,
   readEnvironmentVariable,
+  resolveLinearApiKey,
   setLogFile,
   sleep,
 } from "./util.ts";
@@ -172,35 +173,112 @@ describe(setLogFile, () => {
   });
 });
 
-describe(getLinearClient, () => {
-  const originalKey = readEnvironmentVariable("LINEAR_API_KEY");
+describe("Linear API key resolution", () => {
+  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
+
+  beforeEach(() => {
+    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+  });
 
   afterEach(() => {
-    if (originalKey === undefined) {
+    if (originalGroundcrewKey === undefined) {
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
+    }
+    if (originalLinearKey === undefined) {
       deleteEnvironmentVariable("LINEAR_API_KEY");
     } else {
-      setEnvironmentVariable("LINEAR_API_KEY", originalKey);
+      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
     }
   });
 
-  it("returns a LinearClient when LINEAR_API_KEY is set", () => {
-    setEnvironmentVariable("LINEAR_API_KEY", "lin_api_test");
+  describe(resolveLinearApiKey, () => {
+    it("returns LINEAR_API_KEY as the source when only it is set", () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
 
-    const actual = getLinearClient();
+      const actual = resolveLinearApiKey();
 
-    expect(actual).toBeInstanceOf(LinearClient);
+      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
+    });
+
+    it("returns GROUNDCREW_LINEAR_API_KEY as the source when only it is set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({
+        value: "lin_api_groundcrew",
+        source: "GROUNDCREW_LINEAR_API_KEY",
+      });
+    });
+
+    it("prefers GROUNDCREW_LINEAR_API_KEY when both are set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({
+        value: "lin_api_groundcrew",
+        source: "GROUNDCREW_LINEAR_API_KEY",
+      });
+    });
+
+    it("falls back to LINEAR_API_KEY when GROUNDCREW_LINEAR_API_KEY is empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
+    });
+
+    it("returns undefined when neither variable is set", () => {
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toBeUndefined();
+    });
+
+    it("returns undefined when both variables are empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toBeUndefined();
+    });
   });
 
-  it("throws when LINEAR_API_KEY is missing", () => {
-    deleteEnvironmentVariable("LINEAR_API_KEY");
+  describe(getLinearClient, () => {
+    it("returns a LinearClient when LINEAR_API_KEY is set", () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
 
-    expect(() => getLinearClient()).toThrow(/LINEAR_API_KEY not set/);
-  });
+      const actual = getLinearClient();
 
-  it("throws when LINEAR_API_KEY is empty", () => {
-    setEnvironmentVariable("LINEAR_API_KEY", "");
+      expect(actual).toBeInstanceOf(LinearClient);
+    });
 
-    expect(() => getLinearClient()).toThrow(/LINEAR_API_KEY not set/);
+    it("returns a LinearClient when GROUNDCREW_LINEAR_API_KEY is set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+
+      const actual = getLinearClient();
+
+      expect(actual).toBeInstanceOf(LinearClient);
+    });
+
+    it("throws when neither variable is set", () => {
+      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+    });
+
+    it("throws when both variables are empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "");
+
+      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+    });
   });
 });
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -101,12 +101,33 @@ export function readEnvironmentVariable(name: string): string | undefined {
   return process.env[name];
 }
 
-export function getLinearClient(): LinearClient {
-  const apiKey = readEnvironmentVariable("LINEAR_API_KEY");
-  if (apiKey === undefined || apiKey.length === 0) {
-    throw new Error("LINEAR_API_KEY not set. Add it to your environment.");
+const LINEAR_API_KEY_SOURCES = ["GROUNDCREW_LINEAR_API_KEY", "LINEAR_API_KEY"] as const;
+
+export type LinearApiKeySource = (typeof LINEAR_API_KEY_SOURCES)[number];
+
+export interface ResolvedLinearApiKey {
+  value: string;
+  source: LinearApiKeySource;
+}
+
+export function resolveLinearApiKey(): ResolvedLinearApiKey | undefined {
+  for (const source of LINEAR_API_KEY_SOURCES) {
+    const value = readEnvironmentVariable(source);
+    if (value !== undefined && value.length > 0) {
+      return { value, source };
+    }
   }
-  return new LinearClient({ apiKey });
+  return undefined;
+}
+
+export function getLinearClient(): LinearClient {
+  const resolved = resolveLinearApiKey();
+  if (resolved === undefined) {
+    throw new Error(
+      "Linear API key not set. Set GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY in your environment.",
+    );
+  }
+  return new LinearClient({ apiKey: resolved.value });
 }
 
 export function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary

The Linear API key was previously read only from `LINEAR_API_KEY`, which collides with other tools that consume the same name (shell rc files, direnv, IDE extensions). This PR adds `GROUNDCREW_LINEAR_API_KEY` as a higher-priority alternative so users can scope a Linear workspace specifically for `groundcrew` without disturbing other tooling.

Resolution order: `GROUNDCREW_LINEAR_API_KEY` first, then `LINEAR_API_KEY` (empty strings count as unset). Existing setups using `LINEAR_API_KEY` continue to work unchanged. `crew doctor` now reports which variable supplied the key and lists both names when neither is set. The "no Linear project found" error message no longer hardcodes a specific env var name.

## Validation

- `node --run verify` — 19 test files, 538 tests passing, 100% coverage on statements/branches/functions/lines, 0 lint/format errors.
- TDD red-green: 9 new failing tests in `util.test.ts` + 3 in `doctor.test.ts` exercising the full resolution matrix (only-legacy, only-prefixed, both-set precedence, both-empty, fallback-from-empty) before any implementation; all green after.

## Notes

- Doctor output shape changes from `[ok] $LINEAR_API_KEY  — set` to `[ok] linear api key  — set via $GROUNDCREW_LINEAR_API_KEY` (or `$LINEAR_API_KEY`). Any user script that grepped the prior wording will need adjustment; impact is expected to be low.
- Design spec preserved at `docs/superpowers/specs/2026-05-19-groundcrew-linear-api-key-env-var-design.md` for reviewer reference.

<!-- commit-push-pr:created v1 core@3.4.0 -->