### PR TITLE
feat(workflow): persist run state across setup and cleanup (ORB-2184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,14 +316,16 @@ crew run                                                 # one-shot dispatch
 crew run --watch                                         # poll forever
 crew run --ticket <TICKET>                               # provision one ticket and exit
 crew setup repos [--dry-run] [<repo>...]
+crew interrupt <TICKET> [--reason <text>]                # stop the live workspace, keep the worktree
+crew resume <TICKET>                                     # reopen an existing ticket worktree
 crew cleanup <TICKET>                                    # tear down every worktree carrying this ticket
 ```
 
-`crew doctor --ticket <TICKET>` covers the full per-ticket lifecycle: pre-dispatch eligibility (Todo status, `agent-*` label, model resolution, repository mention, local clone, blockers, model session usage, in-progress capacity) **and** post-dispatch local-state recovery (host worktree, workspace pane, local branch, remote branch, open PR). Verdict precedence runs from post-dispatch outcomes down: `pr-open` > `pr-merged` > `in-flight` > `recoverable` > `unresolvable` > `ineligible` > `would-dispatch` > `lost`. Exits 0 on `would-dispatch`, `pr-open`, or `pr-merged`; any other verdict exits 1. `--watch` and `--ticket` are mutually exclusive. To inspect codexbar session windows directly, run `codexbar usage`.
+`crew doctor --ticket <TICKET>` covers the full per-ticket lifecycle: pre-dispatch eligibility (Todo status, `agent-*` label, model resolution, repository mention, local clone, blockers, model session usage, in-progress capacity) **and** post-dispatch local-state recovery (recorded run state, host worktree, workspace pane, local branch, remote branch, open PR). Verdict precedence starts with PR outcomes (`pr-open` > `pr-merged`). Recorded failed launches report before ordinary local recovery, interrupted runs report concrete recoverable git work first when it exists and otherwise report `interrupted`, and ordinary post-dispatch cases report `in-flight` before `recoverable`. If none of those apply, doctor falls through to `unresolvable` > `ineligible` > `would-dispatch` > `lost`. Exits 0 on `would-dispatch`, `pr-open`, or `pr-merged`; any other verdict exits 1. `--watch` and `--ticket` are mutually exclusive. To inspect codexbar session windows directly, run `codexbar usage`.
 
 ### `crew doctor --ticket <ticket>`
 
-Diagnose where a ticket is in its lifecycle and what to do next. Runs the same resolution and eligibility chain as the dispatcher, plus probes the host worktree, workspace pane, local branch, remote branch, and PR; prints a single verdict with a copy-pasteable recovery step when one applies.
+Diagnose where a ticket is in its lifecycle and what to do next. Runs the same resolution and eligibility chain as the dispatcher, plus probes recorded run state, host worktree, workspace pane, local branch, remote branch, and PR; prints a single verdict with a copy-pasteable recovery step when one applies.
 
 Flags:
 
@@ -343,6 +345,13 @@ Resolution
 
 Eligibility
   (skipped — post-dispatch — pre-dispatch checks are irrelevant)
+
+Run state
+  [ok] Local run state (running)
+  [ok] Recorded model (claude)
+  [ok] Recorded worktree (/Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442)
+  [ok] Recorded branch (paul-hrd-442)
+  [ok] Resume count (0)
 
 Worktree
   [ok] Host worktree exists (/Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442)
@@ -374,10 +383,30 @@ The verdict on the last line maps to a recovery action:
 | `pr-merged`      | Done.                                                                                         |
 | `in-flight`      | The ticket is still being worked on; the verdict line names the workspace pane to attach to.  |
 | `recoverable`    | Run the printed `nextStep` exactly.                                                           |
+| `interrupted`    | Resume the preserved worktree with `crew resume <ticket>` or inspect it by hand.              |
+| `failed-launch`  | Fix the launch failure, then run `crew resume <ticket>` or `crew cleanup <ticket>`.           |
 | `would-dispatch` | Pre-dispatch checks pass; the orchestrator will pick the ticket up on its next tick.          |
 | `ineligible`     | A resolution or eligibility check failed; the reason after the colon names the failing check. |
 | `unresolvable`   | The Linear ticket couldn't be fetched; the reason after the colon names the error.            |
 | `lost`           | No trace exists. Re-dispatch via `crew run --ticket <ticket>`.                                |
+
+### `crew interrupt <ticket>`
+
+Stop a live workspace pane while preserving the ticket worktree and branch. This is the manual pause button for cases where you need terminal capacity back, want to stop an agent that is going in the wrong direction, or need to inspect the diff before letting another agent continue.
+
+```bash
+crew interrupt HRD-442 --reason "wrong implementation direction"
+crew doctor --ticket HRD-442
+crew resume HRD-442
+```
+
+The command closes the cmux/tmux workspace when it exists, records local run state under the groundcrew state directory, and never tears down the worktree. If the workspace was already gone but the worktree is still present, interrupt records that fact so doctor can point at the preserved branch instead of reporting a mystery ticket.
+
+### `crew resume <ticket>`
+
+Reopen an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists, it fails and leaves re-dispatch to `crew run --ticket <ticket>`.
+
+The resume prompt tells the agent to inspect current git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and ticket context.
 
 ## Troubleshooting
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -4,7 +4,9 @@ import { createRequire } from "node:module";
 import { run } from "./cli.ts";
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
+import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
+import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
@@ -19,8 +21,14 @@ vi.mock(import("./commands/cleanupWorkspace.ts"), () => ({
 vi.mock(import("./commands/doctor.ts"), () => ({
   doctor: vi.fn<typeof doctor>(),
 }));
+vi.mock(import("./commands/interruptWorkspace.ts"), () => ({
+  interruptWorkspaceCli: vi.fn<typeof interruptWorkspaceCli>(),
+}));
 vi.mock(import("./commands/orchestrator.ts"), () => ({
   orchestrate: vi.fn<typeof orchestrate>(),
+}));
+vi.mock(import("./commands/resumeWorkspace.ts"), () => ({
+  resumeWorkspaceCli: vi.fn<typeof resumeWorkspaceCli>(),
 }));
 vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
@@ -31,6 +39,8 @@ vi.mock(import("./commands/setupRepos.ts"), () => ({
 
 const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
+const interruptMock = vi.mocked(interruptWorkspaceCli);
+const resumeMock = vi.mocked(resumeWorkspaceCli);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
@@ -65,6 +75,8 @@ describe(run, () => {
     process.exitCode = undefined;
     orchestrateMock.mockResolvedValue();
     doctorMock.mockResolvedValue(true);
+    interruptMock.mockResolvedValue();
+    resumeMock.mockResolvedValue();
     setupMock.mockResolvedValue();
     setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
@@ -314,6 +326,17 @@ describe(run, () => {
     expect(cleanupMock).toHaveBeenCalledWith(["--force", "TEAM-1"]);
   });
 
+  it("dispatches interrupt to interruptWorkspaceCli with the remaining argv", async () => {
+    await run(["interrupt", "TEAM-1", "--reason", "wrong direction"]);
+
+    expect(interruptMock).toHaveBeenCalledWith(["TEAM-1", "--reason", "wrong direction"]);
+  });
+
+  it("dispatches resume to resumeWorkspaceCli with the remaining argv", async () => {
+    await run(["resume", "TEAM-1"]);
+
+    expect(resumeMock).toHaveBeenCalledWith(["TEAM-1"]);
+  });
   it("dispatches `setup repos` to setupReposCli with the remaining argv", async () => {
     await run(["setup", "repos", "--dry-run", "owner/repo"]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,9 @@ import { createRequire } from "node:module";
 
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
+import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
+import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { errorMessage, readTicketArgument, writeError, writeOutput } from "./lib/util.ts";
@@ -114,6 +116,16 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Tear down a worktree",
     usage: "[--force] <ticket>",
     invoke: cleanupWorkspaceCli,
+  },
+  interrupt: {
+    summary: "Stop a live ticket workspace while preserving its worktree",
+    usage: "<ticket> [--reason <text>]",
+    invoke: interruptWorkspaceCli,
+  },
+  resume: {
+    summary: "Reopen an existing ticket worktree with a continuation prompt",
+    usage: "<ticket>",
+    invoke: resumeWorkspaceCli,
   },
   setup: {
     summary: "Project-level setup commands (currently: repos)",

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -1,5 +1,6 @@
 import type { BoardState, Issue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { removeRunState } from "../lib/runState.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
@@ -15,8 +16,13 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     },
   };
 });
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, removeRunState: vi.fn<typeof removeRunState>() };
+});
 
 const teardownMock = vi.mocked(worktrees.teardown);
+const removeRunStateMock = vi.mocked(removeRunState);
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
@@ -111,6 +117,7 @@ describe(createCleaner, () => {
     });
 
     expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry]);
+    expect(removeRunStateMock).toHaveBeenCalledWith(expect.anything(), "team-1");
     expect(consoleLog.output()).toContain("event=cleanup outcome=cleaned ticket=team-1");
   });
 

--- a/src/commands/cleaner.ts
+++ b/src/commands/cleaner.ts
@@ -6,6 +6,7 @@
 
 import { type BoardState, isTerminalStatus } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { log, logEvent } from "../lib/util.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
@@ -71,6 +72,7 @@ export function createCleaner(deps: CleanerDeps): Cleaner {
       signal === undefined
         ? await worktrees.teardown(config, stale)
         : await worktrees.teardown(config, stale, { signal });
+    recordCleanedUpRuns(config, result.removed);
     logTeardown(result);
     recordTeardownEvents(result);
   }

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -1,4 +1,5 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { removeRunState } from "../lib/runState.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
@@ -19,10 +20,15 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     },
   };
 });
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, removeRunState: vi.fn<typeof removeRunState>() };
+});
 
 const loadConfigMock = vi.mocked(loadConfig);
 const findByTicketMock = vi.mocked(worktrees.findByTicket);
 const teardownMock = vi.mocked(worktrees.teardown);
+const removeRunStateMock = vi.mocked(removeRunState);
 
 const hostEntry: WorktreeEntry = {
   repository: "repo-a",
@@ -78,6 +84,7 @@ describe(cleanupWorkspace, () => {
     await cleanupWorkspace(config, { ticket: "team-1" });
 
     expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: false });
+    expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
   });
 
   it("passes --force through to teardown", async () => {
@@ -110,6 +117,18 @@ describe(cleanupWorkspace, () => {
     await cleanupWorkspace(config, { ticket: "team-1" });
 
     expect(consoleLog.output()).toContain("workspace list failed: cmux exploded");
+  });
+
+  it("logs and continues when marking removed run state fails", async () => {
+    findByTicketMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+    removeRunStateMock.mockImplementation(() => {
+      throw new Error("state write failed");
+    });
+
+    await cleanupWorkspace(config, { ticket: "team-1" });
+
+    expect(consoleLog.output()).toContain("Run state cleanup failed");
   });
 
   it("stays silent on workspaceProbe.unavailable when no underlying error is reported", async () => {

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -1,4 +1,5 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { log } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
 import { logTeardown } from "./teardownReporter.ts";
@@ -44,6 +45,7 @@ export async function cleanupWorkspace(
   }
 
   const result = await worktrees.teardown(config, entries, { force });
+  recordCleanedUpRuns(config, result.removed);
   logTeardown(result);
   if (result.failures.length > 0) {
     throw result.failures[0]?.error;

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -21,6 +21,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -1,0 +1,233 @@
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { interruptWorkspace, interruptWorkspaceCli } from "./interruptWorkspace.ts";
+
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    recordRunState: vi.fn<typeof recordRunState>(),
+  };
+});
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
+    },
+  };
+});
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      findByTicket: vi.fn<typeof actual.worktrees.findByTicket>(),
+      teardown: vi.fn<typeof actual.worktrees.teardown>(),
+    },
+  };
+});
+
+const loadConfigMock = vi.mocked(loadConfig);
+const readRunStateMock = vi.mocked(readRunState);
+const recordRunStateMock = vi.mocked(recordRunState);
+const interruptMock = vi.mocked(workspaces.interrupt);
+const findByTicketMock = vi.mocked(worktrees.findByTicket);
+const teardownMock = vi.mocked(worktrees.teardown);
+
+type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
+
+function lastRecordedRunState(): RecordedRunState {
+  const input = recordRunStateMock.mock.calls.at(-1)?.[0];
+  if (input === undefined) {
+    throw new Error("recordRunState was not called");
+  }
+  return input.state;
+}
+
+function makeConfig(): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    ticket: "team-1",
+    repository: "repo-a",
+    model: "claude",
+    worktreeDir: "/work/repo-a-team-1",
+    branchName: "rocky-team-1",
+    workspaceName: "team-1",
+    state: "running",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    resumeCount: 0,
+    ...overrides,
+  };
+}
+
+function makeWorktree(): WorktreeEntry {
+  return {
+    repository: "repo-a",
+    ticket: "team-1",
+    branchName: "rocky-team-1",
+    dir: "/work/repo-a-team-1",
+    kind: "host",
+  };
+}
+
+describe(interruptWorkspace, () => {
+  let consoleLog: ConsoleCapture;
+  const config = makeConfig();
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    interruptMock.mockResolvedValue({ kind: "interrupted" });
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    vi.resetAllMocks();
+  });
+
+  it("interrupts the recorded workspace and preserves the worktree", async () => {
+    await interruptWorkspace(config, { ticket: "TEAM-1", reason: "wrong direction" });
+
+    expect(interruptMock).toHaveBeenCalledWith(config, "team-1");
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      state: "interrupted",
+      reason: "wrong direction",
+      worktreeDir: "/work/repo-a-team-1",
+    });
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("worktree preserved");
+  });
+
+  it("records an interrupted state from a worktree when state is missing", async () => {
+    readRunStateMock.mockReset();
+
+    await interruptWorkspace(config, { ticket: "team-1" });
+
+    expect(lastRecordedRunState()).toMatchObject({
+      model: "claude",
+      repository: "repo-a",
+      state: "interrupted",
+    });
+  });
+
+  it("records workspace missing detail without failing", async () => {
+    interruptMock.mockResolvedValue({ kind: "missing" });
+
+    await interruptWorkspace(config, { ticket: "team-1" });
+
+    expect(lastRecordedRunState()).toMatchObject({
+      state: "interrupted",
+      detail: "workspace missing",
+    });
+  });
+
+  it("fails when there is no run state or worktree", async () => {
+    readRunStateMock.mockReset();
+    findByTicketMock.mockReturnValue([]);
+
+    await expect(interruptWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /nothing to interrupt/,
+    );
+  });
+
+  it("fails when the workspace backend is unavailable", async () => {
+    interruptMock.mockResolvedValue({ kind: "unavailable", error: new Error("cmux down") });
+
+    await expect(interruptWorkspace(config, { ticket: "team-1" })).rejects.toThrow(/cmux down/);
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a generic error when the workspace backend is unavailable without details", async () => {
+    interruptMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(interruptWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /workspace adapter unavailable/,
+    );
+  });
+});
+
+describe(interruptWorkspaceCli, () => {
+  const config = makeConfig();
+
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(config);
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    interruptMock.mockResolvedValue({ kind: "interrupted" });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses ticket and reason", async () => {
+    await interruptWorkspaceCli(["TEAM-1", "--reason", "wrong direction"]);
+
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      reason: "wrong direction",
+    });
+  });
+
+  it("parses a ticket without a reason", async () => {
+    await interruptWorkspaceCli(["TEAM-1"]);
+
+    expect(lastRecordedRunState()).toMatchObject({ ticket: "team-1", state: "interrupted" });
+    expect(lastRecordedRunState().reason).toBeUndefined();
+  });
+
+  it("rejects missing ticket", async () => {
+    await expect(interruptWorkspaceCli([])).rejects.toThrow(/Usage: crew interrupt/);
+  });
+
+  it("rejects missing reason text", async () => {
+    await expect(interruptWorkspaceCli(["team-1", "--reason"])).rejects.toThrow(
+      /reason text is required/,
+    );
+  });
+
+  it("rejects unknown options", async () => {
+    await expect(interruptWorkspaceCli(["--bogus", "team-1"])).rejects.toThrow(
+      /Unknown option: --bogus/,
+    );
+  });
+});

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -1,0 +1,146 @@
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import { errorMessage, log } from "../lib/util.ts";
+import { workspaces, type WorkspaceInterruptResult } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+
+export interface InterruptWorkspaceOptions {
+  ticket: string;
+  reason?: string;
+}
+
+interface InterruptSource {
+  ticket: string;
+  repository: string;
+  model: string;
+  worktreeDir: string;
+  branchName: string;
+  workspaceName: string;
+  resumeCount: number;
+}
+
+function parseArguments(argv: string[]): InterruptWorkspaceOptions {
+  let reason: string | undefined;
+  const positionals: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    /* v8 ignore next @preserve -- loop bounds ensure argv[index] exists; guard satisfies noUncheckedIndexedAccess */
+    if (argument === undefined) {
+      continue;
+    }
+    if (argument === "--reason") {
+      const value = argv[index + 1];
+      if (value === undefined || value.length === 0 || value.startsWith("-")) {
+        throw new Error("crew interrupt --reason: reason text is required");
+      }
+      reason = value;
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(
+        `Unknown option: ${argument}\nUsage: crew interrupt <ticket> [--reason <text>]`,
+      );
+    }
+    positionals.push(argument);
+  }
+  const [ticket, ...extras] = positionals;
+  if (ticket === undefined || ticket.length === 0 || extras.length > 0) {
+    throw new Error("Usage: crew interrupt <ticket> [--reason <text>]");
+  }
+  return { ticket: ticket.toLowerCase(), ...(reason === undefined ? {} : { reason }) };
+}
+
+function sourceFromState(state: RunState): InterruptSource {
+  return {
+    ticket: state.ticket,
+    repository: state.repository,
+    model: state.model,
+    worktreeDir: state.worktreeDir,
+    branchName: state.branchName,
+    workspaceName: state.workspaceName,
+    resumeCount: state.resumeCount,
+  };
+}
+
+function sourceFromWorktree(
+  config: ResolvedConfig,
+  ticket: string,
+  entry: WorktreeEntry,
+): InterruptSource {
+  return {
+    ticket,
+    repository: entry.repository,
+    model: config.models.default,
+    worktreeDir: entry.dir,
+    branchName: entry.branchName,
+    workspaceName: ticket,
+    resumeCount: 0,
+  };
+}
+
+function resolveInterruptSource(arguments_: {
+  config: ResolvedConfig;
+  ticket: string;
+  state: RunState | undefined;
+  entry: WorktreeEntry | undefined;
+}): InterruptSource {
+  if (arguments_.state !== undefined) {
+    return sourceFromState(arguments_.state);
+  }
+  if (arguments_.entry !== undefined) {
+    return sourceFromWorktree(arguments_.config, arguments_.ticket, arguments_.entry);
+  }
+  throw new Error(`No run state or worktree found for ${arguments_.ticket}; nothing to interrupt.`);
+}
+
+function interruptDetail(result: WorkspaceInterruptResult): string | undefined {
+  if (result.kind === "missing") {
+    return "workspace missing";
+  }
+  return undefined;
+}
+
+function failOnUnavailable(result: WorkspaceInterruptResult): void {
+  if (result.kind !== "unavailable") {
+    return;
+  }
+  const detail =
+    result.error === undefined ? "workspace adapter unavailable" : errorMessage(result.error);
+  throw new Error(`Could not interrupt workspace: ${detail}`);
+}
+
+export async function interruptWorkspace(
+  config: ResolvedConfig,
+  options: InterruptWorkspaceOptions,
+): Promise<void> {
+  const ticket = options.ticket.toLowerCase();
+  const state = readRunState(config, ticket);
+  const [entry] = worktrees.findByTicket(config, ticket);
+  const source = resolveInterruptSource({ config, ticket, state, entry });
+  const result = await workspaces.interrupt(config, source.workspaceName);
+  failOnUnavailable(result);
+  const detail = interruptDetail(result);
+  recordRunState({
+    config,
+    state: {
+      ticket,
+      repository: source.repository,
+      model: source.model,
+      worktreeDir: source.worktreeDir,
+      branchName: source.branchName,
+      workspaceName: source.workspaceName,
+      state: "interrupted",
+      resumeCount: source.resumeCount,
+      ...(options.reason === undefined ? {} : { reason: options.reason }),
+      ...(detail === undefined ? {} : { detail }),
+    },
+  });
+  log(`Interrupted ${ticket}; worktree preserved at ${source.worktreeDir}`);
+  log(`Next: crew doctor --ticket ${ticket}`);
+}
+
+export async function interruptWorkspaceCli(argv: string[]): Promise<void> {
+  const config = await loadConfig();
+  await interruptWorkspace(config, parseArguments(argv));
+}

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -41,6 +41,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1,0 +1,405 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type * as nodeFs from "node:fs";
+
+import { ensureClearance } from "@clipboard-health/clearance";
+
+import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import type * as utilModule from "../lib/util.ts";
+import { getLinearClient } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
+
+interface NodeFsMock extends Omit<typeof nodeFs, "mkdtempSync" | "rmSync" | "writeFileSync"> {
+  mkdtempSync: ReturnType<typeof vi.fn<typeof mkdtempSync>>;
+  rmSync: ReturnType<typeof vi.fn<typeof rmSync>>;
+  writeFileSync: ReturnType<typeof vi.fn<typeof writeFileSync>>;
+}
+
+vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
+  const actual = await importOriginal<typeof nodeFs>();
+  return {
+    ...actual,
+    mkdtempSync: vi.fn<typeof mkdtempSync>(),
+    rmSync: vi.fn<typeof rmSync>(),
+    writeFileSync: vi.fn<typeof writeFileSync>(),
+  };
+});
+vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, ensureClearance: vi.fn<typeof ensureClearance>() };
+});
+vi.mock(import("../lib/boardSource.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, fetchResolvedIssue: vi.fn<typeof fetchResolvedIssue>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
+});
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    recordRunState: vi.fn<typeof recordRunState>(),
+  };
+});
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
+  const actual = await importOriginal<typeof utilModule>();
+  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
+});
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      open: vi.fn<typeof actual.workspaces.open>(),
+      probe: vi.fn<typeof actual.workspaces.probe>(),
+    },
+  };
+});
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      findByTicket: vi.fn<typeof actual.worktrees.findByTicket>(),
+      create: vi.fn<typeof actual.worktrees.create>(),
+    },
+  };
+});
+
+const mkdtempMock = vi.mocked(mkdtempSync);
+const rmSyncMock = vi.mocked(rmSync);
+const writeFileMock = vi.mocked(writeFileSync);
+const ensureClearanceMock = vi.mocked(ensureClearance);
+const fetchResolvedIssueMock = vi.mocked(fetchResolvedIssue);
+const loadConfigMock = vi.mocked(loadConfig);
+const detectHostMock = vi.mocked(detectHostCapabilities);
+const readRunStateMock = vi.mocked(readRunState);
+const recordRunStateMock = vi.mocked(recordRunState);
+const getLinearClientMock = vi.mocked(getLinearClient);
+// oxlint-disable-next-line typescript/unbound-method -- workspaces is mocked to plain vi.fn properties in this file.
+const workspacesOpenMock = vi.mocked(workspaces.open);
+const workspacesProbeMock = vi.mocked(workspaces.probe);
+const findByTicketMock = vi.mocked(worktrees.findByTicket);
+const createMock = vi.mocked(worktrees.create);
+
+type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
+type FetchResolvedIssueInput = Parameters<typeof fetchResolvedIssue>[0];
+type IssueLookup = (id: string) => Promise<{ title: string; description?: string | undefined }>;
+
+function lastRecordedRunState(): RecordedRunState {
+  const input = recordRunStateMock.mock.calls.at(-1)?.[0];
+  if (input === undefined) {
+    throw new Error("recordRunState was not called");
+  }
+  return input.state;
+}
+
+function firstFetchResolvedIssueInput(): FetchResolvedIssueInput {
+  const input = fetchResolvedIssueMock.mock.calls[0]?.[0];
+  if (input === undefined) {
+    throw new Error("fetchResolvedIssue was not called");
+  }
+  return input;
+}
+
+function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
+  return {
+    hasSafehouse: true,
+    hasSbx: false,
+    hasCmux: true,
+    hasTmux: false,
+    isMacOS: true,
+    isLinux: false,
+    isSafehouseSupported: true,
+    isSdxSupported: true,
+    ...overrides,
+  };
+}
+
+function makeConfig(): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude --auto", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function makeWorktree(): WorktreeEntry {
+  return {
+    repository: "repo-a",
+    ticket: "team-1",
+    branchName: "rocky-team-1",
+    dir: "/work/repo-a-team-1",
+    kind: "host",
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  const state: RunState = {
+    ticket: "team-1",
+    repository: "repo-a",
+    model: "claude",
+    worktreeDir: "/work/repo-a-team-1",
+    branchName: "rocky-team-1",
+    workspaceName: "team-1",
+    state: "interrupted",
+    reason: "wrong direction",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    resumeCount: 1,
+    ...overrides,
+  };
+  return state;
+}
+
+function makeRunStateWithoutReason(overrides: Partial<RunState> = {}): RunState {
+  const state = makeRunState(overrides);
+  delete state.reason;
+  return state;
+}
+
+function mockLinearIssue(): void {
+  const issue = vi.fn<IssueLookup>().mockResolvedValue({ title: "Title", description: "Body" });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+  getLinearClientMock.mockReturnValue({
+    issue,
+  } as unknown as ReturnType<typeof getLinearClient>);
+}
+
+describe(resumeWorkspace, () => {
+  const config = makeConfig();
+
+  beforeEach(() => {
+    mkdtempMock.mockReturnValue("/tmp/groundcrew-resume-team-1-x");
+    mockLinearIssue();
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesOpenMock.mockResolvedValue();
+    detectHostMock.mockResolvedValue(host());
+    ensureClearanceMock.mockResolvedValue({
+      logPath: "/tmp/clearance/clearance.log",
+      pidPath: "/tmp/clearance/clearance.pid",
+      port: 19_999,
+      status: "already-running",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("opens a new workspace in the existing worktree and records a resume", async () => {
+    await resumeWorkspace(config, { ticket: "TEAM-1" });
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        name: "team-1",
+        cwd: "/work/repo-a-team-1",
+      }),
+    );
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      state: "resumed",
+      resumeCount: 2,
+      reason: "wrong direction",
+    });
+  });
+
+  it("includes continuation context in the staged prompt", async () => {
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("Previous interrupt reason: wrong direction"),
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("inspect the current git status and diff"),
+    );
+  });
+
+  it("falls back to the ticket id when Linear detail lookup fails during state resume", async () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockRejectedValue(new Error("offline")),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("ticket team-1 (TEAM-1)"),
+    );
+  });
+
+  it("renders empty ticket details and no previous reason when state has neither", async () => {
+    readRunStateMock.mockReturnValue(makeRunStateWithoutReason());
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockResolvedValue({ title: "Title" }),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("Previous interrupt reason: none recorded"),
+    );
+  });
+
+  it("falls back to Linear resolution when state is missing", async () => {
+    readRunStateMock.mockReset();
+    fetchResolvedIssueMock.mockResolvedValue({
+      uuid: "uuid-1",
+      title: "Resolved title",
+      description: "Resolved body for repo-a",
+      repository: "repo-a",
+      model: "claude",
+      teamId: "team-1",
+    });
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    const fetchInput = firstFetchResolvedIssueInput();
+    expect(fetchInput.config).toBe(config);
+    expect(fetchInput.ticket).toBe("team-1");
+    expect(fetchInput.client).toBeDefined();
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+  });
+
+  it("fails when the worktree is absent", async () => {
+    findByTicketMock.mockReturnValue([]);
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /No worktree found/,
+    );
+  });
+
+  it("fails when recorded run state refers to an unknown model", async () => {
+    readRunStateMock.mockReturnValue(makeRunState({ model: "missing-model" }));
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /Unknown model: missing-model/,
+    );
+  });
+
+  it("fails when the workspace is already live", async () => {
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(/already live/);
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when workspace liveness cannot be verified", async () => {
+    workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /Could not verify whether workspace for team-1 is already live/,
+    );
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+    expect(mkdtempMock).not.toHaveBeenCalled();
+  });
+
+  it("includes probe error details when workspace liveness verification fails", async () => {
+    workspacesProbeMock.mockResolvedValue({
+      kind: "unavailable",
+      error: new Error("cmux down"),
+    });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /cmux down.*inspect the workspace backend/,
+    );
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("removes the staged prompt directory when opening the workspace fails", async () => {
+    workspacesOpenMock.mockRejectedValue(new Error("cmux failed"));
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(/cmux failed/);
+    expect(rmSyncMock).toHaveBeenCalledWith("/tmp/groundcrew-resume-team-1-x", {
+      recursive: true,
+      force: true,
+    });
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe(resumeWorkspaceCli, () => {
+  const config = makeConfig();
+
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(config);
+    mkdtempMock.mockReturnValue("/tmp/groundcrew-resume-team-1-x");
+    mockLinearIssue();
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    detectHostMock.mockResolvedValue(host());
+    ensureClearanceMock.mockResolvedValue({
+      logPath: "/tmp/clearance/clearance.log",
+      pidPath: "/tmp/clearance/clearance.pid",
+      port: 19_999,
+      status: "already-running",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses the ticket argument", async () => {
+    await resumeWorkspaceCli(["TEAM-1"]);
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+  });
+
+  it("rejects missing ticket", async () => {
+    await expect(resumeWorkspaceCli([])).rejects.toThrow(/Usage: crew resume/);
+  });
+
+  it("rejects extra positional args", async () => {
+    await expect(resumeWorkspaceCli(["team-1", "extra"])).rejects.toThrow(/Usage: crew resume/);
+  });
+});

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,0 +1,212 @@
+import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { ensureAgentSandbox, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
+import { buildLaunchCommand } from "../lib/launchCommand.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import {
+  removeStagedPrompt,
+  stageBuildSecrets,
+  stagePromptText,
+  stageWorkspaceLaunchCommand,
+} from "../lib/stagedLaunch.ts";
+import { errorMessage, getLinearClient, log } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+
+export interface ResumeWorkspaceOptions {
+  ticket: string;
+}
+
+interface TicketDetails {
+  title: string;
+  description: string;
+}
+
+interface ResumeContext {
+  ticket: string;
+  repository: string;
+  model: string;
+  worktree: WorktreeEntry;
+  title: string;
+  description: string;
+  reason?: string;
+  resumeCount: number;
+}
+
+function parseArguments(argv: string[]): ResumeWorkspaceOptions {
+  const [ticket, ...extras] = argv;
+  if (ticket === undefined || ticket.length === 0 || extras.length > 0 || ticket.startsWith("-")) {
+    throw new Error("Usage: crew resume <ticket>");
+  }
+  return { ticket: ticket.toLowerCase() };
+}
+
+async function fetchTicketDetails(ticket: string): Promise<TicketDetails | undefined> {
+  try {
+    const issue = await getLinearClient().issue(ticket.toUpperCase());
+    return {
+      title: issue.title,
+      description: issue.description ?? "",
+    };
+  } catch (error) {
+    log(`Resume Linear detail lookup failed for ${ticket}: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+async function contextFromLinear(
+  config: ResolvedConfig,
+  ticket: string,
+  worktree: WorktreeEntry,
+): Promise<ResumeContext> {
+  const resolved = await fetchResolvedIssue({ client: getLinearClient(), config, ticket });
+  return {
+    ticket,
+    repository: resolved.repository,
+    model: resolved.model,
+    worktree,
+    title: resolved.title,
+    description: resolved.description,
+    resumeCount: 0,
+  };
+}
+
+async function contextFromState(
+  ticket: string,
+  state: RunState,
+  worktree: WorktreeEntry,
+): Promise<ResumeContext> {
+  const details = await fetchTicketDetails(ticket);
+  return {
+    ticket,
+    repository: state.repository,
+    model: state.model,
+    worktree,
+    title: details?.title ?? ticket.toUpperCase(),
+    description: details?.description ?? "",
+    ...(state.reason === undefined ? {} : { reason: state.reason }),
+    resumeCount: state.resumeCount,
+  };
+}
+
+async function buildResumeContext(config: ResolvedConfig, ticket: string): Promise<ResumeContext> {
+  const state = readRunState(config, ticket);
+  const entries = worktrees.findByTicket(config, ticket);
+  const worktree =
+    state === undefined
+      ? entries[0]
+      : (entries.find((entry) => entry.repository === state.repository) ?? entries[0]);
+  if (worktree === undefined) {
+    throw new Error(`No worktree found for ${ticket}; cannot resume.`);
+  }
+  if (state !== undefined) {
+    return await contextFromState(ticket, state, worktree);
+  }
+  return await contextFromLinear(config, ticket, worktree);
+}
+
+function renderResumePrompt(context: ResumeContext): string {
+  return [
+    `You are resuming Groundcrew ticket ${context.ticket} (${context.title}) in an existing worktree.`,
+    "",
+    "Ticket description:",
+    "",
+    context.description,
+    "",
+    "## Continuation context",
+    "",
+    `- Worktree: ${context.worktree.dir}`,
+    `- Branch: ${context.worktree.branchName}`,
+    context.reason === undefined
+      ? "- Previous interrupt reason: none recorded"
+      : `- Previous interrupt reason: ${context.reason}`,
+    "",
+    "Before editing, inspect the current git status and diff. Continue from the work already present in this worktree; do not restart from scratch unless the diff proves that is necessary.",
+    "",
+    "Run the repository's documented verification before stopping, then leave the branch ready or open a PR when possible.",
+  ].join("\n");
+}
+
+async function failIfWorkspaceAlreadyLive(config: ResolvedConfig, ticket: string): Promise<void> {
+  const probe = await workspaces.probe(config);
+  if (probe.kind === "unavailable") {
+    const detail = probe.error === undefined ? "" : `: ${errorMessage(probe.error)}`;
+    throw new Error(
+      `Could not verify whether workspace for ${ticket} is already live${detail}. Retry or inspect the workspace backend manually before resuming.`,
+    );
+  }
+  if (probe.names.has(ticket)) {
+    throw new Error(`Workspace for ${ticket} is already live; attach to it instead of resuming.`);
+  }
+}
+
+export async function resumeWorkspace(
+  config: ResolvedConfig,
+  options: ResumeWorkspaceOptions,
+): Promise<void> {
+  const ticket = options.ticket.toLowerCase();
+  await failIfWorkspaceAlreadyLive(config, ticket);
+  const context = await buildResumeContext(config, ticket);
+  const definition = config.models.definitions[context.model];
+  if (definition === undefined) {
+    throw new Error(`Unknown model: ${context.model}`);
+  }
+
+  const { runner, sandboxName } = await prepareAgentLaunch({
+    config,
+    model: context.model,
+    definition,
+    purpose: "resumes",
+  });
+
+  const stagedPrompt = stagePromptText({
+    prefix: "groundcrew-resume",
+    ticket,
+    text: renderResumePrompt(context),
+  });
+  const secretsFile = stageBuildSecrets(stagedPrompt.directory);
+  await ensureAgentSandbox({ config, definition, sandboxName });
+  const launchCommand = buildLaunchCommand({
+    definition,
+    promptFile: stagedPrompt.file,
+    worktreeDir: context.worktree.dir,
+    secretsFile,
+    runner,
+    sandboxName,
+  });
+  const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
+
+  try {
+    await openAgentWorkspace({
+      config,
+      name: ticket,
+      cwd: context.worktree.dir,
+      command: launchCmd,
+      model: context.model,
+      color: definition.color,
+    });
+  } catch (error) {
+    removeStagedPrompt(stagedPrompt.directory);
+    throw error;
+  }
+  recordRunState({
+    config,
+    state: {
+      ticket,
+      repository: context.repository,
+      model: context.model,
+      worktreeDir: context.worktree.dir,
+      branchName: context.worktree.branchName,
+      workspaceName: ticket,
+      state: "resumed",
+      resumeCount: context.resumeCount + 1,
+      ...(context.reason === undefined ? {} : { reason: context.reason }),
+    },
+  });
+  log(`Resumed ${ticket} in ${context.worktree.dir} (${context.model})`);
+}
+
+export async function resumeWorkspaceCli(argv: string[]): Promise<void> {
+  const config = await loadConfig();
+  await resumeWorkspace(config, parseArguments(argv));
+}

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -6,6 +6,7 @@ import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { SETUP_COMMAND } from "../lib/launchCommand.ts";
+import { recordRunState } from "../lib/runState.ts";
 import type * as utilModule from "../lib/util.ts";
 import { getLinearClient, log } from "../lib/util.ts";
 import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
@@ -61,6 +62,10 @@ vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
     runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
   };
 });
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, recordRunState: vi.fn<typeof recordRunState>() };
+});
 vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
