### PR TITLE
feat(prompt): instruct agents to add `Closes {{ticket}}` to PR description

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -295,7 +295,8 @@ const DEFAULT_PROMPT_INITIAL = [
   "3. Run the repository's documented verification command. If no documented verification exists, run the smallest relevant test suite you can find. Fix failures you introduced before continuing.",
   "4. Review your own diff before stopping. Look for bugs, regressions, missing tests, security issues, and convention violations, then fix any issues you find.",
   "5. If this repository uses GitHub and the `gh` CLI is available and authenticated, open a pull request. If you cannot open one, leave the branch ready and record the blocker.",
-  "6. Include a short continuation note in the PR body when you know how to reattach to this workspace. For the tmux backend, use `tmux attach -t groundcrew:{{ticket}}`.",
+  "6. Include `Closes {{ticket}}` in the PR description.",
+  "7. Include a short continuation note in the PR body when you know how to reattach to this workspace. For the tmux backend, use `tmux attach -t groundcrew:{{ticket}}`.",
   "",
   "Stop after the branch is ready or the PR is open.",
 ].join("\n");


### PR DESCRIPTION
## Summary

Adds a step to the default initial prompt instructing agents to include `Closes {{ticket}}` in the PR description, so the Linear<>GitHub integration auto-links the PR to the Linear ticket.

## Validation

- `node --run verify` — passed

Agent session: claude --resume 19df17cd-f5fc-4aa5-b531-41068392346e
<!-- commit-push-pr:created v1 core@3.4.1 -->