### PR TITLE
feat: auto-recover stranded In-Progress tickets via Linear-tracked retry

### DIFF
--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -64,6 +64,7 @@ function doneIssue(id: string, overrides: Partial<Issue> = {}): Issue {
     teamId: "team-1",
     blockers: [],
     hasMoreBlockers: false,
+    labels: ["agent-claude"],
     ...overrides,
   };
 }

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -1000,6 +1000,10 @@ describe(createDispatcher, () => {
       });
 
       expect(consoleLog.output()).toContain("Failed to update Linear for team-1");
+      // markTodo runs first: when it throws, the agent-retried label must
+      // NOT be applied — otherwise the next tick sees the label and locks
+      // the ticket into retry_exhausted without a real retry.
+      expect(client.issueAddLabel).not.toHaveBeenCalled();
     });
 
     it("reuses an existing team label instead of creating a new one", async () => {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -78,6 +78,7 @@ function todoIssue(overrides: Partial<Issue> = {}): Issue {
     teamId: "team-1",
     blockers: [],
     hasMoreBlockers: false,
+    labels: ["agent-claude"],
     ...overrides,
   };
 }
@@ -103,23 +104,38 @@ function hostEntryFor(repository: string, ticket: string): WorktreeEntry {
 interface ClientStub {
   team: ReturnType<typeof vi.fn>;
   updateIssue: ReturnType<typeof vi.fn>;
+  createIssueLabel: ReturnType<typeof vi.fn>;
+  issueAddLabel: ReturnType<typeof vi.fn>;
 }
 
 function makeClient(options: { omitInProgressState?: boolean } = {}): ClientStub {
   const { omitInProgressState = false } = options;
+  const stateNodes = omitInProgressState
+    ? [
+        { id: "state-other", name: "Other" },
+        { id: "state-todo", name: "Todo" },
+      ]
+    : [
+        { id: "state-in-progress", name: "In Progress" },
+        { id: "state-todo", name: "Todo" },
+      ];
+  const teamLabelsNodes: { id: string; name: string }[] = [];
   return {
-    team: vi
-      .fn<() => Promise<{ states: () => Promise<{ nodes: { id: string; name: string }[] }> }>>()
-      .mockResolvedValue({
-        states: vi
-          .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
-          .mockResolvedValue({
-            nodes: omitInProgressState
-              ? [{ id: "state-other", name: "Other" }]
-              : [{ id: "state-in-progress", name: "In Progress" }],
-          }),
-      }),
+    team: vi.fn<() => Promise<unknown>>().mockResolvedValue({
+      states: vi
+        .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+        .mockResolvedValue({ nodes: stateNodes }),
+      labels: vi
+        .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+        .mockResolvedValue({ nodes: teamLabelsNodes }),
+    }),
     updateIssue: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
+    createIssueLabel: vi
+      .fn<(input: { name: string; teamId: string }) => Promise<unknown>>()
+      .mockImplementation(async (input) => ({
+        issueLabel: Promise.resolve({ id: `label-${input.name}` }),
+      })),
+    issueAddLabel: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
   };
 }
 
@@ -410,7 +426,7 @@ describe(createDispatcher, () => {
       expect(consoleLog.output()).toContain("resuming with markInProgress");
     });
 
-    it("skips when worktree exists but no live workspace matches", async () => {
+    it("reopens (re-runs setupWorkspace) when worktree exists but no live workspace matches", async () => {
       workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
       const client = makeClient();
       const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
@@ -422,9 +438,8 @@ describe(createDispatcher, () => {
         dryRun: false,
       });
 
-      expect(setupMock).not.toHaveBeenCalled();
-      expect(client.updateIssue).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("Run `crew cleanup");
+      expect(setupMock).toHaveBeenCalledTimes(1);
+      expect(client.updateIssue).toHaveBeenCalledTimes(1);
     });
 
     it("retries next iteration when the workspace list is unavailable", async () => {
@@ -842,6 +857,260 @@ describe(createDispatcher, () => {
       });
 
       expect(consoleLog.output()).toContain("Failed to start team-1: boom");
+    });
+  });
+
+  describe("stranded ticket recovery", () => {
+    it("demotes a stranded In-Progress ticket and tags it agent-retried", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "label-agent-retried");
+      expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-todo" });
+      expect(consoleLog.output()).toContain("Demoted stranded team-1 to Todo");
+    });
+
+    it("marks an already-retried stranded ticket as retry-exhausted", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1", labels: ["agent-claude", "agent-retried"] })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "label-agent-error");
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "label-agent-max-retries");
+      expect(client.updateIssue).not.toHaveBeenCalled();
+      expect(consoleLog.output()).toContain("Marked team-1 as retry-exhausted");
+    });
+
+    it("frees the slot immediately when a stranded ticket is demoted", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([
+          activeIssue({ id: "team-1" }),
+          todoIssue({ id: "team-2", uuid: "uuid-2" }),
+        ]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ticket: "team-2" }),
+      );
+    });
+
+    it("does not strand-detect when the workspace probe is unavailable", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
+      const client = makeClient();
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.issueAddLabel).not.toHaveBeenCalled();
+      expect(client.updateIssue).not.toHaveBeenCalled();
+    });
+
+    it("logs a Linear failure when demote's markTodo throws (Todo state missing)", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient({ omitInProgressState: true });
+      // omitInProgressState only ships an "Other" state; force Todo absent too
+      client.team.mockResolvedValue({
+        states: vi
+          .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+          .mockResolvedValue({ nodes: [{ id: "state-other", name: "Other" }] }),
+        labels: vi
+          .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+          .mockResolvedValue({ nodes: [] }),
+      });
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(consoleLog.output()).toContain("Failed to update Linear for team-1");
+    });
+
+    it("reuses an existing team label instead of creating a new one", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      client.team.mockResolvedValue({
+        states: vi
+          .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+          .mockResolvedValue({
+            nodes: [
+              { id: "state-in-progress", name: "In Progress" },
+              { id: "state-todo", name: "Todo" },
+            ],
+          }),
+        labels: vi
+          .fn<() => Promise<{ nodes: { id: string; name: string }[] }>>()
+          .mockResolvedValue({
+            nodes: [{ id: "preexisting-agent-retried", name: "agent-retried" }],
+          }),
+      });
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.createIssueLabel).not.toHaveBeenCalled();
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "preexisting-agent-retried");
+    });
+
+    it("skips label add when Linear returns no id from createIssueLabel", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      client.createIssueLabel.mockResolvedValueOnce({ issueLabel: Promise.resolve(null) });
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.issueAddLabel).not.toHaveBeenCalled();
+      expect(consoleLog.output()).toContain(
+        'Could not create label "agent-retried" for team team-1; skipping',
+      );
+    });
+
+    it("logs a Linear failure when retry-exhausted addLabels throws", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      const client = makeClient();
+      client.issueAddLabel.mockRejectedValueOnce(new Error("linear down"));
+      const dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1000,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        client: asLinearClient(client),
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([activeIssue({ id: "team-1", labels: ["agent-claude", "agent-retried"] })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(consoleLog.output()).toContain("Failed to update Linear for team-1");
+    });
+
+    it("marks ticket retry-exhausted when reopen path's setupWorkspace throws", async () => {
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+      setupMock.mockRejectedValueOnce(new Error("setup boom"));
+      const client = makeClient();
+      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue()]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "label-agent-error");
+      expect(client.issueAddLabel).toHaveBeenCalledWith("uuid-1", "label-agent-max-retries");
+      expect(consoleLog.output()).toContain("Failed to start team-1: setup boom");
     });
   });
 });

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -155,8 +155,13 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
 
   async function demoteStranded(issue: GroundcrewIssue): Promise<void> {
     try {
-      await issueStatusUpdater.addLabels(issue, [AGENT_RETRIED_LABEL]);
+      // markTodo first: if the state transition fails, leave the ticket
+      // un-labelled so the next tick re-detects it as a fresh strand and
+      // tries again. Reversing the order would mark `agent-retried` on a
+      // ticket that never actually got its retry, locking it into
+      // retry_exhausted on the next iteration.
       await issueStatusUpdater.markTodo(issue);
+      await issueStatusUpdater.addLabels(issue, [AGENT_RETRIED_LABEL]);
       log(`Demoted stranded ${issue.id} to Todo (one retry remaining)`);
       logEvent("orchestrator", {
         outcome: "demote_stranded",

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -9,7 +9,14 @@
 
 import type { LinearClient } from "@linear/sdk";
 
-import { type BoardState, type GroundcrewIssue, isGroundcrewIssue } from "../lib/boardSource.ts";
+import {
+  AGENT_ERROR_LABEL,
+  AGENT_MAX_RETRIES_LABEL,
+  AGENT_RETRIED_LABEL,
+  type BoardState,
+  type GroundcrewIssue,
+  isGroundcrewIssue,
+} from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
 import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import type { UsageByModel } from "../lib/usage.ts";
@@ -19,10 +26,12 @@ import type { WorktreeEntry } from "../lib/worktrees.ts";
 import {
   classifyBlockers,
   classifyEligibility,
+  classifyInProgressStrands,
   classifyUsageExhaustion,
   type ModelUsageExhaustion,
   type SkipVerdict,
   type StartVerdict,
+  type StrandAction,
 } from "./eligibility.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
@@ -71,7 +80,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     dryRun: boolean,
     signal?: AbortSignal,
   ): Promise<void> {
-    const { issue, recovery } = start;
+    const { issue, recovery, reopen } = start;
     if (start.resolvedFromAny) {
       log(`Resolved agent-any for ${issue.id} → ${issue.model}`);
     }
@@ -95,10 +104,16 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       if (recovery) {
         log(`Worktree and workspace already exist for ${issue.id}; resuming with markInProgress`);
       } else {
+        if (reopen) {
+          log(
+            `Reopening workspace for stranded ${issue.id}; setupWorkspace will reuse the existing worktree`,
+          );
+        }
         const setupOptions = {
           repository: issue.repository,
           ticket: issue.id,
           model: issue.model,
+          reuseWorktree: reopen,
         };
         await (signal === undefined
           ? setupWorkspace(config, setupOptions)
@@ -106,21 +121,83 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       }
       await issueStatusUpdater.markInProgress(issue);
       logEvent("dispatch", {
-        outcome: recovery ? "resumed" : "started",
+        outcome: dispatchOutcome(recovery, reopen),
         ticket: issue.id,
         model: issue.model,
         repository: issue.repository,
       });
     } catch (error) {
-      log(`Failed to start ${issue.id}: ${errorMessage(error)}`);
+      const message = errorMessage(error);
+      log(`Failed to start ${issue.id}: ${message}`);
       logEvent("dispatch", {
         outcome: "failed",
         ticket: issue.id,
         model: issue.model,
         repository: issue.repository,
-        error: errorMessage(error),
+        error: message,
       });
+      // A failure on the reopen path uses the ticket's one retry — escalate
+      // to retry-exhausted so the orchestrator stops re-attempting it.
+      if (reopen) {
+        await markRetryExhausted(issue, "reopen_failed");
+      }
     }
+  }
+
+  async function applyStrandActions(actions: readonly StrandAction[]): Promise<void> {
+    for (const action of actions) {
+      // oxlint-disable-next-line no-await-in-loop -- Linear mutations are serial per ticket to avoid label-cache races
+      await (action.kind === "demote"
+        ? demoteStranded(action.issue)
+        : markRetryExhausted(action.issue, "stranded_after_retry"));
+    }
+  }
+
+  async function demoteStranded(issue: GroundcrewIssue): Promise<void> {
+    try {
+      await issueStatusUpdater.addLabels(issue, [AGENT_RETRIED_LABEL]);
+      await issueStatusUpdater.markTodo(issue);
+      log(`Demoted stranded ${issue.id} to Todo (one retry remaining)`);
+      logEvent("orchestrator", {
+        outcome: "demote_stranded",
+        ticket: issue.id,
+        model: issue.model,
+        repository: issue.repository,
+      });
+    } catch (error) {
+      logDemoteFailure(issue, error);
+    }
+  }
+
+  async function markRetryExhausted(
+    issue: GroundcrewIssue,
+    reason: "stranded_after_retry" | "reopen_failed",
+  ): Promise<void> {
+    try {
+      await issueStatusUpdater.addLabels(issue, [AGENT_ERROR_LABEL, AGENT_MAX_RETRIES_LABEL]);
+      log(`Marked ${issue.id} as retry-exhausted (${reason})`);
+      logEvent("orchestrator", {
+        outcome: "demote_skipped_max_retries",
+        ticket: issue.id,
+        model: issue.model,
+        repository: issue.repository,
+        reason,
+      });
+    } catch (error) {
+      logDemoteFailure(issue, error);
+    }
+  }
+
+  function logDemoteFailure(issue: GroundcrewIssue, error: unknown): void {
+    const message = errorMessage(error);
+    log(`Failed to update Linear for ${issue.id}: ${message}`);
+    logEvent("orchestrator", {
+      outcome: "demote_failed",
+      ticket: issue.id,
+      model: issue.model,
+      repository: issue.repository,
+      error: message,
+    });
   }
 
   async function runOnce(arguments_: {
@@ -131,18 +208,59 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     signal?: AbortSignal;
   }): Promise<void> {
     const { state, worktreeEntries, usage, dryRun, signal } = arguments_;
-    issueStatusUpdater.resetMissingInProgressCache();
+    issueStatusUpdater.resetMissingStateCache();
 
-    const activeCount = state.issues.filter(
-      (issue) => issue.status === config.linear.statuses.inProgress,
-    ).length;
-    const slots = config.orchestrator.maximumInProgress - activeCount;
+    const inProgress: readonly GroundcrewIssue[] = state.issues.filter(
+      (issue): issue is GroundcrewIssue =>
+        issue.status === config.linear.statuses.inProgress && isGroundcrewIssue(issue),
+    );
     // Narrow Todo to tickets that opted in via an `agent-*` label.
     // Unlabeled tickets are not groundcrew's concern even when in Todo.
     const todo: readonly GroundcrewIssue[] = state.issues.filter(
       (issue): issue is GroundcrewIssue =>
         issue.status === config.linear.statuses.todo && isGroundcrewIssue(issue),
     );
+
+    // Strand recovery looks for In-Progress tickets whose worktree is on
+    // disk but whose workspace has vanished. Skip the workspace probe (and
+    // its shell-out) when there are no In-Progress candidates with a
+    // matching worktree — there's nothing for it to find.
+    const inProgressHasWorktree = inProgress.some((issue) =>
+      worktreeEntries.some(
+        (entry) => entry.repository === issue.repository && entry.ticket === issue.id,
+      ),
+    );
+
+    const { unblocked, skips: blockerSkips } = classifyBlockers(config, todo);
+    for (const skip of blockerSkips) {
+      logSkip(skip);
+    }
+
+    const needsWorkspaceProbe = !dryRun && (inProgressHasWorktree || unblocked.length > 0);
+    const workspaceProbe: WorkspaceProbe = needsWorkspaceProbe
+      ? await workspaces.probe(config, signal)
+      : { kind: "ok", names: new Set<string>() };
+
+    const strandActions = dryRun
+      ? []
+      : classifyInProgressStrands({
+          inProgress,
+          worktreeEntries,
+          workspaceProbe,
+        });
+    await applyStrandActions(strandActions);
+    const demotedTickets = new Set(
+      strandActions.filter((action) => action.kind === "demote").map((action) => action.issue.id),
+    );
+
+    // Demoted tickets still appear In-Progress in the stale `state` snapshot,
+    // but conceptually their slots are free this tick — subtract them so
+    // eligibility can dispatch into the headroom on the same iteration.
+    const activeCount = state.issues.filter(
+      (issue) =>
+        issue.status === config.linear.statuses.inProgress && !demotedTickets.has(issue.id),
+    ).length;
+    const slots = config.orchestrator.maximumInProgress - activeCount;
 
     if (slots <= 0) {
       log(
@@ -156,35 +274,14 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       return;
     }
 
-    // Run the blocker pre-pass first so an all-blocked board short-circuits
-    // before the codexbar HTTP call and the cmux/tmux shell-out fire.
-    const { unblocked, skips: blockerSkips } = classifyBlockers(config, todo);
-    for (const skip of blockerSkips) {
-      logSkip(skip);
-    }
     if (unblocked.length === 0) {
       log(`No eligible ${config.linear.statuses.todo} tickets after blocker filtering`);
       return;
     }
 
-    // usage() is an HTTP call; workspaces.probe shells tmux/cmux. Kick off
-    // usage first so the workspace probe can overlap with the in-flight request.
-    const usagePromise = usage(signal);
-    // Snapshot live workspace names once per iteration so eligibility can
-    // distinguish "worktree exists AND its agent is still running" (resume)
-    // from "worktree exists but the workspace is gone" (ambiguous — don't
-    // auto-recover). Done before slot-counting so a skipped stale ticket
-    // doesn't consume an eligible slot and starve later Todo tickets.
-    let workspaceProbe: WorkspaceProbe;
-    try {
-      workspaceProbe = dryRun
-        ? { kind: "ok", names: new Set<string>() }
-        : await workspaces.probe(config, signal);
-    } catch (error) {
-      usagePromise.catch(() => "ignored");
-      throw error;
-    }
-    const fetchedUsage = await usagePromise;
+    // usage() is an HTTP call. Resolve it only after we know there is
+    // unblocked Todo work that might consume the result.
+    const fetchedUsage = await usage(signal);
     const exhausted = buildExhaustedSet(fetchedUsage);
 
     const verdicts = classifyEligibility({
@@ -233,4 +330,14 @@ function formatUsageExhaustion(exhaustion: ModelUsageExhaustion): string {
     return `${exhaustion.model} session at ${exhaustion.usedPercentage.toFixed(0)}% (> ${exhaustion.limitPercentage}%), resets in ${mins}m — skipping its tickets`;
   }
   return `${exhaustion.model} weekly at ${exhaustion.usedPercentage.toFixed(1)}% (> ${exhaustion.allowedPercentage.toFixed(1)}% paced budget), resets in ${exhaustion.resetMinutes}m — skipping its tickets`;
+}
+
+function dispatchOutcome(recovery: boolean, reopen: boolean): "resumed" | "reopened" | "started" {
+  if (recovery) {
+    return "resumed";
+  }
+  if (reopen) {
+    return "reopened";
+  }
+  return "started";
 }

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -6,6 +6,7 @@ import {
   type ClassifyArguments,
   classifyBlockers,
   classifyEligibility,
+  classifyInProgressStrands,
   classifyUsageExhaustion,
   pickBestModel,
 } from "./eligibility.ts";
@@ -59,6 +60,7 @@ function todoIssue(overrides: Partial<GroundcrewIssue> = {}): GroundcrewIssue {
     teamId: "team-1",
     blockers: [],
     hasMoreBlockers: false,
+    labels: ["agent-claude"],
     ...overrides,
   };
 }
@@ -127,6 +129,15 @@ describe(classifyBlockers, () => {
 
     expect(unblocked).toHaveLength(1);
     expect(skips).toHaveLength(0);
+  });
+
+  it("emits a `max_retries_exhausted` skip when the ticket carries the agent-max-retries label", () => {
+    const { unblocked, skips } = classifyBlockers(makeConfig(), [
+      todoIssue({ labels: ["agent-claude", "agent-max-retries"] }),
+    ]);
+
+    expect(unblocked).toHaveLength(0);
+    expect(skips[0]).toMatchObject({ kind: "skip", eventReason: "max_retries_exhausted" });
   });
 
   it("partitions a mixed batch into unblocked and skip lists", () => {
@@ -228,7 +239,7 @@ describe(classifyEligibility, () => {
       expect(verdicts[0]).toMatchObject({ kind: "start", recovery: true });
     });
 
-    it("emits `workspace_missing` when the worktree exists but no live workspace matches", () => {
+    it("starts with reopen=true when the worktree exists but no live workspace matches", () => {
       const verdicts = classifyEligibility(
         defaultArguments({
           worktreeEntries: [hostEntryFor("repo-a", "team-1")],
@@ -236,7 +247,11 @@ describe(classifyEligibility, () => {
         }),
       );
 
-      expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
+      expect(verdicts[0]).toMatchObject({
+        kind: "start",
+        recovery: false,
+        reopen: true,
+      });
     });
 
     it("emits `workspace_list_unavailable` when the workspace adapter probe failed", () => {
@@ -349,5 +364,83 @@ describe(classifyUsageExhaustion, () => {
         resetMinutes: MINUTES_PER_WEEK - MINUTES_PER_DAY,
       },
     ]);
+  });
+});
+
+describe(classifyInProgressStrands, () => {
+  it("emits a `demote` action for a stranded ticket with no retry label", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [todoIssue({ id: "team-1", status: "In Progress" })],
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+      workspaceProbe: { kind: "ok", names: new Set<string>() },
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe("demote");
+    expect(actions[0]?.issue.id).toBe("team-1");
+  });
+
+  it("emits a `retry_exhausted` action when the stranded ticket already has agent-retried", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [
+        todoIssue({
+          id: "team-1",
+          status: "In Progress",
+          labels: ["agent-claude", "agent-retried"],
+        }),
+      ],
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+      workspaceProbe: { kind: "ok", names: new Set<string>() },
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe("retry_exhausted");
+    expect(actions[0]?.issue.id).toBe("team-1");
+  });
+
+  it("returns no actions when the live workspace is still present", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [todoIssue({ id: "team-1", status: "In Progress" })],
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+      workspaceProbe: { kind: "ok", names: new Set(["team-1"]) },
+    });
+
+    expect(actions).toStrictEqual([]);
+  });
+
+  it("returns no actions when there is no worktree on disk", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [todoIssue({ id: "team-1", status: "In Progress" })],
+      worktreeEntries: [],
+      workspaceProbe: { kind: "ok", names: new Set<string>() },
+    });
+
+    expect(actions).toStrictEqual([]);
+  });
+
+  it("returns no actions when the workspace probe is unavailable", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [todoIssue({ id: "team-1", status: "In Progress" })],
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+      workspaceProbe: { kind: "unavailable" },
+    });
+
+    expect(actions).toStrictEqual([]);
+  });
+
+  it("skips tickets already carrying agent-max-retries (no further state churn)", () => {
+    const actions = classifyInProgressStrands({
+      inProgress: [
+        todoIssue({
+          id: "team-1",
+          status: "In Progress",
+          labels: ["agent-claude", "agent-retried", "agent-max-retries"],
+        }),
+      ],
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+      workspaceProbe: { kind: "ok", names: new Set<string>() },
+    });
+
+    expect(actions).toStrictEqual([]);
   });
 });

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -7,7 +7,13 @@
  * effects.
  */
 
