### PR TITLE
feat(workflow): add resume command (ORB-2186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,14 +316,16 @@ crew run                                                 # one-shot dispatch
 crew run --watch                                         # poll forever
 crew run --ticket <TICKET>                               # provision one ticket and exit
 crew setup repos [--dry-run] [<repo>...]
+crew interrupt <TICKET> [--reason <text>]                # stop the live workspace, keep the worktree
+crew resume <TICKET>                                     # reopen an existing ticket worktree
 crew cleanup <TICKET>                                    # tear down every worktree carrying this ticket
 ```
 
-`crew doctor --ticket <TICKET>` covers the full per-ticket lifecycle: pre-dispatch eligibility (Todo status, `agent-*` label, model resolution, repository mention, local clone, blockers, model session usage, in-progress capacity) **and** post-dispatch local-state recovery (host worktree, workspace pane, local branch, remote branch, open PR). Verdict precedence runs from post-dispatch outcomes down: `pr-open` > `pr-merged` > `in-flight` > `recoverable` > `unresolvable` > `ineligible` > `would-dispatch` > `lost`. Exits 0 on `would-dispatch`, `pr-open`, or `pr-merged`; any other verdict exits 1. `--watch` and `--ticket` are mutually exclusive. To inspect codexbar session windows directly, run `codexbar usage`.
+`crew doctor --ticket <TICKET>` covers the full per-ticket lifecycle: pre-dispatch eligibility (Todo status, `agent-*` label, model resolution, repository mention, local clone, blockers, model session usage, in-progress capacity) **and** post-dispatch local-state recovery (recorded run state, host worktree, workspace pane, local branch, remote branch, open PR). Verdict precedence starts with PR outcomes (`pr-open` > `pr-merged`). Recorded failed launches report before ordinary local recovery, interrupted runs report concrete recoverable git work first when it exists and otherwise report `interrupted`, and ordinary post-dispatch cases report `in-flight` before `recoverable`. If none of those apply, doctor falls through to `unresolvable` > `ineligible` > `would-dispatch` > `lost`. Exits 0 on `would-dispatch`, `pr-open`, or `pr-merged`; any other verdict exits 1. `--watch` and `--ticket` are mutually exclusive. To inspect codexbar session windows directly, run `codexbar usage`.
 
 ### `crew doctor --ticket <ticket>`
 
-Diagnose where a ticket is in its lifecycle and what to do next. Runs the same resolution and eligibility chain as the dispatcher, plus probes the host worktree, workspace pane, local branch, remote branch, and PR; prints a single verdict with a copy-pasteable recovery step when one applies.
+Diagnose where a ticket is in its lifecycle and what to do next. Runs the same resolution and eligibility chain as the dispatcher, plus probes recorded run state, host worktree, workspace pane, local branch, remote branch, and PR; prints a single verdict with a copy-pasteable recovery step when one applies.
 
 Flags:
 
@@ -343,6 +345,13 @@ Resolution
 
 Eligibility
   (skipped — post-dispatch — pre-dispatch checks are irrelevant)
+
+Run state
+  [ok] Local run state (running)
+  [ok] Recorded model (claude)
+  [ok] Recorded worktree (/Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442)
+  [ok] Recorded branch (paul-hrd-442)
+  [ok] Resume count (0)
 
 Worktree
   [ok] Host worktree exists (/Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442)
@@ -374,10 +383,30 @@ The verdict on the last line maps to a recovery action:
 | `pr-merged`      | Done.                                                                                         |
 | `in-flight`      | The ticket is still being worked on; the verdict line names the workspace pane to attach to.  |
 | `recoverable`    | Run the printed `nextStep` exactly.                                                           |
+| `interrupted`    | Resume the preserved worktree with `crew resume <ticket>` or inspect it by hand.              |
+| `failed-launch`  | Fix the launch failure, then run `crew resume <ticket>` or `crew cleanup <ticket>`.           |
 | `would-dispatch` | Pre-dispatch checks pass; the orchestrator will pick the ticket up on its next tick.          |
 | `ineligible`     | A resolution or eligibility check failed; the reason after the colon names the failing check. |
 | `unresolvable`   | The Linear ticket couldn't be fetched; the reason after the colon names the error.            |
 | `lost`           | No trace exists. Re-dispatch via `crew run --ticket <ticket>`.                                |
+
+### `crew interrupt <ticket>`
+
+Stop a live workspace pane while preserving the ticket worktree and branch. This is the manual pause button for cases where you need terminal capacity back, want to stop an agent that is going in the wrong direction, or need to inspect the diff before letting another agent continue.
+
+```bash
+crew interrupt HRD-442 --reason "wrong implementation direction"
+crew doctor --ticket HRD-442
+crew resume HRD-442
+```
+
+The command closes the cmux/tmux workspace when it exists, records local run state under the groundcrew state directory, and never tears down the worktree. If the workspace was already gone but the worktree is still present, interrupt records that fact so doctor can point at the preserved branch instead of reporting a mystery ticket.
+
+### `crew resume <ticket>`
+
+Reopen an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists, it fails and leaves re-dispatch to `crew run --ticket <ticket>`.
+
+The resume prompt tells the agent to inspect current git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and ticket context.
 
 ## Troubleshooting
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -6,6 +6,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
+import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
@@ -26,6 +27,9 @@ vi.mock(import("./commands/interruptWorkspace.ts"), () => ({
 vi.mock(import("./commands/orchestrator.ts"), () => ({
   orchestrate: vi.fn<typeof orchestrate>(),
 }));
+vi.mock(import("./commands/resumeWorkspace.ts"), () => ({
+  resumeWorkspaceCli: vi.fn<typeof resumeWorkspaceCli>(),
+}));
 vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
 }));
@@ -36,6 +40,7 @@ vi.mock(import("./commands/setupRepos.ts"), () => ({
 const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
 const interruptMock = vi.mocked(interruptWorkspaceCli);
+const resumeMock = vi.mocked(resumeWorkspaceCli);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
@@ -71,6 +76,7 @@ describe(run, () => {
     orchestrateMock.mockResolvedValue();
     doctorMock.mockResolvedValue(true);
     interruptMock.mockResolvedValue();
+    resumeMock.mockResolvedValue();
     setupMock.mockResolvedValue();
     setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
@@ -326,6 +332,11 @@ describe(run, () => {
     expect(interruptMock).toHaveBeenCalledWith(["TEAM-1", "--reason", "wrong direction"]);
   });
 
+  it("dispatches resume to resumeWorkspaceCli with the remaining argv", async () => {
+    await run(["resume", "TEAM-1"]);
+
+    expect(resumeMock).toHaveBeenCalledWith(["TEAM-1"]);
+  });
   it("dispatches `setup repos` to setupReposCli with the remaining argv", async () => {
     await run(["setup", "repos", "--dry-run", "owner/repo"]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
+import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { errorMessage, readTicketArgument, writeError, writeOutput } from "./lib/util.ts";
@@ -120,6 +121,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Stop a live ticket workspace while preserving its worktree",
     usage: "<ticket> [--reason <text>]",
     invoke: interruptWorkspaceCli,
+  },
+  resume: {
+    summary: "Reopen an existing ticket worktree with a continuation prompt",
+    usage: "<ticket>",
+    invoke: resumeWorkspaceCli,
   },
   setup: {
     summary: "Project-level setup commands (currently: repos)",

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1,0 +1,405 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type * as nodeFs from "node:fs";
+
+import { ensureClearance } from "@clipboard-health/clearance";
+
+import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import type * as utilModule from "../lib/util.ts";
+import { getLinearClient } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
+
+interface NodeFsMock extends Omit<typeof nodeFs, "mkdtempSync" | "rmSync" | "writeFileSync"> {
+  mkdtempSync: ReturnType<typeof vi.fn<typeof mkdtempSync>>;
+  rmSync: ReturnType<typeof vi.fn<typeof rmSync>>;
+  writeFileSync: ReturnType<typeof vi.fn<typeof writeFileSync>>;
+}
+
+vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
+  const actual = await importOriginal<typeof nodeFs>();
+  return {
+    ...actual,
+    mkdtempSync: vi.fn<typeof mkdtempSync>(),
+    rmSync: vi.fn<typeof rmSync>(),
+    writeFileSync: vi.fn<typeof writeFileSync>(),
+  };
+});
+vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, ensureClearance: vi.fn<typeof ensureClearance>() };
+});
+vi.mock(import("../lib/boardSource.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, fetchResolvedIssue: vi.fn<typeof fetchResolvedIssue>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
+});
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    recordRunState: vi.fn<typeof recordRunState>(),
+  };
+});
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
+  const actual = await importOriginal<typeof utilModule>();
+  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
+});
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      open: vi.fn<typeof actual.workspaces.open>(),
+      probe: vi.fn<typeof actual.workspaces.probe>(),
+    },
+  };
+});
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      findByTicket: vi.fn<typeof actual.worktrees.findByTicket>(),
+      create: vi.fn<typeof actual.worktrees.create>(),
+    },
+  };
+});
+
+const mkdtempMock = vi.mocked(mkdtempSync);
+const rmSyncMock = vi.mocked(rmSync);
+const writeFileMock = vi.mocked(writeFileSync);
+const ensureClearanceMock = vi.mocked(ensureClearance);
+const fetchResolvedIssueMock = vi.mocked(fetchResolvedIssue);
+const loadConfigMock = vi.mocked(loadConfig);
+const detectHostMock = vi.mocked(detectHostCapabilities);
+const readRunStateMock = vi.mocked(readRunState);
+const recordRunStateMock = vi.mocked(recordRunState);
+const getLinearClientMock = vi.mocked(getLinearClient);
+// oxlint-disable-next-line typescript/unbound-method -- workspaces is mocked to plain vi.fn properties in this file.
+const workspacesOpenMock = vi.mocked(workspaces.open);
+const workspacesProbeMock = vi.mocked(workspaces.probe);
+const findByTicketMock = vi.mocked(worktrees.findByTicket);
+const createMock = vi.mocked(worktrees.create);
+
+type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
+type FetchResolvedIssueInput = Parameters<typeof fetchResolvedIssue>[0];
+type IssueLookup = (id: string) => Promise<{ title: string; description?: string | undefined }>;
+
+function lastRecordedRunState(): RecordedRunState {
+  const input = recordRunStateMock.mock.calls.at(-1)?.[0];
+  if (input === undefined) {
+    throw new Error("recordRunState was not called");
+  }
+  return input.state;
+}
+
+function firstFetchResolvedIssueInput(): FetchResolvedIssueInput {
+  const input = fetchResolvedIssueMock.mock.calls[0]?.[0];
+  if (input === undefined) {
+    throw new Error("fetchResolvedIssue was not called");
+  }
+  return input;
+}
+
+function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
+  return {
+    hasSafehouse: true,
+    hasSbx: false,
+    hasCmux: true,
+    hasTmux: false,
+    isMacOS: true,
+    isLinux: false,
+    isSafehouseSupported: true,
+    isSdxSupported: true,
+    ...overrides,
+  };
+}
+
+function makeConfig(): ResolvedConfig {
+  return {
+    linear: {
+      projectSlug: "x-aaaaaaaaaaaa",
+      slugId: "aaaaaaaaaaaa",
+      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+    },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude --auto", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function makeWorktree(): WorktreeEntry {
+  return {
+    repository: "repo-a",
+    ticket: "team-1",
+    branchName: "rocky-team-1",
+    dir: "/work/repo-a-team-1",
+    kind: "host",
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  const state: RunState = {
+    ticket: "team-1",
+    repository: "repo-a",
+    model: "claude",
+    worktreeDir: "/work/repo-a-team-1",
+    branchName: "rocky-team-1",
+    workspaceName: "team-1",
+    state: "interrupted",
+    reason: "wrong direction",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    resumeCount: 1,
+    ...overrides,
+  };
+  return state;
+}
+
+function makeRunStateWithoutReason(overrides: Partial<RunState> = {}): RunState {
+  const state = makeRunState(overrides);
+  delete state.reason;
+  return state;
+}
+
+function mockLinearIssue(): void {
+  const issue = vi.fn<IssueLookup>().mockResolvedValue({ title: "Title", description: "Body" });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+  getLinearClientMock.mockReturnValue({
+    issue,
+  } as unknown as ReturnType<typeof getLinearClient>);
+}
+
+describe(resumeWorkspace, () => {
+  const config = makeConfig();
+
+  beforeEach(() => {
+    mkdtempMock.mockReturnValue("/tmp/groundcrew-resume-team-1-x");
+    mockLinearIssue();
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesOpenMock.mockResolvedValue();
+    detectHostMock.mockResolvedValue(host());
+    ensureClearanceMock.mockResolvedValue({
+      logPath: "/tmp/clearance/clearance.log",
+      pidPath: "/tmp/clearance/clearance.pid",
+      port: 19_999,
+      status: "already-running",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("opens a new workspace in the existing worktree and records a resume", async () => {
+    await resumeWorkspace(config, { ticket: "TEAM-1" });
+
+    expect(createMock).not.toHaveBeenCalled();
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        name: "team-1",
+        cwd: "/work/repo-a-team-1",
+      }),
+    );
+    expect(lastRecordedRunState()).toMatchObject({
+      ticket: "team-1",
+      state: "resumed",
+      resumeCount: 2,
+      reason: "wrong direction",
+    });
+  });
+
+  it("includes continuation context in the staged prompt", async () => {
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("Previous interrupt reason: wrong direction"),
+    );
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("inspect the current git status and diff"),
+    );
+  });
+
+  it("falls back to the ticket id when Linear detail lookup fails during state resume", async () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockRejectedValue(new Error("offline")),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("ticket team-1 (TEAM-1)"),
+    );
+  });
+
+  it("renders empty ticket details and no previous reason when state has neither", async () => {
+    readRunStateMock.mockReturnValue(makeRunStateWithoutReason());
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockResolvedValue({ title: "Title" }),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("Previous interrupt reason: none recorded"),
+    );
+  });
+
+  it("falls back to Linear resolution when state is missing", async () => {
+    readRunStateMock.mockReset();
+    fetchResolvedIssueMock.mockResolvedValue({
+      uuid: "uuid-1",
+      title: "Resolved title",
+      description: "Resolved body for repo-a",
+      repository: "repo-a",
+      model: "claude",
+      teamId: "team-1",
+    });
+
+    await resumeWorkspace(config, { ticket: "team-1" });
+
+    const fetchInput = firstFetchResolvedIssueInput();
+    expect(fetchInput.config).toBe(config);
+    expect(fetchInput.ticket).toBe("team-1");
+    expect(fetchInput.client).toBeDefined();
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+  });
+
+  it("fails when the worktree is absent", async () => {
+    findByTicketMock.mockReturnValue([]);
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /No worktree found/,
+    );
+  });
+
+  it("fails when recorded run state refers to an unknown model", async () => {
+    readRunStateMock.mockReturnValue(makeRunState({ model: "missing-model" }));
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /Unknown model: missing-model/,
+    );
+  });
+
+  it("fails when the workspace is already live", async () => {
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(/already live/);
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when workspace liveness cannot be verified", async () => {
+    workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /Could not verify whether workspace for team-1 is already live/,
+    );
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+    expect(mkdtempMock).not.toHaveBeenCalled();
+  });
+
+  it("includes probe error details when workspace liveness verification fails", async () => {
+    workspacesProbeMock.mockResolvedValue({
+      kind: "unavailable",
+      error: new Error("cmux down"),
+    });
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(
+      /cmux down.*inspect the workspace backend/,
+    );
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("removes the staged prompt directory when opening the workspace fails", async () => {
+    workspacesOpenMock.mockRejectedValue(new Error("cmux failed"));
+
+    await expect(resumeWorkspace(config, { ticket: "team-1" })).rejects.toThrow(/cmux failed/);
+    expect(rmSyncMock).toHaveBeenCalledWith("/tmp/groundcrew-resume-team-1-x", {
+      recursive: true,
+      force: true,
+    });
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe(resumeWorkspaceCli, () => {
+  const config = makeConfig();
+
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(config);
+    mkdtempMock.mockReturnValue("/tmp/groundcrew-resume-team-1-x");
+    mockLinearIssue();
+    readRunStateMock.mockReturnValue(makeRunState());
+    findByTicketMock.mockReturnValue([makeWorktree()]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    detectHostMock.mockResolvedValue(host());
+    ensureClearanceMock.mockResolvedValue({
+      logPath: "/tmp/clearance/clearance.log",
+      pidPath: "/tmp/clearance/clearance.pid",
+      port: 19_999,
+      status: "already-running",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses the ticket argument", async () => {
+    await resumeWorkspaceCli(["TEAM-1"]);
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+  });
+
+  it("rejects missing ticket", async () => {
+    await expect(resumeWorkspaceCli([])).rejects.toThrow(/Usage: crew resume/);
+  });
+
+  it("rejects extra positional args", async () => {
+    await expect(resumeWorkspaceCli(["team-1", "extra"])).rejects.toThrow(/Usage: crew resume/);
+  });
+});

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,0 +1,212 @@
+import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { ensureAgentSandbox, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
+import { buildLaunchCommand } from "../lib/launchCommand.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import {
+  removeStagedPrompt,
+  stageBuildSecrets,
+  stagePromptText,
+  stageWorkspaceLaunchCommand,
+} from "../lib/stagedLaunch.ts";
+import { errorMessage, getLinearClient, log } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+
+export interface ResumeWorkspaceOptions {
+  ticket: string;
+}
+
+interface TicketDetails {
+  title: string;
+  description: string;
+}
+
+interface ResumeContext {
+  ticket: string;
+  repository: string;
+  model: string;
+  worktree: WorktreeEntry;
+  title: string;
+  description: string;
+  reason?: string;
+  resumeCount: number;
+}
+
+function parseArguments(argv: string[]): ResumeWorkspaceOptions {
+  const [ticket, ...extras] = argv;
+  if (ticket === undefined || ticket.length === 0 || extras.length > 0 || ticket.startsWith("-")) {
+    throw new Error("Usage: crew resume <ticket>");
+  }
+  return { ticket: ticket.toLowerCase() };
+}
+
+async function fetchTicketDetails(ticket: string): Promise<TicketDetails | undefined> {
+  try {
+    const issue = await getLinearClient().issue(ticket.toUpperCase());
+    return {
+      title: issue.title,
+      description: issue.description ?? "",
+    };
+  } catch (error) {
+    log(`Resume Linear detail lookup failed for ${ticket}: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+async function contextFromLinear(
+  config: ResolvedConfig,
+  ticket: string,
+  worktree: WorktreeEntry,
+): Promise<ResumeContext> {
+  const resolved = await fetchResolvedIssue({ client: getLinearClient(), config, ticket });
+  return {
+    ticket,
+    repository: resolved.repository,
+    model: resolved.model,
+    worktree,
+    title: resolved.title,
+    description: resolved.description,
+    resumeCount: 0,
+  };
+}
+
+async function contextFromState(
+  ticket: string,
+  state: RunState,
+  worktree: WorktreeEntry,
+): Promise<ResumeContext> {
+  const details = await fetchTicketDetails(ticket);
+  return {
+    ticket,
+    repository: state.repository,
+    model: state.model,
+    worktree,
+    title: details?.title ?? ticket.toUpperCase(),
+    description: details?.description ?? "",
+    ...(state.reason === undefined ? {} : { reason: state.reason }),
+    resumeCount: state.resumeCount,
+  };
+}
+
+async function buildResumeContext(config: ResolvedConfig, ticket: string): Promise<ResumeContext> {
+  const state = readRunState(config, ticket);
+  const entries = worktrees.findByTicket(config, ticket);
+  const worktree =
+    state === undefined
+      ? entries[0]
+      : (entries.find((entry) => entry.repository === state.repository) ?? entries[0]);
+  if (worktree === undefined) {
+    throw new Error(`No worktree found for ${ticket}; cannot resume.`);
+  }
+  if (state !== undefined) {
+    return await contextFromState(ticket, state, worktree);
+  }
+  return await contextFromLinear(config, ticket, worktree);
+}
+
+function renderResumePrompt(context: ResumeContext): string {
+  return [
+    `You are resuming Groundcrew ticket ${context.ticket} (${context.title}) in an existing worktree.`,
+    "",
+    "Ticket description:",
+    "",
+    context.description,
+    "",
+    "## Continuation context",
+    "",
+    `- Worktree: ${context.worktree.dir}`,
+    `- Branch: ${context.worktree.branchName}`,
+    context.reason === undefined
+      ? "- Previous interrupt reason: none recorded"
+      : `- Previous interrupt reason: ${context.reason}`,
+    "",
+    "Before editing, inspect the current git status and diff. Continue from the work already present in this worktree; do not restart from scratch unless the diff proves that is necessary.",
+    "",
+    "Run the repository's documented verification before stopping, then leave the branch ready or open a PR when possible.",
+  ].join("\n");
+}
+
+async function failIfWorkspaceAlreadyLive(config: ResolvedConfig, ticket: string): Promise<void> {
+  const probe = await workspaces.probe(config);
+  if (probe.kind === "unavailable") {
+    const detail = probe.error === undefined ? "" : `: ${errorMessage(probe.error)}`;
+    throw new Error(
+      `Could not verify whether workspace for ${ticket} is already live${detail}. Retry or inspect the workspace backend manually before resuming.`,
+    );
+  }
+  if (probe.names.has(ticket)) {
+    throw new Error(`Workspace for ${ticket} is already live; attach to it instead of resuming.`);
+  }
+}
+
+export async function resumeWorkspace(
+  config: ResolvedConfig,
+  options: ResumeWorkspaceOptions,
+): Promise<void> {
+  const ticket = options.ticket.toLowerCase();
+  await failIfWorkspaceAlreadyLive(config, ticket);
+  const context = await buildResumeContext(config, ticket);
+  const definition = config.models.definitions[context.model];
+  if (definition === undefined) {
+    throw new Error(`Unknown model: ${context.model}`);
+  }
+
+  const { runner, sandboxName } = await prepareAgentLaunch({
+    config,
+    model: context.model,
+    definition,
+    purpose: "resumes",
+  });
+
+  const stagedPrompt = stagePromptText({
+    prefix: "groundcrew-resume",
+    ticket,
+    text: renderResumePrompt(context),
+  });
+  const secretsFile = stageBuildSecrets(stagedPrompt.directory);
+  await ensureAgentSandbox({ config, definition, sandboxName });
+  const launchCommand = buildLaunchCommand({
+    definition,
+    promptFile: stagedPrompt.file,
+    worktreeDir: context.worktree.dir,
+    secretsFile,
+    runner,
+    sandboxName,
+  });
+  const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
+
+  try {
+    await openAgentWorkspace({
+      config,
+      name: ticket,
+      cwd: context.worktree.dir,
+      command: launchCmd,
+      model: context.model,
+      color: definition.color,
+    });
+  } catch (error) {
+    removeStagedPrompt(stagedPrompt.directory);
+    throw error;
+  }
+  recordRunState({
+    config,
+    state: {
+      ticket,
+      repository: context.repository,
+      model: context.model,
+      worktreeDir: context.worktree.dir,
+      branchName: context.worktree.branchName,
+      workspaceName: ticket,
+      state: "resumed",
+      resumeCount: context.resumeCount + 1,
+      ...(context.reason === undefined ? {} : { reason: context.reason }),
+    },
+  });
+  log(`Resumed ${ticket} in ${context.worktree.dir} (${context.model})`);
+}
+
+export async function resumeWorkspaceCli(argv: string[]): Promise<void> {
+  const config = await loadConfig();
+  await resumeWorkspace(config, parseArguments(argv));
+}

--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 
 import type { RawLinearIssue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import type { RunState } from "../lib/runState.ts";
 import type { WorkspaceAccessHint, WorkspaceProbe } from "../lib/workspaces.ts";
 import type { WorktreeDirtiness, WorktreeEntry } from "../lib/worktrees.ts";
 import {
@@ -114,6 +115,7 @@ function makeStubDependencies(
     probePullRequest: vi
       .fn<TicketDoctorDependencies["probePullRequest"]>()
       .mockResolvedValue({ kind: "absent" } satisfies PullRequestProbe),
+    readRunState: vi.fn<TicketDoctorDependencies["readRunState"]>(),
     doFetch: true,
     ...overrides,
   };
@@ -126,6 +128,22 @@ function makeWorktreeEntry(overrides: Partial<WorktreeEntry> = {}): WorktreeEntr
     branchName: "rocky-hrd-1",
     dir: "/work/repo-a-hrd-1",
     kind: "host",
+    ...overrides,
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    ticket: "hrd-1",
+    repository: "repo-a",
+    model: "claude",
+    worktreeDir: "/work/repo-a-hrd-1",
+    branchName: "rocky-hrd-1",
+    workspaceName: "hrd-1",
+    state: "interrupted",
+    resumeCount: 0,
+    createdAt: "2026-05-21T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -144,6 +162,7 @@ function makeVerdictInput(overrides: Partial<DecideVerdictInput> = {}): DecideVe
     branch: "rocky-hrd-1",
     worktreeDir: undefined,
     workspaceName: undefined,
+    runState: undefined,
     ...overrides,
   };
 }
@@ -276,6 +295,76 @@ describe(decidePostDispatchVerdict, () => {
       }),
     );
     expect(verdict).toMatchObject({ kind: "pr-open" });
