### PR TITLE
fix: resolve bare repo name to full owner/repo in ticket descriptions

### DIFF
--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -244,6 +244,54 @@ describe(createBoardSource, () => {
       expect(first?.repository).toBe("api-admin");
     });
 
+    it("resolves bare repo name to full owner/repo when org is omitted from description", async () => {
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                description: "Affects security-alerts-agent somehow.",
+                labels: { nodes: [{ name: "agent-claude" }] },
+              }),
+            ],
+          ],
+        }),
+        makeConfig({
+          workspace: {
+            projectDir: "/work",
+            knownRepositories: ["ClipboardHealth/security-alerts-agent"],
+          },
+        }),
+      );
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.repository).toBe("ClipboardHealth/security-alerts-agent");
+    });
+
+    it("rejects when a bare repo name is ambiguous across multiple orgs", async () => {
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                description: "Touches shared-repo.",
+                labels: { nodes: [{ name: "agent-claude" }] },
+              }),
+            ],
+          ],
+        }),
+        makeConfig({
+          workspace: {
+            projectDir: "/work",
+            knownRepositories: ["OrgA/shared-repo", "OrgB/shared-repo"],
+          },
+        }),
+      );
+      await expect(source.fetch()).rejects.toThrow(
+        /No known repository found in ticket TEAM-1 description/,
+      );
+    });
+
     it("longer repository names beat shorter ones (api-admin vs api)", async () => {
       // Without the descending-length sort, `api` would match first.
       const { source } = makeBoardSource(

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -277,7 +277,11 @@ function escapeRegex(value: string): string {
 // must beat `api` when both are configured. `\b` treats `-` as a word
 // boundary, so without this ordering `api` would win on `api-admin`.
 function buildRepositoryRegex(config: ResolvedConfig): RegExp {
-  const alternation = config.workspace.knownRepositories
+  const candidates = config.workspace.knownRepositories.flatMap((repo) => {
+    const slashIndex = repo.indexOf("/");
+    return slashIndex === -1 ? [repo] : [repo, repo.slice(slashIndex + 1)];
+  });
+  const alternation = candidates
     .toSorted((a, b) => b.length - a.length)
     .map(escapeRegex)
     .join("|");
@@ -372,14 +376,28 @@ function parseRepository(arguments_: ParseRepositoryArguments): string {
       repositories: config.workspace.knownRepositories,
     });
   }
-  const repository = repositoryRegex.exec(description)?.[1];
-  if (repository === undefined) {
+  const matched = repositoryRegex.exec(description)?.[1];
+  if (matched === undefined) {
     throw new RepositoryResolutionError({
       ticket,
       repositories: config.workspace.knownRepositories,
     });
   }
-  return repository;
+  if (matched.includes("/")) {
+    return matched;
+  }
+  // Bare repo name matched — resolve to full owner/repo. Reject if ambiguous.
+  const candidates = config.workspace.knownRepositories.filter(
+    (r) => r === matched || r.endsWith(`/${matched}`),
+  );
+  const [resolved] = candidates;
+  if (candidates.length !== 1 || resolved === undefined) {
+    throw new RepositoryResolutionError({
+      ticket,
+      repositories: config.workspace.knownRepositories,
+    });
+  }
+  return resolved;
 }
 
 /**

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -383,21 +383,24 @@ function parseRepository(arguments_: ParseRepositoryArguments): string {
       repositories: config.workspace.knownRepositories,
     });
   }
-  if (matched.includes("/")) {
-    return matched;
-  }
-  // Bare repo name matched — resolve to full owner/repo. Reject if ambiguous.
+  // Resolve the match to a known repo. The regex may capture a bare repo name
+  // (no org prefix) when only that appears in the description; the filter
+  // handles both full "owner/repo" and bare "repo" matches. Reject if
+  // ambiguous (same bare name under multiple orgs).
   const candidates = config.workspace.knownRepositories.filter(
     (r) => r === matched || r.endsWith(`/${matched}`),
   );
-  const [resolved] = candidates;
-  if (candidates.length !== 1 || resolved === undefined) {
+  if (candidates.length !== 1) {
     throw new RepositoryResolutionError({
       ticket,
       repositories: config.workspace.knownRepositories,
     });
   }
-  return resolved;
+  /* v8 ignore next 3 @preserve -- candidates.length===1 guarantees [0] is defined */
+  if (candidates[0] === undefined) {
+    throw new Error("unreachable");
+  }
+  return candidates[0];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `buildRepositoryRegex` now adds bare repo names (the part after `/`) as regex alternatives alongside full `owner/repo` strings, so a ticket description can mention just `security-alerts-agent` instead of `ClipboardHealth/security-alerts-agent`
- `parseRepository` normalizes any match back to its full `owner/repo` by looking it up in `knownRepositories`; rejects with `RepositoryResolutionError` only when the bare name is ambiguous across multiple orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)