### PR TITLE
docs(agents): document how to run the crew CLI from a local checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ IMPORTANT: You MUST read the relevant rule files below before writing or reviewi
 1. Use red, green, refactor test-driven development
 2. Validate changes with at least `node --run verify`
 3. Invoke core:go skill for ALL code changes
+4. To exercise the `crew` CLI against the local checkout, run it via the npm script: `node --run crew -- <args>` (e.g. `node --run crew -- cleanup HRD-442`). The globally-installed `crew` binary runs the published version and will not reflect your in-progress changes. See [Hacking on groundcrew](./README.md#hacking-on-groundcrew) for the `crew:op` 1Password variant.
 
 ### Vitest coverage ignores
 

--- a/OVERLAY.md
+++ b/OVERLAY.md
@@ -5,6 +5,7 @@
 1. Use red, green, refactor test-driven development
 2. Validate changes with at least `node --run verify`
 3. Invoke core:go skill for ALL code changes
+4. To exercise the `crew` CLI against the local checkout, run it via the npm script: `node --run crew -- <args>` (e.g. `node --run crew -- cleanup HRD-442`). The globally-installed `crew` binary runs the published version and will not reflect your in-progress changes. See [Hacking on groundcrew](./README.md#hacking-on-groundcrew) for the `crew:op` 1Password variant.
 
 ### Vitest coverage ignores
 


### PR DESCRIPTION
## Summary

- Adds a fourth item to the **Development workflow** list in `OVERLAY.md`, pointing agents (and humans skimming agent rules) at `node --run crew -- <args>` when exercising the CLI against a local checkout.
- Mirrors the same line into `AGENTS.md` so the change is visible immediately without running `node --run sync-ai-rules` (which requires `node_modules` to be installed).
- Links to the README's existing `Hacking on groundcrew` section instead of duplicating the `crew:op` 1Password variant — that keeps the agent rules terse and the README as the long-form reference.

## Why

Agents working in this repo kept defaulting to the globally-installed `crew` binary, which runs the published version and silently bypasses in-progress source changes. The README documents the `node --run crew -- <args>` pattern under `Hacking on groundcrew`, but `CLAUDE.md` → `AGENTS.md` does not surface it, so the rule never enters an agent's working context. Adding it to the agent-facing rule list closes that gap.

## Test plan

- [ ] Verify `OVERLAY.md` and `AGENTS.md` Development-workflow sections match item-for-item
- [ ] After running `npm install && node --run sync-ai-rules`, confirm `AGENTS.md` is unchanged (i.e., the manual mirror matches what the generator would produce)
- [ ] Sanity-check the README anchor `#hacking-on-groundcrew` still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)