### PR TITLE
docs(readme): document build-time secret-passing model (tg-3691)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ Installs the `crew` binary. `@clipboard-health/clearance` is pulled in transitiv
    crew run --watch               # poll forever
    ```
 
+## Secrets
+
+Groundcrew forwards a small allowlist of build-time secrets from your shell into the setup phase (so `npm install` can authenticate against private registries) and then strips them before the agent runs. The agent process never inherits these values in its environment.
+
+**Recognized names.** Defined in [`BUILD_SECRET_NAMES`](./src/lib/buildSecrets.ts):
+
+- `NPM_TOKEN`
+- `BUF_TOKEN`
+
+Set them in the shell you run `crew` from. Anything not in this list is ignored by the secret-shuttling path.
+
+**Flow.** For each ticket:
+
+1. If any recognized var is set and non-empty, groundcrew writes `secrets.env` (mode `0600`) into the ticket's temp prompt dir as `KEY='value'` lines — see `stageBuildSecrets` in [`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts).
+2. The launch script sources `secrets.env` with `set -a` so the values are exported into the setup phase only (and under `sdx`, forwarded into the sandbox via `-e KEY` flags).
+3. After setup completes, the script `unset`s every name in `BUILD_SECRET_NAMES` before `exec`'ing the agent. See `sourceSecretsLine` / `unsetSecretsLine` in [`src/lib/launchCommand.ts`](./src/lib/launchCommand.ts).
+
+**Caveat.** `secrets.env` itself stays on disk inside the prompt dir for the agent's lifetime — the launch command `rm -rf`s the temp dir on exit, but a sufficiently-motivated agent process could read the file while it's running, even though the values are no longer in its environment. If that's in your threat model, don't set these vars when invoking `crew`.
+
 ## Runners
 
 `local.runner` picks the local isolation backend. `auto` resolves per platform.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Set them in the shell you run `crew` from. Anything not in this list is ignored 
 
 1. If any recognized var is set and non-empty, groundcrew writes `secrets.env` (mode `0600`) into the ticket's temp prompt dir as `KEY='value'` lines — see `stageBuildSecrets` in [`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts).
 2. The launch script sources `secrets.env` with `set -a` so the values are exported into the setup phase only (and under `sdx`, forwarded into the sandbox via `-e KEY` flags).
-3. After setup completes, the script `unset`s every name in `BUILD_SECRET_NAMES` before `exec`'ing the agent. See `sourceSecretsLine` / `unsetSecretsLine` in [`src/lib/launchCommand.ts`](./src/lib/launchCommand.ts).
+3. After setup completes, the script `unset`s every name in `BUILD_SECRET_NAMES` and then `rm -rf`s the entire prompt dir (including `secrets.env`) before `exec`'ing the agent. See `sourceSecretsLine` / `unsetSecretsLine` and the `rm -rf` / `exec` lines in [`src/lib/launchCommand.ts`](./src/lib/launchCommand.ts). The rollback path on setup failure ([`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts)) wipes the prompt dir too.
 
-**Caveat.** `secrets.env` itself stays on disk inside the prompt dir for the agent's lifetime — the launch command `rm -rf`s the temp dir on exit, but a sufficiently-motivated agent process could read the file while it's running, even though the values are no longer in its environment. If that's in your threat model, don't set these vars when invoking `crew`.
+Net effect: by the time the agent process exists, the values are gone from the environment and the file is gone from disk.
 
 ## Runners
 


### PR DESCRIPTION
## Summary

- Adds a **Secrets** section to the README (between Quickstart and Runners) so new users can understand how `NPM_TOKEN` / `BUF_TOKEN` flow through groundcrew without grepping `src/lib/launchCommand.ts` or `src/lib/buildSecrets.ts`.
- Covers: recognized var names (with link to `BUILD_SECRET_NAMES`), `secrets.env` staging at mode `0600`, source-before-setup, `unset` + `rm -rf` of the prompt dir before `exec`'ing the agent — net effect: by the time the agent runs, the values are gone from the environment and the file is gone from disk.

Needs to land in **ClipboardHealth/groundcrew**.

Closes tg-3691.

## Test plan

- [x] `node --run verify` (685 tests, 100% coverage)
- [x] Reviewer skim: confirm the Secrets section reads end-to-end without needing the source