### PR TITLE
fix(dispatch): surface parent-ticket skips in doctor and daemon log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "3.1.0",
+  "version": "3.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "3.1.0",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@clipboard-health/clearance": "1.0.8",

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -84,7 +84,7 @@ function todoIssue(id: string, overrides: Partial<Issue> = {}): Issue {
 }
 
 function boardOf(issues: Issue[]): BoardState {
-  return { timestamp: "2025-01-01T00:00:00.000Z", issues };
+  return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
 }
 
 function hostEntryFor(repository: string, ticket: string): WorktreeEntry {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -93,7 +93,7 @@ function activeIssue(overrides: Partial<Issue> = {}): Issue {
 }
 
 function boardOf(issues: Issue[]): BoardState {
-  return { timestamp: "2025-01-01T00:00:00.000Z", issues };
+  return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
 }
 
 function hostEntryFor(repository: string, ticket: string): WorktreeEntry {
@@ -877,6 +877,54 @@ describe(createDispatcher, () => {
       });
 
       expect(consoleLog.output()).toContain("Failed to start team-1: boom");
+    });
+  });
+
+  // Without these logs, a parent Todo ticket disappears silently from the
+  // daemon log — operators see "No Todo tickets to pick up" and can't tell
+  // why. Surfacing each parent skip makes the silent fetchBoard filter
+  // visible.
+  describe("parent ticket logging", () => {
+    it("emits a dispatch skip event for every parent ticket in state.parentSkips", async () => {
+      const client = makeClient();
+      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+
+      await dispatcher.runOnce({
+        state: {
+          timestamp: "2025-01-01T00:00:00.000Z",
+          issues: [],
+          parentSkips: [
+            { id: "team-9", title: "Umbrella epic", childCount: 3 },
+            { id: "team-10", title: "Another epic", childCount: 1 },
+          ],
+        },
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      const output = consoleLog.output();
+      expect(output).toContain(
+        "event=dispatch outcome=skipped reason=parent_with_children ticket=team-9",
+      );
+      expect(output).toContain(
+        "event=dispatch outcome=skipped reason=parent_with_children ticket=team-10",
+      );
+      expect(output).toMatch(/team-9.*3 sub-issue/);
+    });
+
+    it("does not log parent skips when state.parentSkips is empty", async () => {
+      const client = makeClient();
+      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+
+      await dispatcher.runOnce({
+        state: boardOf([]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(consoleLog.output()).not.toContain("reason=parent_with_children");
     });
   });
 });

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -138,6 +138,21 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     const { state, worktreeEntries, usage, dryRun, signal } = arguments_;
     issueStatusUpdater.resetMissingInProgressCache();
 
+    // Surface parent tickets that fetchBoard silently dropped. Without this
+    // an operator sees "No Todo tickets to pick up" with no signal that an
+    // expected Todo+labelled ticket was skipped because it has sub-issues.
+    for (const skip of state.parentSkips) {
+      log(
+        `Skipping ${skip.id}: parent ticket with ${skip.childCount} sub-issue(s) — groundcrew works sub-issues, not parents`,
+      );
+      logEvent("dispatch", {
+        outcome: "skipped",
+        reason: "parent_with_children",
+        ticket: skip.id,
+        children: skip.childCount,
+      });
+    }
+
     const activeCount = state.issues.filter(
       (issue) => issue.status === projectFor(issue, config).statuses.inProgress,
     ).length;

--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -84,6 +84,7 @@ function makeStubRawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIss
     stateName: "Todo",
     blockers: [],
     hasMoreBlockers: false,
+    hasChildren: false,
     ...overrides,
   };
 }
@@ -642,6 +643,48 @@ describe("ticketDoctor resolution checks", () => {
     expect(modelCheck?.status).toBe("ok");
     expect(modelCheck?.detail).toMatch(/claude/);
   });
+
+  // A parent ticket (one with sub-issues) is silently dropped by
+  // `fetchBoard` so the dispatcher never sees it. Doctor must surface that
+  // explicitly — otherwise the diagnostic lies, reporting "would dispatch"
+  // for a ticket the orchestrator will never touch.
+  it("records 'Has no sub-issues' as fail when the ticket has children", async () => {
+    const dependencies = makeStubDependencies({
+      fetchRawIssue: vi
+        .fn<NonNullable<TicketDoctorDependencies["fetchRawIssue"]>>()
+        .mockResolvedValue(
+          makeStubRawIssue({
+            labels: [{ name: "agent-claude" }],
+            stateName: "Todo",
+            description: "see repo-a",
+            hasChildren: true,
+          }),
+        ),
+    });
+    const result = await ticketDoctor(dependencies);
+    const childrenCheck = result.resolution.find((check) => check.name === "Has no sub-issues");
+    expect(childrenCheck?.status).toBe("fail");
+    const ineligible = narrowVerdict(result.verdict, "ineligible");
+    expect(ineligible.reason).toMatch(/sub-issue/i);
+  });
+
+  it("records 'Has no sub-issues' as ok when the ticket has no children", async () => {
+    const dependencies = makeStubDependencies({
+      fetchRawIssue: vi
+        .fn<NonNullable<TicketDoctorDependencies["fetchRawIssue"]>>()
+        .mockResolvedValue(
+          makeStubRawIssue({
+            labels: [{ name: "agent-claude" }],
+            stateName: "Todo",
+            description: "see repo-a",
+            hasChildren: false,
+          }),
+        ),
+    });
+    const result = await ticketDoctor(dependencies);
+    const childrenCheck = result.resolution.find((check) => check.name === "Has no sub-issues");
+    expect(childrenCheck?.status).toBe("ok");
+  });
 });
 
 describe("ticketDoctor — env checks", () => {
@@ -664,6 +707,7 @@ describe("ticketDoctor — env checks", () => {
             stateName: "Todo",
             blockers: [],
             hasMoreBlockers: false,
+            hasChildren: false,
           }),
       });
       const result = await ticketDoctor(dependencies);
