### PR TITLE
feat: ship unattended default prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Agent selection uses Linear labels: `agent-claude`, `agent-codex`, `agent-<name>
 
 ### Prompt customization
 
-Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a draft PR when GitHub/`gh` is available, include a workspace continuation hint when known, and avoid moving the Linear ticket to a terminal status.
+Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.
 
 For a personal workflow, keep the prompt next to your local config and load it with `readFileSync`:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ Three keys are required; everything else has a default.
 
 Agent selection uses Linear labels: `agent-claude`, `agent-codex`, `agent-<name>`. `crew run` without `--ticket` only fetches tickets carrying an `agent-*` label — the GraphQL query filters server-side, so unlabeled tickets are never returned by Linear and do not appear on the board. Use `crew run --ticket <TICKET>` to provision an unlabeled ticket on demand (falls back to `models.default`). `agent-any` routes to the model with the most available session capacity. Todo tickets blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
 
+### Prompt customization
+
+Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a draft PR when GitHub/`gh` is available, include a workspace continuation hint when known, and avoid moving the Linear ticket to a terminal status.
+
+For a personal workflow, keep the prompt next to your local config and load it with `readFileSync`:
+
+```ts
+import { readFileSync } from "node:fs";
+
+export const config = {
+  // ...
+  prompts: {
+    initial: readFileSync(new URL("./initial-prompt.md", import.meta.url), "utf8"),
+  },
+};
+```
+
+This keeps package defaults portable while letting your private config reference team-specific statuses, tools, plugins, or review loops.
+
 <details>
 <summary>Full reference table</summary>
 
@@ -195,7 +214,7 @@ Agent selection uses Linear labels: `agent-claude`, `agent-codex`, `agent-<name>
 | `models.definitions.<name>.usage`       | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Omit to never gate. When `usage.codexbar.source` is omitted, groundcrew uses `oauth` for Codex/Claude on macOS, `auto` for other macOS providers, and `cli` elsewhere.                            |
 | `models.definitions.<name>.sandbox`     | optional            | Docker Sandboxes binding for the model. Required at launch when `local.runner` resolves to `sdx`. Fields: `agent` (required sbx agent name), `template`, `kits`, `setupCommand` (override for the inside-sandbox setup script).                                                           |
 | `models.definitions.<name>.disabled`    | optional            | When set to exactly `true`, drops the named shipped default (`claude` or `codex`). Doctor skips probing it; `agent-<name>` labels fall back to `models.default` with a warning.                                                                                                           |
