### PR TITLE
fix(doctor): fail when codexbar is missing for a usage-gated model

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -820,10 +820,9 @@ describe(doctor, () => {
     const actual = await doctor();
 
     expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain("[--] codexbar");
-    expect(consoleLog.output()).toContain("required for usage gating on `claude`");
-    expect(consoleLog.output()).toContain("install codexbar");
-    expect(consoleLog.output()).toContain("disable gating");
+    expect(consoleLog.output()).toContain(
+      "[--] codexbar  — required for usage gating on `claude` — install codexbar, or set `models.definitions.<name>.usage` to disable gating",
+    );
   });
 
   it("reports codexbar as ok when usage is configured and codexbar is on PATH", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -802,7 +802,7 @@ describe(doctor, () => {
     expect(consoleLog.output()).toContain("required for local runs");
   });
 
-  it("adds an optional codexbar check when any model has usage configured", async () => {
+  it("fails doctor when codexbar is missing and an enabled model has usage configured", async () => {
     loadConfigMock.mockResolvedValue(
       makeConfig({
         default: "claude",
@@ -819,10 +819,33 @@ describe(doctor, () => {
 
     const actual = await doctor();
 
-    // codexbar is not required; doctor still passes when only it is missing.
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("[--] codexbar");
+    expect(consoleLog.output()).toContain("required for usage gating on `claude`");
+    expect(consoleLog.output()).toContain("install codexbar");
+    expect(consoleLog.output()).toContain("disable gating");
+  });
+
+  it("reports codexbar as ok when usage is configured and codexbar is on PATH", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "claude",
+        definitions: {
+          claude: {
+            cmd: "claude",
+            color: "#fff",
+            usage: { codexbar: { provider: "claude", source: "oauth" } },
+          },
+        },
+      }),
+    );
+    // Make every `which` succeed (no target throws), so codexbar resolves.
+    mockWhichFailure("__never__", "unreachable");
+
+    const actual = await doctor();
+
     expect(actual).toBe(true);
-    expect(consoleLog.output()).toContain("[? ] codexbar");
-    expect(consoleLog.output()).toContain("optional");
+    expect(consoleLog.output()).toContain("[ok] codexbar");
   });
 
   it("omits the hint when both `which` and the caller produce nothing", async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
+import { gatedModels } from "../lib/usage.ts";
 import { errorMessage, resolveLinearApiKey, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
 import { runTicketDoctor } from "./ticketDoctor.ts";
@@ -128,12 +129,6 @@ function gatherToolTokens(config: ResolvedConfig): string[] {
   return [...all];
 }
 
-function anyModelUsesUsage(config: ResolvedConfig): boolean {
-  return Object.values(config.models.definitions).some(
-    (definition) => definition.usage !== undefined,
-  );
-}
-
 function format(check: Check): string {
   let tag: string;
   if (check.ok) {
@@ -215,8 +210,20 @@ async function doctorHost(): Promise<boolean> {
     checks.push(check);
   }
 
-  if (anyModelUsesUsage(config)) {
-    checks.push(await checkCmd("codexbar", false, "optional — only used for usage gating"));
+  const usageGatedModels = gatedModels(config);
+  if (usageGatedModels.length > 0) {
+    const codexbarPath = await which("codexbar");
+    if (codexbarPath === undefined) {
+      const modelList = usageGatedModels.map((name) => `\`${name}\``).join(", ");
+      checks.push({
+        name: "codexbar",
+        ok: false,
+        required: true,
+        hint: `required for usage gating on ${modelList} — install codexbar, or set \`models.definitions.<name>.usage\` to disable gating`,
+      });
+    } else {
+      checks.push({ name: "codexbar", ok: true, required: true, hint: codexbarPath });
+    }
   }
 
   for (const check of checks) {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -159,7 +159,7 @@ function normalize(usage: Usage): NormalizedUsage {
   };
 }
 
-function gatedModels(config: ResolvedConfig): string[] {
+export function gatedModels(config: ResolvedConfig): string[] {
   return Object.entries(config.models.definitions)
     .filter(([, definition]) => definition.usage !== undefined)
     .map(([name]) => name);


### PR DESCRIPTION
Lands in `ClipboardHealth/groundcrew`. Closes TG-3689.

## Summary
- The default `claude` entry in `DEFAULT_MODEL_DEFINITIONS` carries a `usage` block, so on a host without codexbar `crew run` skips every claude-bound ticket at dispatch time with only an opaque log line (`claude session at Infinity% (> 85%) — skipping its tickets`).
- `crew doctor` reported codexbar as `[? ] optional`, so the problem never surfaced before dispatch.
- Doctor now treats codexbar as required whenever any enabled model has `usage` configured. The failure hint names the gated model(s) and points at both remediations: install codexbar, or override `models.definitions.<name>.usage` to disable gating.
- Pulled the model-iteration helper out of `src/lib/usage.ts` as an exported `gatedModels` so doctor and the runtime usage path share one source of truth.

## Test plan
- [x] `node --run verify` (686 tests, 100% coverage)
- [ ] `crew doctor` without codexbar on PATH → fails with the new hint
- [ ] `crew doctor` with codexbar installed → `[ok] codexbar`
- [ ] Override the default `claude.usage` to disable gating → codexbar check is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)