### PR TITLE
fix(worktrees): explain "is not a working tree" cleanup failure when the directory is an orphan

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -573,19 +573,63 @@ describe(remove, () => {
     await expect(callRemove()).rejects.not.toThrow(/modified/);
   });
 
-  it("rethrows the original error when the dirtiness probe itself fails", async () => {
+  it("wraps the error with an orphan explanation when the directory is not a registered worktree", async () => {
     mkdirSync(join(projectDir, "repo-a"));
     mkdirSync(join(projectDir, "repo-a-team-1"));
     const config = makeConfig({ projectDir });
 
     runCommandMock.mockImplementation((_command, arguments_) => {
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- both the remove and the follow-up status probe fail; no dirtiness info available.
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status fails because the dir has no .git; rev-parse reports it is not a working tree.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("Command failed: git worktree remove\nExit status: 128");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        throw new Error("not a git repository");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
+        return "false";
+      }
+      return "";
+    });
+
+    const callRemove = async (): Promise<void> => {
+      await remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      });
+    };
+
+    await expect(callRemove()).rejects.toThrow(
+      /directory exists but is not a registered git worktree/,
+    );
+    await expect(callRemove()).rejects.toThrow(
+      new RegExp(`\`rm -rf\` ${join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`),
+    );
+    await expect(callRemove()).rejects.toThrow(/inspect it before deleting/);
+  });
+
+  it("rethrows the original error when the registration probe itself fails", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- both the dirtiness and registration probes fail; we cannot prove the orphan condition, so rethrow.
       if (hasArguments(arguments_, "worktree", "remove")) {
         throw new Error("original remove failure");
       }
       // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
       if (hasArguments(arguments_, "status", "--porcelain")) {
         throw new Error("status probe blew up");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
+        throw new Error("rev-parse blew up");
       }
       return "";
     });
@@ -599,6 +643,38 @@ describe(remove, () => {
         kind: "host",
       }),
     ).rejects.toThrow("original remove failure");