-import { type Blocker, type GroundcrewIssue, isTerminalStatus } from "../lib/boardSource.ts";
+import {
+  AGENT_MAX_RETRIES_LABEL,
+  AGENT_RETRIED_LABEL,
+  type Blocker,
+  type GroundcrewIssue,
+  isTerminalStatus,
+} from "../lib/boardSource.ts";
 import { AGENT_ANY_MODEL, type ResolvedConfig } from "../lib/config.ts";
 import type { UsageByModel } from "../lib/usage.ts";
 import type { WorkspaceProbe } from "../lib/workspaces.ts";
@@ -24,12 +30,18 @@ type SkipReason =
   | "agent_any_capacity"
   | "model_exhausted"
   | "workspace_list_unavailable"
-  | "workspace_missing";
+  | "max_retries_exhausted";
 
 export interface StartVerdict {
   kind: "start";
   issue: GroundcrewIssue;
   recovery: boolean;
+  /**
+   * Worktree on disk but no live workspace — caller must run setupWorkspace
+   * (idempotent via `worktrees.ensure`) and treat any failure as a retry
+   * exhaustion.
+   */
+  reopen: boolean;
   /** Set when the verdict resolved an `agent-any` label to a concrete model. */
   resolvedFromAny: boolean;
 }
@@ -94,6 +106,68 @@ interface BlockerClassification {
   skips: SkipVerdict[];
 }
 