@@ -698,6 +742,7 @@ describe("ticketDoctor — env checks", () => {
             stateName: "Todo",
             blockers: [],
             hasMoreBlockers: false,
+            hasChildren: false,
           }),
       });
       const result = await ticketDoctor(dependencies);
@@ -728,6 +773,7 @@ describe("ticketDoctor — env checks", () => {
           stateName: "Todo",
           blockers: [],
           hasMoreBlockers: false,
+          hasChildren: false,
         }),
     });
     const result = await ticketDoctor(dependencies);
@@ -764,6 +810,7 @@ describe("ticketDoctor — eligibility phase", () => {
           stateName: "Todo",
           blockers: [],
           hasMoreBlockers: false,
+          hasChildren: false,
         }),
       fetchUsage: vi.fn<TicketDoctorDependencies["fetchUsage"]>().mockResolvedValue({
         claude: { session: 0.23, sessionEndDuration: null, weekly: null, weekEndDuration: null },
@@ -912,6 +959,7 @@ describe("ticketDoctor — eligibility phase", () => {
             stateName: "Todo",
             blockers: [],
             hasMoreBlockers: false,
+            hasChildren: false,
           }),
         fetchUsage: vi.fn<TicketDoctorDependencies["fetchUsage"]>().mockResolvedValue({
           claude: { session: 0.1, sessionEndDuration: null, weekly: null, weekEndDuration: null },

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -422,6 +422,19 @@ function buildRepoChecks(
   return { resolvedRepository, checks };
 }
 
+function buildChildrenCheck(raw: RawLinearIssue): TicketCheck {
+  if (raw.hasChildren) {
+    return {
+      name: "Has no sub-issues",
+      status: "fail",
+      detail:
+        "parent ticket with sub-issues — groundcrew works sub-issues, not parents; label a sub-issue or detach the children",
+      failureSummary: "parent ticket with sub-issues — groundcrew works sub-issues, not parents",
+    };
+  }
+  return { name: "Has no sub-issues", status: "ok" };
+}
+
 interface EligibilityCheckArguments {
   ticket: string;
   raw: RawLinearIssue;
@@ -922,6 +935,13 @@ async function runPreDispatch(input: PreDispatchInput): Promise<PreDispatchOutpu
 
   const { resolvedModel, checks: modelChecks } = buildModelChecks(raw, config);
   resolutionExtra.push(...modelChecks);
+
+  // Children check comes before repo checks: a parent ticket is a
+  // structural property of the issue itself (filtered out by `fetchBoard`,
+  // so the dispatcher will never act on it). Reporting that first beats
+  // surfacing "your repo isn't cloned" for a ticket groundcrew won't pick
+  // up either way.
+  resolutionExtra.push(buildChildrenCheck(raw));
 
   const { resolvedRepository, checks: repoChecks } = buildRepoChecks(raw, config, ticket);
   resolutionExtra.push(...repoChecks);

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -305,6 +305,48 @@ describe(createBoardSource, () => {
       expect(state.issues.map((index) => index.id)).toStrictEqual(["team-2"]);
     });
 
+    it("surfaces Todo parents as parentSkips so the dispatcher can log them", async () => {
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                identifier: "TEAM-1",
+                id: "uuid-1",
+                title: "Umbrella epic",
+                state: { id: "state-todo", name: "Todo" },
+                children: { nodes: [{ id: "c1" }, { id: "c2" }, { id: "c3" }] },
+              }),
+              issueNode({ identifier: "TEAM-2", id: "uuid-2" }),
+            ],
+          ],
+        }),
+      );
+      const state = await source.fetch();
+      expect(state.parentSkips).toStrictEqual([
+        { id: "team-1", title: "Umbrella epic", childCount: 3 },
+      ]);
+    });
+
+    it("omits non-Todo parents from parentSkips — a Done epic isn't a surprising drop", async () => {
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                identifier: "TEAM-1",
+                id: "uuid-1",
+                state: { id: "state-done", name: "Done" },
+                children: { nodes: [{ id: "c1" }] },
+              }),
+            ],
+          ],
+        }),
+      );
+      const state = await source.fetch();
+      expect(state.parentSkips).toStrictEqual([]);
+    });
+
     it("drops issues whose project slugId isn't in linear.projects", async () => {
       // The GraphQL slugId filter normally scopes results to configured
       // projects; this guards against a degenerate Linear response that

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -66,9 +66,24 @@ export function isGroundcrewIssue(issue: Issue): issue is GroundcrewIssue {
   return issue.model !== undefined && issue.repository !== undefined;
 }
 
+/**
+ * Linear ticket that was silently dropped from `issues` because it has at
+ * least one sub-issue and groundcrew works sub-issues rather than parents.
+ * The dispatcher logs each one per tick so operators see WHY a Todo ticket
+ * isn't being picked up instead of just "No Todo tickets to pick up." Only
+ * Todo+agent-labelled parents qualify — non-actionable parents (e.g. Done
+ * epics) would be noise.
+ */
+export interface ParentSkip {
+  id: string;
+  title: string;
+  childCount: number;
+}
+
 export interface BoardState {
   timestamp: string;
   issues: Issue[];
+  parentSkips: ParentSkip[];
 }
 
 export class RepositoryResolutionError extends Error {
@@ -337,7 +352,35 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
     .filter((node) => issueStatusBelongsToOwnProject(node, config))
     .map((node) => issueFromNode(node, config, repositoryRegex));
 
-  return { timestamp: new Date().toISOString(), issues };
+  const parentSkips: ParentSkip[] = nodes
+    .filter((node) => node.children.nodes.length > 0)
+    .filter((node) => isTodoParentForOwnProject(node, config))
+    .map((node) => ({
+      id: node.identifier.toLowerCase(),
+      title: node.title,
+      childCount: node.children.nodes.length,
+    }));
+
+  return { timestamp: new Date().toISOString(), issues, parentSkips };
+}
+
+/**
+ * Narrows parent tickets to those the dispatcher would otherwise pick up —
+ * Todo status under their own project's configured status names. Done /
+ * In Progress parents aren't surprising drops, so we don't log them.
+ */
+function isTodoParentForOwnProject(node: IssueNode, config: ResolvedConfig): boolean {
+  const slugId = node.project?.slugId?.toLowerCase();
+  /* v8 ignore next 3 @preserve -- GraphQL slugId filter scopes results to configured projects */
+  if (slugId === undefined) {
+    return false;
+  }
+  const project = findProjectBySlugId(config, slugId);
+  /* v8 ignore next 3 @preserve -- GraphQL slugId filter scopes results to configured projects */
+  if (project === undefined) {
+    return false;
+  }
+  return node.state?.name === project.statuses.todo;
 }
 
 function modelForResolution(resolution: ModelResolution): string | undefined {
@@ -464,6 +507,13 @@ export interface RawLinearIssue {
   stateName: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
+  /**
+   * `true` when the ticket has at least one sub-issue (child). Parent
+   * tickets are filtered out by `fetchBoard` and never dispatched —
+   * doctor reads this to surface that decision instead of falsely
+   * reporting "would dispatch."
+   */
+  hasChildren: boolean;
 }
 
 export async function fetchBlockersForTicket(arguments_: {
@@ -533,6 +583,7 @@ export async function fetchRawLinearIssue(arguments_: {
         team { id }
         project { slugId }
         state { name }
+        children { nodes { id } }
         labels(first: ${ISSUE_LABEL_PAGE_SIZE}) {
           nodes { name }
         }
@@ -561,6 +612,7 @@ export async function fetchRawLinearIssue(arguments_: {
       team?: { id: string } | null;
       project?: { slugId: string } | null;
       state?: { name: string } | null;
+      children?: { nodes: { id: string }[] } | null;
       labels: { nodes: { name: string }[] };
       inverseRelations?: {
         nodes: IssueRelationNode[];
@@ -581,6 +633,7 @@ export async function fetchRawLinearIssue(arguments_: {
     stateName: issue.state?.name ?? "",
     blockers: blockersFromRelations(issue.inverseRelations?.nodes ?? []),
     hasMoreBlockers: issue.inverseRelations?.pageInfo.hasNextPage ?? false,
+    hasChildren: (issue.children?.nodes.length ?? 0) > 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Symptom: `crew doctor --ticket <id>` reports "→ would be dispatched on next tick" for a Todo ticket, but the daemon never picks it up and just logs "No Todo tickets to pick up" each tick.

Root cause: `boardSource.fetchBoard` silently drops parent tickets (issues with sub-issues) via the client-side filter `node.children.nodes.length === 0`. The dispatcher only sees the filtered list and emits no skip event. Meanwhile `crew doctor` uses `fetchRawLinearIssue`, a separate single-issue query that never asks Linear for `children` — so it can't detect the same filter trip. Two queries, two different answers, no visibility for the operator.

## Changes

- **doctor** (`src/commands/ticketDoctor.ts`): new ``Has no sub-issues`` resolution check. When it fails, the verdict flips to `ineligible: parent ticket with sub-issues`. Placed before the repo-cloned check so the structural ticket problem reports first instead of an irrelevant local-env error.
- **boardSource** (`src/lib/boardSource.ts`):
  - `BoardState` gains `parentSkips: ParentSkip[]`; `fetchBoard` populates it from nodes that have children **and** are in their own project's Todo status (Done / In Progress parents aren't a surprising drop and would be noise).
  - `RawLinearIssue` gains `hasChildren: boolean`; `fetchRawLinearIssue`'s GraphQL query now includes `children { nodes { id } }` so doctor can see what `fetchBoard` sees.
- **dispatcher** (`src/commands/dispatcher.ts`): `runOnce` iterates `state.parentSkips` at the start of each tick and emits both a human log line and the structured event `event=dispatch outcome=skipped reason=parent_with_children ticket=<id> children=<n>`, matching the existing skip-event format.

## Why

When a Todo ticket isn't being picked up, the operator's first move is `crew doctor`. Today that diagnostic can confidently report the ticket is eligible while the daemon silently skips it forever — there's no signal anywhere in the system that the ticket is a parent. After this change:

- doctor catches the parent case and reports it as `ineligible`.
- the daemon log emits one `parent_with_children` skip per parent per tick, so tailing the log shows exactly which tickets were passed over and why.

## Test plan

- [x] Red-green TDD for each production change (doctor check, dispatcher logging, fetchBoard parentSkips population).
- [x] `node --run verify` — all 858 tests across 26 files pass, 100% coverage.
- [x] Existing "filters out parent issues that have children" tests in `boardSource.test.ts` and `orchestrator.test.ts` remain green — no behavior change to the issues list, only an addition (`parentSkips`).