+  });
+
+  it("ranks pr-open above interrupted run state", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        pullRequest: { kind: "open", number: 9, url: "u" },
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "pr-open" });
+  });
+
+  it("returns interrupted when the local run state was stopped and no recovery action wins", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted", reason: "freeing terminal" }),
+      }),
+    );
+    const interrupted = narrowVerdict(verdict, "interrupted");
+    expect(interrupted.reason).toBe("freeing terminal");
+    expect(interrupted.nextStep).toContain("crew resume hrd-1");
+  });
+
+  it("uses interrupted run detail when no interrupt reason was recorded", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted", detail: "workspace missing" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "interrupted", reason: "workspace missing" });
+  });
+
+  it("uses a generic interrupted reason when no detail was recorded", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "interrupted", reason: "workspace stopped" });
+  });
+
+  it("ranks recoverable work above interrupted run state", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        worktree: { kind: "present-dirty", modified: 1, untracked: 0 },
+        worktreeDir: "/work/repo-a-hrd-1",
+        runState: makeRunState({ state: "interrupted" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "recoverable" });
+  });
+
+  it("returns failed-launch when setup recorded a launch failure", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "failed-to-launch", detail: "cmux missing" }),
+      }),
+    );
+    const failedLaunch = narrowVerdict(verdict, "failed-launch");
+    expect(failedLaunch.reason).toBe("cmux missing");
+    expect(failedLaunch.nextStep).toContain("crew resume hrd-1");
+  });
+
+  it("uses a generic failed-launch reason when setup did not record details", () => {
+    const verdict = decidePostDispatchVerdict(
+      makeVerdictInput({
+        runState: makeRunState({ state: "failed-to-launch" }),
+      }),
+    );
+    expect(verdict).toMatchObject({ kind: "failed-launch", reason: "workspace launch failed" });
   });
 
   it("treats present-unknown-dirtiness as worktree-present for in-flight", () => {
@@ -918,6 +1007,64 @@ describe("ticketDoctor — Workspace section", () => {
   });
 });
 
