### PR TITLE
fix: explain dirty worktree condition on crew cleanup failure

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -45,7 +45,10 @@ vi.mock(import("./workspaces.ts"), async (importOriginal) => {
 });
 vi.mock("node:os", async (importOriginal): Promise<NodeOsMock> => {
   const actual = await importOriginal<typeof nodeOs>();
-  return { ...actual, userInfo: vi.fn<typeof actual.userInfo>(actual.userInfo) };
+  return {
+    ...actual,
+    userInfo: vi.fn<typeof actual.userInfo>(actual.userInfo),
+  };
 });
 
 const userInfoMock = vi.mocked(userInfo);
@@ -57,12 +60,19 @@ function makeConfig(overrides: {
   models?: ResolvedConfig["models"]["definitions"];
 }): ResolvedConfig {
   const knownRepositories = overrides.knownRepositories ?? ["repo-a"];
-  const models = overrides.models ?? { claude: { cmd: "claude", color: "#fff" } };
+  const models = overrides.models ?? {
+    claude: { cmd: "claude", color: "#fff" },
+  };
   return {
     linear: {
       projectSlug: "x-aaaaaaaaaaaa",
       slugId: "aaaaaaaaaaaa",
-      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+      statuses: {
+        todo: "Todo",
+        inProgress: "In Progress",
+        done: "Done",
+        terminal: ["Done"],
+      },
     },
     git: overrides.git ?? { remote: "origin", defaultBranch: "main" },
     workspace: {
@@ -83,6 +93,10 @@ function makeConfig(overrides: {
 
 function makeUserInfo(username: string): ReturnType<typeof userInfo> {
   return { username, uid: 0, gid: 0, shell: null, homedir: "/tmp" };
+}
+
+function hasArguments(arguments_: readonly string[], ...needles: readonly string[]): boolean {
+  return needles.every((needle) => arguments_.includes(needle));
 }
 
 let projectDir: string;
@@ -112,7 +126,9 @@ describe(list, () => {
   });
 
   it("returns an empty list when the project directory cannot be read", () => {
-    const config = makeConfig({ projectDir: join(projectDir, "does-not-exist") });
+    const config = makeConfig({
+      projectDir: join(projectDir, "does-not-exist"),
+    });
 
     expect(list(config)).toStrictEqual([]);
   });
@@ -157,7 +173,10 @@ describe(list, () => {
     // not the project root, to find it.
     mkdirSync(join(projectDir, "owner", "repo"), { recursive: true });
     mkdirSync(join(projectDir, "owner", "repo-team-1"));
-    const config = makeConfig({ projectDir, knownRepositories: ["owner/repo"] });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["owner/repo"],
+    });
 
     expect(list(config)).toStrictEqual([
       {
@@ -215,7 +234,10 @@ describe(findByTicket, () => {
   it("returns every host entry matching the ticket regardless of repo", () => {
     mkdirSync(join(projectDir, "repo-a-team-1"));
     mkdirSync(join(projectDir, "repo-b-team-1"));
-    const config = makeConfig({ projectDir, knownRepositories: ["repo-a", "repo-b"] });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["repo-a", "repo-b"],
+    });
 
     const actual = findByTicket(config, "team-1");
 
@@ -449,6 +471,191 @@ describe(remove, () => {
     await expect(callRemove()).resolves.toBeUndefined();
   });
 
+  it("wraps the error with a dirtiness explanation and --force hint when the worktree has modifications", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status --porcelain reports a dirty tree.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("Command failed: git worktree remove\nExit status: 128");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        return " M src/foo.ts\nM  src/bar.ts\n?? src/new.ts\n?? src/other.ts\n";
+      }
+      return "";
+    });
+
+    const callRemove = async (): Promise<void> => {
+      await remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      });
+    };
+
+    await expect(callRemove()).rejects.toThrow(/2 modified files and 2 untracked files/);
+    await expect(callRemove()).rejects.toThrow(/crew cleanup --force team-1/);
+    await expect(callRemove()).rejects.toThrow(
+      new RegExp(
+        `commit/stash in ${join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`,
+      ),
+    );
+  });
+
+  it("uses singular wording when exactly one modified file is dirty", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- single modified file produces singular "modified file"/"it" wording.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("remove failed");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        return " M src/foo.ts\n";
+      }
+      return "";
+    });
+
+    const callRemove = async (): Promise<void> => {
+      await remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      });
+    };
+
+    await expect(callRemove()).rejects.toThrow(/worktree has 1 modified file\./);
+    await expect(callRemove()).rejects.toThrow(/to discard it/);
+    await expect(callRemove()).rejects.not.toThrow(/untracked/);
+  });
+
+  it("uses singular wording when exactly one untracked file is dirty", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- single untracked file produces singular "untracked file"/"it" wording.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("remove failed");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        return "?? src/new.ts\n";
+      }
+      return "";
+    });
+
+    const callRemove = async (): Promise<void> => {
+      await remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      });
+    };
+
+    await expect(callRemove()).rejects.toThrow(/worktree has 1 untracked file\./);
+    await expect(callRemove()).rejects.toThrow(/to discard it/);
+    await expect(callRemove()).rejects.not.toThrow(/modified/);
+  });
+
+  it("rethrows the original error when the dirtiness probe itself fails", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- both the remove and the follow-up status probe fail; no dirtiness info available.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("original remove failure");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        throw new Error("status probe blew up");
+      }
+      return "";
+    });
+
+    await expect(
+      remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      }),
+    ).rejects.toThrow("original remove failure");
+  });
+
+  it("rethrows the original error when removal fails but the worktree is clean", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status --porcelain returns clean.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("git worktree remove failed for some other reason");
+      }
+      return "";
+    });
+
+    await expect(
+      remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      }),
+    ).rejects.toThrow("git worktree remove failed for some other reason");
+  });
+
+  it("skips the dirtiness probe and rethrows when --force is already set", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator fails the worktree-remove call even with --force.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("forced remove still failed");
+      }
+      return "";
+    });
+
+    await expect(
+      remove(
+        config,
+        {
+          repository: "repo-a",
+          ticket: "team-1",
+          branchName: "rocky-team-1",
+          dir: join(projectDir, "repo-a-team-1"),
+          kind: "host",
+        },
+        { force: true },
+      ),
+    ).rejects.toThrow("forced remove still failed");
+
+    const statusCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
+      hasArguments(arguments_, "status", "--porcelain"),
+    );
+    expect(statusCalls).toHaveLength(0);
+  });
+
   it("rethrows branch deletion failures after the shutdown signal fires", async () => {
     mkdirSync(join(projectDir, "repo-a"));
     mkdirSync(join(projectDir, "repo-a-team-1"));
@@ -512,7 +719,10 @@ describe(teardown, () => {
   });
 
   it("closes the matching workspace before removing the worktree", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
     const config = makeConfig({ projectDir });
     const entry = hostEntry("team-1");
 
@@ -525,8 +735,14 @@ describe(teardown, () => {
   });
 
   it("dedupes the workspace close across duplicate host entries for one ticket", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
-    const config = makeConfig({ projectDir, knownRepositories: ["repo-a", "repo-b"] });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["repo-a", "repo-b"],
+    });
     mkdirSync(join(projectDir, "repo-b-team-1"), { recursive: true });
     mkdirSync(join(projectDir, "repo-b"), { recursive: true });
     const entries = [
@@ -548,7 +764,10 @@ describe(teardown, () => {
   });
 
   it("skips workspace close when the ticket is not in the live name set", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set<string>(),
+    });
     const config = makeConfig({ projectDir });
 
     const result = await teardown(config, [hostEntry("team-1")]);
@@ -594,7 +813,10 @@ describe(teardown, () => {
 
   it("only best-effort closes a ticket once when duplicate entries exist and probe is unavailable", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
-    const config = makeConfig({ projectDir, knownRepositories: ["repo-a", "repo-b"] });
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["repo-a", "repo-b"],
+    });
     mkdirSync(join(projectDir, "repo-b-team-1"), { recursive: true });
     mkdirSync(join(projectDir, "repo-b"), { recursive: true });
     const entries = [
@@ -617,7 +839,10 @@ describe(teardown, () => {
   });
 
   it("records workspace_close failures and continues to remove the worktree", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
     workspacesCloseMock.mockImplementation(() => {
       throw new Error("close down");
     });
@@ -635,7 +860,10 @@ describe(teardown, () => {
   it("rethrows workspace_close failures after the shutdown signal fires", async () => {
     const controller = new AbortController();
     controller.abort();
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
     workspacesCloseMock.mockRejectedValue(new Error("close interrupted"));
     const config = makeConfig({ projectDir });
 
@@ -645,7 +873,10 @@ describe(teardown, () => {
   });
 
   it("records worktree_remove failures and continues to the next entry", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set<string>(),
+    });
     // The first runCommand fired by teardown is the `worktree remove` for
     // entry 1; subsequent calls (entry 1 branch -D, entry 2 remove + -D)
     // fall back to the beforeEach mockReturnValue.
@@ -665,7 +896,10 @@ describe(teardown, () => {
   it("rethrows worktree_remove failures after the shutdown signal fires", async () => {
     const controller = new AbortController();
     controller.abort();
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set<string>(),
+    });
     runCommandMock.mockImplementationOnce(() => {
       throw new Error("remove interrupted");
     });
@@ -677,7 +911,10 @@ describe(teardown, () => {
   });
 
   it("passes force through to the underlying remove", async () => {
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set<string>(),
+    });
     const config = makeConfig({ projectDir });
 
     await teardown(config, [hostEntry("team-1")], { force: true });

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -230,7 +230,30 @@ async function removeWorktree(
       removeArguments.push("--force");
     }
     removeArguments.push(entry.dir);
-    await runCommandAsync("git", removeArguments, longRunningCommandOptions(options.signal));
+    try {
+      await runCommandAsync("git", removeArguments, longRunningCommandOptions(options.signal));
+    } catch (error) {
+      // git's `fatal: ... use --force to delete it` line goes to inherited
+      // stderr, so the captured error is just "Exit status: 128". Probe the
+      // worktree ourselves so the failure message explains the condition
+      // (modified/untracked files) and points at `crew cleanup --force`.
+      if (options.force || options.signal?.aborted === true) {
+        throw error;
+      }
+      const dirtiness = await probeWorktreeDirtiness(entry.dir, options.signal);
+      if (dirtiness.kind !== "dirty") {
+        throw error;
+      }
+      throw new Error(
+        describeDirtyWorktree({
+          ticket: entry.ticket,
+          dir: entry.dir,
+          modified: dirtiness.modified,
+          untracked: dirtiness.untracked,
+        }),
+        { cause: error },
+      );
+    }
   } else {
     log(`Worktree directory ${entry.dir} not found, pruning stale refs...`);
     await runCommandAsync(
@@ -245,6 +268,62 @@ async function removeWorktree(
     branchName: entry.branchName,
     ...signalProperty(options.signal),
   });
+}
+
+type WorktreeDirtiness =
+  | { kind: "dirty"; modified: number; untracked: number }
+  | { kind: "clean" }
+  | { kind: "unknown" };
+
+async function probeWorktreeDirtiness(
+  worktreeDir: string,
+  signal: AbortSignal | undefined,
+): Promise<WorktreeDirtiness> {
+  let output: string;
+  try {
+    output = await runCommandAsync(
+      "git",
+      ["-C", worktreeDir, "status", "--porcelain"],
+      signalProperty(signal),
+    );
+  } catch {
+    return { kind: "unknown" };
+  }
+  let modified = 0;
+  let untracked = 0;
+  for (const line of output.split("\n")) {
+    if (line.length === 0) {
+      continue;
+    }
+    if (line.startsWith("??")) {
+      untracked += 1;
+    } else {
+      modified += 1;
+    }
+  }
+  if (modified === 0 && untracked === 0) {
+    return { kind: "clean" };
+  }
+  return { kind: "dirty", modified, untracked };
+}
+
+function describeDirtyWorktree(arguments_: {
+  ticket: string;
+  dir: string;
+  modified: number;
+  untracked: number;
+}): string {
+  const { ticket, dir, modified, untracked } = arguments_;
+  const parts: string[] = [];
+  if (modified > 0) {
+    parts.push(`${modified} modified file${modified === 1 ? "" : "s"}`);
+  }
+  if (untracked > 0) {
+    parts.push(`${untracked} untracked file${untracked === 1 ? "" : "s"}`);
+  }
+  const summary = parts.join(" and ");
+  const pronoun = modified + untracked === 1 ? "it" : "them";
+  return `worktree has ${summary}. Run \`crew cleanup --force ${ticket}\` to discard ${pronoun}, or commit/stash in ${dir} first.`;
 }
 
 function list(config: ResolvedConfig): WorktreeEntry[] {


### PR DESCRIPTION
## Summary

`crew cleanup <ticket>` previously failed with `Exit status: 128` and no hint about the cause or what to do next, because git's `fatal: ... use --force to delete it` line is written to **inherited** stderr and never reaches our captured error. Reading the message gave the user no clue that `--force` would resolve it or that uncommitted work was the reason.

After a `git worktree remove` failure, we now probe the worktree ourselves with `git status --porcelain` and throw a self-explanatory error that names the condition (modified/untracked file counts) and points at the exact remediation. The probe is skipped when `--force` is already set or the abort signal has fired, preserving the existing teardown contract.

### Before

```
Cleanup failed for hrd-442 (host): Command failed: git -C ... worktree remove ...
Exit status: 128
Cause: Command exited unsuccessfully
```

### After

```
Cleanup failed for hrd-442 (host): worktree has 2 modified files and 1 untracked file. Run `crew cleanup --force hrd-442` to discard them, or commit/stash in /path/to/worktree first.
```

## Validation

- `node --run verify` — all 10 checks pass (architecture, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint, test).
- `node --run test` — 535 tests passing, 100% statement / branch / function / line coverage.
- Six new tests in `src/lib/worktrees.test.ts` cover: plural wording (2 modified + 2 untracked), singular wording for one modified, singular wording for one untracked, probe failure → rethrow original error, clean worktree → rethrow original error, `--force` short-circuit (no probe call).

## Notes

- The dirtiness probe runs **only** on `worktree remove` failures, not on the `worktree prune` path (prune can't fail for the "modified files" reason).
- Locale-independent: we don't pattern-match git's English `fatal:` wording — we re-probe with `git status --porcelain` and form the explanation from our own counts.
- When the probe itself fails (e.g. broken `.git` link), we rethrow the original error rather than fabricating a misleading explanation.
- The original error is preserved as `cause` on the new error, so downstream tooling can still inspect the underlying `git` failure if needed.