### PR TITLE
chore: allow GitHub codeload through clearance

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -33,6 +33,7 @@ datadoghq.com
 # GitHub + GHA artifact storage (Azure blobs)
 api.github.com
 cafe.github.com
+codeload.github.com
 github.com
 productionresultssa0.blob.core.windows.net
 productionresultssa1.blob.core.windows.net


### PR DESCRIPTION
## Summary

Adds `codeload.github.com` to the bundled clearance allowlist so safehouse-backed agent runs can follow GitHub archive/action download redirects without opening broader GitHub wildcard access.

## Validation

- `node --run verify` passed
- Push hook ran `node --run verify` and passed

<!-- commit-push-pr:created v1 core@3.4.0 -->