@@ -90,8 +95,19 @@ const detectHostMock = vi.mocked(detectHostCapabilities);
 const ensureClearanceMock = vi.mocked(ensureClearance);
 const linearClientMock = vi.mocked(getLinearClient);
 const logMock = vi.mocked(log);
+const recordRunStateMock = vi.mocked(recordRunState);
 const createMock = vi.mocked(worktrees.create);
 const teardownMock = vi.mocked(worktrees.teardown);
+
+type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
+
+function lastRecordedRunState(): RecordedRunState {
+  const input = recordRunStateMock.mock.calls.at(-1)?.[0];
+  if (input === undefined) {
+    throw new Error("recordRunState was not called");
+  }
+  return input.state;
+}
 
 interface MockedLabel {
   name: string;
@@ -412,6 +428,15 @@ describe(setupWorkspace, () => {
       "cmux",
       expect.arrayContaining(["set-status", "model", "claude", "--workspace", "workspace:42"]),
     );
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      worktreeDir: "/work/repo-a-team-1",
+      branchName: "rocky-team-1",
+      workspaceName: "team-1",
+      state: "running",
+    });
   });
 
   it("keeps the local cmux command short by staging the full launcher in a local script", async () => {
@@ -1064,6 +1089,35 @@ describe(setupWorkspace, () => {
     await expect(
       setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
     ).rejects.toThrow(/cmux down/);
+  });
+
+  it("records failed launch state after rollback", async () => {
+    const config = makeConfig();
+    mockCmuxFailure();
+
+    await expect(
+      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+    ).rejects.toThrow(/cmux down/);
+
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      state: "failed-to-launch",
+    });
+    expect(lastRecordedRunState().detail).toContain("cmux down");
+  });
+
+  it("logs and continues when recording run state fails after launch", async () => {
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+
+    expect(logMock).toHaveBeenCalledWith(expect.stringContaining("Run state update failed"));
   });
 
   it("ignores worktree remove failures reported by teardown during rollback", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -4,6 +4,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { ensureAgentSandbox, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { buildLaunchCommand } from "../lib/launchCommand.ts";
 import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
+import { recordRunState } from "../lib/runState.ts";
 import {
   stageBuildSecrets,
   stagePromptFromTemplate,
@@ -142,6 +143,16 @@ export async function setupWorkspace(
       color: definition.color,
       ...(signal === undefined ? {} : { signal }),
     });
+    recordRunStateBestEffort({
+      config,
+      ticket,
+      repository,
+      model,
+      worktreeDir: launchDir,
+      branchName,
+      workspaceName: ticket,
+      state: "running",
+    });
 
     log(`Workspace "${ticket}" launched (${model})`);
     log(`  Worktree: ${launchDir}`);
@@ -149,6 +160,17 @@ export async function setupWorkspace(
     await logWorkspaceAccessHint({ config, ticket, signal });
   } catch (error) {
     await rollbackWorktree({ config, entry: created, promptDir });
+    recordRunStateBestEffort({
+      config,
+      ticket,
+      repository,
+      model,
+      worktreeDir: launchDir,
+      branchName,
+      workspaceName: ticket,
+      state: "failed-to-launch",
+      detail: errorMessage(error),
+    });
     throw error;
   }
 }
@@ -196,6 +218,36 @@ async function logWorkspaceAccessHint(arguments_: {
 
 function logAccessHint(accessHint: WorkspaceAccessHint): void {
   log(`  Attach:   ${accessHint.command}`);
+}
+
+function recordRunStateBestEffort(arguments_: {
+  config: ResolvedConfig;
+  ticket: string;
+  repository: string;
+  model: string;
+  worktreeDir: string;
+  branchName: string;
+  workspaceName: string;
+  state: "running" | "failed-to-launch";
+  detail?: string;
+}): void {
+  try {
+    recordRunState({
+      config: arguments_.config,
+      state: {
+        ticket: arguments_.ticket,
+        repository: arguments_.repository,
+        model: arguments_.model,
+        worktreeDir: arguments_.worktreeDir,
+        branchName: arguments_.branchName,
+        workspaceName: arguments_.workspaceName,
+        state: arguments_.state,
+        ...(arguments_.detail === undefined ? {} : { detail: arguments_.detail }),
+      },
+    });
+  } catch (error) {
+    log(`Run state update failed for ${arguments_.ticket}: ${errorMessage(error)}`);
+  }
 }
 
 async function rollbackWorktree(arguments_: {

--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import type { RawLinearIssue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import type { RunState } from "../lib/runState.ts";
 import type { WorkspaceAccessHint, WorkspaceProbe } from "../lib/workspaces.ts";
 import type { WorktreeDirtiness, WorktreeEntry } from "../lib/worktrees.ts";
 import {
@@ -114,6 +115,7 @@ function makeStubDependencies(
     probePullRequest: vi
       .fn<TicketDoctorDependencies["probePullRequest"]>()
       .mockResolvedValue({ kind: "absent" } satisfies PullRequestProbe),
+    readRunState: vi.fn<TicketDoctorDependencies["readRunState"]>(),
     doFetch: true,
     ...overrides,
   };
@@ -126,6 +128,22 @@ function makeWorktreeEntry(overrides: Partial<WorktreeEntry> = {}): WorktreeEntr
     branchName: "rocky-hrd-1",
     dir: "/work/repo-a-hrd-1",
     kind: "host",
+    ...overrides,
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    ticket: "hrd-1",
+    repository: "repo-a",
+    model: "claude",
+    worktreeDir: "/work/repo-a-hrd-1",
+    branchName: "rocky-hrd-1",
+    workspaceName: "hrd-1",
+    state: "interrupted",
+    resumeCount: 0,
+    createdAt: "2026-05-21T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -144,6 +162,7 @@ function makeVerdictInput(overrides: Partial<DecideVerdictInput> = {}): DecideVe
     branch: "rocky-hrd-1",
     worktreeDir: undefined,
     workspaceName: undefined,
+    runState: undefined,
     ...overrides,
   };
 }
@@ -276,6 +295,76 @@ describe(decidePostDispatchVerdict, () => {
       }),
     );
     expect(verdict).toMatchObject({ kind: "pr-open" });
+  });
+
+  it("ranks pr-open above interrupted run state", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        pullRequest: { kind: "open", number: 9, url: "u" },
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "pr-open" });
+  });
+
+  it("returns interrupted when the local run state was stopped and no recovery action wins", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted", reason: "freeing terminal" }),
+      }),
+    );
+    const interrupted = narrowVerdict(verdict, "interrupted");
+    expect(interrupted.reason).toBe("freeing terminal");
+    expect(interrupted.nextStep).toContain("crew resume hrd-1");
+  });
+
+  it("uses interrupted run detail when no interrupt reason was recorded", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted", detail: "workspace missing" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "interrupted", reason: "workspace missing" });
+  });
+
+  it("uses a generic interrupted reason when no detail was recorded", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "interrupted", reason: "workspace stopped" });
+  });
+
+  it("ranks recoverable work above interrupted run state", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        worktree: { kind: "present-dirty", modified: 1, untracked: 0 },
+        worktreeDir: "/work/repo-a-hrd-1",
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "recoverable" });
+  });
+
+  it("returns failed-launch when setup recorded a launch failure", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "failed-to-launch", detail: "cmux missing" }),
+      }),
+    );
+    const failedLaunch = narrowVerdict(verdict, "failed-launch");
+    expect(failedLaunch.reason).toBe("cmux missing");
+    expect(failedLaunch.nextStep).toContain("crew resume hrd-1");
+  });
+
+  it("uses a generic failed-launch reason when setup did not record details", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "failed-to-launch" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "failed-launch", reason: "workspace launch failed" });
   });
 
   it("treats present-unknown-dirtiness as worktree-present for in-flight", () => {
@@ -918,6 +1007,64 @@ describe("ticketDoctor — Workspace section", () => {
   });
 });
 