-| `prompts.initial`                       | (template)          | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`.                                                                                                                                                                              |
+| `prompts.initial`                       | unattended template | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override this from `config.ts` for team-specific statuses, tools, plugins, or review loops.                                                                                  |
 | `workspaceKind`                         | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing.                                                                                                                                 |
 | `local.runner`                          | `"auto"`            | Local isolation backend. `"auto"` → `safehouse` on macOS, `sdx` on Linux/WSL. Explicit: `"safehouse"`, `"sdx"`, `"none"`. `"none"` is never picked implicitly.                                                                                                                            |
 | `logging.file`                          | XDG state path      | Append-mode log file. `log()` / `logEvent()` tee here in addition to stdout. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                                                                                                                               |

--- a/configExample.ts
+++ b/configExample.ts
@@ -1,4 +1,5 @@
 import type { Config } from "./src/lib/config.js";
+// import { readFileSync } from "node:fs";
 
 export const config: Config = {
   linear: {
@@ -57,13 +58,10 @@ export const config: Config = {
   // local: { runner: "auto" },
   //
   // prompts: {
-  //   initial: [
-  //     "Begin work on {{ticket}} ({{title}}) in the {{worktree}} wt subdirectory.",
-  //     "",
-  //     "Ticket description:",
-  //     "",
-  //     "{{description}}",
-  //   ].join("\n"),
+  //   // Keep personal workflow instructions next to this config, for example
+  //   // `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/initial-prompt.md`.
+  //   // If you uncomment this, also uncomment the readFileSync import above.
+  //   initial: readFileSync(new URL("./initial-prompt.md", import.meta.url), "utf8"),
   // },
   //
   // // Terminal session manager. "auto" picks cmux when on PATH, else tmux.

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -138,9 +138,11 @@ describe("loadConfig", () => {
 
     expect(actual.prompts.initial).toContain("There is no human watching this session");
     expect(actual.prompts.initial).toMatch(/documented verification/i);
-    expect(actual.prompts.initial).toMatch(/draft pull request/i);
+    expect(actual.prompts.initial).toMatch(/open a pull request/i);
     expect(actual.prompts.initial).toContain("tmux attach -t groundcrew:{{ticket}}");
-    expect(actual.prompts.initial).toMatch(/terminal status/i);
+    expect(actual.prompts.initial).not.toContain("draft");
+    expect(actual.prompts.initial).not.toMatch(/terminal status/i);
+    expect(actual.prompts.initial).not.toContain("Do not wait for review feedback");
     expect(actual.prompts.initial).not.toContain("superpowers");
     expect(actual.prompts.initial).not.toContain("babysit-pr");
     expect(actual.prompts.initial).not.toContain("CodeRabbit");

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -123,6 +123,31 @@ describe("loadConfig", () => {
     expect(actual.prompts.initial).toContain("{{ticket}}");
   });
 
+  it("ships a model-agnostic unattended default prompt", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toContain("There is no human watching this session");
+    expect(actual.prompts.initial).toMatch(/documented verification/i);
+    expect(actual.prompts.initial).toMatch(/draft pull request/i);
+    expect(actual.prompts.initial).toContain("tmux attach -t groundcrew:{{ticket}}");
+    expect(actual.prompts.initial).toMatch(/terminal status/i);
+    expect(actual.prompts.initial).not.toContain("superpowers");
+    expect(actual.prompts.initial).not.toContain("babysit-pr");
+    expect(actual.prompts.initial).not.toContain("CodeRabbit");
+    expect(actual.prompts.initial).not.toContain("Generated with Claude Code");
+    expect(actual.prompts.initial).not.toContain("Co-Authored-By: Claude");
+  });
+
   it("accepts custom terminal statuses and dedupes them with done", async () => {
     const path = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -268,11 +268,27 @@ const DEFAULT_MODEL_DEFINITIONS: Record<string, ModelDefinition> = {
 };
 
 const DEFAULT_PROMPT_INITIAL = [
-  "Begin work on {{ticket}} ({{title}}) in the {{worktree}} wt subdirectory.",
+  "You are working on Linear ticket {{ticket}} ({{title}}) in the {{worktree}} worktree subdirectory.",
   "",
   "Ticket description:",
   "",
   "{{description}}",
+  "",
+  "## Operating mode",
+  "",
+  "There is no human watching this session. Do not stop to ask clarifying questions. When the ticket is ambiguous or incomplete, choose the simplest reasonable interpretation consistent with the ticket and the codebase, then document that choice in the PR description.",
+  "",
+  "## Workflow",
+  "",
+  "1. Inspect the repository instructions and existing patterns before editing.",
+  "2. Implement the smallest sensible change that completes the ticket.",
+  "3. Run the repository's documented verification command. If no documented verification exists, run the smallest relevant test suite you can find. Fix failures you introduced before continuing.",
+  "4. Review your own diff before stopping. Look for bugs, regressions, missing tests, security issues, and convention violations, then fix any issues you find.",
+  "5. If this repository uses GitHub and the `gh` CLI is available and authenticated, open a draft pull request. If you cannot open one, leave the branch ready and record the blocker.",
+  "6. Include a short continuation note in the PR body when you know how to reattach to this workspace. For the tmux backend, use `tmux attach -t groundcrew:{{ticket}}`.",
+  "7. Do not move the Linear ticket to Done or any other terminal status. Only move it to a non-terminal review status if the repository or project instructions explicitly name one.",
+  "",
+  "Stop after the branch is ready or the draft PR is open. Do not wait for review feedback.",
 ].join("\n");
 
 const ALLOWED_PROMPT_PLACEHOLDERS = new Set([

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -284,11 +284,10 @@ const DEFAULT_PROMPT_INITIAL = [
   "2. Implement the smallest sensible change that completes the ticket.",
   "3. Run the repository's documented verification command. If no documented verification exists, run the smallest relevant test suite you can find. Fix failures you introduced before continuing.",
   "4. Review your own diff before stopping. Look for bugs, regressions, missing tests, security issues, and convention violations, then fix any issues you find.",
-  "5. If this repository uses GitHub and the `gh` CLI is available and authenticated, open a draft pull request. If you cannot open one, leave the branch ready and record the blocker.",
+  "5. If this repository uses GitHub and the `gh` CLI is available and authenticated, open a pull request. If you cannot open one, leave the branch ready and record the blocker.",
   "6. Include a short continuation note in the PR body when you know how to reattach to this workspace. For the tmux backend, use `tmux attach -t groundcrew:{{ticket}}`.",
-  "7. Do not move the Linear ticket to Done or any other terminal status. Only move it to a non-terminal review status if the repository or project instructions explicitly name one.",
   "",
-  "Stop after the branch is ready or the draft PR is open. Do not wait for review feedback.",
+  "Stop after the branch is ready or the PR is open.",
 ].join("\n");
 
 const ALLOWED_PROMPT_PLACEHOLDERS = new Set([


### PR DESCRIPTION
## Summary

Replace the minimal default prompt with a portable unattended workflow prompt. The new default tells agents to make reasonable assumptions, follow repository instructions, run documented verification, review their diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.

Also documents the supported path for personal workflows: keep a Markdown prompt next to local config and load it with `readFileSync`, so package defaults stay model- and tool-agnostic.

## Validation

- `node --run verify`
- Pre-push hook reran `node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->