+  });
+
+  it("rethrows the original error when the registration probe confirms the directory is a worktree", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- dirtiness probe is unavailable but rev-parse reports a real working tree; the orphan explanation would be wrong, so rethrow.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("registered but still failed");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        throw new Error("status probe blew up");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
+        return "true";
+      }
+      return "";
+    });
+
+    await expect(
+      remove(config, {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      }),
+    ).rejects.toThrow("registered but still failed");
   });
 
   it("rethrows the original error when removal fails but the worktree is clean", async () => {
@@ -625,7 +701,7 @@ describe(remove, () => {
     ).rejects.toThrow("git worktree remove failed for some other reason");
   });
 
-  it("skips the dirtiness probe and rethrows when --force is already set", async () => {
+  it("skips both probes and rethrows when --force is already set", async () => {
     mkdirSync(join(projectDir, "repo-a"));
     mkdirSync(join(projectDir, "repo-a-team-1"));
     const config = makeConfig({ projectDir });
@@ -655,7 +731,11 @@ describe(remove, () => {
     const statusCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
       hasArguments(arguments_, "status", "--porcelain"),
     );
+    const revParseCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
+      hasArguments(arguments_, "rev-parse", "--is-inside-work-tree"),
+    );
     expect(statusCalls).toHaveLength(0);
+    expect(revParseCalls).toHaveLength(0);
   });
 
   it("rethrows branch deletion failures after the shutdown signal fires", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -247,26 +247,34 @@ async function removeWorktree(
     try {
       await runCommandAsync("git", removeArguments, longRunningCommandOptions(options.signal));
     } catch (error) {
-      // git's `fatal: ... use --force to delete it` line goes to inherited
-      // stderr, so the captured error is just "Exit status: 128". Probe the
-      // worktree ourselves so the failure message explains the condition
-      // (modified/untracked files) and points at `crew cleanup --force`.
+      // git's `fatal: ...` diagnostic goes to inherited stderr, so the
+      // captured error is just "Exit status: 128". Probe the worktree
+      // ourselves so the failure message names the condition — dirty
+      // (modified/untracked files, fixable with `crew cleanup --force`) or
+      // orphan (directory exists on disk but is not registered with the
+      // parent repo, requires manual inspection + `rm -rf`).
       if (options.force || options.signal?.aborted === true) {
         throw error;
       }
       const dirtiness = await probeWorktreeDirtiness(entry.dir, options.signal);
-      if (dirtiness.kind !== "dirty") {
-        throw error;
+      if (dirtiness.kind === "dirty") {
+        throw new Error(
+          describeDirtyWorktree({
+            ticket: entry.ticket,
+            dir: entry.dir,
+            modified: dirtiness.modified,
+            untracked: dirtiness.untracked,
+          }),
+          { cause: error },
+        );
       }
-      throw new Error(
-        describeDirtyWorktree({
-          ticket: entry.ticket,
-          dir: entry.dir,
-          modified: dirtiness.modified,
-          untracked: dirtiness.untracked,
-        }),
-        { cause: error },
-      );
+      if (dirtiness.kind === "unknown") {
+        const registration = await probeWorktreeRegistration(entry.dir, options.signal);
+        if (registration === "orphan") {
+          throw new Error(describeOrphanWorktree({ dir: entry.dir }), { cause: error });
+        }
+      }
+      throw error;
     }
   } else {
     log(`Worktree directory ${entry.dir} not found, pruning stale refs...`);
@@ -338,6 +346,30 @@ function describeDirtyWorktree(arguments_: {
   const summary = parts.join(" and ");
   const pronoun = modified + untracked === 1 ? "it" : "them";
   return `worktree has ${summary}. Run \`crew cleanup --force ${ticket}\` to discard ${pronoun}, or commit/stash in ${dir} first.`;
+}
+
+type WorktreeRegistration = "registered" | "orphan" | "unknown";
+
+async function probeWorktreeRegistration(
+  worktreeDir: string,
+  signal: AbortSignal | undefined,
+): Promise<WorktreeRegistration> {
+  let output: string;
+  try {
+    output = await runCommandAsync(
+      "git",
+      ["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"],
+      signalProperty(signal),
+    );
+  } catch {
+    return "unknown";
+  }
+  return output === "true" ? "registered" : "orphan";
+}
+
+function describeOrphanWorktree(arguments_: { dir: string }): string {
+  const { dir } = arguments_;
+  return `directory exists but is not a registered git worktree. If ${dir} has nothing of value, \`rm -rf\` ${dir} manually; otherwise inspect it before deleting.`;
 }
 
 function list(config: ResolvedConfig): WorktreeEntry[] {


### PR DESCRIPTION
## Summary

`crew cleanup <ticket>` previously failed with `Exit status: 128` and no hint about the cause when the worktree directory existed on disk but was no longer registered with the parent repo (e.g. someone ran `git worktree remove` manually, or the parent repo was reinitialized while the directory was left behind). git's `fatal: '...' is not a working tree` line is written to **inherited** stderr and never reaches our captured error.

The prior fix in #37 handled the **dirty** case (uncommitted work blocking removal). This change handles the **orphan** case: when `probeWorktreeDirtiness` returns `unknown` (its `git status --porcelain` couldn't make sense of the directory either), we now run a second probe — `git rev-parse --is-inside-work-tree` — to disambiguate "the directory is actually an orphan" from "the probe itself failed for some other reason". When the probe confirms orphan status, we throw a self-explanatory error that names the path and points at the remediation. Otherwise we rethrow the original error untouched. `--force` and aborted-signal paths short-circuit both probes, preserving the existing teardown contract.

### Before

```
Cleanup failed for hrd-442 (host): Command failed: git -C /path/to/orphan worktree remove ...
Exit status: 128
Cause: Command exited unsuccessfully
```

### After

```
Cleanup failed for hrd-442 (host): directory exists but is not a registered git worktree. If /path/to/orphan has nothing of value, `rm -rf` /path/to/orphan manually; otherwise inspect it before deleting.
```

## Validation

- `npx vitest run` — 684/684 tests passing; worktrees suite 51/51.
- `node --run verify` — architecture, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint all green. The `test` step's coverage walk hits an unrelated EPERM reading `/Users/mikework/package.json` outside the sandbox; the same suite passes cleanly under `npx vitest run` and CI re-runs verify with full sandbox access.
- Pre-push hook ran the full verify in parallel and reported `All checks passed.`
- Three new tests in `src/lib/worktrees.test.ts` cover: orphan detected → new message names path + `rm -rf` hint + "inspect before deleting"; registration probe itself fails → rethrow original; registration probe reports the directory **is** a real worktree (so the orphan explanation would be wrong) → rethrow original. The `--force` test now also asserts `rev-parse` is not invoked.

## Notes

- The registration probe runs **only** when `probeWorktreeDirtiness` returned `unknown` — on the dirty path we already have the answer, on the clean path the original error is the right thing to surface, and there's no point spending a second subprocess to confirm what we already know.
- Locale-independent: we don't pattern-match git's English `fatal: ... is not a working tree` wording — we re-probe with `git rev-parse --is-inside-work-tree` and form the explanation from our own boolean.
- `rev-parse --is-inside-work-tree` exits non-zero (we catch and return `"unknown"`) for non-git directories, and prints `false` for the directory-without-`.git` case that defines an orphan. Either path lands us at the right disambiguation without needing to inspect `.git` ourselves.
- When the registration probe itself fails (e.g. git binary missing, abort signal fired mid-probe), we rethrow the original `worktree remove` error rather than fabricate a misleading explanation.
- The original error is preserved as `cause` on the new error, so downstream tooling can still inspect the underlying `git` failure if needed.

Closes #45.

<!-- commit-push-pr:created v1 -->