### PR TITLE
fix: update stale resolved config test fixtures

### DIFF
--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -59,9 +59,13 @@ function lastRecordedRunState(): RecordedRunState {
 function makeConfig(): ResolvedConfig {
   return {
     linear: {
-      projectSlug: "x-aaaaaaaaaaaa",
-      slugId: "aaaaaaaaaaaa",
-      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+      projects: [
+        {
+          projectSlug: "x-aaaaaaaaaaaa",
+          slugId: "aaaaaaaaaaaa",
+          statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+        },
+      ],
     },
     git: { remote: "origin", defaultBranch: "main" },
     workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -132,9 +132,13 @@ function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
 function makeConfig(): ResolvedConfig {
   return {
     linear: {
-      projectSlug: "x-aaaaaaaaaaaa",
-      slugId: "aaaaaaaaaaaa",
-      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+      projects: [
+        {
+          projectSlug: "x-aaaaaaaaaaaa",
+          slugId: "aaaaaaaaaaaa",
+          statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+        },
+      ],
     },
     git: { remote: "origin", defaultBranch: "main" },
     workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
@@ -289,6 +293,7 @@ describe(resumeWorkspace, () => {
       repository: "repo-a",
       model: "claude",
       teamId: "team-1",
+      projectSlugId: "aaaaaaaaaaaa",
     });
 
     await resumeWorkspace(config, { ticket: "team-1" });

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -16,9 +16,13 @@ import {
 function makeConfig(stateRoot: string): ResolvedConfig {
   return {
     linear: {
-      projectSlug: "x-aaaaaaaaaaaa",
-      slugId: "aaaaaaaaaaaa",
-      statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+      projects: [
+        {
+          projectSlug: "x-aaaaaaaaaaaa",
+          slugId: "aaaaaaaaaaaa",
+          statuses: { todo: "Todo", inProgress: "In Progress", done: "Done", terminal: ["Done"] },
+        },
+      ],
     },
     git: { remote: "origin", defaultBranch: "main" },
     workspace: {


### PR DESCRIPTION
## Summary

Fix main CI lint by updating stale test fixtures to match the current resolved Linear config shape and the current `fetchResolvedIssue` return type.

## Validation

- `node --run lint`
- `npx vitest run src/commands/interruptWorkspace.test.ts src/commands/resumeWorkspace.test.ts src/lib/runState.test.ts`
- `node --run verify`
- Pre-push hook reran `node --run verify`

## Notes

No Linear ticket was provided in the request.

<!-- commit-push-pr:created v1 core@3.4.0 -->
