### PR TITLE
feat: print workspace access hint on launch and stale-worktree errors

### DIFF
--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -21,6 +21,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
     },
   };
 });

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -21,7 +21,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
-      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
+      accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };
 });

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -41,7 +41,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
-      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
+      accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };
 });

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -41,6 +41,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
     },
   };
 });

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -7,7 +7,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities } from "../lib/host.ts";
 import type * as utilModule from "../lib/util.ts";
 import { getLinearClient, log } from "../lib/util.ts";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import { setupWorkspace, setupWorkspaceCli } from "./setupWorkspace.ts";
@@ -215,6 +215,25 @@ function mockCmuxFailure(): void {
     }
     return "";
   });
+}
+
+function mockTmuxHost(): void {
+  detectHostMock.mockResolvedValue({
+    hasSafehouse: true,
+    hasCmux: false,
+    hasTmux: true,
+    isMacOS: true,
+    isSafehouseSupported: true,
+  });
+}
+
+function mockTmuxWindows(names: readonly string[]): void {
+  const lines = ["_groundcrew_idle\t0", ...names.map((name) => `${name}\t0`)];
+  runCommandMock.mockReturnValue(`${lines.join("\n")}\n`);
+}
+
+function mockExistingWorktree(): void {
+  createMock.mockRejectedValue(new WorktreeAlreadyExistsError("/work/repo-a-team-1"));
 }
 
 function lastRunArgumentFromCallWithArgument(argument: string): string {
@@ -531,14 +550,8 @@ describe(setupWorkspace, () => {
     });
   });
 
