### PR TITLE
chore(clearance): allow release-assets.githubusercontent.com

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -55,6 +55,7 @@ productionresultssa17.blob.core.windows.net
 productionresultssa18.blob.core.windows.net
 productionresultssa19.blob.core.windows.net
 raw.githubusercontent.com
+release-assets.githubusercontent.com
 results-receiver.actions.githubusercontent.com
 
 # npm registry


### PR DESCRIPTION
## Summary

Add `release-assets.githubusercontent.com` to `clearance-allow-hosts` so agent runs can fetch GitHub release assets via clearance's egress allowlist. Placed alphabetically between `raw.githubusercontent.com` and `results-receiver.actions.githubusercontent.com`.

## Validation

- `node --run verify` passed locally (685 tests, 100% coverage).
- Pre-push hook (`node --run hook:pre-push`) fails on pre-existing `knip` issues on main (unused devDependencies + unlisted binaries in `package.json`) — unrelated to this change. Pushed with `--no-verify` per user authorization.

<!-- commit-push-pr:created v1 core@3.4.1 -->