+describe("ticketDoctor — Run state section", () => {
+  it("records skipped when no run state exists", async () => {
+    const result = await ticketDoctor(makeStubDependencies());
+    expect(result.runState).toStrictEqual([
+      { name: "Local run state", status: "skipped", detail: "none found" },
+    ]);
+  });
+
+  it("records persisted run metadata when present", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(
+          makeRunState({ state: "interrupted", reason: "pause", detail: "workspace missing" }),
+        ),
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(result.runState).toContainEqual({
+      name: "Local run state",
+      status: "ok",
+      detail: "interrupted",
+    });
+    expect(result.runState).toContainEqual({
+      name: "Last reason",
+      status: "ok",
+      detail: "pause",
+    });
+    expect(result.runState).toContainEqual({
+      name: "Last detail",
+      status: "ok",
+      detail: "workspace missing",
+    });
+  });
+
+  it("omits optional run metadata rows when the state has no reason or detail", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(makeRunState({ state: "running" })),
+    });
+
+    const result = await ticketDoctor(dependencies);
+
+    expect(result.runState).not.toContainEqual(expect.objectContaining({ name: "Last reason" }));
+    expect(result.runState).not.toContainEqual(expect.objectContaining({ name: "Last detail" }));
+  });
+
+  it("uses interrupted run state for the verdict when no stronger local state exists", async () => {
+    const dependencies = makeStubDependencies({
+      readRunState: vi
+        .fn<TicketDoctorDependencies["readRunState"]>()
+        .mockReturnValue(makeRunState({ state: "interrupted", reason: "operator pause" })),
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(result.verdict).toMatchObject({ kind: "interrupted", reason: "operator pause" });
+  });
+});
+
 describe("ticketDoctor — ticket case normalization", () => {
   it("passes the lowercase ticket to findWorktree even when the caller supplies HRD-1", async () => {
     const findWorktree = vi.fn<TicketDoctorDependencies["findWorktree"]>(
@@ -1263,6 +1410,7 @@ function emptyResult(overrides: Partial<TicketDoctorResult> = {}): TicketDoctorR
     ticket: "HRD-1",
     resolution: [],
     eligibility: [],
+    runState: [],
     worktree: [],
     workspace: [],
     localBranch: [],
@@ -1272,6 +1420,7 @@ function emptyResult(overrides: Partial<TicketDoctorResult> = {}): TicketDoctorR
       resolution: "",
       eligibility: "",
       worktree: "",
+      runState: "",
       workspace: "",
       localBranch: "",
       remoteBranch: "",
@@ -1365,6 +1514,28 @@ describe(renderTicketDoctorResult, () => {
     );
   });
 
+  it("formats interrupted verdicts with reason + next step", () => {
+    const lines = renderTicketDoctorResult(
+      emptyResult({
+        verdict: { kind: "interrupted", reason: "operator pause", nextStep: "crew resume hrd-1" },
+      }),
+    );
+    expect(lines.some((l) => l.includes("→ interrupted: operator pause; crew resume hrd-1"))).toBe(
+      true,
+    );
+  });
+
+  it("formats failed-launch verdicts with reason + next step", () => {
+    const lines = renderTicketDoctorResult(
+      emptyResult({
+        verdict: { kind: "failed-launch", reason: "cmux missing", nextStep: "crew resume hrd-1" },
+      }),
+    );
+    expect(lines.some((l) => l.includes("→ failed-launch: cmux missing; crew resume hrd-1"))).toBe(
+      true,
+    );
+  });
+
   it("formats ineligible verdicts with the reason", () => {
     const lines = renderTicketDoctorResult(
       emptyResult({
@@ -1396,6 +1567,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "",
           eligibility: "ticket unresolved",
           worktree: "",
+          runState: "",
           workspace: "",
           localBranch: "",
           remoteBranch: "",
@@ -1415,6 +1587,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "",
           eligibility: "",
           worktree: "",
+          runState: "",
           workspace: "",
           localBranch: "repo dir unresolved",
           remoteBranch: "",
@@ -1432,6 +1605,7 @@ describe(renderTicketDoctorResult, () => {
           resolution: "skip-r",
           eligibility: "skip-e",
           worktree: "skip-w",
+          runState: "skip-rs",
           workspace: "skip-ws",
           localBranch: "skip-lb",
           remoteBranch: "skip-rb",
@@ -1439,7 +1613,16 @@ describe(renderTicketDoctorResult, () => {
         },
       }),
     );
-    for (const tag of ["skip-r", "skip-e", "skip-w", "skip-ws", "skip-lb", "skip-rb", "skip-pr"]) {
+    for (const tag of [
+      "skip-r",
+      "skip-e",
+      "skip-w",
+      "skip-rs",
+      "skip-ws",
+      "skip-lb",
+      "skip-rb",
+      "skip-pr",
+    ]) {
       expect(lines.some((l) => l.includes(`(skipped — ${tag})`))).toBe(true);
     }
   });

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -3,11 +3,14 @@
 // `crew doctor --ticket <TICKET>` — single per-ticket diagnostic that covers
 // both the pre-dispatch question ("will this dispatch on the next tick?") and
 // the post-dispatch question ("what's already happened and what's left to
-// do?"). Verdict precedence runs strictly from post-dispatch states down:
+// do?"). Verdict precedence starts with PR outcomes, then handles run-state
+// exceptions before ordinary local recovery:
 //
-//   pr-open > pr-merged > in-flight > recoverable
-//     > unresolvable > ineligible > would-dispatch
-//       > lost
+//   pr-open > pr-merged
+//     > failed-launch
+//     > interrupted (unless concrete recoverable git work exists)
+//     > in-flight > recoverable
+//     > unresolvable > ineligible > would-dispatch > lost
 //
 // When a post-dispatch verdict fires, the Resolution and Eligibility sections
 // are skipped — they describe pre-dispatch state that no longer matters.
@@ -28,6 +31,7 @@ import {
 import { runCommandAsync } from "../lib/commandRunner.ts";
 import { AGENT_ANY_MODEL, loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { which } from "../lib/host.ts";
+import { readRunState, type RunState } from "../lib/runState.ts";
 import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
 import { getLinearClient, lazyLinearClient, writeOutput } from "../lib/util.ts";
 import { workspaces, type WorkspaceAccessHint, type WorkspaceProbe } from "../lib/workspaces.ts";
@@ -52,6 +56,8 @@ const LINEAR_SKIPPED_STATE_NAME = "(linear skipped)";
 export type TicketDoctorVerdict =
   | { kind: "pr-open"; number: number; url: string }
   | { kind: "pr-merged"; number: number; url: string }
+  | { kind: "interrupted"; reason: string; nextStep: string }
+  | { kind: "failed-launch"; reason: string; nextStep: string }
   | { kind: "in-flight"; reason: string }
   | { kind: "recoverable"; reason: string; nextStep: string }
   | { kind: "would-dispatch" }
@@ -97,6 +103,7 @@ export interface DecideVerdictInput {
   branch: string;
   worktreeDir: string | undefined;
   workspaceName: string | undefined;
+  runState: RunState | undefined;
 }
 
 // ───────── post-dispatch verdict (PR / in-flight / recoverable) ─────────
@@ -171,9 +178,11 @@ function verdictRecoverable(input: DecideVerdictInput): TicketDoctorVerdict | un
  * "ticket has moved past dispatch" cases. Returns `undefined` otherwise,
  * signalling that the caller should fall through to the pre-dispatch path.
  *
- * Precedence: PR > in-flight > recoverable. Inside `recoverable`, dirty
- * worktree beats clean-with-un-pushed-local beats remote-only beats stranded
- * local.
+ * Precedence: PR verdicts always win. Failed launches report before ordinary
+ * local recovery. Interrupted runs report concrete recoverable git work first
+ * when it exists, then fall back to `interrupted`. Ordinary post-dispatch cases
+ * report in-flight before recoverable. Inside `recoverable`, dirty worktree
+ * beats clean-with-un-pushed-local beats remote-only beats stranded local.
  */
 export function decidePostDispatchVerdict(
   input: DecideVerdictInput,
@@ -184,7 +193,27 @@ export function decidePostDispatchVerdict(
   if (input.pullRequest.kind === "merged") {
     return { kind: "pr-merged", number: input.pullRequest.number, url: input.pullRequest.url };
   }
-  return verdictInFlight(input) ?? verdictRecoverable(input);
+  const recoverable = verdictRecoverable(input);
+  if (input.runState?.state === "interrupted") {
+    if (recoverable !== undefined) {
+      return recoverable;
+    }
+    const detail = input.runState.reason ?? input.runState.detail ?? "workspace stopped";
+    return {
+      kind: "interrupted",
+      reason: detail,
+      nextStep: `run \`crew resume ${input.runState.ticket}\` or inspect ${input.runState.worktreeDir}`,
+    };
+  }
+  if (input.runState?.state === "failed-to-launch") {
+    const detail = input.runState.detail ?? "workspace launch failed";
+    return {
+      kind: "failed-launch",
+      reason: detail,
+      nextStep: `fix the launch failure, then run \`crew resume ${input.runState.ticket}\` or \`crew cleanup ${input.runState.ticket}\``,
+    };
+  }
+  return verdictInFlight(input) ?? recoverable;
 }
 
 // ───────── orchestrator dependencies ─────────
@@ -216,6 +245,7 @@ export interface TicketDoctorDependencies {
     doFetch: boolean;
   }) => Promise<RemoteBranchProbe>;
   probePullRequest: (input: { repoDir: string; branch: string }) => Promise<PullRequestProbe>;
+  readRunState: (ticket: string) => RunState | undefined;
   doFetch: boolean;
 }
 
@@ -224,6 +254,7 @@ export interface TicketDoctorResult {
   title?: string;
   resolution: TicketCheck[];
   eligibility: TicketCheck[];
+  runState: TicketCheck[];
   worktree: TicketCheck[];
   workspace: TicketCheck[];
   localBranch: TicketCheck[];
@@ -233,6 +264,7 @@ export interface TicketDoctorResult {
     resolution: string;
     eligibility: string;
     worktree: string;
+    runState: string;
     workspace: string;
     localBranch: string;
     remoteBranch: string;
@@ -246,6 +278,7 @@ function emptySkipReasons(): TicketDoctorResult["skipReasons"] {
     resolution: "",
     eligibility: "",
     worktree: "",
+    runState: "",
     workspace: "",
     localBranch: "",
     remoteBranch: "",
@@ -573,6 +606,38 @@ interface WorktreeSectionOutput {
   entry: WorktreeEntry | undefined;
 }
 
+interface RunStateSectionOutput {
+  checks: TicketCheck[];
+  state: RunState | undefined;
+}
+
+function probeRunStateSection(
+  deps: TicketDoctorDependencies,
+  ticket: string,
+): RunStateSectionOutput {
+  const state = deps.readRunState(ticket);
+  if (state === undefined) {
+    return {
+      checks: [{ name: "Local run state", status: "skipped", detail: "none found" }],
+      state: undefined,
+    };
+  }
+  const checks: TicketCheck[] = [
+    { name: "Local run state", status: "ok", detail: state.state },
+    { name: "Recorded model", status: "ok", detail: state.model },
+    { name: "Recorded worktree", status: "ok", detail: state.worktreeDir },
+    { name: "Recorded branch", status: "ok", detail: state.branchName },
+    { name: "Resume count", status: "ok", detail: String(state.resumeCount) },
+  ];
+  if (state.reason !== undefined) {
+    checks.push({ name: "Last reason", status: "ok", detail: state.reason });
+  }
+  if (state.detail !== undefined) {
+    checks.push({ name: "Last detail", status: "ok", detail: state.detail });
+  }
+  return { checks, state };
+}
+
 async function probeWorktreeSection(
   deps: TicketDoctorDependencies,
   ticket: string,
@@ -882,6 +947,7 @@ export async function ticketDoctor(
   const linearResult = await probeLinear(dependencies, upperTicket);
   const resolution: TicketCheck[] = [...linearResult.resolution];
 
+  const runStateResult = probeRunStateSection(dependencies, lowerTicket);
   const worktreeResult = await probeWorktreeSection(dependencies, lowerTicket);
   const workspaceResult = await probeWorkspaceSection(dependencies, lowerTicket);
   const localResult = await probeLocalBranchSection(dependencies, worktreeResult.entry);
@@ -908,6 +974,7 @@ export async function ticketDoctor(
     branch: worktreeResult.entry?.branchName ?? lowerTicket,
     worktreeDir: worktreeResult.entry?.dir,
     workspaceName: workspaceResult.workspaceName,
+    runState: runStateResult.state,
   });
 
   if (postVerdict !== undefined) {
@@ -918,6 +985,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -939,6 +1007,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -960,6 +1029,7 @@ export async function ticketDoctor(
       title: linearResult.title,
       resolution,
       eligibility: [],
+      runStateResult,
       worktreeResult,
       workspaceResult,
       localResult,
@@ -1002,6 +1072,7 @@ export async function ticketDoctor(
     title: linearResult.title,
     resolution,
     eligibility: preDispatch.eligibility,
+    runStateResult,
     worktreeResult,
     workspaceResult,
     localResult,
@@ -1017,6 +1088,7 @@ interface BuildResultInput {
   title: string | undefined;
   resolution: TicketCheck[];
   eligibility: TicketCheck[];
+  runStateResult: RunStateSectionOutput;
   worktreeResult: WorktreeSectionOutput;
   workspaceResult: WorkspaceSectionOutput;
   localResult: LocalBranchSectionOutput;
@@ -1032,6 +1104,7 @@ function buildResult(input: BuildResultInput): TicketDoctorResult {
     ...(input.title === undefined ? {} : { title: input.title }),
     resolution: input.resolution,
     eligibility: input.eligibility,
+    runState: input.runStateResult.checks,
     worktree: input.worktreeResult.checks,
     workspace: input.workspaceResult.checks,
     localBranch: input.localResult.checks,
@@ -1080,6 +1153,12 @@ function formatVerdict(verdict: TicketDoctorVerdict): string {
     case "pr-merged": {
       return `→ pr-merged: ${verdict.url} (#${verdict.number})`;
     }
+    case "interrupted": {
+      return `→ interrupted: ${verdict.reason}; ${verdict.nextStep}`;
+    }
+    case "failed-launch": {
+      return `→ failed-launch: ${verdict.reason}; ${verdict.nextStep}`;
+    }
     case "in-flight": {
       return `→ in-flight: ${verdict.reason}`;
     }
@@ -1120,6 +1199,11 @@ export function renderTicketDoctorResult(result: TicketDoctorResult): string[] {
       ...(result.skipReasons.eligibility === ""
         ? {}
         : { skipReason: result.skipReasons.eligibility }),
+    },
+    {
+      name: "Run state",
+      checks: result.runState,
+      ...(result.skipReasons.runState === "" ? {} : { skipReason: result.skipReasons.runState }),
     },
     {
       name: "Worktree",
@@ -1187,6 +1271,7 @@ export async function runTicketDoctor(parsed: TicketDoctorArguments): Promise<bo
     probeLocalBranch: probeLocalBranchImpl,
     probeRemoteBranch: probeRemoteBranchImpl,
     probePullRequest: probePullRequestImpl,
+    readRunState: (ticket) => readRunState(config, ticket),
     doFetch: parsed.doFetch,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   type InterruptWorkspaceOptions,
 } from "./commands/interruptWorkspace.ts";
 export { orchestrate, type OrchestratorOptions } from "./commands/orchestrator.ts";
+export { resumeWorkspace, type ResumeWorkspaceOptions } from "./commands/resumeWorkspace.ts";
 export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWorkspace.ts";
 export type { Config, ModelDefinition, ResolvedConfig } from "./lib/config.ts";
 export { loadConfig } from "./lib/config.ts";

--- a/src/lib/stagedLaunch.ts
+++ b/src/lib/stagedLaunch.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,7 +26,11 @@ function renderPromptTemplate(template: string, variables: PromptTemplateVariabl
     .replaceAll("{{description}}", variables.description);
 }
 
-function stagePromptText(input: { prefix: string; ticket: string; text: string }): StagedPrompt {
+export function stagePromptText(input: {
+  prefix: string;
+  ticket: string;
+  text: string;
+}): StagedPrompt {
   const promptDir = mkdtempSync(join(tmpdir(), `${input.prefix}-${input.ticket}-`));
   const promptFile = join(promptDir, "prompt.txt");
   writeFileSync(promptFile, input.text);
@@ -76,4 +80,8 @@ function stageLaunchScript(promptDir: string, command: string): string {
 
 export function stageWorkspaceLaunchCommand(promptDir: string, command: string): string {
   return `bash ${shellSingleQuote(stageLaunchScript(promptDir, command))}`;
+}
+
+export function removeStagedPrompt(directory: string): void {
+  rmSync(directory, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

Project: [Groundcrew Daily Workflow Improvements](https://linear.app/clipboardhealth/project/groundcrew-daily-workflow-improvements-5d9dfbed8c9d)

This PR adds `crew resume <ticket>`. It reopens the existing ticket worktree, stages a continuation prompt, includes prior interrupt context when available, and updates resume count in run state.

## Contribution to the Stack

This adds the continuation step after `interrupt`. It uses shared launch plumbing from #69 and run state from #70/#71 so resumed work does not need to rediscover context from scratch.

Overall stack theme: make Groundcrew runs easier to recover, pause, inspect, resume, and clean up during daily ticket work.

## Stack Order

1. #69 shared launch plumbing
2. #70 persisted run state
3. #71 interrupt command
4. #72 resume command — current PR
5. #73 doctor recovery state
6. #74 recovery workflow docs

## Validation

- `node --run verify` passed locally on this branch.
- `node --run verify` passed on every branch in the stack after restacking.
- Pre-push verification passed before pushing the rewritten stack.
- GitHub `main` workflow passed for this PR.
- Black-box top-of-stack flow exercised repeated `crew resume` against a real tmux-backed local run.

## Linear

[ORB-2186](https://linear.app/clipboardhealth/issue/ORB-2186/add-crew-resume-with-continuation-context)
