### PR TITLE
fix(ci): create GitHub release after npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,33 @@ jobs:
           git config user.name "GitHub Bot"
           git config user.email "open-source@clipboardhealth.com"
 
-      - env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-          NX_PREFER_NODE_STRIP_TYPES: "true"
-        run: npx nx release --skip-publish
-
-      - run: node --run build
-
-      - env:
+      - name: Verify npm publish token
+        env:
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          NX_PREFER_NODE_STRIP_TYPES: "true"
         run: |
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
           npm whoami --registry=https://registry.npmjs.org/
-          npx nx release publish
+
+      - name: Version package
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          NX_PREFER_NODE_STRIP_TYPES: "true"
+        run: npx nx release version
+
+      - run: node --run build
+
+      - name: Publish to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NX_PREFER_NODE_STRIP_TYPES: "true"
+        run: npx nx release publish
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          NX_PREFER_NODE_STRIP_TYPES: "true"
+        run: |
+          package_version="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+          npx nx release changelog "${package_version}"

--- a/nx.json
+++ b/nx.json
@@ -3,15 +3,15 @@
   "release": {
     "changelog": {
       "automaticFromRef": true,
+      "git": {
+        "commit": false,
+        "tag": false
+      },
       "projectChangelogs": {
         "createRelease": "github",
         "file": false
       },
       "workspaceChangelogs": false
-    },
-    "git": {
-      "commit": true,
-      "commitMessage": "chore(release): publish {projectName} {version} [skip actions]"
     },
     "projects": ["groundcrew"],
     "projectsRelationship": "independent",
@@ -19,7 +19,12 @@
       "conventionalCommits": true,
       "fallbackCurrentVersionResolver": "disk",
       "updateDependents": "auto",
-      "preserveLocalDependencyProtocols": false
+      "preserveLocalDependencyProtocols": false,
+      "git": {
+        "commit": true,
+        "commitMessage": "chore(release): publish {projectName} {version} [skip actions]",
+        "tag": true
+      }
     }
   },
   "analytics": false


### PR DESCRIPTION
## Summary

Split the CI release flow so npm authentication is verified before any release work, npm publish happens before the GitHub Release is created, and Nx direct release subcommands keep the version commit/tag local until the post-publish changelog step pushes and creates the GitHub Release.

## Validation

- `NX_PREFER_NODE_STRIP_TYPES=true npx nx release version --printConfig`
- `NX_PREFER_NODE_STRIP_TYPES=true npx nx release changelog 2.3.4 --printConfig`
- `git diff --check`
- `node --run verify`
- Push hook reran `node --run verify`

## Notes

`scripts/find-session-id.sh` is not present in this repo, so no agent session footer was added.

<!-- commit-push-pr:created v1 core@3.4.0 -->