### PR TITLE
feat(doctor): warn when linear.statuses.todo missing on project teams

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -190,13 +190,24 @@ function activeNodes(count: number): { id: string }[] {
   return Array.from({ length: count }, (_value, index) => ({ id: `active-${index}` }));
 }
 
+interface TeamStub {
+  key: string;
+  name: string;
+  statuses: string[];
+}
+
+const DEFAULT_PROJECT_TEAMS: TeamStub[] = [
+  { key: "TEAM", name: "Team Default", statuses: ["Todo", "In Progress", "Done"] },
+];
+
 function makeLinearClient(
   options: {
     issue?: RawIssueStub | null;
     activePages?: number[];
+    projectTeams?: TeamStub[] | "no-project" | null;
   } = {},
 ): LinearClient {
-  const { issue = rawIssue(), activePages = [0] } = options;
+  const { issue = rawIssue(), activePages = [0], projectTeams = DEFAULT_PROJECT_TEAMS } = options;
   let activePageIndex = 0;
   let blockerPageIndex = 0;
   const rawRequest = vi.fn<LinearRawRequest>(async (query) => {
@@ -220,6 +231,31 @@ function makeLinearClient(
                 endCursor: hasNextPage ? issue.inverseRelations.pageInfo.endCursor : "",
               },
             },
+          },
+        },
+      };
+    }
+    if (query.includes("ProjectTeamStatuses")) {
+      if (projectTeams === null) {
+        throw new Error("linear unreachable");
+      }
+      if (projectTeams === "no-project") {
+        return { data: { projects: { nodes: [] } } };
+      }
+      return {
+        data: {
+          projects: {
+            nodes: [
+              {
+                teams: {
+                  nodes: projectTeams.map((team) => ({
+                    key: team.key,
+                    name: team.name,
+                    states: { nodes: team.statuses.map((name) => ({ name })) },
+                  })),
+                },
+              },
+            ],
           },
         },
       };
@@ -907,6 +943,81 @@ describe(doctor, () => {
     expect(lines).toMatch(/requested=tmux, resolved=tmux/);
     expect(checkedCommands()).toContain("tmux");
     expect(checkedCommands()).not.toContain("cmux");
+  });
+
+  it("fails when linear.statuses.todo is missing on a project team", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    getLinearClientMocked.mockReturnValue(
+      makeLinearClient({
+        projectTeams: [{ key: "GAIA", name: "Gaia", statuses: ["Backlog", "In Progress", "Done"] }],
+      }),
+    );
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    const output = consoleLog.output();
+    expect(output).toContain('[--] linear.statuses.todo "Todo" on team GAIA');
+    expect(output).toContain("Backlog, In Progress, Done");
+    expect(output).toContain("Remap linear.statuses.todo");
+  });
+
+  it("passes when linear.statuses.todo exists on every project team", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    getLinearClientMocked.mockReturnValue(
+      makeLinearClient({
+        projectTeams: [
+          { key: "ALPHA", name: "Alpha", statuses: ["Todo", "Done"] },
+          { key: "BETA", name: "Beta", statuses: ["Todo", "In Progress", "Done"] },
+        ],
+      }),
+    );
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const output = consoleLog.output();
+    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team ALPHA');
+    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team BETA');
+  });
+
+  it("fails when the project has no teams", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    getLinearClientMocked.mockReturnValue(makeLinearClient({ projectTeams: [] }));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("no teams found on project");
+  });
+
+  it("fails when no project is found for the configured slugId", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    getLinearClientMocked.mockReturnValue(makeLinearClient({ projectTeams: "no-project" }));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("no teams found on project");
+  });
+
+  it("warns but does not fail when the Linear team-status query throws", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    getLinearClientMocked.mockReturnValue(makeLinearClient({ projectTeams: null }));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    expect(consoleLog.output()).toContain("could not fetch project teams from Linear");
+  });
+
+  it("skips the team-status check when no Linear API key is set", async () => {
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    await doctor();
+
+    expect(consoleLog.output()).not.toContain("linear.statuses.todo");
   });
 
   it("reports a workspaceKind failure when the chosen backend's binary is missing", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -956,10 +956,9 @@ describe(doctor, () => {
     const actual = await doctor();
 
     expect(actual).toBe(false);
-    const output = consoleLog.output();
-    expect(output).toContain('[--] linear.statuses.todo "Todo" on team GAIA');
-    expect(output).toContain("Backlog, In Progress, Done");
-    expect(output).toContain("Remap linear.statuses.todo");
+    expect(consoleLog.output()).toContain(
+      '[--] linear.statuses.todo "Todo" on team GAIA  — team GAIA (Gaia) has no "Todo" status — available: Backlog, In Progress, Done. Remap linear.statuses.todo in your groundcrew config.',
+    );
   });
 
   it("passes when linear.statuses.todo exists on every project team", async () => {
@@ -977,8 +976,34 @@ describe(doctor, () => {
 
     expect(actual).toBe(true);
     const output = consoleLog.output();
-    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team ALPHA');
-    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team BETA');
+    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team ALPHA  — present');
+    expect(output).toContain('[ok] linear.statuses.todo "Todo" on team BETA  — present');
+  });
+
+  it("passes when the user remaps linear.statuses.todo to a status the team has", async () => {
+    // Mirrors the Team Gaia case: team has no "Todo" status, but the user
+    // pointed `linear.statuses.todo` at "Backlog" instead. Doctor should
+    // recognize the remap and not flag the team.
+    const config = makeConfig();
+    loadConfigMock.mockResolvedValue({
+      ...config,
+      linear: {
+        ...config.linear,
+        statuses: { ...config.linear.statuses, todo: "Backlog" },
+      },
+    });
+    getLinearClientMocked.mockReturnValue(
+      makeLinearClient({
+        projectTeams: [{ key: "GAIA", name: "Gaia", statuses: ["Backlog", "In Progress", "Done"] }],
+      }),
+    );
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    expect(consoleLog.output()).toContain(
+      '[ok] linear.statuses.todo "Backlog" on team GAIA  — present',
+    );
   });
 
   it("fails when the project has no teams", async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, statSync } from "node:fs";
 
+import { fetchProjectTeamStatuses } from "../lib/boardSource.ts";
 import {
   type LocalRunner,
   type LocalRunnerSetting,
@@ -13,7 +14,7 @@ import {
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
-import { errorMessage, resolveLinearApiKey, writeOutput } from "../lib/util.ts";
+import { errorMessage, getLinearClient, resolveLinearApiKey, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
 import { runTicketDoctor } from "./ticketDoctor.ts";
 
@@ -219,6 +220,8 @@ async function doctorHost(): Promise<boolean> {
     checks.push(await checkCmd("codexbar", false, "optional — only used for usage gating"));
   }
 
+  checks.push(...(await checkLinearTodoStatus(config)));
+
   for (const check of checks) {
     if (check === localCapability) {
       continue;
@@ -303,6 +306,57 @@ function reportWorkspaceKind(config: ResolvedConfig, outcome: WorkspaceOutcome):
   } else {
     writeOutput(`[--] requested=${outcome.requested} — ${outcome.reason}`);
   }
+}
+
+/**
+ * Verify the configured `linear.statuses.todo` actually exists as a workflow
+ * state on every team the project is attached to. The dispatch loop filters
+ * Linear server-side by this status name; when it doesn't exist on a team,
+ * `crew run --watch` silently produces "no eligible tickets" and never
+ * dispatches. Surfacing the mismatch here gives the user a remap hint
+ * instead of a silent no-op.
+ */
+async function checkLinearTodoStatus(config: ResolvedConfig): Promise<Check[]> {
+  // Already flagged by `checkLinearApiKey` — don't double-warn or attempt
+  // a query that's guaranteed to fail.
+  if (resolveLinearApiKey() === undefined) {
+    return [];
+  }
+  let teams: Awaited<ReturnType<typeof fetchProjectTeamStatuses>>;
+  try {
+    teams = await fetchProjectTeamStatuses({ client: getLinearClient(), config });
+  } catch (error) {
+    return [
+      {
+        name: "linear.statuses.todo team check",
+        ok: false,
+        required: false,
+        hint: `could not fetch project teams from Linear: ${errorMessage(error)}`,
+      },
+    ];
+  }
+  if (teams.length === 0) {
+    return [
+      {
+        name: "linear.statuses.todo team check",
+        ok: false,
+        required: true,
+        hint: `no teams found on project "${config.linear.projectSlug}" — verify linear.projectSlug and API key access`,
+      },
+    ];
+  }
+  const { todo } = config.linear.statuses;
+  return teams.map((team) => {
+    const ok = team.statuses.includes(todo);
+    return {
+      name: `linear.statuses.todo "${todo}" on team ${team.key}`,
+      ok,
+      required: true,
+      hint: ok
+        ? "present"
+        : `team ${team.key} (${team.name}) has no "${todo}" status — available: ${team.statuses.join(", ")}. Remap linear.statuses.todo in your groundcrew config.`,
+    };
+  });
 }
 
 async function workspaceChecks(outcome: WorkspaceOutcome): Promise<Check[]> {

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -126,6 +126,66 @@ interface IssueRelationNode {
   } | null;
 }
 
+interface ProjectTeamStatuses {
+  key: string;
+  name: string;
+  statuses: string[];
+}
+
+/**
+ * Fetch every team attached to the configured Linear project, along with
+ * each team's workflow-state names. `doctor` uses this to detect when the
+ * configured `linear.statuses.todo` doesn't exist on a project team — the
+ * silent cause of "no eligible Backlog tickets" during `crew run --watch`.
+ */
+export async function fetchProjectTeamStatuses(arguments_: {
+  client: LinearClient;
+  config: ResolvedConfig;
+}): Promise<ProjectTeamStatuses[]> {
+  const { client, config } = arguments_;
+  const response: { data?: unknown } = await client.client.rawRequest(
+    `query ProjectTeamStatuses($slugId: String!) {
+      projects(filter: { slugId: { eq: $slugId } }, first: 1) {
+        nodes {
+          teams(first: 50) {
+            nodes {
+              key
+              name
+              states(first: 100) {
+                nodes { name }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    { slugId: config.linear.slugId },
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shape is fixed by our GraphQL query above
+  const { projects } = response.data as {
+    projects: {
+      nodes: {
+        teams: {
+          nodes: {
+            key: string;
+            name: string;
+            states: { nodes: { name: string }[] };
+          }[];
+        };
+      }[];
+    };
+  };
+  const [project] = projects.nodes;
+  if (!project) {
+    return [];
+  }
+  return project.teams.nodes.map((team) => ({
+    key: team.key,
+    name: team.name,
+    statuses: team.states.nodes.map((state) => state.name),
+  }));
+}
+
 async function verifyProject(client: LinearClient, config: ResolvedConfig): Promise<void> {
   const response: { data?: unknown } = await client.client.rawRequest(
     `query VerifyProject($slugId: String!) {


### PR DESCRIPTION
## Summary
- `crew run --watch` filters Linear tickets server-side by `linear.statuses.todo`. When the configured status name doesn't exist on a project team, dispatch silently produces "no eligible tickets" with no hint to the user.
- Reproducing case: Team Gaia at Clipboard Health has no `Todo` status — `Backlog` plays that role — so a default groundcrew config targeting a Gaia project sees zero dispatches.
- `crew doctor` now fetches each team attached to the configured Linear project and fails with a `[--]` line listing that team's actual statuses when `linear.statuses.todo` is missing, so the user can remap it.

Needs to land in `ClipboardHealth/groundcrew`.

Closes TG-3688.

## Test plan
- [x] `node --run verify` (all checks pass, 100% coverage)
- [ ] On a Linear project whose team lacks `Todo`, `crew doctor` exits non-zero and prints the available statuses with a remap hint
- [ ] On a project whose team(s) all have `Todo`, `crew doctor` reports `[ok]` for each team
- [ ] When the Linear API key is unset, the team-status check is skipped (no double-warning)
- [ ] When the team-status GraphQL query fails, doctor surfaces a non-blocking `[? ]` warning rather than aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)