### PR TITLE
fix(worktrees): auto-detect per-repo default branch (master vs main)

### DIFF
--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -1198,9 +1198,33 @@ describe("ticketDoctor — Local branch section", () => {
     expect(probeLocalBranchMock).toHaveBeenCalledWith({
       repoDir: "/work/repo-a",
       branch: entry.branchName,
+      remote: "origin",
       defaultBranch: "master",
     });
     expect(result.localBranch[0]?.detail).toContain("origin/master");
+  });
+
+  it("uses the configured remote name for local branch probes and details", async () => {
+    const entry = makeWorktreeEntry();
+    const probeLocalBranchMock = vi
+      .fn<TicketDoctorDependencies["probeLocalBranch"]>()
+      .mockResolvedValue({ kind: "present", ahead: 1, behind: 0, defaultBranch: "master" });
+    const dependencies = makeStubDependencies({
+      config: makeConfig({ git: { remote: "upstream", defaultBranch: "main" } }),
+      findWorktree: vi.fn<TicketDoctorDependencies["findWorktree"]>().mockReturnValue(entry),
+      resolveDefaultBranch: vi
+        .fn<TicketDoctorDependencies["resolveDefaultBranch"]>()
+        .mockResolvedValue("master"),
+      probeLocalBranch: probeLocalBranchMock,
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(probeLocalBranchMock).toHaveBeenCalledWith({
+      repoDir: "/work/repo-a",
+      branch: entry.branchName,
+      remote: "upstream",
+      defaultBranch: "master",
+    });
+    expect(result.localBranch[0]?.detail).toContain("upstream/master");
   });
 
   it("records fail when the branch is not in git", async () => {
@@ -1300,6 +1324,24 @@ describe("ticketDoctor — Remote branch section", () => {
       }),
     );
     expect(probeRemoteBranch).toHaveBeenCalledWith(expect.objectContaining({ doFetch: false }));
+  });
+
+  it("uses the configured remote name for remote branch probes and check names", async () => {
+    const probeRemoteBranch = vi
+      .fn<TicketDoctorDependencies["probeRemoteBranch"]>()
+      .mockResolvedValue({ kind: "present" });
+    const dependencies = makeStubDependencies({
+      config: makeConfig({ git: { remote: "upstream", defaultBranch: "main" } }),
+      findWorktree: vi
+        .fn<TicketDoctorDependencies["findWorktree"]>()
+        .mockReturnValue(makeWorktreeEntry()),
+      probeRemoteBranch,
+    });
+
+    const result = await ticketDoctor(dependencies);
+
+    expect(probeRemoteBranch).toHaveBeenCalledWith(expect.objectContaining({ remote: "upstream" }));
+    expect(result.remoteBranch[0]?.name).toBe("Branch present on upstream");
   });
 });
 