-  it("logs the tmux attach command after launch so the user knows how to reach the workspace", async () => {
-    detectHostMock.mockResolvedValue({
-      hasSafehouse: true,
-      hasCmux: false,
-      hasTmux: true,
-      isMacOS: true,
-      isSafehouseSupported: true,
-    });
+  it("logs the tmux access hint after launch so the user knows how to reach the workspace", async () => {
+    mockTmuxHost();
     const config = makeConfig();
 
     await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
@@ -546,7 +559,7 @@ describe(setupWorkspace, () => {
     expect(logMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
   });
 
-  it("omits the Attach line when the backend has no shell attach hint (cmux)", async () => {
+  it("omits the access hint when the backend has no external hint (cmux)", async () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
@@ -592,9 +605,7 @@ describe(setupWorkspace, () => {
   });
 
   it("propagates worktree-creation errors without launching cmux", async () => {
-    createMock.mockImplementation(() => {
-      throw new Error("Worktree already exists: /work/repo-a-team-1");
-    });
+    createMock.mockRejectedValue(new Error("git fetch failed"));
 
     await expect(
       setupWorkspace(makeConfig(), {
@@ -602,27 +613,17 @@ describe(setupWorkspace, () => {
         repository: "repo-a",
         model: "claude",
       }),
-    ).rejects.toThrow(/Worktree already exists/);
+    ).rejects.toThrow(/git fetch failed/);
     expect(runCommandMock).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["new-workspace"]),
     );
   });
 
-  it("logs the tmux attach command when the worktree already exists and the previous workspace is still live", async () => {
-    detectHostMock.mockResolvedValue({
-      hasSafehouse: true,
-      hasCmux: false,
-      hasTmux: true,
-      isMacOS: true,
-      isSafehouseSupported: true,
-    });
-    createMock.mockImplementation(() => {
-      throw new Error("Worktree already exists: /work/repo-a-team-1");
-    });
-    // createMock short-circuits before any runCommand call, so the only
-    // runCommand after the throw is tmux list-windows from workspaces.probe.
-    runCommandMock.mockReturnValue("_groundcrew_idle\t0\nteam-1\t0\n");
+  it("logs the tmux access hint when the worktree already exists and the previous workspace is still live", async () => {
+    mockTmuxHost();
+    mockExistingWorktree();
+    mockTmuxWindows(["team-1"]);
 
     await expect(
       setupWorkspace(makeConfig(), {
@@ -635,19 +636,10 @@ describe(setupWorkspace, () => {
     expect(logMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
   });
 
-  it("does not log an attach hint when the worktree exists but no live workspace remains", async () => {
-    detectHostMock.mockResolvedValue({
-      hasSafehouse: true,
-      hasCmux: false,
-      hasTmux: true,
-      isMacOS: true,
-      isSafehouseSupported: true,
-    });
-    createMock.mockImplementation(() => {
-      throw new Error("Worktree already exists: /work/repo-a-team-1");
-    });
-    // Probe returns only the idle sentinel — no live ticket window for team-1.
-    runCommandMock.mockReturnValue("_groundcrew_idle\t0\n");
+  it("does not log an access hint when the worktree exists but no live workspace remains", async () => {
+    mockTmuxHost();
+    mockExistingWorktree();
+    mockTmuxWindows([]);
 
     await expect(
       setupWorkspace(makeConfig(), {
@@ -657,6 +649,21 @@ describe(setupWorkspace, () => {
       }),
     ).rejects.toThrow(/Worktree already exists/);
 
+    expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}Attach:/));
+  });
+
+  it("does not probe for an existing workspace when the backend has no external hint", async () => {
+    mockExistingWorktree();
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      }),
+    ).rejects.toThrow(/Worktree already exists/);
+
+    expect(runCommandMock).not.toHaveBeenCalled();
     expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}Attach:/));
   });
 

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -531,6 +531,30 @@ describe(setupWorkspace, () => {
     });
   });
 
+  it("logs the tmux attach command after launch so the user knows how to reach the workspace", async () => {
+    detectHostMock.mockResolvedValue({
+      hasSafehouse: true,
+      hasCmux: false,
+      hasTmux: true,
+      isMacOS: true,
+      isSafehouseSupported: true,
+    });
+    const config = makeConfig();
+
+    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+
+    expect(logMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
+  });
+
+  it("omits the Attach line when the backend has no shell attach hint (cmux)", async () => {
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+
+    expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}Attach:/));
+  });
+
   it("fails before creating a worktree when local runs are requested off macOS", async () => {
     detectHostMock.mockResolvedValue({
       hasSafehouse: false,
@@ -583,6 +607,57 @@ describe(setupWorkspace, () => {
       "cmux",
       expect.arrayContaining(["new-workspace"]),
     );
+  });
+
+  it("logs the tmux attach command when the worktree already exists and the previous workspace is still live", async () => {
+    detectHostMock.mockResolvedValue({
+      hasSafehouse: true,
+      hasCmux: false,
+      hasTmux: true,
+      isMacOS: true,
+      isSafehouseSupported: true,
+    });
+    createMock.mockImplementation(() => {
+      throw new Error("Worktree already exists: /work/repo-a-team-1");
+    });
+    // createMock short-circuits before any runCommand call, so the only
+    // runCommand after the throw is tmux list-windows from workspaces.probe.
+    runCommandMock.mockReturnValue("_groundcrew_idle\t0\nteam-1\t0\n");
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      }),
+    ).rejects.toThrow(/Worktree already exists/);
+
+    expect(logMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
+  });
+
+  it("does not log an attach hint when the worktree exists but no live workspace remains", async () => {
+    detectHostMock.mockResolvedValue({
+      hasSafehouse: true,
+      hasCmux: false,
+      hasTmux: true,
+      isMacOS: true,
+      isSafehouseSupported: true,
+    });
+    createMock.mockImplementation(() => {
+      throw new Error("Worktree already exists: /work/repo-a-team-1");
+    });
+    // Probe returns only the idle sentinel — no live ticket window for team-1.
+    runCommandMock.mockReturnValue("_groundcrew_idle\t0\n");
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      }),
+    ).rejects.toThrow(/Worktree already exists/);
+
+    expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}Attach:/));
   });
 
   it("rejects unknown models", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -11,8 +11,8 @@ import { buildLaunchCommand, shellSingleQuote } from "../lib/launchCommand.ts";
 import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import { assertLocalRunnerRequirements } from "../lib/localRunner.ts";
 import { errorMessage, getLinearClient, log, readEnvironmentVariable } from "../lib/util.ts";
-import { workspaces } from "../lib/workspaces.ts";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
+import { isWorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 interface TicketDetails {
   title: string;
@@ -133,7 +133,9 @@ export async function setupWorkspace(
         ? await worktrees.create(config, spec)
         : await worktrees.create(config, spec, signal);
   } catch (error) {
-    await logAttachHintForExistingWorkspace({ config, ticket, signal });
+    if (isWorktreeAlreadyExistsError(error)) {
+      await logAccessHintForExistingWorkspace({ config, ticket, signal });
+    }
     throw error;
   }
   const { branchName, dir: launchDir } = created;
@@ -184,10 +186,7 @@ export async function setupWorkspace(
     log(`Workspace "${ticket}" launched (${model})`);
     log(`  Worktree: ${launchDir}`);
     log(`  Branch:   ${branchName}`);
-    const attach = await workspaces.attachHint(config, ticket, signal);
-    if (attach !== undefined) {
-      log(`  Attach:   ${attach}`);
-    }
+    await logWorkspaceAccessHint({ config, ticket, signal });
   } catch (error) {
     await rollbackWorktree({ config, entry: created, promptDir });
     throw error;
@@ -196,27 +195,47 @@ export async function setupWorkspace(
 
 /**
  * Probe the workspace backend and, if a workspace for `ticket` is still
- * live, log the attach hint. Used on the pre-launch error path (e.g. the
+ * live, log the access hint. Used on the pre-launch error path (e.g. the
  * worktree already exists from a prior run) so the user can find the
  * still-running session instead of being told only that the worktree is
  * in the way. Silent when the probe is unavailable or the workspace is
  * gone — we don't want to point at a window that doesn't exist.
  */
-async function logAttachHintForExistingWorkspace(arguments_: {
+async function logAccessHintForExistingWorkspace(arguments_: {
   config: ResolvedConfig;
   ticket: string;
   signal: AbortSignal | undefined;
 }): Promise<void> {
   const { config, ticket, signal } = arguments_;
+  const accessHint = await workspaces.accessHint(config, ticket, signal);
+  if (accessHint === undefined) {
+    return;
+  }
   const probe = await workspaces.probe(config, signal);
   if (probe.kind !== "ok" || !probe.names.has(ticket)) {
     return;
   }
-  const attach = await workspaces.attachHint(config, ticket, signal);
-  /* v8 ignore else @preserve -- attachHint is undefined only for cmux, but cmux probe would've returned the workspace too; tmux always emits a hint */
-  if (attach !== undefined) {
-    log(`  Attach:   ${attach}`);
+  logAccessHint(accessHint);
+}
+
+async function logWorkspaceAccessHint(arguments_: {
+  config: ResolvedConfig;
+  ticket: string;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const accessHint = await workspaces.accessHint(
+    arguments_.config,
+    arguments_.ticket,
+    arguments_.signal,
+  );
+  if (accessHint === undefined) {
+    return;
   }
+  logAccessHint(accessHint);
+}
+
+function logAccessHint(accessHint: WorkspaceAccessHint): void {
+  log(`  Attach:   ${accessHint.command}`);
 }
 
 async function rollbackWorktree(arguments_: {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -126,10 +126,16 @@ export async function setupWorkspace(
   await ensureClearance({ logger: log });
 
   const spec = { repository, ticket };
-  const created =
-    signal === undefined
-      ? await worktrees.create(config, spec)
-      : await worktrees.create(config, spec, signal);
+  let created: WorktreeEntry;
+  try {
+    created =
+      signal === undefined
+        ? await worktrees.create(config, spec)
+        : await worktrees.create(config, spec, signal);
+  } catch (error) {
+    await logAttachHintForExistingWorkspace({ config, ticket, signal });
+    throw error;
+  }
   const { branchName, dir: launchDir } = created;
   const worktreeName = `${repository}-${ticket}`;
 
@@ -178,9 +184,38 @@ export async function setupWorkspace(
     log(`Workspace "${ticket}" launched (${model})`);
     log(`  Worktree: ${launchDir}`);
     log(`  Branch:   ${branchName}`);
+    const attach = await workspaces.attachHint(config, ticket, signal);
+    if (attach !== undefined) {
+      log(`  Attach:   ${attach}`);
+    }
   } catch (error) {
     await rollbackWorktree({ config, entry: created, promptDir });
     throw error;
+  }
+}
+
+/**
+ * Probe the workspace backend and, if a workspace for `ticket` is still
+ * live, log the attach hint. Used on the pre-launch error path (e.g. the
+ * worktree already exists from a prior run) so the user can find the
+ * still-running session instead of being told only that the worktree is
+ * in the way. Silent when the probe is unavailable or the workspace is
+ * gone — we don't want to point at a window that doesn't exist.
+ */
+async function logAttachHintForExistingWorkspace(arguments_: {
+  config: ResolvedConfig;
+  ticket: string;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const { config, ticket, signal } = arguments_;
+  const probe = await workspaces.probe(config, signal);
+  if (probe.kind !== "ok" || !probe.names.has(ticket)) {
+    return;
+  }
+  const attach = await workspaces.attachHint(config, ticket, signal);
+  /* v8 ignore else @preserve -- attachHint is undefined only for cmux, but cmux probe would've returned the workspace too; tmux always emits a hint */
+  if (attach !== undefined) {
+    log(`  Attach:   ${attach}`);
   }
 }
 

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -762,26 +762,27 @@ describe("workspaces.close (tmux)", () => {
   });
 });
 
-describe("workspaces.attachHint (cmux)", () => {
+describe("workspaces.accessHint (cmux)", () => {
   beforeEach(commonBeforeEach);
   afterEach(commonAfterEach);
 
-  it("returns undefined (cmux has no shell attach equivalent; workspace surfaces in the cmux UI)", async () => {
-    await expect(workspaces.attachHint(makeConfig(), "TEAM-1")).resolves.toBeUndefined();
+  it("returns undefined (cmux has no concise external hint; workspace surfaces in the cmux UI)", async () => {
+    await expect(workspaces.accessHint(makeConfig(), "TEAM-1")).resolves.toBeUndefined();
   });
 });
 
-describe("workspaces.attachHint (tmux)", () => {
+describe("workspaces.accessHint (tmux)", () => {
   beforeEach(() => {
     commonBeforeEach();
     detectHostMock.mockResolvedValue(makeHost({ hasCmux: false, hasTmux: true }));
   });
   afterEach(commonAfterEach);
 
-  it("returns the tmux attach command targeting the ticket window inside the groundcrew session", async () => {
-    await expect(workspaces.attachHint(makeConfig("tmux"), "TEAM-1")).resolves.toBe(
-      "tmux attach -t groundcrew:TEAM-1",
-    );
+  it("returns an access hint for the ticket window inside the groundcrew tmux session", async () => {
+    await expect(workspaces.accessHint(makeConfig("tmux"), "TEAM-1")).resolves.toStrictEqual({
+      kind: "attachCommand",
+      command: "tmux attach -t groundcrew:TEAM-1",
+    });
   });
 });
 

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -762,6 +762,29 @@ describe("workspaces.close (tmux)", () => {
   });
 });
 
+describe("workspaces.attachHint (cmux)", () => {
+  beforeEach(commonBeforeEach);
+  afterEach(commonAfterEach);
+
+  it("returns undefined (cmux has no shell attach equivalent; workspace surfaces in the cmux UI)", async () => {
+    await expect(workspaces.attachHint(makeConfig(), "TEAM-1")).resolves.toBeUndefined();
+  });
+});
+
+describe("workspaces.attachHint (tmux)", () => {
+  beforeEach(() => {
+    commonBeforeEach();
+    detectHostMock.mockResolvedValue(makeHost({ hasCmux: false, hasTmux: true }));
+  });
+  afterEach(commonAfterEach);
+
+  it("returns the tmux attach command targeting the ticket window inside the groundcrew session", async () => {
+    await expect(workspaces.attachHint(makeConfig("tmux"), "TEAM-1")).resolves.toBe(
+      "tmux attach -t groundcrew:TEAM-1",
+    );
+  });
+});
+
 describe(resolveWorkspaceKind, () => {
   beforeEach(commonBeforeEach);
   afterEach(commonAfterEach);

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -53,6 +53,11 @@ interface Adapter {
   list(signal?: AbortSignal): Promise<Workspace[] | undefined>;
   /** No-op when no workspace exists for `name`. */
   close(name: string, signal?: AbortSignal): Promise<void>;
+  /**
+   * Shell-attach hint for the workspace, or `undefined` when the backend
+   * has no equivalent (e.g. cmux surfaces workspaces in its own UI).
+   */
+  attachHint(name: string): string | undefined;
 }
 
 async function runWorkspaceCommand(
@@ -217,6 +222,12 @@ const cmuxAdapter: Adapter = {
       }
       throw error;
     }
+  },
+  attachHint(_name) {
+    // cmux is a TUI; users surface workspaces by launching the cmux app,
+    // not a shell command. No useful hint to emit.
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit signal that the backend has no hint
+    return undefined;
   },
 };
 
@@ -437,6 +448,9 @@ const tmuxAdapter: Adapter = {
       throw error;
     }
   },
+  attachHint(name) {
+    return `tmux attach -t ${TMUX_SESSION}:${name}`;
+  },
 };
 
 // Per-config cache: production resolves the adapter once at first use
@@ -487,5 +501,13 @@ export const workspaces = {
   async close(config: ResolvedConfig, name: string, signal?: AbortSignal): Promise<void> {
     const adapter = await adapterFor(config, signal);
     await adapter.close(name, signal);
+  },
+  async attachHint(
+    config: ResolvedConfig,
+    name: string,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    const adapter = await adapterFor(config, signal);
+    return adapter.attachHint(name);
   },
 };

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -23,6 +23,11 @@ export interface WorkspaceStatus {
   icon?: string;
 }
 
+export interface WorkspaceAccessHint {
+  kind: "attachCommand";
+  command: string;
+}
+
 export interface OpenSpec {
   /** Ticket id; becomes the workspace's name. */
   name: string;
@@ -54,10 +59,10 @@ interface Adapter {
   /** No-op when no workspace exists for `name`. */
   close(name: string, signal?: AbortSignal): Promise<void>;
   /**
-   * Shell-attach hint for the workspace, or `undefined` when the backend
-   * has no equivalent (e.g. cmux surfaces workspaces in its own UI).
+   * User-facing way to reach the workspace, or `undefined` when the backend
+   * has no concise external hint.
    */
-  attachHint(name: string): string | undefined;
+  accessHint(name: string): WorkspaceAccessHint | undefined;
 }
 
 async function runWorkspaceCommand(
@@ -223,7 +228,7 @@ const cmuxAdapter: Adapter = {
       throw error;
     }
   },
-  attachHint(_name) {
+  accessHint(_name) {
     // cmux is a TUI; users surface workspaces by launching the cmux app,
     // not a shell command. No useful hint to emit.
     // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit signal that the backend has no hint
@@ -296,6 +301,10 @@ const TMUX_SESSION = "groundcrew";
 // sentinel and filter it out — it stays around as a placeholder so the
 // session doesn't collapse when the last ticket window closes.
 const TMUX_IDLE_WINDOW = "_groundcrew_idle";
+
+function tmuxTarget(name: string): string {
+  return `${TMUX_SESSION}:${name}`;
+}
 
 function isTmuxNotFoundError(error: unknown): boolean {
   // runCommand surfaces the child's stderr in error.message, so the "no
@@ -391,7 +400,7 @@ function parseTmuxWindows(output: string): Workspace[] {
 const tmuxAdapter: Adapter = {
   async open(spec, signal) {
     await ensureTmuxSession(signal);
-    const target = `${TMUX_SESSION}:${spec.name}`;
+    const target = tmuxTarget(spec.name);
     const keepDeadWindowsEnv = readEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
     const keepDeadWindows = keepDeadWindowsEnv !== undefined && keepDeadWindowsEnv.length > 0;
     await runWorkspaceCommand(
@@ -437,7 +446,7 @@ const tmuxAdapter: Adapter = {
   },
   async close(name, signal) {
     try {
-      await runWorkspaceCommand("tmux", ["kill-window", "-t", `${TMUX_SESSION}:${name}`], signal);
+      await runWorkspaceCommand("tmux", ["kill-window", "-t", tmuxTarget(name)], signal);
     } catch (error) {
       if (isSignalAborted(signal)) {
         throw error;
@@ -448,8 +457,8 @@ const tmuxAdapter: Adapter = {
       throw error;
     }
   },
-  attachHint(name) {
-    return `tmux attach -t ${TMUX_SESSION}:${name}`;
+  accessHint(name) {
+    return { kind: "attachCommand", command: `tmux attach -t ${tmuxTarget(name)}` };
   },
 };
 
@@ -502,12 +511,12 @@ export const workspaces = {
     const adapter = await adapterFor(config, signal);
     await adapter.close(name, signal);
   },
-  async attachHint(
+  async accessHint(
     config: ResolvedConfig,
     name: string,
     signal?: AbortSignal,
-  ): Promise<string | undefined> {
+  ): Promise<WorkspaceAccessHint | undefined> {
     const adapter = await adapterFor(config, signal);
-    return adapter.attachHint(name);
+    return adapter.accessHint(name);
   },
 };

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -40,6 +40,7 @@ vi.mock(import("./workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
     },
   };
 });

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -40,7 +40,7 @@ vi.mock(import("./workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
-      attachHint: vi.fn<typeof actual.workspaces.attachHint>(),
+      accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };
 });

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -21,6 +21,20 @@ const LONG_RUNNING_COMMAND_OPTIONS = { stdio: "inherit", timeoutMs: 0 } as const
 
 export type WorktreeKind = "host";
 
+export class WorktreeAlreadyExistsError extends Error {
+  public readonly dir: string;
+
+  public constructor(dir: string) {
+    super(`Worktree already exists: ${dir}`);
+    this.dir = dir;
+    this.name = "WorktreeAlreadyExistsError";
+  }
+}
+
+export function isWorktreeAlreadyExistsError(error: unknown): error is WorktreeAlreadyExistsError {
+  return error instanceof WorktreeAlreadyExistsError;
+}
+
 export interface WorktreeEntry {
   repository: string;
   /** Linear ticket id, lowercased — e.g. "team-220". */
@@ -260,13 +274,11 @@ async function create(
   spec: WorktreeSpec,
   signal?: AbortSignal,
 ): Promise<WorktreeEntry> {
-  const existing = findByTicket(config, spec.ticket).filter(
+  const existing = findByTicket(config, spec.ticket).find(
     (entry) => entry.repository === spec.repository,
   );
-  if (existing.length > 0) {
-    const [first] = existing;
-    /* v8 ignore next @preserve -- length>0 guarantees [0] is defined */
-    throw new Error(`Worktree already exists: ${first?.dir}`);
+  if (existing !== undefined) {
+    throw new WorktreeAlreadyExistsError(existing.dir);
   }
   return await createWorktree(config, spec, signal);
 }


### PR DESCRIPTION
## Summary

- After a workspace launches, log a copy-paste-ready `Attach:` line alongside the existing `Worktree:` / `Branch:` lines when the selected workspace backend exposes an external access hint.
- When `setupWorkspace` aborts with **"Worktree already exists"** from a stranded prior run, print the same hint only if the backend has one and the previous workspace is still live.
- Generalizes the workspace adapter from `attachHint(name): string | undefined` to `accessHint(name): WorkspaceAccessHint | undefined`; tmux returns a typed attach-command hint, while cmux returns `undefined` because its workspaces surface in the cmux UI.

### Why

Today, after `crew run --ticket HRD-442` succeeds, the user has to remember the tmux session name and ticket id to attach. Worse, on the re-run after a partial failure path, they only see `Worktree already exists: ...` and have no signal that their previous session is still alive in tmux.

### Sample output

Successful launch:

```text
[...] Workspace "hrd-442" launched (claude)
[...]   Worktree: /Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442
[...]   Branch:   paul-hrd-442
[...]   Attach:   tmux attach -t groundcrew:hrd-442
```

Re-run with a stale worktree and live workspace:

```text
[...] Resolved HRD-442: repository=herds-social/herds, model=claude
[...] Clearance already listening on http://127.0.0.1:19999
[...]   Attach:   tmux attach -t groundcrew:hrd-442
Worktree already exists: /Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442
```

If the worktree is stranded but the workspace is gone, no `Attach:` line is printed.

## Validation

- [x] `node --run verify` - 536 tests pass, 100% statement/branch/function/line coverage, lint/format/markdown/spell clean.
- [x] Simplify pass over the full PR diff; follow-up changes centralized access-hint logging, removed tmux target duplication, avoided extra probes for non-existing-worktree errors, and covered the cmux no-hint path.
- [ ] Manual smoke against a real `crew run --ticket ...` (pending reviewer).

<!-- commit-push-pr:created v1 core@3.4.0 -->
