### PR TITLE
feat(secrets): forward LINEAR_API_KEY to launched agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Set them in the shell you run `crew` from. Anything not in this list is ignored 
 
 Net effect: by the time the agent process exists, the values are gone from the environment and the file is gone from disk.
 
+### Agent-runtime secrets
+
+A separate, narrower allowlist gets forwarded **into** the agent's environment so it can talk back to the same upstreams the host does (groundcrew needs Linear to dispatch tickets; agents commonly need it to move their own ticket to "In Review" or post update comments). These values survive the build-secret scrub and are inherited by the agent process.
+
+**Recognized names.** Defined in [`AGENT_RUNTIME_SECRET_NAMES`](./src/lib/agentSecrets.ts):
+
+- `LINEAR_API_KEY` — sourced from `GROUNDCREW_LINEAR_API_KEY` (preferred) or `LINEAR_API_KEY` on the host and forwarded under the canonical name `LINEAR_API_KEY`, which is what the `@linear/sdk`, Linear MCP server, and `linear` CLI all look for.
+
+If the host has no Linear key set, agent.env is not staged — there's nothing to forward.
+
+**Flow.** Same shape as the build-secret flow, with two differences: agent.env is sourced **after** the build-secret `unset` (so the agent inherits it), and the names are **never** unset before exec. Under `sdx`, names are forwarded into the sandbox via `-e KEY` flags. See `stageAgentSecrets` in [`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts) and the `agentSecretsFile` branches in [`src/lib/launchCommand.ts`](./src/lib/launchCommand.ts).
+
 ## Runners
 
 `local.runner` picks the local isolation backend. `auto` resolves per platform.

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -707,6 +707,108 @@ describe(setupWorkspace, () => {
     });
   });
 
+  describe("agent-runtime secret shuttling (LINEAR_API_KEY)", () => {
+    afterEach(() => {
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    });
+
+    it("stages agent.env (mode 0600) with LINEAR_API_KEY when the host has LINEAR_API_KEY set", async () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_test_abc");
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      });
+
+      expect(writeFileMock).toHaveBeenCalledWith(
+        "/tmp/groundcrew-team-1-x/agent.env",
+        "LINEAR_API_KEY='lin_test_abc'\n",
+        { mode: 0o600 },
+      );
+      const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+      expect(launchScript).toContain(". '/tmp/groundcrew-team-1-x/agent.env'");
+      expect(launchScript).not.toMatch(/unset[^&|;]*LINEAR_API_KEY/);
+    });
+
+    it("canonicalizes GROUNDCREW_LINEAR_API_KEY to LINEAR_API_KEY in agent.env", async () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_groundcrew_xyz");
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      });
+
+      expect(writeFileMock).toHaveBeenCalledWith(
+        "/tmp/groundcrew-team-1-x/agent.env",
+        "LINEAR_API_KEY='lin_groundcrew_xyz'\n",
+        { mode: 0o600 },
+      );
+    });
+
+    it("prefers GROUNDCREW_LINEAR_API_KEY over LINEAR_API_KEY when both are set", async () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_groundcrew_wins");
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_plain_loses");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      });
+
+      expect(writeFileMock).toHaveBeenCalledWith(
+        "/tmp/groundcrew-team-1-x/agent.env",
+        "LINEAR_API_KEY='lin_groundcrew_wins'\n",
+        { mode: 0o600 },
+      );
+    });
+
+    it("escapes single quotes in the Linear API key so the file is sourceable", async () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_with'quote");
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      });
+
+      expect(writeFileMock).toHaveBeenCalledWith(
+        "/tmp/groundcrew-team-1-x/agent.env",
+        `${String.raw`LINEAR_API_KEY='lin_with'\''quote'`}\n`,
+        { mode: 0o600 },
+      );
+    });
+
+    it("skips agent.env entirely when no Linear API key is set on the host", async () => {
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+      });
+
+      expect(writeFileMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("agent.env"),
+        expect.anything(),
+        expect.anything(),
+      );
+      const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+      expect(launchScript).not.toContain("agent.env");
+    });
+  });
+
   it("logs the tmux access hint after launch so the user knows how to reach the workspace", async () => {
     mockTmuxHost();
     const config = makeConfig();

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -11,7 +11,13 @@ import { detectHostCapabilities } from "../lib/host.ts";
 import { buildLaunchCommand, shellSingleQuote } from "../lib/launchCommand.ts";
 import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "../lib/localRunner.ts";
-import { errorMessage, getLinearClient, log, readEnvironmentVariable } from "../lib/util.ts";
+import {
+  errorMessage,
+  getLinearClient,
+  log,
+  readEnvironmentVariable,
+  resolveLinearApiKey,
+} from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import { isWorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
@@ -79,6 +85,29 @@ function stageBuildSecrets(promptDir: string): string | undefined {
   const secretsFile = join(promptDir, "secrets.env");
   writeFileSync(secretsFile, `${lines.join("\n")}\n`, { mode: 0o600 });
   return secretsFile;
+}
+
+/**
+ * Stage a `KEY='value'` env file for agent-runtime secrets so the launched
+ * agent inherits them across the build-secret unset. Today the only
+ * runtime secret is `LINEAR_API_KEY` — sourced from either
+ * `GROUNDCREW_LINEAR_API_KEY` (preferred) or `LINEAR_API_KEY` on the host
+ * and canonicalized to `LINEAR_API_KEY` for the agent (which is what the
+ * Linear SDK, MCP server, and `linear` CLI all look for). Returns
+ * `undefined` when the host has no key, leaving the launch command
+ * unchanged. The temp dir is `rm -rf`'d by the launch command (and
+ * rollback path), so cleanup is already handled.
+ */
+function stageAgentSecrets(promptDir: string): string | undefined {
+  const resolved = resolveLinearApiKey();
+  if (resolved === undefined) {
+    return undefined;
+  }
+  const agentSecretsFile = join(promptDir, "agent.env");
+  writeFileSync(agentSecretsFile, `LINEAR_API_KEY=${shellSingleQuote(resolved.value)}\n`, {
+    mode: 0o600,
+  });
+  return agentSecretsFile;
 }
 
 function stageLaunchScript(promptDir: string, command: string): string {
@@ -173,6 +202,7 @@ export async function setupWorkspace(
     promptDir = stagedPrompt.directory;
 
     const secretsFile = stageBuildSecrets(promptDir);
+    const agentSecretsFile = stageAgentSecrets(promptDir);
 
     const sandboxName =
       runner === "sdx" && definition.sandbox !== undefined
@@ -193,6 +223,7 @@ export async function setupWorkspace(
       promptFile: stagedPrompt.file,
       worktreeDir: launchDir,
       secretsFile,
+      agentSecretsFile,
       runner,
       sandboxName,
     });

--- a/src/lib/agentSecrets.ts
+++ b/src/lib/agentSecrets.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime secrets shuttled into the agent's environment. Unlike
+ * `BUILD_SECRET_NAMES` (which are scrubbed before the agent execs), these
+ * survive across the build-secret unset so the agent process inherits them
+ * — agents commonly need to talk back to the same upstreams the host does
+ * (e.g. Linear) and otherwise have no way to authenticate inside the
+ * sandbox.
+ *
+ * Names listed here are the canonical names the agent sees. The host may
+ * read its own value from a different env var (e.g. `LINEAR_API_KEY` is
+ * sourced from `GROUNDCREW_LINEAR_API_KEY` first); resolution happens in
+ * `stageAgentSecrets` (see `src/commands/setupWorkspace.ts`).
+ */
+export const AGENT_RUNTIME_SECRET_NAMES = ["LINEAR_API_KEY"] as const;

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -132,6 +132,55 @@ describe(buildLaunchCommand, () => {
     });
   });
 
+  describe("agentSecretsFile (runtime secret shuttling)", () => {
+    it("omits agent.env references when agentSecretsFile is undefined", () => {
+      const out = buildLaunchCommand(arguments_());
+
+      expect(out).not.toContain("agent.env");
+    });
+
+    it("sources agentSecretsFile after the build-secret unset so the agent inherits the values", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          secretsFile: "/tmp/prompt-team-1/secrets.env",
+          agentSecretsFile: "/tmp/prompt-team-1/agent.env",
+        }),
+      );
+
+      const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
+      const agentSourceIndex = out.indexOf(". '/tmp/prompt-team-1/agent.env'");
+      const execIndex = out.indexOf("safehouse-clearance");
+      expect(unsetIndex).toBeGreaterThan(-1);
+      expect(agentSourceIndex).toBeGreaterThan(unsetIndex);
+      expect(execIndex).toBeGreaterThan(agentSourceIndex);
+      expect(out).toContain(
+        "if [ -f '/tmp/prompt-team-1/agent.env' ]; then set -a && . '/tmp/prompt-team-1/agent.env' && set +a; fi",
+      );
+    });
+
+    it("sources agentSecretsFile even when no build secrets file is staged", () => {
+      const out = buildLaunchCommand(
+        arguments_({ agentSecretsFile: "/tmp/prompt-team-1/agent.env" }),
+      );
+
+      expect(out).toContain(". '/tmp/prompt-team-1/agent.env'");
+      expect(out).not.toContain("unset NPM_TOKEN");
+      // Agent-runtime names must NOT be unset — they need to survive into exec.
+      expect(out).not.toContain("unset LINEAR_API_KEY");
+    });
+
+    it("does not unset agent-runtime secret names before exec", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          secretsFile: "/tmp/prompt-team-1/secrets.env",
+          agentSecretsFile: "/tmp/prompt-team-1/agent.env",
+        }),
+      );
+
+      expect(out).not.toMatch(/unset[^&|;]*LINEAR_API_KEY/);
+    });
+  });
+
   describe("runner='none'", () => {
     it("execs the agent directly without the safehouse wrapper", () => {
       const out = buildLaunchCommand(arguments_({ runner: "none" }));
@@ -224,6 +273,36 @@ describe(buildLaunchCommand, () => {
 
       expect(out).not.toContain("-e NPM_TOKEN");
       expect(out).not.toContain("-e BUF_TOKEN");
+    });
+
+    it("forwards agent-runtime secret names into the sandbox via `-e KEY` when agentSecretsFile is staged", () => {
+      const out = buildLaunchCommand(
+        sdxArguments({ agentSecretsFile: "/tmp/prompt-team-1/agent.env" }),
+      );
+
+      expect(out).toContain(". '/tmp/prompt-team-1/agent.env'");
+      expect(out).toContain("-e LINEAR_API_KEY");
+      // Agent runtime names must not be unset inside the sandbox.
+      expect(out).not.toContain("unset LINEAR_API_KEY");
+    });
+
+    it("omits -e LINEAR_API_KEY when no agentSecretsFile is staged", () => {
+      const out = buildLaunchCommand(sdxArguments());
+
+      expect(out).not.toContain("-e LINEAR_API_KEY");
+    });
+
+    it("forwards both build and agent secrets when both files are staged", () => {
+      const out = buildLaunchCommand(
+        sdxArguments({
+          secretsFile: "/tmp/prompt-team-1/secrets.env",
+          agentSecretsFile: "/tmp/prompt-team-1/agent.env",
+        }),
+      );
+
+      expect(out).toContain("-e NPM_TOKEN -e BUF_TOKEN -e LINEAR_API_KEY");
+      expect(out).toContain("unset NPM_TOKEN BUF_TOKEN");
+      expect(out).not.toContain("unset LINEAR_API_KEY");
     });
   });
 });

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
+import { AGENT_RUNTIME_SECRET_NAMES } from "./agentSecrets.ts";
 import { BUILD_SECRET_NAMES, type LocalRunner, type ModelDefinition } from "./config.ts";
 import { shellSingleQuote } from "./shell.ts";
 
@@ -71,6 +72,27 @@ function unsetSecretsLine(): string {
   return `unset ${BUILD_SECRET_NAMES.join(" ")}`;
 }
 
+/**
+ * Append the shared tail: source the agent-runtime secrets file (if any),
+ * read the prompt into `$_p`, then wipe the prompt dir (including any
+ * staged env files — they've already been sourced into the shell env that
+ * `exec` will inherit). Callers append the runner-specific `exec` line
+ * after this.
+ */
+function appendAgentSecretsAndPromptTail(
+  lines: string[],
+  arguments_: { agentSecretsFile?: string | undefined; promptFile: string },
+  promptDir: string,
+): void {
+  if (arguments_.agentSecretsFile !== undefined) {
+    lines.push(sourceSecretsLine(arguments_.agentSecretsFile));
+  }
+  lines.push(
+    `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
+    `rm -rf ${shellSingleQuote(promptDir)}`,
+  );
+}
+
 interface LaunchCommandArguments {
   definition: ModelDefinition;
   promptFile: string;
@@ -83,6 +105,14 @@ interface LaunchCommandArguments {
    * agent process never inherits them.
    */
   secretsFile?: string | undefined;
+  /**
+   * Optional path to a `KEY='value'` env file containing agent-runtime
+   * secrets (see `AGENT_RUNTIME_SECRET_NAMES`). Sourced AFTER the
+   * build-secret unset so the values survive into the agent's `exec`; for
+   * the sdx runner the names are propagated into the sandbox via `sbx
+   * exec -e KEY`. Never unset before agent exec.
+   */
+  agentSecretsFile?: string | undefined;
   /**
    * Concrete local isolation backend chosen for this launch. Resolved
    * from `config.local.runner` via `resolveLocalRunner` before this
@@ -135,11 +165,8 @@ function buildHostLaunchCommand(arguments_: LaunchCommandArguments): string {
   if (arguments_.secretsFile !== undefined) {
     lines.push(unsetSecretsLine());
   }
-  lines.push(
-    `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
-    `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec ${wrapped} "$_p"`,
-  );
+  appendAgentSecretsAndPromptTail(lines, arguments_, promptDir);
+  lines.push(`exec ${wrapped} "$_p"`);
   return lines.join(" && ");
 }
 
@@ -194,17 +221,23 @@ function buildSdxLaunchCommand(arguments_: LaunchCommandArguments): string {
   // from its own env at invocation time — populated by sourceSecretsLine
   // a few lines up. Avoids `-e KEY="$KEY"`, which would embed the value
   // in argv and break on `"`, `$`, or backticks in the token.
+  const sbxEnvironmentNames: string[] = [];
+  if (arguments_.secretsFile !== undefined) {
+    sbxEnvironmentNames.push(...BUILD_SECRET_NAMES);
+  }
+  if (arguments_.agentSecretsFile !== undefined) {
+    sbxEnvironmentNames.push(...AGENT_RUNTIME_SECRET_NAMES);
+  }
   const sbxEnvironmentFlags =
-    arguments_.secretsFile === undefined
+    sbxEnvironmentNames.length === 0
       ? ""
-      : `${BUILD_SECRET_NAMES.map((name) => `-e ${name}`).join(" ")} `;
+      : `${sbxEnvironmentNames.map((name) => `-e ${name}`).join(" ")} `;
   const lines: string[] = [];
   if (arguments_.secretsFile !== undefined) {
     lines.push(sourceSecretsLine(arguments_.secretsFile));
   }
+  appendAgentSecretsAndPromptTail(lines, arguments_, promptDir);
   lines.push(
-    `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
-    `rm -rf ${shellSingleQuote(promptDir)}`,
     `exec sbx exec -it ${sbxEnvironmentFlags}-w ${shellSingleQuote(arguments_.worktreeDir)} ${shellSingleQuote(arguments_.sandboxName)} sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
   );
   return lines.join(" && ");


### PR DESCRIPTION
## Summary

- Add an agent-runtime secret channel parallel to `BUILD_SECRET_NAMES`, so launched agents can authenticate to Linear from inside the sandbox.
- New `AGENT_RUNTIME_SECRET_NAMES = ["LINEAR_API_KEY"]`; values survive the build-secret unset and are forwarded under the canonical name `LINEAR_API_KEY` (sourced from `GROUNDCREW_LINEAR_API_KEY` || `LINEAR_API_KEY` on the host — whichever is set).
- sdx runner forwards via `-e LINEAR_API_KEY` to `sbx exec`; agent-runtime names are never unset before exec.

## Why

The existing `BUILD_SECRET_NAMES` mechanism is deliberately scrubbed before the agent execs — the comment in `src/lib/buildSecrets.ts` is explicit: *"The launched agent process must not inherit these values."* That hardening is correct for `NPM_TOKEN` / `BUF_TOKEN`, which only need to live through `npm install`.

But groundcrew-dispatched agents commonly need to talk back to the same upstreams the host does — e.g. moving their own ticket to "In Review", posting follow-up comments, or reading sibling tickets — and had no Linear key inside the sandbox. Symptom: an agent finishing a ticket reports back *"Linear ticket move: ⚠️ Could not be completed autonomously. No Linear API token is accessible in this sandbox"* and asks the human to move the ticket by hand.

Network was never the blocker (`api.linear.app`, `mcp.linear.app`, `linear.app` are already in `clearance-allow-hosts`); the gap was purely the missing credential. This PR adds the credential channel without weakening the existing build-secret scrub.

## Design notes

- **Canonical name out.** Host can use either `GROUNDCREW_LINEAR_API_KEY` (preferred, disambiguates groundcrew's key from a user's general shell var) or `LINEAR_API_KEY` (fallback). Either way the agent only ever sees `LINEAR_API_KEY` — which is what `@linear/sdk`, the Linear MCP server, and the `linear` CLI all read.
- **Always-on, mirroring build secrets.** No new config surface — if the host has a key, the agent gets it. Same trust model as `NPM_TOKEN` / `BUF_TOKEN`.
- **Two distinct lifecycles.** `secrets.env` (build) is sourced → setup runs → unset → gone. `agent.env` (runtime) is sourced **after** that unset and never unset, so it survives into `exec`. The prompt dir's `rm -rf` deletes the file from disk before exec; the values are already in the shell env that `exec` inherits.
- **sdx specifics.** Host shell sources `agent.env`, then `sbx exec -e LINEAR_API_KEY ...` passthrough propagates the value into the sandbox at invocation time. The sandbox's inner `unset NPM_TOKEN BUF_TOKEN` never touches the agent runtime names.

## Test plan

- [x] `node --run verify` — all 10 checks pass; **770 tests**; **100% coverage** maintained.
- [x] New unit tests in `launchCommand.test.ts` cover host runner ordering (source-after-unset, never-unset of agent names), sdx `-e KEY` passthrough including the combined `-e NPM_TOKEN -e BUF_TOKEN -e LINEAR_API_KEY` shape, and the no-op path.
- [x] New unit tests in `setupWorkspace.test.ts` cover `agent.env` staging, canonicalization of `GROUNDCREW_LINEAR_API_KEY` → `LINEAR_API_KEY`, precedence (`GROUNDCREW_*` wins when both set), single-quote escaping, and the no-op when no host key is set.
- [ ] Manual smoke: dispatch a ticket, confirm the launched agent can authenticate against Linear (e.g. via `linear` CLI or Linear MCP) without prompting for setup, and that it can autonomously move its own ticket to "In Review" / "Done".