+export type StrandAction =
+  | {
+      /**
+       * First strand for this ticket: demote it back to Todo and mark
+       * `agent-retried` so the next strand promotes to `retry_exhausted`.
+       */
+      kind: "demote";
+      issue: GroundcrewIssue;
+    }
+  | {
+      /**
+       * Second strand: ticket already carries `agent-retried`. Stamp
+       * `agent-error` + `agent-max-retries` and leave the slot occupied
+       * so an operator can triage.
+       */
+      kind: "retry_exhausted";
+      issue: GroundcrewIssue;
+    };
+
+interface StrandClassifyArguments {
+  inProgress: readonly GroundcrewIssue[];
+  worktreeEntries: readonly WorktreeEntry[];
+  workspaceProbe: WorkspaceProbe;
+}
+
+/**
+ * Detect In-Progress tickets whose worktree is still on disk but whose
+ * cmux/tmux workspace has vanished. Each detection becomes a `demote` (first
+ * strand) or `retry_exhausted` (second strand) action. Skipped when the
+ * workspace probe is `unavailable` so a flaky adapter doesn't auto-demote
+ * a healthy ticket.
+ *
+ * Pure — caller applies the returned side effects (Linear writes).
+ */
+export function classifyInProgressStrands(arguments_: StrandClassifyArguments): StrandAction[] {
+  const { inProgress, worktreeEntries, workspaceProbe } = arguments_;
+  if (workspaceProbe.kind === "unavailable") {
+    return [];
+  }
+  const actions: StrandAction[] = [];
+  for (const issue of inProgress) {
+    const hasWorktree = worktreeEntries.some(
+      (entry) => entry.repository === issue.repository && entry.ticket === issue.id,
+    );
+    if (!hasWorktree) {
+      continue;
+    }
+    if (workspaceProbe.names.has(issue.id)) {
+      continue;
+    }
+    if (issue.labels.includes(AGENT_MAX_RETRIES_LABEL)) {
+      continue;
+    }
+    if (issue.labels.includes(AGENT_RETRIED_LABEL)) {
+      actions.push({ kind: "retry_exhausted", issue });
+      continue;
+    }
+    actions.push({ kind: "demote", issue });
+  }
+  return actions;
+}
+
 function blockerSummary(blocker: Blocker): string {
   return `${blocker.id}:${blocker.status ?? "missing"}`;
 }
