### PR TITLE
fix(workspaces): suppress noise when cmux dropped set-status

### DIFF
--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -4,8 +4,11 @@ import type { RunCommandOptions } from "./commandRunner.ts";
 import type { ResolvedConfig, WorkspaceKindSetting } from "./config.ts";
 import type * as hostModule from "./host.ts";
 import { detectHostCapabilities, type HostCapabilities } from "./host.ts";
+import { log } from "./util.ts";
 import type * as utilModule from "./util.ts";
 import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
+
+const logMock = vi.mocked(log);
 
 type RunCommandMock = (
   command: string,
@@ -406,6 +409,30 @@ describe("workspaces.open (cmux)", () => {
     ).resolves.toBeUndefined();
 
     expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
+    expect(logMock).toHaveBeenCalledWith(expect.stringContaining("cmux set-status failed"));
+  });
+
+  it("silently swallows set-status when the cmux build reports `unknown command`", async () => {
+    runMock
+      .mockReturnValueOnce(JSON.stringify({ ref: "workspace:42" }))
+      .mockImplementationOnce(() => {
+        throw new Error(
+          'Command failed: cmux set-status model claude\nExit status: 2\nStderr:\ncmux: unknown command "set-status"\nCause: Command exited unsuccessfully',
+        );
+      })
+      .mockReturnValue("");
+
+    await expect(
+      workspaces.open(makeConfig(), {
+        name: "TEAM-1",
+        cwd: "/cwd",
+        command: "x",
+        status: { text: "claude" },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
+    expect(logMock).not.toHaveBeenCalledWith(expect.stringContaining("set-status"));
   });
 
   it("caches the resolved adapter per config so detectHostCapabilities is not re-run", async () => {

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -294,6 +294,10 @@ async function closeCmuxWorkspace(workspaceId: string, signal?: AbortSignal): Pr
   await runWorkspaceCommand("cmux", ["close-workspace", "--workspace", workspaceId], signal);
 }
 
+function isCmuxSetStatusUnsupported(error: unknown): boolean {
+  return errorMessage(error).includes('unknown command "set-status"');
+}
+
 const cmuxAdapter: Adapter = {
   async open(spec, signal) {
     const inheritedRemote = await probeCurrentCmuxRemote(signal);
@@ -318,10 +322,12 @@ const cmuxAdapter: Adapter = {
       try {
         await applyCmuxStatus(workspaceId, spec.status, signal);
       } catch (error) {
-        // v2 cmux builds may not implement `set-status`; status pills are
-        // a nice-to-have, not load-bearing. Log and keep the workspace
-        // rather than tearing down a successful launch.
-        log(`cmux set-status failed for ${spec.name} (continuing): ${errorMessage(error)}`);
+        // Status pills are best-effort. cmux v2+ dropped `set-status` entirely,
+        // so swallow that specific gap silently; surface anything else so a real
+        // regression doesn't hide behind the same swallow.
+        if (!isCmuxSetStatusUnsupported(error)) {
+          log(`cmux set-status failed for ${spec.name} (continuing): ${errorMessage(error)}`);
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary

On Linux, `cmux` is a wrapper that execs `cmuxd-remote-current` — the Go-based remote daemon, a separate binary from the macOS Swift CLI where `set-status` lives. The Linux daemon has never implemented `set-status` (and likely never will, since status pills are a macOS sidebar feature). Every `crew run` was therefore logging `cmux set-status failed for <ticket> (continuing): ... cmux: unknown command "set-status"` even though status pills have always been documented as best-effort.

Detect that specific error in the catch and stay quiet. Any other failure still logs so a real regression doesn't hide behind the same swallow. The macOS path is unaffected — `set-status` succeeds there and the pill paints as before.

## Validation

- `node --run verify` — 22 files, 684 tests pass, 100% coverage.
- Cross-checked the cmux source tree: `set-status` is defined in `CLI/cmux.swift` (macOS-only), zero matches in `daemon/remote/cmd/cmuxd-remote/cli.go` (Linux daemon).

<!-- commit-push-pr:created v1 core@3.4.1 -->