### PR TITLE
fix(workspaces): pass --cwd to local cmux new-workspace (#36 regression)

### DIFF
--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -120,7 +120,7 @@ describe("workspaces.open (cmux)", () => {
       "new-workspace",
       "--name",
       "TEAM-1",
-      "--working-directory",
+      "--cwd",
       "/work/repo-a-TEAM-1",
       "--command",
       "exec claude",
@@ -282,7 +282,7 @@ describe("workspaces.open (cmux)", () => {
     ]);
   });
 
-  it("does not wrap or pass --working-directory when no SSH remote is detected", async () => {
+  it("does not wrap or pass --cwd when no SSH remote is detected", async () => {
     runMock.mockReturnValueOnce(JSON.stringify({ workspace_id: "new-ws-id" })).mockReturnValue("");
 
     await workspaces.open(makeConfig(), {
@@ -296,7 +296,7 @@ describe("workspaces.open (cmux)", () => {
       "new-workspace",
       "--name",
       "TEAM-1",
-      "--working-directory",
+      "--cwd",
       "/work/repo-a-TEAM-1",
       "--command",
       "exec claude",
@@ -384,7 +384,7 @@ describe("workspaces.open (cmux)", () => {
       "new-workspace",
       "--name",
       "TEAM-1",
-      "--working-directory",
+      "--cwd",
       "/srv/x",
       "--command",
       "exec claude",

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -282,7 +282,7 @@ describe("workspaces.open (cmux)", () => {
     ]);
   });
 
-  it("does not wrap or pass --cwd when no SSH remote is detected", async () => {
+  it("does not wrap with ssh and passes --cwd when no SSH remote is detected", async () => {
     runMock.mockReturnValueOnce(JSON.stringify({ workspace_id: "new-ws-id" })).mockReturnValue("");
 
     await workspaces.open(makeConfig(), {

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -303,11 +303,11 @@ const cmuxAdapter: Adapter = {
     const inheritedRemote = await probeCurrentCmuxRemote(signal);
     const newWorkspaceArguments = ["--json", "new-workspace", "--name", spec.name];
     if (inheritedRemote === undefined) {
-      newWorkspaceArguments.push("--working-directory", spec.cwd, "--command", spec.command);
+      newWorkspaceArguments.push("--cwd", spec.cwd, "--command", spec.command);
     } else {
-      // Skip --working-directory: the path is on the SSH remote and would
-      // fall back to $HOME (macOS) when cmux tries to chdir locally. The
-      // wrapped ssh command does its own `cd` on the remote side.
+      // Skip --cwd: the path is on the SSH remote and would fall back to
+      // $HOME (macOS) when cmux tries to chdir locally. The wrapped ssh
+      // command does its own `cd` on the remote side.
       newWorkspaceArguments.push("--command", buildSshWrappedCommand(spec, inheritedRemote));
     }
     const output = await runWorkspaceCommand("cmux", newWorkspaceArguments, signal);


### PR DESCRIPTION
## Summary
- Revert `--working-directory` → `--cwd` on the local-cmux branch of `cmuxAdapter.open()`. The cmux Swift CLI never accepted `--working-directory`; only `--cwd`. The SSH branch is unaffected — it already omits the flag and lets the wrapped `ssh` command do its own `cd`.
- Update three test assertions and one `it()` title to match.

## Why
PR #36 ([#36](https://github.com/ClipboardHealth/groundcrew/pull/36)) renamed `--cwd` → `--working-directory` as a drive-by change unrelated to its stated purpose (reintroducing Docker sdx). The likely cause is the AI co-author misreading commit 19f4840's note about a v2 JSON-RPC parameter rename and applying it to the CLI flag. cmux's CLI did not change; the local-cmux launch path has been broken in every release since **groundcrew@2.3.0**.

Users running SSH cmux workspaces never hit this because the else branch in `cmuxAdapter.open` skips the cwd flag entirely.

Verified by patching the same one-line change into the installed `groundcrew@2.3.1` dist on cmux 0.64.7 and successfully launching a local cmux workspace via `op-crew run --watch`.

## Test plan
- [x] `node --run verify` — 685 tests pass, 100% coverage
- [x] Manual: patched dist file with the same change → `op-crew run --watch` successfully launched local cmux workspace (cmux 0.64.7)
- [ ] Reviewer: confirm SSH-cmux workspace path still launches as before

<!-- commit-push-pr:created v1 -->