### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tsconfig.tsbuildinfo
 vitest.config.*.timestamp*
 
 .nx/self-healing
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Add `.claude/settings.local.json` to `.gitignore` so per-machine Claude Code settings (personal tool allowlists, local overrides) don't get accidentally committed and don't pollute teammates' configs.

## Validation

- Not run: pure `.gitignore` addition, no code paths exercised.

Agent session: claude --resume 80f1a566-96bc-4006-a383-d71e3a0ff9e0
<!-- commit-push-pr:created v1 core@3.4.0 -->