+describe("ticketDoctor — Run state section", () => {
+  it("records skipped when no run state exists", async () => {
+    const result = await ticketDoctor(makeStubDependencies());
+    expect(result.runState).toStrictEqual([
+      { name: "Local run state", status: "skipped", detail: "none found" },
+    ]);
+  });
+
+  it("records persisted run metadata when present", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(
+          makeRunState({ state: "interrupted", reason: "pause", detail: "workspace missing" }),
+        ),
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(result.runState).toContainEqual({
+      name: "Local run state",
+      status: "ok",
+      detail: "interrupted",
+    });
+    expect(result.runState).toContainEqual({
+      name: "Last reason",
+      status: "ok",
+      detail: "pause",
+    });
+    expect(result.runState).toContainEqual({
+      name: "Last detail",
+      status: "ok",
+      detail: "workspace missing",
+    });
+  });
+
+  it("omits optional run metadata rows when the state has no reason or detail", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(makeRunState({ state: "running" })),
+    });
+
+    const result = await ticketDoctor(dependencies);
+
+    expect(result.runState).not.toContainEqual(expect.objectContaining({ name: "Last reason" }));
+    expect(result.runState).not.toContainEqual(expect.objectContaining({ name: "Last detail" }));
+  });
+
+  it("uses interrupted run state for the verdict when no stronger local state exists", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(makeRunState({ state: "interrupted", reason: "operator pause" })),
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(result.verdict).toMatchObject({ kind: "interrupted", reason: "operator pause" });
+  });
+});
+
 describe("ticketDoctor — ticket case normalization", () => {
   it("passes the lowercase ticket to findWorktree even when the caller supplies HRD-1", async () => {
     const findWorktree = vi.fn<TicketDoctorDependencies["findWorktree"]>(
@@ -1263,6 +1410,7 @@ function emptyResult(overrides: Partial<TicketDoctorResult> = {}): TicketDoctorR
     ticket: "HRD-1",
     resolution: [],
     eligibility: [],
+    runState: [],
     worktree: [],
     workspace: [],
     localBranch: [],
@@ -1272,6 +1420,7 @@ function emptyResult(overrides: Partial<TicketDoctorResult> = {}): TicketDoctorR
       resolution: "",
       eligibility: "",
       worktree: "",
+      runState: "",
       workspace: "",
       localBranch: "",
       remoteBranch: "",
@@ -1365,6 +1514,28 @@ describe(renderTicketDoctorResult, () => {
     );
   });
 
+  it("formats interrupted verdicts with reason + next step", () => {
+    const lines = renderTicketDoctorResult(
+      emptyResult({
+        verdict: { kind: "interrupted", reason: "operator pause", nextStep: "crew resume hrd-1" },
+      }),
+    );
+    expect(lines.some((l) => l.includes("→ interrupted: operator pause; crew resume hrd-1"))).toBe(
+      true,
+    );
+  });
+
+  it("formats failed-launch verdicts with reason + next step", () => {
+    const lines = renderTicketDoctorResult(
+      emptyResult({
+        verdict: { kind: "failed-launch", reason: "cmux missing", nextStep: "crew resume hrd-1" },
+      }),
+    );
+    expect(lines.some((l) => l.includes("→ failed-launch: cmux missing; crew resume hrd-1"))).toBe(
+      true,
+    );
+  });
+
   it("formats ineligible verdicts with the reason", () => {
     const lines = renderTicketDoctorResult(
       emptyResult({
@@ -1396,6 +1567,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "",
           eligibility: "ticket unresolved",
           worktree: "",
+          runState: "",
           workspace: "",
           localBranch: "",
           remoteBranch: "",
@@ -1415,6 +1587,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "",
           eligibility: "",
           worktree: "",
+          runState: "",
           workspace: "",
           localBranch: "repo dir unresolved",
           remoteBranch: "",
@@ -1432,6 +1605,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "skip-r",
           eligibility: "skip-e",
           worktree: "skip-w",
+          runState: "skip-rs",
           workspace: "skip-ws",
           localBranch: "skip-lb",
           remoteBranch: "skip-rb",
@@ -1439,7 +1613,16 @@ describe(renderTicketDoctorResult, () => {
         },
       }),
     );
-    for (const tag of ["skip-r", "skip-e", "skip-w", "skip-ws", "skip-lb", "skip-rb", "skip-pr"]) {
+    for (const tag of [
+      "skip-r",
+      "skip-e",
+      "skip-w",
+      "skip-rs",
+      "skip-ws",
+      "skip-lb",
+      "skip-rb",
+      "skip-pr",
+    ]) {
       expect(lines.some((l) => l.includes(`(skipped — ${tag})`))).toBe(true);
     }
   });

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -3,11 +3,14 @@
 // `crew doctor --ticket <TICKET>` — single per-ticket diagnostic that covers
 // both the pre-dispatch question ("will this dispatch on the next tick?") and
 // the post-dispatch question ("what's already happened and what's left to
-// do?"). Verdict precedence runs strictly from post-dispatch states down:
+// do?"). Verdict precedence starts with PR outcomes, then handles run-state
+// exceptions before ordinary local recovery:
 //
-//   pr-open > pr-merged > in-flight > recoverable
-//     > unresolvable > ineligible > would-dispatch
-//       > lost
+//   pr-open > pr-merged
+//     > failed-launch
+//     > interrupted (unless concrete recoverable git work exists)
+//     > in-flight > recoverable
+//     > unresolvable > ineligible > would-dispatch > lost
 //
 // When a post-dispatch verdict fires, the Resolution and Eligibility sections
 // are skipped — they describe pre-dispatch state that no longer matters.
@@ -28,6 +31,7 @@ import {
 import { runCommandAsync } from "../lib/commandRunner.ts";
 import { AGENT_ANY_MODEL, loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { which } from "../lib/host.ts";
+import { readRunState, type RunState } from "../lib/runState.ts";
 import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
 import { getLinearClient, lazyLinearClient, writeOutput } from "../lib/util.ts";
 import { workspaces, type WorkspaceAccessHint, type WorkspaceProbe } from "../lib/workspaces.ts";
@@ -52,6 +56,8 @@ const LINEAR_SKIPPED_STATE_NAME = "(linear skipped)";
 export type TicketDoctorVerdict =
   | { kind: "pr-open"; number: number; url: string }
   | { kind: "pr-merged"; number: number; url: string }
+  | { kind: "interrupted"; reason: string; nextStep: string }
+  | { kind: "failed-launch"; reason: string; nextStep: string }
   | { kind: "in-flight"; reason: string }
   | { kind: "recoverable"; reason: string; nextStep: string }
   | { kind: "would-dispatch" }
@@ -97,6 +103,7 @@ export interface DecideVerdictInput {
   branch: string;
   worktreeDir: string | undefined;
   workspaceName: string | undefined;
+  runState: RunState | undefined;
 }
 
 // ───────── post-dispatch verdict (PR / in-flight / recoverable) ─────────
@@ -171,9 +178,11 @@ function verdictRecoverable(input: DecideVerdictInput): TicketDoctorVerdict | un
  * "ticket has moved past dispatch" cases. Returns `undefined` otherwise,
  * signalling that the caller should fall through to the pre-dispatch path.
  *
- * Precedence: PR > in-flight > recoverable. Inside `recoverable`, dirty
- * worktree beats clean-with-un-pushed-local beats remote-only beats stranded
- * local.
+ * Precedence: PR verdicts always win. Failed launches report before ordinary
+ * local recovery. Interrupted runs report concrete recoverable git work first
+ * when it exists, then fall back to `interrupted`. Ordinary post-dispatch cases
+ * report in-flight before recoverable. Inside `recoverable`, dirty worktree
+ * beats clean-with-un-pushed-local beats remote-only beats stranded local.
  */
 export function decidePostDispatchVerdict(
   input: DecideVerdictInput,
@@ -184,7 +193,27 @@ export function decidePostDispatchVerdict(
   if (input.pullRequest.kind === "merged") {
     return { kind: "pr-merged", number: input.pullRequest.number, url: input.pullRequest.url };
   }
-  return verdictInFlight(input) ?? verdictRecoverable(input);
+  const recoverable = verdictRecoverable(input);
+  if (input.runState?.state === "interrupted") {
+    if (recoverable !== undefined) {
+      return recoverable;
+    }
+    const detail = input.runState.reason ?? input.runState.detail ?? "workspace stopped";
+    return {
+      kind: "interrupted",
+      reason: detail,
+      nextStep: `run \`crew resume ${input.runState.ticket}\` or inspect ${input.runState.worktreeDir}`,
+    };
+  }
+  if (input.runState?.state === "failed-to-launch") {
+    const detail = input.runState.detail ?? "workspace launch failed";
+    return {
+      kind: "failed-launch",
+      reason: detail,
+      nextStep: `fix the launch failure, then run \`crew resume ${input.runState.ticket}\` or \`crew cleanup ${input.runState.ticket}\``,
+    };
+  }
+  return verdictInFlight(input) ?? recoverable;
 }
 
 // ───────── orchestrator dependencies ─────────
@@ -216,6 +245,7 @@ export interface TicketDoctorDependencies {
     doFetch: boolean;
   }) => Promise<RemoteBranchProbe>;
   probePullRequest: (input: { repoDir: string; branch: string }) => Promise<PullRequestProbe>;
+  readRunState: (ticket: string) => RunState | undefined;
   doFetch: boolean;
 }
 
@@ -224,6 +254,7 @@ export interface TicketDoctorResult {
   title?: string;
   resolution: TicketCheck[];
   eligibility: TicketCheck[];
+  runState: TicketCheck[];
   worktree: TicketCheck[];
   workspace: TicketCheck[];
   localBranch: TicketCheck[];
@@ -233,6 +264,7 @@ export interface TicketDoctorResult {
     resolution: string;
     eligibility: string;
     worktree: string;
+    runState: string;
     workspace: string;
     localBranch: string;
     remoteBranch: string;
@@ -246,6 +278,7 @@ function emptySkipReasons(): TicketDoctorResult["skipReasons"] {
     resolution: "",
     eligibility: "",
     worktree: "",
+    runState: "",
     workspace: "",
     localBranch: "",
     remoteBranch: "",
@@ -573,6 +606,38 @@ interface WorktreeSectionOutput {
   entry: WorktreeEntry | undefined;
 }
 
+interface RunStateSectionOutput {
+  checks: TicketCheck[];
+  state: RunState | undefined;
+}
+
+function probeRunStateSection(
+  deps: TicketDoctorDependencies,
+  ticket: string,
+): RunStateSectionOutput {
+  const state = deps.readRunState(ticket);
+  if (state === undefined) {
+    return {
+      checks: [{ name: "Local run state", status: "skipped", detail: "none found" }],
+      state: undefined,
+    };
+  }
+  const checks: TicketCheck[] = [
+    { name: "Local run state", status: "ok", detail: state.state },
+    { name: "Recorded model", status: "ok", detail: state.model },
+    { name: "Recorded worktree", status: "ok", detail: state.worktreeDir },
+    { name: "Recorded branch", status: "ok", detail: state.branchName },
+    { name: "Resume count", status: "ok", detail: String(state.resumeCount) },
+  ];
+  if (state.reason !== undefined) {
+    checks.push({ name: "Last reason", status: "ok", detail: state.reason });
+  }
+  if (state.detail !== undefined) {
+    checks.push({ name: "Last detail", status: "ok", detail: state.detail });
+  }
+  return { checks, state };
+}
+
 async function probeWorktreeSection(
   deps: TicketDoctorDependencies,
   ticket: string,
@@ -882,6 +947,7 @@ export async function ticketDoctor(
   const linearResult = await probeLinear(dependencies, upperTicket);
   const resolution: TicketCheck[] = [...linearResult.resolution];
 
+  const runStateResult = probeRunStateSection(dependencies, lowerTicket);
   const worktreeResult = await probeWorktreeSection(dependencies, lowerTicket);
   const workspaceResult = await probeWorkspaceSection(dependencies, lowerTicket);
   const localResult = await probeLocalBranchSection(dependencies, worktreeResult.entry);
@@ -908,6 +974,7 @@ export async function ticketDoctor(
     branch: worktreeResult.entry?.branchName ?? lowerTicket,
     worktreeDir: worktreeResult.entry?.dir,
     workspaceName: workspaceResult.workspaceName,
+    runState: runStateResult.state,
   });
 
   if (postVerdict !== undefined) {
@@ -918,6 +985,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -939,6 +1007,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -960,6 +1029,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -1002,6 +1072,7 @@ export async function ticketDoctor(
     title: linearResult.title,
     resolution,
     eligibility: preDispatch.eligibility,
+    runStateResult,
     worktreeResult,
     workspaceResult,
     localResult,
@@ -1017,6 +1088,7 @@ interface BuildResultInput {
   title: string | undefined;
   resolution: TicketCheck[];
   eligibility: TicketCheck[];
+  runStateResult: RunStateSectionOutput;
   worktreeResult: WorktreeSectionOutput;
   workspaceResult: WorkspaceSectionOutput;
   localResult: LocalBranchSectionOutput;
@@ -1032,6 +1104,7 @@ function buildResult(input: BuildResultInput): TicketDoctorResult {
     ...(input.title === undefined ? {} : { title: input.title }),
     resolution: input.resolution,
     eligibility: input.eligibility,
+    runState: input.runStateResult.checks,
     worktree: input.worktreeResult.checks,
     workspace: input.workspaceResult.checks,
     localBranch: input.localResult.checks,
@@ -1080,6 +1153,12 @@ function formatVerdict(verdict: TicketDoctorVerdict): string {
     case "pr-merged": {
       return `→ pr-merged: ${verdict.url} (#${verdict.number})`;
     }
+    case "interrupted": {
+      return `→ interrupted: ${verdict.reason}; ${verdict.nextStep}`;
+    }
+    case "failed-launch": {
+      return `→ failed-launch: ${verdict.reason}; ${verdict.nextStep}`;
+    }
     case "in-flight": {
       return `→ in-flight: ${verdict.reason}`;
     }
@@ -1120,6 +1199,11 @@ export function renderTicketDoctorResult(result: TicketDoctorResult): string[] {
       ...(result.skipReasons.eligibility === ""
         ? {}
         : { skipReason: result.skipReasons.eligibility }),
+    },
+    {
+      name: "Run state",
+      checks: result.runState,
+      ...(result.skipReasons.runState === "" ? {} : { skipReason: result.skipReasons.runState }),
     },
     {
       name: "Worktree",
@@ -1187,6 +1271,7 @@ export async function runTicketDoctor(parsed: TicketDoctorArguments): Promise<bo
     probeLocalBranch: probeLocalBranchImpl,
     probeRemoteBranch: probeRemoteBranchImpl,
     probePullRequest: probePullRequestImpl,
+    readRunState: (ticket) => readRunState(config, ticket),
     doFetch: parsed.doFetch,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 export { run } from "./cli.ts";
 export { cleanupWorkspace, type CleanupWorkspaceOptions } from "./commands/cleanupWorkspace.ts";
 export { doctor } from "./commands/doctor.ts";
+export {
+  interruptWorkspace,
+  type InterruptWorkspaceOptions,
+} from "./commands/interruptWorkspace.ts";
 export { orchestrate, type OrchestratorOptions } from "./commands/orchestrator.ts";
+export { resumeWorkspace, type ResumeWorkspaceOptions } from "./commands/resumeWorkspace.ts";
 export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWorkspace.ts";
 export type { Config, ModelDefinition, ResolvedConfig } from "./lib/config.ts";
 export { loadConfig } from "./lib/config.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,16 @@ export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWork
 export type { Config, ModelDefinition, ResolvedConfig } from "./lib/config.ts";
 export { loadConfig } from "./lib/config.ts";
 export {
+  readRunState,
+  recordRunState,
+  removeRunState,
+  runStateDirectory,
+  runStatePath,
+  updateRunState,
+  type RunLifecycleState,
+  type RunState,
+} from "./lib/runState.ts";
+export {
   fetchBlockersForTicket,
   fetchInProgressIssueCount,
   fetchRawLinearIssue,

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -1,0 +1,231 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { ResolvedConfig } from "./config.ts";
+import {
+  readRunState,
+  recordRunState,
+  removeRunState,
+  type RunLifecycleState,
+  runStateDirectory,
+  runStatePath,
+  updateRunState,
+} from "./runState.ts";
+
+function makeConfig(stateRoot: string): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: join(stateRoot, "groundcrew.log") },
+  };
+}
+
+describe("run state store", () => {
+  let stateRoot: string;
+  let config: ResolvedConfig;
+
+  beforeEach(() => {
+    stateRoot = mkdtempSync(join(tmpdir(), "groundcrew-run-state-"));
+    config = makeConfig(stateRoot);
+  });
+
+  afterEach(() => {
+    rmSync(stateRoot, { recursive: true, force: true });
+  });
+
+  it("stores one JSON file per ticket next to the configured log file", () => {
+    const actual = recordRunState({
+      config,
+      state: {
+        ticket: "TEAM-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+      },
+    });
+
+    expect(runStateDirectory(config)).toBe(join(stateRoot, "runs"));
+    expect(runStatePath(config, "team-1")).toBe(join(stateRoot, "runs", "team-1.json"));
+    expect(actual.ticket).toBe("team-1");
+    expect(readRunState(config, "TEAM-1")).toMatchObject({
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      state: "running",
+      resumeCount: 0,
+    });
+  });
+
+  it("stores optional reason, detail, and explicit resume count", () => {
+    const actual = recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "interrupted",
+        reason: "pause",
+        detail: "workspace missing",
+        resumeCount: 3,
+      },
+    });
+
+    expect(actual).toMatchObject({
+      reason: "pause",
+      detail: "workspace missing",
+      resumeCount: 3,
+    });
+    expect(readRunState(config, "team-1")).toMatchObject({
+      reason: "pause",
+      detail: "workspace missing",
+      resumeCount: 3,
+    });
+  });
+
+  it("round-trips every lifecycle state", () => {
+    const states: RunLifecycleState[] = ["running", "interrupted", "resumed", "failed-to-launch"];
+
+    for (const state of states) {
+      recordRunState({
+        config,
+        state: {
+          ticket: "team-1",
+          repository: "repo-a",
+          model: "claude",
+          worktreeDir: "/work/repo-a-team-1",
+          branchName: "rocky-team-1",
+          workspaceName: "team-1",
+          state,
+        },
+      });
+      expect(readRunState(config, "team-1")?.state).toBe(state);
+    }
+  });
+
+  it("updates existing state while preserving createdAt", () => {
+    const first = recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+      },
+    });
+
+    const updated = updateRunState({
+      config,
+      ticket: "team-1",
+      patch: {
+        state: "interrupted",
+        reason: "wrong direction",
+      },
+    });
+
+    expect(updated).toMatchObject({ state: "interrupted", reason: "wrong direction" });
+    expect(updated?.createdAt).toBe(first.createdAt);
+  });
+
+  it("returns undefined when updating missing state", () => {
+    expect(
+      updateRunState({
+        config,
+        ticket: "team-1",
+        patch: {
+          state: "interrupted",
+          reason: "wrong direction",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for missing or malformed state files", () => {
+    expect(readRunState(config, "team-1")).toBeUndefined();
+    mkdirSync(dirname(runStatePath(config, "team-1")), { recursive: true });
+    writeFileSync(runStatePath(config, "team-1"), "{not json");
+
+    expect(readRunState(config, "team-1")).toBeUndefined();
+  });
+
+  it("returns undefined for JSON that is not a valid run state object", () => {
+    mkdirSync(dirname(runStatePath(config, "team-1")), { recursive: true });
+    writeFileSync(runStatePath(config, "team-1"), "null");
+    expect(readRunState(config, "team-1")).toBeUndefined();
+
+    writeFileSync(runStatePath(config, "team-1"), JSON.stringify({ ticket: "team-1" }));
+    expect(readRunState(config, "team-1")).toBeUndefined();
+  });
+
+  it("rejects ticket ids that are not plain Linear-style ids", () => {
+    expect(() => runStatePath(config, "../team-1")).toThrow(/plain ticket id/);
+  });
+
+  it("removes a run state file", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+      },
+    });
+
+    removeRunState(config, "team-1");
+
+    expect(readRunState(config, "team-1")).toBeUndefined();
+  });
+
+  it("writes readable JSON", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+      },
+    });
+
+    expect(JSON.parse(readFileSync(runStatePath(config, "team-1"), "utf8"))).toMatchObject({
+      ticket: "team-1",
+      state: "running",
+    });
+  });
+});

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -1,0 +1,198 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import type { ResolvedConfig } from "./config.ts";
+
+export type RunLifecycleState = "running" | "interrupted" | "resumed" | "failed-to-launch";
+
+export interface RunState {
+  ticket: string;
+  repository: string;
+  model: string;
+  worktreeDir: string;
+  branchName: string;
+  workspaceName: string;
+  state: RunLifecycleState;
+  createdAt: string;
+  updatedAt: string;
+  resumeCount: number;
+  reason?: string;
+  detail?: string;
+}
+
+export interface RunStateDraft {
+  ticket: string;
+  repository: string;
+  model: string;
+  worktreeDir: string;
+  branchName: string;
+  workspaceName: string;
+  state: RunLifecycleState;
+  reason?: string;
+  detail?: string;
+  resumeCount?: number;
+}
+
+export interface RecordRunStateInput {
+  config: ResolvedConfig;
+  state: RunStateDraft;
+}
+
+export interface UpdateRunStateInput {
+  config: ResolvedConfig;
+  ticket: string;
+  patch: Partial<Omit<RunState, "createdAt" | "ticket">> & {
+    state: RunLifecycleState;
+  };
+}
+
+const TICKET_RE = /^[a-z][\da-z]*-\d+$/;
+const RUN_STATE_DIRECTORY_NAME = "runs";
+
+function ticketKey(ticket: string): string {
+  const normalized = ticket.toLowerCase();
+  if (!TICKET_RE.test(normalized)) {
+    throw new Error(`Invalid ticket "${ticket}": must be a plain ticket id`);
+  }
+  return normalized;
+}
+
+export function runStateDirectory(config: Pick<ResolvedConfig, "logging">): string {
+  return resolve(dirname(config.logging.file), RUN_STATE_DIRECTORY_NAME);
+}
+
+export function runStatePath(config: Pick<ResolvedConfig, "logging">, ticket: string): string {
+  return resolve(runStateDirectory(config), `${ticketKey(ticket)}.json`);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, key: keyof RunState): string | undefined {
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function isRunLifecycleState(value: unknown): value is RunLifecycleState {
+  return (
+    value === "running" ||
+    value === "interrupted" ||
+    value === "resumed" ||
+    value === "failed-to-launch"
+  );
+}
+
+function parseRunState(value: unknown): RunState | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  const ticket = stringField(value, "ticket");
+  const repository = stringField(value, "repository");
+  const model = stringField(value, "model");
+  const worktreeDir = stringField(value, "worktreeDir");
+  const branchName = stringField(value, "branchName");
+  const workspaceName = stringField(value, "workspaceName");
+  const { state, resumeCount } = value;
+  const createdAt = stringField(value, "createdAt");
+  const updatedAt = stringField(value, "updatedAt");
+  const reason = stringField(value, "reason");
+  const detail = stringField(value, "detail");
+  if (
+    ticket === undefined ||
+    repository === undefined ||
+    model === undefined ||
+    worktreeDir === undefined ||
+    branchName === undefined ||
+    workspaceName === undefined ||
+    !isRunLifecycleState(state) ||
+    createdAt === undefined ||
+    updatedAt === undefined ||
+    typeof resumeCount !== "number" ||
+    !Number.isInteger(resumeCount) ||
+    resumeCount < 0
+  ) {
+    return undefined;
+  }
+  return {
+    ticket,
+    repository,
+    model,
+    worktreeDir,
+    branchName,
+    workspaceName,
+    state,
+    createdAt,
+    updatedAt,
+    resumeCount,
+    ...(reason === undefined ? {} : { reason }),
+    ...(detail === undefined ? {} : { detail }),
+  };
+}
+
+function writeState(config: ResolvedConfig, state: RunState): void {
+  const path = runStatePath(config, state.ticket);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify(state, undefined, 2)}\n`, { mode: 0o600 });
+  renameSync(tmpPath, path);
+}
+
+export function readRunState(config: ResolvedConfig, ticket: string): RunState | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(runStatePath(config, ticket), "utf8");
+  } catch {
+    return undefined;
+  }
+  try {
+    return parseRunState(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+export function recordRunState(input: RecordRunStateInput): RunState {
+  const existing = readRunState(input.config, input.state.ticket);
+  const timestamp = nowIso();
+  const state: RunState = {
+    ticket: ticketKey(input.state.ticket),
+    repository: input.state.repository,
+    model: input.state.model,
+    worktreeDir: input.state.worktreeDir,
+    branchName: input.state.branchName,
+    workspaceName: input.state.workspaceName,
+    state: input.state.state,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    resumeCount: input.state.resumeCount ?? existing?.resumeCount ?? 0,
+    ...(input.state.reason === undefined ? {} : { reason: input.state.reason }),
+    ...(input.state.detail === undefined ? {} : { detail: input.state.detail }),
+  };
+  writeState(input.config, state);
+  return state;
+}
+
+export function updateRunState(input: UpdateRunStateInput): RunState | undefined {
+  const existing = readRunState(input.config, input.ticket);
+  if (existing === undefined) {
+    return undefined;
+  }
+  const state: RunState = {
+    ...existing,
+    ...input.patch,
+    ticket: existing.ticket,
+    createdAt: existing.createdAt,
+    updatedAt: nowIso(),
+  };
+  writeState(input.config, state);
+  return state;
+}
+
+export function removeRunState(config: ResolvedConfig, ticket: string): void {
+  rmSync(runStatePath(config, ticket), { force: true });
+}

--- a/src/lib/runStateCleanup.ts
+++ b/src/lib/runStateCleanup.ts
@@ -1,0 +1,17 @@
+import type { ResolvedConfig } from "./config.ts";
+import { removeRunState } from "./runState.ts";
+import { errorMessage, log } from "./util.ts";
+import type { WorktreeEntry } from "./worktrees.ts";
+
+export function recordCleanedUpRuns(
+  config: ResolvedConfig,
+  entries: readonly WorktreeEntry[],
+): void {
+  for (const entry of entries) {
+    try {
+      removeRunState(config, entry.ticket);
+    } catch (error) {
+      log(`Run state cleanup failed for ${entry.ticket}: ${errorMessage(error)}`);
+    }
+  }
+}

--- a/src/lib/stagedLaunch.ts
+++ b/src/lib/stagedLaunch.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,7 +26,11 @@ function renderPromptTemplate(template: string, variables: PromptTemplateVariabl
     .replaceAll("{{description}}", variables.description);
 }
 
-function stagePromptText(input: { prefix: string; ticket: string; text: string }): StagedPrompt {
+export function stagePromptText(input: {
+  prefix: string;
+  ticket: string;
+  text: string;
+}): StagedPrompt {
   const promptDir = mkdtempSync(join(tmpdir(), `${input.prefix}-${input.ticket}-`));
   const promptFile = join(promptDir, "prompt.txt");
   writeFileSync(promptFile, input.text);
@@ -76,4 +80,8 @@ function stageLaunchScript(promptDir: string, command: string): string {
 
 export function stageWorkspaceLaunchCommand(promptDir: string, command: string): string {
   return `bash ${shellSingleQuote(stageLaunchScript(promptDir, command))}`;
+}
+
+export function removeStagedPrompt(directory: string): void {
+  rmSync(directory, { recursive: true, force: true });
 }

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -6,7 +6,12 @@ import type * as hostModule from "./host.ts";
 import { detectHostCapabilities, type HostCapabilities } from "./host.ts";
 import { log } from "./util.ts";
 import type * as utilModule from "./util.ts";
-import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
+import {
+  resolveWorkspaceKind,
+  type WorkspaceCloseResult,
+  type WorkspaceInterruptResult,
+  workspaces,
+} from "./workspaces.ts";
 
 const logMock = vi.mocked(log);
 
@@ -100,6 +105,20 @@ function commonBeforeEach(): void {
 
 function commonAfterEach(): void {
   vi.resetAllMocks();
+}
+
+function workspaceInterruptError(result: WorkspaceInterruptResult): unknown {
+  if (!("error" in result)) {
+    throw new Error("Expected workspace interrupt result to include error details");
+  }
+  return result.error;
+}
+
+function workspaceCloseError(result: WorkspaceCloseResult): unknown {
+  if (result.kind !== "unavailable" || !("error" in result)) {
+    throw new Error("Expected workspace close result to include error details");
+  }
+  return result.error;
 }
 
 describe("workspaces.open (cmux)", () => {
@@ -529,7 +548,9 @@ describe("workspaces.close (cmux)", () => {
       JSON.stringify({ workspaces: [{ title: "TEAM-1", ref: "workspace:42" }] }),
     );
 
-    await workspaces.close(makeConfig(), "TEAM-1");
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
 
     expect(runMock).toHaveBeenCalledWith("cmux", [
       "close-workspace",
@@ -541,7 +562,9 @@ describe("workspaces.close (cmux)", () => {
   it("falls back to the workspace id when ref is omitted", async () => {
     runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "abc123" }] }));
 
-    await workspaces.close(makeConfig(), "TEAM-1");
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
 
     expect(runMock).toHaveBeenCalledWith("cmux", ["close-workspace", "--workspace", "abc123"]);
   });
@@ -549,7 +572,9 @@ describe("workspaces.close (cmux)", () => {
   it("is a no-op when no workspace exists for the name", async () => {
     runMock.mockReturnValue(JSON.stringify({ workspaces: [] }));
 
-    await workspaces.close(makeConfig(), "TEAM-1");
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "missing",
+    });
 
     expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
   });
@@ -559,7 +584,9 @@ describe("workspaces.close (cmux)", () => {
       throw new Error("cmux down");
     });
 
-    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toBeUndefined();
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "unavailable",
+    });
     expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
   });
 
@@ -573,7 +600,9 @@ describe("workspaces.close (cmux)", () => {
       })
       .mockReturnValueOnce(JSON.stringify({ workspaces: [] }));
 
-    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toBeUndefined();
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
   });
 
   it("rethrows cmux close failures when the workspace is still present", async () => {
@@ -591,7 +620,7 @@ describe("workspaces.close (cmux)", () => {
     await expect(workspaces.close(makeConfig(), "TEAM-1")).rejects.toThrow("permission denied");
   });
 
-  it("rethrows cmux close failures when the follow-up list is unavailable", async () => {
+  it("returns unavailable when a failed close cannot be confirmed by a follow-up list", async () => {
     runMock
       .mockReturnValueOnce(
         JSON.stringify({ workspaces: [{ title: "TEAM-1", ref: "workspace:42" }] }),
@@ -603,7 +632,10 @@ describe("workspaces.close (cmux)", () => {
         throw new Error("cmux down");
       });
 
-    await expect(workspaces.close(makeConfig(), "TEAM-1")).rejects.toThrow("permission denied");
+    const result = await workspaces.close(makeConfig(), "TEAM-1");
+
+    expect(result.kind).toBe("unavailable");
+    expect(workspaceCloseError(result)).toBeInstanceOf(Error);
   });
 
   it("rethrows cmux close failures after the shutdown signal fires", async () => {
@@ -902,7 +934,9 @@ describe("workspaces.close (tmux)", () => {
   afterEach(commonAfterEach);
 
   it("calls kill-window directly without a pre-probe list", async () => {
-    await workspaces.close(makeConfig("tmux"), "TEAM-1");
+    await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
 
     expect(runMock).toHaveBeenCalledWith("tmux", ["kill-window", "-t", "groundcrew:TEAM-1"]);
     expect(runMock).not.toHaveBeenCalledWith("tmux", expect.arrayContaining(["list-windows"]));
@@ -913,7 +947,9 @@ describe("workspaces.close (tmux)", () => {
       throw new Error("can't find window: TEAM-1");
     });
 
-    await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).resolves.toBeUndefined();
+    await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).resolves.toStrictEqual({
+      kind: "missing",
+    });
   });
 
   it("is a no-op when the session does not exist", async () => {
@@ -921,7 +957,9 @@ describe("workspaces.close (tmux)", () => {
       throw new Error("can't find session: groundcrew");
     });
 
-    await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).resolves.toBeUndefined();
+    await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).resolves.toStrictEqual({
+      kind: "missing",
+    });
   });
 
   it("rethrows tmux close failures after the shutdown signal fires", async () => {
@@ -944,6 +982,93 @@ describe("workspaces.close (tmux)", () => {
     await expect(workspaces.close(makeConfig("tmux"), "TEAM-1")).rejects.toThrow(
       /permission denied/,
     );
+  });
+});
+
+describe("workspaces.interrupt", () => {
+  beforeEach(commonBeforeEach);
+  afterEach(commonAfterEach);
+
+  it("returns missing without closing when the workspace is not live", async () => {
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [] }));
+
+    await expect(workspaces.interrupt(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "missing",
+    });
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
+  });
+
+  it("closes a live cmux workspace by id", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "workspace-id" }] }),
+    );
+
+    await expect(workspaces.interrupt(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "interrupted",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "close-workspace",
+      "--workspace",
+      "workspace-id",
+    ]);
+  });
+
+  it("returns unavailable when the workspace backend cannot be probed", async () => {
+    runMock.mockImplementation(() => {
+      throw new Error("cmux down");
+    });
+
+    await expect(workspaces.interrupt(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("returns unavailable with error details when adapter resolution fails", async () => {
+    detectHostMock.mockResolvedValue(makeHost({ hasCmux: false, hasTmux: false }));
+
+    const result = await workspaces.interrupt(makeConfig("auto"), "TEAM-1");
+
+    expect(result.kind).toBe("unavailable");
+    expect(workspaceInterruptError(result)).toBeInstanceOf(Error);
+  });
+
+  it("returns unavailable without error details when the adapter cannot list workspaces", async () => {
+    runMock.mockReturnValueOnce("not json");
+
+    await expect(workspaces.interrupt(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("returns unavailable when cmux cannot confirm the close after the initial probe", async () => {
+    runMock
+      .mockReturnValueOnce(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }))
+      .mockReturnValueOnce(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }))
+      .mockImplementationOnce(() => {
+        throw new Error("permission denied");
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("cmux down");
+      });
+
+    const result = await workspaces.interrupt(makeConfig(), "TEAM-1");
+
+    expect(result.kind).toBe("unavailable");
+    expect(workspaceInterruptError(result)).toBeInstanceOf(Error);
+  });
+
+  it("returns unavailable without error details when cmux cannot list during close", async () => {
+    runMock
+      .mockReturnValueOnce(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }))
+      .mockImplementationOnce(() => {
+        throw new Error("cmux down");
+      });
+
+    await expect(workspaces.interrupt(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "unavailable",
+    });
   });
 });
 

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -48,6 +48,16 @@ export type WorkspaceProbe =
   | { kind: "ok"; names: Set<string> }
   | { kind: "unavailable"; error?: unknown };
 
+export type WorkspaceInterruptResult =
+  | { kind: "interrupted" }
+  | { kind: "missing" }
+  | { kind: "unavailable"; error?: unknown };
+
+export type WorkspaceCloseResult =
+  | { kind: "closed" }
+  | { kind: "missing" }
+  | { kind: "unavailable"; error?: unknown };
+
 interface Adapter {
   open(spec: OpenSpec, signal?: AbortSignal): Promise<void>;
   /**
@@ -57,8 +67,8 @@ interface Adapter {
    *   distinguish "no live workspaces" from "couldn't ask".
    */
   list(signal?: AbortSignal): Promise<Workspace[] | undefined>;
-  /** No-op when no workspace exists for `name`. */
-  close(name: string, signal?: AbortSignal): Promise<void>;
+  /** Closes the workspace or confirms it is not present. */
+  close(name: string, signal?: AbortSignal): Promise<WorkspaceCloseResult>;
   /**
    * User-facing way to reach the workspace, or `undefined` when the backend
    * has no concise external hint.
@@ -342,24 +352,26 @@ const cmuxAdapter: Adapter = {
       // would always fail. The list failure has already been logged by
       // `listCmuxRaw`; bail rather than guarantee a downstream error.
       log(`cmux close-workspace skipped for ${name}: list-workspaces failed, no usable id`);
-      return;
+      return { kind: "unavailable" };
     }
     const match = raw.find((ws) => ws.title === name);
     if (match === undefined) {
-      return;
+      return { kind: "missing" };
     }
     try {
       await closeCmuxWorkspace(match.id, signal);
+      return { kind: "closed" };
     } catch (error) {
       if (isSignalAborted(signal)) {
         throw error;
       }
       const remaining = await listCmuxRaw(signal);
-      if (remaining !== undefined) {
-        const isStillPresent = remaining.some((ws) => ws.title === name);
-        if (!isStillPresent) {
-          return;
-        }
+      if (remaining === undefined) {
+        return { kind: "unavailable", error };
+      }
+      const isStillPresent = remaining.some((ws) => ws.title === name);
+      if (!isStillPresent) {
+        return { kind: "closed" };
       }
       throw error;
     }
@@ -583,12 +595,13 @@ const tmuxAdapter: Adapter = {
   async close(name, signal) {
     try {
       await runWorkspaceCommand("tmux", ["kill-window", "-t", tmuxTarget(name)], signal);
+      return { kind: "closed" };
     } catch (error) {
       if (isSignalAborted(signal)) {
         throw error;
       }
       if (isTmuxNotFoundError(error)) {
-        return;
+        return { kind: "missing" };
       }
       throw error;
     }
@@ -637,16 +650,42 @@ async function probeWorkspaces(
   return { kind: "ok", names: new Set(raw.map((ws) => ws.name)) };
 }
 
+async function interruptWorkspace(
+  config: ResolvedConfig,
+  name: string,
+  signal?: AbortSignal,
+): Promise<WorkspaceInterruptResult> {
+  const probe = await probeWorkspaces(config, signal);
+  if (probe.kind === "unavailable") {
+    return { kind: "unavailable", ...(probe.error === undefined ? {} : { error: probe.error }) };
+  }
+  if (!probe.names.has(name)) {
+    return { kind: "missing" };
+  }
+  const result = await workspaces.close(config, name, signal);
+  if (result.kind === "unavailable") {
+    return result.error === undefined
+      ? { kind: "unavailable" }
+      : { kind: "unavailable", error: result.error };
+  }
+  return { kind: "interrupted" };
+}
+
 export const workspaces = {
   async open(config: ResolvedConfig, spec: OpenSpec, signal?: AbortSignal): Promise<void> {
     const adapter = await adapterFor(config, signal);
     await adapter.open(spec, signal);
   },
   probe: probeWorkspaces,
-  async close(config: ResolvedConfig, name: string, signal?: AbortSignal): Promise<void> {
+  async close(
+    config: ResolvedConfig,
+    name: string,
+    signal?: AbortSignal,
+  ): Promise<WorkspaceCloseResult> {
     const adapter = await adapterFor(config, signal);
-    await adapter.close(name, signal);
+    return await adapter.close(name, signal);
   },
+  interrupt: interruptWorkspace,
   async accessHint(
     config: ResolvedConfig,
     name: string,

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -41,6 +41,7 @@ vi.mock(import("./workspaces.ts"), async (importOriginal) => {
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
       close: vi.fn<typeof actual.workspaces.close>(),
+      interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };
@@ -775,6 +776,10 @@ describe(teardown, () => {
   // oxlint-disable-next-line typescript/unbound-method -- vi.mocked needs the function reference
   const workspacesCloseMock = vi.mocked(workspaces.close);
 
+  beforeEach(() => {
+    workspacesCloseMock.mockResolvedValue({ kind: "closed" });
+  });
+
   function hostEntry(ticket: string): WorktreeEntry {
     mkdirSync(join(projectDir, `repo-a-${ticket}`), { recursive: true });
     mkdirSync(join(projectDir, "repo-a"), { recursive: true });
@@ -815,6 +820,21 @@ describe(teardown, () => {
     expect(Number(workspacesCloseMock.mock.invocationCallOrder[0])).toBeLessThan(
       Number(runCommandMock.mock.invocationCallOrder[0]),
     );
+  });
+
+  it("does not report a closed workspace when close only confirms absence", async () => {
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
+    workspacesCloseMock.mockResolvedValue({ kind: "missing" });
+    const config = makeConfig({ projectDir });
+
+    const result = await teardown(config, [hostEntry("team-1")]);
+
+    expect(workspacesCloseMock).toHaveBeenCalledWith(config, "team-1", undefined);
+    expect(result.closed).toStrictEqual([]);
+    expect(result.removed).toHaveLength(1);
   });
 
   it("dedupes the workspace close across duplicate host entries for one ticket", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -423,6 +423,26 @@ export interface TeardownResult {
   workspaceProbe: WorkspaceProbe;
 }
 
+async function closeWorkspaceForTeardown(
+  config: ResolvedConfig,
+  ticket: string,
+  signal: AbortSignal | undefined,
+): Promise<boolean> {
+  const closeResult = await workspaces.close(config, ticket, signal);
+  return closeResult.kind === "closed";
+}
+
+function shouldCloseWorkspaceForTeardown(
+  ticket: string,
+  workspaceProbe: WorkspaceProbe,
+  liveNames: ReadonlySet<string>,
+  closedTickets: ReadonlySet<string>,
+): boolean {
+  return (
+    !closedTickets.has(ticket) && (workspaceProbe.kind === "unavailable" || liveNames.has(ticket))
+  );
+}
+
 // A flaky cmux/tmux must not abort the batch — otherwise every on-disk
 // worktree gets stranded. The probe verdict is captured on the result and
 // removal proceeds with no live-workspace knowledge (so no close attempts).
@@ -451,14 +471,13 @@ async function teardown(
   };
 
   for (const entry of entries) {
-    if (
-      !closedTickets.has(entry.ticket) &&
-      (workspaceProbe.kind === "unavailable" || liveNames.has(entry.ticket))
-    ) {
+    if (shouldCloseWorkspaceForTeardown(entry.ticket, workspaceProbe, liveNames, closedTickets)) {
       try {
         // oxlint-disable-next-line no-await-in-loop -- teardown is intentionally sequential per ticket
-        await workspaces.close(config, entry.ticket, options?.signal);
-        result.closed.push(entry.ticket);
+        const closed = await closeWorkspaceForTeardown(config, entry.ticket, options?.signal);
+        if (closed) {
+          result.closed.push(entry.ticket);
+        }
       } catch (error) {
         if (options?.signal?.aborted === true) {
           throw error;


### PR DESCRIPTION
## Summary

Project: [Groundcrew Daily Workflow Improvements](https://linear.app/clipboardhealth/project/groundcrew-daily-workflow-improvements-5d9dfbed8c9d)

This PR adds persisted per-ticket run state for Groundcrew. Setup records successful and failed launches; cleanup records when local work has been cleaned up.

## Contribution to the Stack

This gives later commands a durable local source of truth instead of making them infer everything from Linear, tmux, and git worktrees. `interrupt`, `resume`, and `doctor` build on this state.

Overall stack theme: make Groundcrew runs easier to recover, pause, inspect, resume, and clean up during daily ticket work.

## Stack Order

1. #69 shared launch plumbing
2. #70 persisted run state — current PR
3. #71 interrupt command
4. #72 resume command
5. #73 doctor recovery state
6. #74 recovery workflow docs

## Validation

- `node --run verify` passed locally on this branch.
- `node --run verify` passed on every branch in the stack after restacking.
- Pre-push verification passed before pushing the rewritten stack.
- GitHub `main` workflow passed for this PR.

## Linear

[ORB-2184](https://linear.app/clipboardhealth/issue/ORB-2184/persist-groundcrew-run-state-for-recoverable-agent-sessions)