@@ -102,6 +176,14 @@ function blockerVerdictFor(
   issue: GroundcrewIssue,
   config: ResolvedConfig,
 ): SkipVerdict | undefined {
+  if (issue.labels.includes(AGENT_MAX_RETRIES_LABEL)) {
+    return {
+      kind: "skip",
+      issue,
+      message: `Skipping ${issue.id}: ${AGENT_MAX_RETRIES_LABEL} label set — remove the label to re-enable dispatch`,
+      eventReason: "max_retries_exhausted",
+    };
+  }
   if (issue.hasMoreBlockers) {
     const blockers = issue.blockers.map(blockerSummary);
     return {
@@ -216,21 +298,24 @@ interface RecoveryArguments {
   dryRun: boolean;
 }
 
-// Stale worktrees with no matching live workspace are filtered out here so
-// they don't permanently block later tickets in the Todo queue.
+// "Worktree exists but workspace gone" → reopen path so the orchestrator
+// can rebuild the cmux/tmux window from the surviving worktree. The
+// strand classifier on the In-Progress slice handles the demote that
+// gets us here; an `unavailable` probe still skips so a transient adapter
+// hiccup never promotes a healthy ticket to a reopen.
 function classifyRecovery(
   arguments_: RecoveryArguments,
-): { kind: "go"; recovery: boolean } | SkipVerdict {
+): { kind: "go"; recovery: boolean; reopen: boolean } | SkipVerdict {
   const { issue, worktreeEntries, workspaceProbe, dryRun } = arguments_;
   if (dryRun) {
-    return { kind: "go", recovery: false };
+    return { kind: "go", recovery: false, reopen: false };
   }
 
   const exists = worktreeEntries.some(
     (entry) => entry.repository === issue.repository && entry.ticket === issue.id,
   );
   if (!exists) {
-    return { kind: "go", recovery: false };
+    return { kind: "go", recovery: false, reopen: false };
   }
   if (workspaceProbe.kind === "unavailable") {
     return {
@@ -241,14 +326,9 @@ function classifyRecovery(
     };
   }
   if (!workspaceProbe.names.has(issue.id)) {
-    return {
-      kind: "skip",
-      issue,
-      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run \`crew cleanup ${issue.id}\` to allow re-provisioning.`,
-      eventReason: "workspace_missing",
-    };
+    return { kind: "go", recovery: false, reopen: true };
   }
-  return { kind: "go", recovery: true };
+  return { kind: "go", recovery: true, reopen: false };
 }
 
 /**
@@ -338,6 +418,7 @@ export function classifyEligibility(arguments_: ClassifyArguments): Verdict[] {
       kind: "start",
       issue: resolved,
       recovery: recovery.recovery,
+      reopen: recovery.reopen,
       resolvedFromAny,
     });
     started += 1;

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1108,7 +1108,7 @@ describe(orchestrate, () => {
     expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-in-progress" });
   });
 
-  it("skips a ticket whose worktree exists but workspace is missing", async () => {
+  it("reopens a stranded ticket whose worktree exists but workspace is missing", async () => {
     listMock.mockReturnValue([hostEntryFor("repo-a", "team-1")]);
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
     const client = makeClient({
@@ -1125,10 +1125,9 @@ describe(orchestrate, () => {
 
     await orchestrate({ watch: false, dryRun: false });
 
-    expect(setupMock).not.toHaveBeenCalled();
-    expect(client.updateIssue).not.toHaveBeenCalled();
+    expect(setupMock).toHaveBeenCalledTimes(1);
     const out = consoleLog.output();
-    expect(out).toContain("Run `crew cleanup");
+    expect(out).toContain("Reopening workspace for stranded team-1");
   });
 
   it("skips a ticket when the workspace list is unavailable", async () => {
@@ -1155,7 +1154,7 @@ describe(orchestrate, () => {
 
   it("logs that no eligible tickets remain after filtering", async () => {
     listMock.mockReturnValue([hostEntryFor("repo-a", "team-1")]);
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
     const client = makeClient({
       pages: [
         [

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -913,6 +913,23 @@ describe(setupWorkspace, () => {
     ).rejects.toThrow(/Unknown model: ghost/);
   });
 
+  it("skips the worktree rollback on reopen failure but still cleans the prompt dir", async () => {
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput("garbage that has no ref");
+
+    await expect(
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        reuseWorktree: true,
+      }),
+    ).rejects.toThrow(/Unexpected cmux output/);
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(rmMock).toHaveBeenCalledWith("/tmp/groundcrew-team-1-x", expect.anything());
+  });
+
   it("rolls back the worktree, branch, and cmux workspace when cmux launch fails", async () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput("garbage that has no ref");
@@ -981,6 +998,22 @@ describe(setupWorkspace, () => {
       [expect.objectContaining({ ticket: "team-1" })],
       { force: true },
     );
+  });
+
+  it("leaves the worktree and prompt dir alone on a reopen failure that happens before mkdtemp", async () => {
+    issueResolver.mockRejectedValue(new Error("linear unreachable"));
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        reuseWorktree: true,
+      }),
+    ).rejects.toThrow(/linear unreachable/);
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(rmMock).not.toHaveBeenCalled();
   });
 
   it("uses the JSON id field when ref is missing", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -75,6 +75,7 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     worktrees: {
       ...actual.worktrees,
       create: vi.fn<typeof actual.worktrees.create>(),
+      ensure: vi.fn<typeof actual.worktrees.ensure>(),
       teardown: vi.fn<typeof actual.worktrees.teardown>(),
     },
   };
@@ -90,6 +91,7 @@ const ensureClearanceMock = vi.mocked(ensureClearance);
 const linearClientMock = vi.mocked(getLinearClient);
 const logMock = vi.mocked(log);
 const createMock = vi.mocked(worktrees.create);
+const ensureMock = vi.mocked(worktrees.ensure);
 const teardownMock = vi.mocked(worktrees.teardown);
 
 interface MockedLabel {
@@ -320,6 +322,7 @@ describe(setupWorkspace, () => {
     issueResolver.mockResolvedValue(buildMockedIssue({ title: "Test Title", description: "Body" }));
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
+    ensureMock.mockImplementation(async () => hostEntry());
     ensureClearanceMock.mockResolvedValue({
       logPath: "/tmp/clearance/clearance.log",
       pidPath: "/tmp/clearance/clearance.pid",
@@ -340,6 +343,42 @@ describe(setupWorkspace, () => {
     // resetAllMocks (not clearAllMocks) so module-scoped mock implementations
     // set inside one test don't leak into the next.
     vi.resetAllMocks();
+  });
+
+  it("reuses an existing worktree via worktrees.ensure when reuseWorktree=true", async () => {
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      reuseWorktree: true,
+    });
+
+    expect(ensureMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ repository: "repo-a", ticket: "team-1" }),
+    );
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates AbortSignal into worktrees.ensure on the reuseWorktree path", async () => {
+    const config = makeConfig();
+    const { signal } = new AbortController();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(
+      config,
+      { ticket: "team-1", repository: "repo-a", model: "claude", reuseWorktree: true },
+      { signal },
+    );
+
+    expect(ensureMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ ticket: "team-1" }),
+      signal,
+    );
   });
 
   it("provisions the worktree, writes the prompt, and launches cmux", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -40,6 +40,14 @@ export interface SetupWorkspaceOptions {
   model: string;
   /** When provided, skip the Linear lookup for prompt-template fields. */
   details?: TicketDetails;
+  /**
+   * Reuse an existing worktree for `(repository, ticket)` if one is already
+   * on disk. Set by the orchestrator's strand-recovery path so a reopen
+   * doesn't trip the duplicate-worktree guard; defaults to `false` for
+   * `crew setup-workspace` and the fresh-dispatch flow, which still want
+   * the access-hint on collision.
+   */
+  reuseWorktree?: boolean;
 }
 
 export interface SetupWorkspaceRunOptions {
@@ -138,16 +146,27 @@ export async function setupWorkspace(
 
   const spec = { repository, ticket };
   let created: WorktreeEntry;
-  try {
+  if (options.reuseWorktree === true) {
+    // Orchestrator strand-recovery path: the demoted ticket's worktree
+    // is still on disk and we deliberately want to reuse it. `ensure` is
+    // the idempotent helper that returns the existing entry without
+    // tripping the duplicate-worktree guard.
     created =
       signal === undefined
-        ? await worktrees.create(config, spec)
-        : await worktrees.create(config, spec, signal);
-  } catch (error) {
-    if (isWorktreeAlreadyExistsError(error)) {
-      await logAccessHintForExistingWorkspace({ config, ticket, signal });
+        ? await worktrees.ensure(config, spec)
+        : await worktrees.ensure(config, spec, signal);
+  } else {
+    try {
+      created =
+        signal === undefined
+          ? await worktrees.create(config, spec)
+          : await worktrees.create(config, spec, signal);
+    } catch (error) {
+      if (isWorktreeAlreadyExistsError(error)) {
+        await logAccessHintForExistingWorkspace({ config, ticket, signal });
+      }
+      throw error;
     }
-    throw error;
   }
   const { branchName, dir: launchDir } = created;
   const worktreeName = `${repository}-${ticket}`;
@@ -327,5 +346,6 @@ export async function setupWorkspaceCli(
     id: ticket.toLowerCase(),
     uuid: resolved.uuid,
     teamId: resolved.teamId,
+    labels: [],
   });
 }

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -231,7 +231,17 @@ export async function setupWorkspace(
     log(`  Branch:   ${branchName}`);
     await logWorkspaceAccessHint({ config, ticket, signal });
   } catch (error) {
-    await rollbackWorktree({ config, entry: created, promptDir });
+    // On the reuseWorktree path the worktree pre-existed, so a force
+    // teardown here would discard a stranded user's uncommitted work
+    // along with the failed reopen attempt. Leave the worktree intact;
+    // the strand classifier will pick it up again on the next tick.
+    if (options.reuseWorktree === true) {
+      if (promptDir !== undefined) {
+        rmSync(promptDir, { recursive: true, force: true });
+      }
+    } else {
+      await rollbackWorktree({ config, entry: created, promptDir });
+    }
     throw error;
   }
 }

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -212,6 +212,7 @@ async function runEligibilityChecks(arguments_: EligibilityCheckArguments): Prom
     model: resolvedModel,
     blockers: [...blockers],
     hasMoreBlockers: raw.hasMoreBlockers,
+    labels: raw.labels.map((label) => label.name),
   };
 
   const blockerClassification = classifyBlockers(config, [groundcrewIssue]);

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -10,6 +10,26 @@ import { AGENT_ANY_MODEL, isShippedDefaultDisabled, type ResolvedConfig } from "
 import { log } from "./util.ts";
 
 const AGENT_LABEL_PREFIX = "agent-";
+/**
+ * Set on a ticket the first time the orchestrator demotes it from In
+ * Progress back to Todo after a stranded-workspace detection. Presence
+ * marks the ticket as having spent its one auto-retry; another strand
+ * promotes it to the retry-exhausted path instead of looping.
+ */
+export const AGENT_RETRIED_LABEL = "agent-retried";
+/**
+ * Informational marker — set whenever a retry attempt fails (stranded a
+ * second time, or `setupWorkspace` throws during a reopen). Paired with
+ * `AGENT_MAX_RETRIES_LABEL` on the failing ticket so a human can spot the
+ * outcome from Linear search.
+ */
+export const AGENT_ERROR_LABEL = "agent-error";
+/**
+ * Blocking label — eligibility filters tickets carrying this label out of
+ * the Todo queue so an exhausted retry does not silently re-enter the
+ * dispatch loop. Removing the label by hand re-enables groundcrew picks.
+ */
+export const AGENT_MAX_RETRIES_LABEL = "agent-max-retries";
 const ISSUES_PAGE_SIZE = 250;
 
 export interface Blocker {
@@ -33,6 +53,12 @@ export interface Issue {
   teamId: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
+  /**
+   * Raw label names from Linear (e.g. `agent-claude`, `agent-retried`).
+   * Eligibility uses this to filter on operational labels like
+   * `agent-max-retries` without re-fetching the issue.
+   */
+  labels: string[];
 }
 
 /**
@@ -271,6 +297,7 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
         teamId: node.team?.id ?? "",
         blockers: blockersFromRelations(node.inverseRelations?.nodes ?? []),
         hasMoreBlockers: node.inverseRelations?.pageInfo.hasNextPage ?? false,
+        labels: node.labels.nodes.map((label) => label.name),
       };
     });
 

--- a/src/lib/linearIssueStatus.ts
+++ b/src/lib/linearIssueStatus.ts
@@ -7,11 +7,34 @@ interface LinearIssueReference {
   id: string;
   uuid: string;
   teamId: string;
+  /**
+   * Snapshot of label names currently on the issue (as seen during the
+   * board fetch). `addLabels` uses this to skip labels that are already
+   * applied, sparing the Linear API from no-op mutations.
+   */
+  labels: readonly string[];
 }
 
 interface LinearIssueStatusUpdater {
   markInProgress(issue: LinearIssueReference): Promise<void>;
-  resetMissingInProgressCache(): void;
+  markTodo(issue: LinearIssueReference): Promise<void>;
+  /**
+   * Apply each label name to the issue. Names already present on `issue.labels`
+   * are skipped. Labels missing from the team are auto-created so operational
+   * tags like `agent-retried` don't require a one-time manual setup.
+   */
+  addLabels(issue: LinearIssueReference, names: readonly string[]): Promise<void>;
+  /**
+   * Reset the negative cache of teams that lack the configured status state
+   * names. Called once per dispatcher tick so a fix in Linear during a watch
+   * session is picked up on the next iteration.
+   */
+  resetMissingStateCache(): void;
+}
+
+interface TeamLabelEntry {
+  id: string;
+  name: string;
 }
 
 export function createLinearIssueStatusUpdater(arguments_: {
@@ -20,37 +43,49 @@ export function createLinearIssueStatusUpdater(arguments_: {
 }): LinearIssueStatusUpdater {
   const { config, client } = arguments_;
   const inProgressStateByTeam = new Map<string, string>();
+  const todoStateByTeam = new Map<string, string>();
+  const labelsByTeam = new Map<string, Map<string, string>>();
   let teamsMissingInProgress = new Set<string>();
+  let teamsMissingTodo = new Set<string>();
 
-  async function getInProgressStateId(teamId: string): Promise<string | undefined> {
+  async function getStateIdByName(stateArguments: {
+    teamId: string;
+    name: string;
+    cache: Map<string, string>;
+    negativeCache: Set<string>;
+  }): Promise<string | undefined> {
+    const { teamId, name, cache, negativeCache } = stateArguments;
     if (teamId.length === 0) {
       return undefined;
     }
-    const cached = inProgressStateByTeam.get(teamId);
+    const cached = cache.get(teamId);
     if (cached !== undefined) {
       return cached;
     }
     // Negative cache is reset by dispatcher each iteration so a team that's
     // fixed in Linear during a watch session auto-recovers on the next tick.
-    if (teamsMissingInProgress.has(teamId)) {
+    if (negativeCache.has(teamId)) {
       return undefined;
     }
 
     const team = await client.team(teamId);
     const states = await team.states();
-    const inProgress = states.nodes.find(
-      (state) => state.name === config.linear.statuses.inProgress,
-    );
-    if (inProgress?.id === undefined) {
-      teamsMissingInProgress.add(teamId);
+    const match = states.nodes.find((state) => state.name === name);
+    if (match?.id === undefined) {
+      negativeCache.add(teamId);
       return undefined;
     }
-    inProgressStateByTeam.set(teamId, inProgress.id);
-    return inProgress.id;
+    cache.set(teamId, match.id);
+    return match.id;
   }
 
   async function markInProgress(issue: LinearIssueReference): Promise<void> {
-    const stateId = await getInProgressStateId(issue.teamId);
+    const stateId = await getStateIdByName({
+      teamId: issue.teamId,
+      name: config.linear.statuses.inProgress,
+      cache: inProgressStateByTeam,
+      negativeCache: teamsMissingInProgress,
+    });
     if (stateId === undefined) {
       throw new Error(
         `Could not find "${config.linear.statuses.inProgress}" state for ${issue.id} (team ${issue.teamId.length > 0 ? issue.teamId : "?"}). Verify the status name in linear.statuses.inProgress matches the team's workflow.`,
@@ -60,9 +95,73 @@ export function createLinearIssueStatusUpdater(arguments_: {
     log(`Marked ${issue.id} as ${config.linear.statuses.inProgress}`);
   }
 
-  function resetMissingInProgressCache(): void {
-    teamsMissingInProgress = new Set();
+  async function markTodo(issue: LinearIssueReference): Promise<void> {
+    const stateId = await getStateIdByName({
+      teamId: issue.teamId,
+      name: config.linear.statuses.todo,
+      cache: todoStateByTeam,
+      negativeCache: teamsMissingTodo,
+    });
+    if (stateId === undefined) {
+      /* v8 ignore next @preserve -- ternary's empty-teamId branch only fires for malformed issues that fail upstream validation */
+      const teamLabel = issue.teamId.length > 0 ? issue.teamId : "?";
+      throw new Error(
+        `Could not find "${config.linear.statuses.todo}" state for ${issue.id} (team ${teamLabel}). Verify the status name in linear.statuses.todo matches the team's workflow.`,
+      );
+    }
+    await client.updateIssue(issue.uuid, { stateId });
+    log(`Marked ${issue.id} as ${config.linear.statuses.todo}`);
   }
 
-  return { markInProgress, resetMissingInProgressCache };
+  async function loadTeamLabels(teamId: string): Promise<Map<string, string>> {
+    const cached = labelsByTeam.get(teamId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const team = await client.team(teamId);
+    const labels = await team.labels();
+    const byName = new Map<string, string>();
+    for (const label of labels.nodes as TeamLabelEntry[]) {
+      byName.set(label.name, label.id);
+    }
+    labelsByTeam.set(teamId, byName);
+    return byName;
+  }
+
+  async function ensureLabel(teamId: string, name: string): Promise<string | undefined> {
+    const labels = await loadTeamLabels(teamId);
+    const existing = labels.get(name);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const payload = await client.createIssueLabel({ name, teamId });
+    const createdLabel = await payload.issueLabel;
+    if (createdLabel?.id === undefined) {
+      log(`Could not create label "${name}" for team ${teamId}; skipping`);
+      return undefined;
+    }
+    labels.set(name, createdLabel.id);
+    return createdLabel.id;
+  }
+
+  async function addLabels(issue: LinearIssueReference, names: readonly string[]): Promise<void> {
+    const pending = names.filter((name) => !issue.labels.includes(name));
+    for (const name of pending) {
+      // oxlint-disable-next-line no-await-in-loop -- Linear mutations are serial per ticket to avoid label-cache races
+      const labelId = await ensureLabel(issue.teamId, name);
+      if (labelId === undefined) {
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- same reason as above
+      await client.issueAddLabel(issue.uuid, labelId);
+      log(`Added label "${name}" to ${issue.id}`);
+    }
+  }
+
+  function resetMissingStateCache(): void {
+    teamsMissingInProgress = new Set();
+    teamsMissingTodo = new Set();
+  }
+
+  return { markInProgress, markTodo, addLabels, resetMissingStateCache };
 }

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -9,7 +9,7 @@ import type { ResolvedConfig } from "./config.ts";
 import { workspaces } from "./workspaces.ts";
 import { type WorktreeEntry, worktrees } from "./worktrees.ts";
 
-const { create, findByTicket, list, remove, teardown } = worktrees;
+const { create, ensure, findByTicket, list, remove, teardown } = worktrees;
 
 type NodeOsMock = Omit<typeof nodeOs, "userInfo"> & {
   userInfo: ReturnType<typeof vi.fn<typeof userInfo>>;
@@ -358,6 +358,53 @@ describe(create, () => {
         ticket: "team-1",
       }),
     ).rejects.toThrow(/Could not determine OS username/);
+  });
+});
+
+describe(ensure, () => {
+  setupTempProjectDir();
+
+  it("returns the existing host entry when a worktree already exists for the same repo + ticket", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    const actual = await ensure(config, {
+      repository: "repo-a",
+      ticket: "team-1",
+    });
+
+    expect(actual.repository).toBe("repo-a");
+    expect(actual.ticket).toBe("team-1");
+    expect(actual.dir).toBe(join(projectDir, "repo-a-team-1"));
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a worktree when none exists for the repo + ticket", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    const config = makeConfig({ projectDir });
+
+    const actual = await ensure(config, {
+      repository: "repo-a",
+      ticket: "team-1",
+    });
+
+    expect(actual.kind).toBe("host");
+    expect(actual.dir).toBe(join(projectDir, "repo-a-team-1"));
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      [
+        "-C",
+        join(projectDir, "repo-a"),
+        "worktree",
+        "add",
+        "-b",
+        "rocky-team-1",
+        join(projectDir, "repo-a-team-1"),
+        "origin/main",
+      ],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
   });
 });
 

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -353,13 +353,37 @@ async function create(
   spec: WorktreeSpec,
   signal?: AbortSignal,
 ): Promise<WorktreeEntry> {
-  const existing = findByTicket(config, spec.ticket).find(
-    (entry) => entry.repository === spec.repository,
-  );
+  const existing = findExistingForSpec(config, spec);
   if (existing !== undefined) {
     throw new WorktreeAlreadyExistsError(existing.dir);
   }
   return await createWorktree(config, spec, signal);
+}
+
+/**
+ * Idempotent variant of `create`. Returns the existing worktree entry when
+ * `(repository, ticket)` already has one on disk; otherwise creates a fresh
+ * worktree. Used by the stranded-ticket recovery path so a reopen does not
+ * trip the "already exists" guard while still rejecting accidental double
+ * provisioning through `create`.
+ */
+async function ensure(
+  config: ResolvedConfig,
+  spec: WorktreeSpec,
+  signal?: AbortSignal,
+): Promise<WorktreeEntry> {
+  const existing = findExistingForSpec(config, spec);
+  if (existing !== undefined) {
+    return existing;
+  }
+  return await createWorktree(config, spec, signal);
+}
+
+function findExistingForSpec(
+  config: ResolvedConfig,
+  spec: WorktreeSpec,
+): WorktreeEntry | undefined {
+  return findByTicket(config, spec.ticket).find((entry) => entry.repository === spec.repository);
 }
 
 async function remove(
@@ -452,6 +476,7 @@ async function teardown(
 
 export const worktrees = {
   create,
+  ensure,
   list,
   findByTicket,
   remove,


### PR DESCRIPTION
## Summary

- Orchestrator detects In-Progress tickets whose worktree is on disk but whose cmux/tmux workspace has vanished, demotes them back to Todo for a one-shot auto-retry, and reopens the surviving worktree on the next tick.
- Retry budget tracked in Linear labels (`agent-retried`, `agent-error`, `agent-max-retries`) so the policy survives orchestrator restarts. A retry failure or a second strand stamps `agent-max-retries`, which eligibility treats as a blocking label so wedged tickets never silently re-enter dispatch.
- `worktrees.ensure` is opt-in via a new `reuseWorktree` flag on `setupWorkspace`, so the existing duplicate-worktree access hint still fires for `crew setup-workspace` and the fresh-dispatch flow.

## Why

A stranded ticket previously occupied its slot forever — Linear still said In Progress, the workspace was gone, and the recovery classifier only ran on Todo. The capacity pool wedged at `maximumInProgress` with no way out short of human intervention. With auto-recovery the slot is freed on the same tick the demote fires, so other Todo work can dispatch into the headroom immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)