### PR TITLE
chore: combine watch-loop idle logs and allow app.terraform.io

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -65,6 +65,7 @@ registry.npmjs.org
 www.npmjs.com
 
 # Developer tooling
+app.terraform.io
 buf.build
 cdn.playwright.dev
 formulae.brew.sh

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -44,6 +44,12 @@ export interface Dispatcher {
     usage: (signal?: AbortSignal) => Promise<UsageByModel>;
     dryRun: boolean;
     signal?: AbortSignal;
+    /**
+     * Appended to the dispatcher's idle-branch log lines so the watch loop
+     * can fold its `next poll in Xs` heartbeat into the same line instead of
+     * printing a second line per tick.
+     */
+    idleSuffix?: string;
   }): Promise<void>;
 }
 
@@ -134,8 +140,9 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     usage: (signal?: AbortSignal) => Promise<UsageByModel>;
     dryRun: boolean;
     signal?: AbortSignal;
+    idleSuffix?: string;
   }): Promise<void> {
-    const { state, worktreeEntries, usage, dryRun, signal } = arguments_;
+    const { state, worktreeEntries, usage, dryRun, signal, idleSuffix = "" } = arguments_;
     issueStatusUpdater.resetMissingInProgressCache();
 
     const activeCount = state.issues.filter(
@@ -151,13 +158,13 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
 
     if (slots <= 0) {
       log(
-        `At capacity (${activeCount}/${config.orchestrator.maximumInProgress}), no new work to start`,
+        `At capacity (${activeCount}/${config.orchestrator.maximumInProgress}), no new work to start${idleSuffix}`,
       );
       return;
     }
 
     if (todo.length === 0) {
-      log(`No Todo tickets to pick up`);
+      log(`No Todo tickets to pick up${idleSuffix}`);
       return;
     }
 
@@ -168,7 +175,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       logSkip(skip);
     }
     if (unblocked.length === 0) {
-      log(`No eligible Todo tickets after blocker filtering`);
+      log(`No eligible Todo tickets after blocker filtering${idleSuffix}`);
       return;
     }
 

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -218,7 +218,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     }
 
     if (starts.length === 0) {
-      log(`No eligible Todo tickets after eligibility filtering`);
+      log(`No eligible Todo tickets after eligibility filtering${idleSuffix}`);
       return;
     }
 

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -92,6 +92,12 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
   const cleaner: Cleaner = createCleaner({ config });
   const dispatcher: Dispatcher = createDispatcher({ config, client });
 
+  // Folded into the dispatcher's idle log lines in watch mode so each idle
+  // tick prints one combined line instead of "<reason>" + "Next poll in Xs".
+  const idleSuffix = options.watch
+    ? `; next poll in ${config.orchestrator.pollIntervalMilliseconds / MS_PER_SECOND}s`
+    : undefined;
+
   const tick = async (signal?: AbortSignal): Promise<void> => {
     const state: BoardState = await withRetry(async () => await boardSource.fetch(), signal);
     const worktreeEntries = worktrees.list(config);
@@ -107,6 +113,7 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
       // Lazy: dispatcher only invokes this after its own early-returns, so
       // an idle board doesn't burn a codexbar shell-out per tick.
       usage: async (usageSignal) => await fetchUsageOrEmpty(config, usageSignal),
+      ...(idleSuffix === undefined ? {} : { idleSuffix }),
     });
   };
 
@@ -184,7 +191,6 @@ async function runWatchLoop(
       if (shutdown.signal.aborted) {
         break;
       }
-      log(`Next poll in ${config.orchestrator.pollIntervalMilliseconds / MS_PER_SECOND}s...`);
       // oxlint-disable-next-line no-await-in-loop -- watch loop is intentionally serial
       await sleep(config.orchestrator.pollIntervalMilliseconds, shutdown.signal);
     }


### PR DESCRIPTION
## Summary

On every idle watch tick groundcrew was printing two log lines — the dispatcher's idle reason (e.g. `No Todo tickets to pick up`) and then the orchestrator's `Next poll in 120s...` heartbeat on the same timestamp. Fold the heartbeat into the dispatcher's idle messages via an optional `idleSuffix` so each idle tick prints one combined line like `No Todo tickets to pick up; next poll in 120s`. The standalone `Next poll` log is dropped; non-watch (single-shot) runs still print the idle reason with no suffix. Also adds `app.terraform.io` to `clearance-allow-hosts` under Developer tooling.

## Validation

- `node --run verify` — 852 tests pass, 100% coverage.

Agent session: claude --resume 88407ea2-a7d7-4a5f-a421-743c8f402a60
<!-- commit-push-pr:created v1 core@3.4.1 -->