--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -111,6 +111,9 @@ function makeStubDependencies(
     probeWorkingTree: vi
       .fn<TicketDoctorDependencies["probeWorkingTree"]>()
       .mockResolvedValue({ kind: "unknown" } satisfies WorktreeDirtiness),
+    resolveDefaultBranch: vi
+      .fn<TicketDoctorDependencies["resolveDefaultBranch"]>()
+      .mockResolvedValue("main"),
     probeLocalBranch: vi
       .fn<TicketDoctorDependencies["probeLocalBranch"]>()
       .mockResolvedValue({ kind: "absent" } satisfies LocalBranchProbe),
@@ -1177,6 +1180,27 @@ describe("ticketDoctor — Local branch section", () => {
     });
     const result = await ticketDoctor(dependencies);
     expect(result.localBranch[0]?.detail).toContain("origin/main");
+  });
+
+  it("resolves the per-repo default branch and feeds it to probeLocalBranch (e.g. master)", async () => {
+    const entry = makeWorktreeEntry();
+    const probeLocalBranchMock = vi
+      .fn<TicketDoctorDependencies["probeLocalBranch"]>()
+      .mockResolvedValue({ kind: "present", ahead: 1, behind: 0, defaultBranch: "master" });
+    const dependencies = makeStubDependencies({
+      findWorktree: vi.fn<TicketDoctorDependencies["findWorktree"]>().mockReturnValue(entry),
+      resolveDefaultBranch: vi
+        .fn<TicketDoctorDependencies["resolveDefaultBranch"]>()
+        .mockResolvedValue("master"),
+      probeLocalBranch: probeLocalBranchMock,
+    });
+    const result = await ticketDoctor(dependencies);
+    expect(probeLocalBranchMock).toHaveBeenCalledWith({
+      repoDir: "/work/repo-a",
+      branch: entry.branchName,
+      defaultBranch: "master",
+    });
+    expect(result.localBranch[0]?.detail).toContain("origin/master");
   });
 
   it("records fail when the branch is not in git", async () => {

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -29,6 +29,7 @@ import {
   type RawLinearIssue,
 } from "../lib/boardSource.ts";
 import { runCommandAsync } from "../lib/commandRunner.ts";
+import { resolveDefaultBranch } from "../lib/defaultBranch.ts";
 import {
   AGENT_ANY_MODEL,
   findProjectBySlugId,
@@ -239,6 +240,14 @@ export interface TicketDoctorDependencies {
   probeWorkspaces: () => Promise<WorkspaceProbe>;
   workspaceAccessHint: (name: string) => Promise<WorkspaceAccessHint | undefined>;
   probeWorkingTree: (input: { worktreeDir: string }) => Promise<WorktreeDirtiness>;
+  /**
+   * Resolves the default branch for `repoDir` (e.g. "master" vs "main") from
+   * the local clone's `refs/remotes/<remote>/HEAD`, falling back to
+   * `config.git.defaultBranch`. Injected so probeLocalBranchSection can pass a
+   * per-repo branch into `probeLocalBranch` without each probe needing to
+   * shell out to git itself.
+   */
+  resolveDefaultBranch: (input: { repoDir: string }) => Promise<string>;
   probeLocalBranch: (input: {
     repoDir: string;
     branch: string;
@@ -772,10 +781,11 @@ async function probeLocalBranchSection(
     };
   }
   const repoDir = repoDirFromEntry(entry, deps);
+  const defaultBranch = await deps.resolveDefaultBranch({ repoDir });
   const probe = await deps.probeLocalBranch({
     repoDir,
     branch: entry.branchName,
-    defaultBranch: deps.config.git.defaultBranch,
+    defaultBranch,
   });
   if (probe.kind === "present") {
     const defaultBranchName = probe.defaultBranch ?? deps.config.git.defaultBranch;
@@ -1300,6 +1310,12 @@ export async function runTicketDoctor(parsed: TicketDoctorArguments): Promise<bo
     probeWorkspaces: async () => await workspaces.probe(config),
     workspaceAccessHint: async (name) => await workspaces.accessHint(config, name),
     probeWorkingTree: async ({ worktreeDir }) => await worktrees.probeWorkingTree({ worktreeDir }),
+    resolveDefaultBranch: async ({ repoDir }) =>
+      await resolveDefaultBranch({
+        repoDir,
+        remote: config.git.remote,
+        fallback: config.git.defaultBranch,
+      }),
     probeLocalBranch: probeLocalBranchImpl,
     probeRemoteBranch: probeRemoteBranchImpl,
     probePullRequest: probePullRequestImpl,

--- a/src/commands/ticketDoctor.ts
+++ b/src/commands/ticketDoctor.ts
@@ -251,11 +251,13 @@ export interface TicketDoctorDependencies {
   probeLocalBranch: (input: {
     repoDir: string;
     branch: string;
+    remote: string;
     defaultBranch: string;
   }) => Promise<LocalBranchProbe>;
   probeRemoteBranch: (input: {
     repoDir: string;
     branch: string;
+    remote: string;
     doFetch: boolean;
   }) => Promise<RemoteBranchProbe>;
   probePullRequest: (input: { repoDir: string; branch: string }) => Promise<PullRequestProbe>;
@@ -785,6 +787,7 @@ async function probeLocalBranchSection(
   const probe = await deps.probeLocalBranch({
     repoDir,
     branch: entry.branchName,
+    remote: deps.config.git.remote,
     defaultBranch,
   });
   if (probe.kind === "present") {
@@ -794,7 +797,7 @@ async function probeLocalBranchSection(
         {
           name: "Local branch exists",
           status: "ok",
-          detail: `${entry.branchName}, ${probe.ahead} ahead / ${probe.behind} behind origin/${defaultBranchName}`,
+          detail: `${entry.branchName}, ${probe.ahead} ahead / ${probe.behind} behind ${deps.config.git.remote}/${defaultBranchName}`,
         },
       ],
       skipReason: "",
@@ -833,24 +836,26 @@ async function probeRemoteBranchSection(
     return { checks: [], skipReason: "repo dir unresolved", probe: { kind: "absent" } };
   }
   const repoDir = repoDirFromEntry(entry, deps);
+  const checkName = `Branch present on ${deps.config.git.remote}`;
   const probe = await deps.probeRemoteBranch({
     repoDir,
     branch: entry.branchName,
+    remote: deps.config.git.remote,
     doFetch: deps.doFetch,
   });
   if (probe.kind === "present") {
-    return { checks: [{ name: "Branch present on origin", status: "ok" }], skipReason: "", probe };
+    return { checks: [{ name: checkName, status: "ok" }], skipReason: "", probe };
   }
   if (probe.kind === "absent") {
     return {
-      checks: [{ name: "Branch present on origin", status: "fail", detail: "not pushed" }],
+      checks: [{ name: checkName, status: "fail", detail: "not pushed" }],
       skipReason: "",
       probe,
     };
   }
   // probe.kind === "unknown"
   return {
-    checks: [{ name: "Branch present on origin", status: "skipped", detail: probe.reason }],
+    checks: [{ name: checkName, status: "skipped", detail: probe.reason }],
     skipReason: "",
     probe,
   };
@@ -1354,6 +1359,7 @@ function parseExitStatus(error: unknown): number | undefined {
 async function probeLocalBranchImpl(input: {
   repoDir: string;
   branch: string;
+  remote: string;
   defaultBranch: string;
 }): Promise<LocalBranchProbe> {
   if (!existsSync(input.repoDir)) {
@@ -1386,7 +1392,7 @@ async function probeLocalBranchImpl(input: {
       "rev-list",
       "--left-right",
       "--count",
-      `${input.branch}...origin/${input.defaultBranch}`,
+      `${input.branch}...${input.remote}/${input.defaultBranch}`,
     ]);
     const [aheadString, behindString] = output.trim().split(/\s+/);
     const ahead = Number.parseInt(aheadString ?? "0", 10);
@@ -1400,6 +1406,7 @@ async function probeLocalBranchImpl(input: {
 async function probeRemoteBranchImpl(input: {
   repoDir: string;
   branch: string;
+  remote: string;
   doFetch: boolean;
 }): Promise<RemoteBranchProbe> {
   if (!existsSync(input.repoDir)) {
@@ -1413,7 +1420,7 @@ async function probeRemoteBranchImpl(input: {
         input.repoDir,
         "fetch",
         "--quiet",
-        "origin",
+        input.remote,
         input.branch,
       ]);
     } catch {
@@ -1427,7 +1434,7 @@ async function probeRemoteBranchImpl(input: {
       input.repoDir,
       "ls-remote",
       "--exit-code",
-      "origin",
+      input.remote,
       `refs/heads/${input.branch}`,
     ]);
     return { kind: "present" };

--- a/src/lib/defaultBranch.test.ts
+++ b/src/lib/defaultBranch.test.ts
@@ -1,0 +1,134 @@
+import type { RunCommandOptions } from "./commandRunner.ts";
+import { resolveDefaultBranch } from "./defaultBranch.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mock shares one recorder across the sync and async command APIs.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+
+describe(resolveDefaultBranch, () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it("returns the branch reported by `git symbolic-ref` (stripping the remote prefix)", async () => {
+    runCommandMock.mockReturnValue("origin/master\n");
+
+    const actual = await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "origin",
+      fallback: "main",
+    });
+
+    expect(actual).toBe("master");
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/work/repo-a", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      {},
+    );
+  });
+
+  it("respects a non-default remote name", async () => {
+    runCommandMock.mockReturnValue("upstream/develop\n");
+
+    const actual = await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "upstream",
+      fallback: "main",
+    });
+
+    expect(actual).toBe("develop");
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/work/repo-a", "symbolic-ref", "--short", "refs/remotes/upstream/HEAD"],
+      {},
+    );
+  });
+
+  it("falls back when `git symbolic-ref` exits non-zero (origin/HEAD unset)", async () => {
+    runCommandMock.mockImplementation(() => {
+      throw new Error(
+        "Command failed: git symbolic-ref --short refs/remotes/origin/HEAD\nExit status: 1",
+      );
+    });
+
+    const actual = await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "origin",
+      fallback: "trunk",
+    });
+
+    expect(actual).toBe("trunk");
+  });
+
+  it("falls back when the output does not start with `<remote>/`", async () => {
+    runCommandMock.mockReturnValue("refs/heads/somewhere-else\n");
+
+    const actual = await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "origin",
+      fallback: "main",
+    });
+
+    expect(actual).toBe("main");
+  });
+
+  it("falls back when the branch portion is empty", async () => {
+    runCommandMock.mockReturnValue("origin/\n");
+
+    const actual = await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "origin",
+      fallback: "main",
+    });
+
+    expect(actual).toBe("main");
+  });
+
+  it("passes the abort signal through to runCommandAsync", async () => {
+    runCommandMock.mockReturnValue("origin/main\n");
+    const controller = new AbortController();
+
+    await resolveDefaultBranch({
+      repoDir: "/work/repo-a",
+      remote: "origin",
+      fallback: "main",
+      signal: controller.signal,
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/work/repo-a", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      { signal: controller.signal },
+    );
+  });
+
+  it("re-throws when the call fails after the signal aborted", async () => {
+    const controller = new AbortController();
+    runCommandMock.mockImplementation(() => {
+      controller.abort();
+      throw new Error("aborted");
+    });
+
+    await expect(
+      resolveDefaultBranch({
+        repoDir: "/work/repo-a",
+        remote: "origin",
+        fallback: "main",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+});

--- a/src/lib/defaultBranch.ts
+++ b/src/lib/defaultBranch.ts
@@ -1,0 +1,51 @@
+/**
+ * Resolve the default branch of a local clone from `refs/remotes/<remote>/HEAD`.
+ *
+ * `git clone` sets this symbolic ref to the remote's default branch (the one
+ * GitHub/GitLab marks as default), so a repo cloned with `master` as its
+ * primary branch reports `<remote>/master` and one on `main` reports
+ * `<remote>/main`. Reading it locally means no network round-trip and no
+ * per-repo config to maintain.
+ *
+ * Best-effort: when the HEAD ref is unset (rare — e.g. an out-of-band clone or
+ * a `git remote set-head --delete`) or git otherwise fails, fall back to the
+ * caller-supplied default so worktree creation and branch probes keep working.
+ * Abort signals still propagate so a cancelled run doesn't waste time on the
+ * fallback path.
+ */
+
+import { runCommandAsync } from "./commandRunner.ts";
+
+interface ResolveDefaultBranchInput {
+  repoDir: string;
+  remote: string;
+  fallback: string;
+  signal?: AbortSignal;
+}
+
+export async function resolveDefaultBranch(input: ResolveDefaultBranchInput): Promise<string> {
+  const remoteHeadRef = `refs/remotes/${input.remote}/HEAD`;
+  const remotePrefix = `${input.remote}/`;
+  const options = input.signal === undefined ? {} : { signal: input.signal };
+  let output: string;
+  try {
+    output = await runCommandAsync(
+      "git",
+      ["-C", input.repoDir, "symbolic-ref", "--short", remoteHeadRef],
+      options,
+    );
+  } catch (error) {
+    if (input.signal?.aborted === true) {
+      throw error;
+    }
+    return input.fallback;
+  }
+  const trimmed = output.trim();
+  if (trimmed.startsWith(remotePrefix)) {
+    const branch = trimmed.slice(remotePrefix.length);
+    if (branch.length > 0) {
+      return branch;
+    }
+  }
+  return input.fallback;
+}

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -262,15 +262,27 @@ describe(findByTicket, () => {
 describe(create, () => {
   setupTempProjectDir();
 
-  it("fetches origin/main then runs git worktree add for the host strategy", async () => {
+  it("probes origin/HEAD, then fetches and worktree-adds the auto-detected default branch", async () => {
     mkdirSync(join(projectDir, "repo-a"));
     const config = makeConfig({ projectDir });
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator picks out the symbolic-ref probe so it returns origin/<branch>
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        return "origin/main\n";
+      }
+      return "";
+    });
 
     const actual = await create(config, {
       repository: "repo-a",
       ticket: "team-1",
     });
 
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", join(projectDir, "repo-a"), "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      {},
+    );
     expect(runCommandMock).toHaveBeenCalledWith(
       "git",
       ["-C", join(projectDir, "repo-a"), "fetch", "origin", "main"],
@@ -292,6 +304,90 @@ describe(create, () => {
     );
     expect(actual.kind).toBe("host");
     expect(actual.dir).toBe(join(projectDir, "repo-a-team-1"));
+  });
+
+  it("uses the per-repo default branch reported by origin/HEAD (e.g. master)", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    const config = makeConfig({ projectDir });
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator picks out the symbolic-ref probe so it reports a master-backed repo
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        return "origin/master\n";
+      }
+      return "";
+    });
+
+    await create(config, {
+      repository: "repo-a",
+      ticket: "team-1",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", join(projectDir, "repo-a"), "fetch", "origin", "master"],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      [
+        "-C",
+        join(projectDir, "repo-a"),
+        "worktree",
+        "add",
+        "-b",
+        "rocky-team-1",
+        join(projectDir, "repo-a-team-1"),
+        "origin/master",
+      ],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
+  });
+
+  it("falls back to config.git.defaultBranch when origin/HEAD is not set", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    const config = makeConfig({
+      projectDir,
+      git: { remote: "origin", defaultBranch: "trunk" },
+    });
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- mirrors `git symbolic-ref` exit status 1 when refs/remotes/origin/HEAD is unset
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        throw new Error(
+          "Command failed: git symbolic-ref --short refs/remotes/origin/HEAD\nExit status: 1",
+        );
+      }
+      return "";
+    });
+
+    await create(config, {
+      repository: "repo-a",
+      ticket: "team-1",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", join(projectDir, "repo-a"), "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      {},
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", join(projectDir, "repo-a"), "fetch", "origin", "trunk"],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      [
+        "-C",
+        join(projectDir, "repo-a"),
+        "worktree",
+        "add",
+        "-b",
+        "rocky-team-1",
+        join(projectDir, "repo-a-team-1"),
+        "origin/trunk",
+      ],
+      { stdio: "inherit", timeoutMs: 0 },
+    );
   });
 
   it("rejects when a host worktree already exists for the same ticket", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -14,6 +14,7 @@ import { resolve } from "node:path";
 
 import { runCommandAsync, type RunCommandOptions } from "./commandRunner.ts";
 import type { ResolvedConfig } from "./config.ts";
+import { resolveDefaultBranch } from "./defaultBranch.ts";
 import { errorMessage, log } from "./util.ts";
 import { type WorkspaceProbe, workspaces } from "./workspaces.ts";
 
@@ -145,11 +146,17 @@ async function createWorktree(
   signal?: AbortSignal,
 ): Promise<WorktreeEntry> {
   const base = basePaths(config, spec.repository, spec.ticket);
-  const baseRef = `${config.git.remote}/${config.git.defaultBranch}`;
+  const defaultBranch = await resolveDefaultBranch({
+    repoDir: base.repoDir,
+    remote: config.git.remote,
+    fallback: config.git.defaultBranch,
+    ...signalProperty(signal),
+  });
+  const baseRef = `${config.git.remote}/${defaultBranch}`;
   log(`Fetching ${baseRef} in ${spec.repository}...`);
   await runCommandAsync(
     "git",
-    ["-C", base.repoDir, "fetch", config.git.remote, config.git.defaultBranch],
+    ["-C", base.repoDir, "fetch", config.git.remote, defaultBranch],
     longRunningCommandOptions(signal),
   );
   log(


### PR DESCRIPTION
## Summary
- `createWorktree` was hardcoded to fetch `${config.git.defaultBranch}` for every repo, so any repo whose primary branch isn't the configured global (e.g. `herds-social/herds_mobile_app` on `master` vs a global `main`) failed with `fatal: couldn't find remote ref main` and aborted dispatch.
- Resolve the default branch per repo from `refs/remotes/<remote>/HEAD` (set by `git clone`), falling back to `config.git.defaultBranch` only when the symbolic ref is unset. No config changes needed — mixed-default workspaces just work.
- Same per-repo resolution flows into `ticketDoctor`'s local-branch probe, and `ticketDoctor` now uses `config.git.remote` for local ahead/behind probes, remote branch probes, and rendered remote branch check names instead of hardcoding `origin`.

## Why this shape
- `git symbolic-ref --short refs/remotes/<remote>/HEAD` is local-only (no network), so there's no per-fetch latency cost.
- The new helper lives in `src/lib/defaultBranch.ts` and is shared between the two consumers. `worktrees.ts` calls it inline; `ticketDoctor.ts` injects it as a dep so probe tests stay pure.
- Best-effort fallback semantics mirror the existing `deleteBranchBestEffort` pattern: errors fall back to the config default, but abort signals still propagate so cancelled runs don't waste time.

## Repro of the original failure
```
[crew run --watch]
[11:18:31 p.m.] Fetching origin/main in herds-social/herds_mobile_app...
fatal: couldn't find remote ref main
[11:18:33 p.m.] Failed to start hrd-453: Command failed: git -C /Users/paul/dev/groundcrew-workspaces/herds-social/herds_mobile_app fetch origin main
```

The affected repo's `origin/HEAD` resolves to `origin/master` — verified locally — so after this change `crew run` fetches `origin master` and worktree-adds `origin/master`.

## Test plan
- [x] 7 new unit tests in `src/lib/defaultBranch.test.ts` covering happy path, non-default remote, exit-non-zero fallback, malformed-output fallback, empty-branch fallback, signal forwarding, abort propagation
- [x] 3 new/updated tests in `src/lib/worktrees.test.ts` covering symbolic-ref probe path, `master`-reported repo, fallback when HEAD unset
- [x] 3 new/updated tests in `src/commands/ticketDoctor.test.ts` covering per-repo default branch flow, configured remote propagation to local branch probes/details, and configured remote propagation to remote branch probes/check names
- [x] `node_modules/.bin/vitest run --coverage=false src/commands/ticketDoctor.test.ts` (101 tests)
- [x] `node --run verify` green end-to-end: architecture, build, cpd, format, knip, lint, markdown, spell, syncpack, test (864 tests, 100% coverage on branches/functions/lines/statements)

Agent session: codex resume 019e505c-3ba2-7e31-883e-b87966990f2a
<!-- commit-push-pr:created v1 core@3.4.0 -->