### PR TITLE
chore: allow npm package website in clearance

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -59,9 +59,10 @@ raw.githubusercontent.com
 release-assets.githubusercontent.com
 results-receiver.actions.githubusercontent.com
 
-# npm registry
+# npm registry + package website
 api.npmjs.org
 registry.npmjs.org
+www.npmjs.com
 
 # Developer tooling
 buf.build


### PR DESCRIPTION
## Summary

Adds the public npm package website host (`www.npmjs.com`) to the shipped Clearance starter allowlist so Safehouse-wrapped agent runs can reach npm package pages while retaining the existing exact-host allowlist model.

## Validation

- `node --run verify`
- Pre-push hook: `node --run verify`

## Notes

Clearance exact-host rules still limit this to `www.npmjs.com`, not a wildcard for npmjs.com.

Agent session: codex resume 019e472e-5afa-78a0-946d-2d032b038137
<!-- commit-push-pr:created v1 core@3.4.0 -->