### PR TITLE
fix: make missing setup hook a no-op

### DIFF
--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -2,7 +2,11 @@ import type { LinearClient } from "@linear/sdk";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import * as boardSource from "../../boardSource.ts";
-import type { Blocker as LinearBlocker, Issue as LinearIssue } from "../../boardSource.ts";
+import type {
+  Blocker as LinearBlocker,
+  BoardState as LinearBoardState,
+  Issue as LinearIssue,
+} from "../../boardSource.ts";
 import type { ResolvedConfig, ResolvedProjectConfig } from "../../config.ts";
 import * as linearIssueStatus from "../../linearIssueStatus.ts";
 import * as util from "../../util.ts";
@@ -254,7 +258,7 @@ describe(createLinearTicketSource, () => {
     const innerVerify = vi.fn<() => Promise<void>>().mockResolvedValue();
     vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
       verify: innerVerify,
-      fetch: vi.fn<() => Promise<{ timestamp: string; issues: LinearIssue[] }>>(),
+      fetch: vi.fn<() => Promise<LinearBoardState>>(),
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -264,15 +268,11 @@ describe(createLinearTicketSource, () => {
   });
 
   it("fetch() converts each LinearIssue into a canonical Issue", async () => {
-    const innerFetch = vi
-      .fn<() => Promise<{ timestamp: string; issues: LinearIssue[] }>>()
-      .mockResolvedValue({
-        timestamp: "2026-01-01T00:00:00Z",
-        issues: [
-          linearIssue({ id: "team-1" }),
-          linearIssue({ id: "team-2", status: "In Progress" }),
-        ],
-      });
+    const innerFetch = vi.fn<() => Promise<LinearBoardState>>().mockResolvedValue({
+      timestamp: "2026-01-01T00:00:00Z",
+      issues: [linearIssue({ id: "team-1" }), linearIssue({ id: "team-2", status: "In Progress" })],
+      parentSkips: [],
+    });
     vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
       verify: vi.fn<() => Promise<void>>(),
       fetch: innerFetch,

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -1,4 +1,7 @@
-import { statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { ModelDefinition } from "./config.ts";
 import {
@@ -38,6 +41,37 @@ describe(resolveSafehouseClearancePath, () => {
 });
 
 describe(buildLaunchCommand, () => {
+  describe(SETUP_COMMAND, () => {
+    function runSetupCommand(cwd: string): number | undefined {
+      return spawnSync("sh", ["-c", SETUP_COMMAND], { cwd }).status ?? undefined;
+    }
+
+    it("is a successful no-op when the repo setup hook is absent", () => {
+      const worktreeDir = mkdtempSync(join(tmpdir(), "groundcrew-no-setup-"));
+      try {
+        const actual = runSetupCommand(worktreeDir);
+
+        expect(actual).toBe(0);
+      } finally {
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("preserves the repo setup hook status when the hook exists", () => {
+      const worktreeDir = mkdtempSync(join(tmpdir(), "groundcrew-failing-setup-"));
+      try {
+        mkdirSync(join(worktreeDir, ".groundcrew"));
+        writeFileSync(join(worktreeDir, ".groundcrew", "setup.sh"), "exit 7\n");
+
+        const actual = runSetupCommand(worktreeDir);
+
+        expect(actual).toBe(7);
+      } finally {
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("cd's into the worktree, runs setup, then execs the Safehouse-wrapped agent with the prompt", () => {
     const out = buildLaunchCommand(arguments_());
 

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -38,7 +38,8 @@ const SAFEHOUSE_CLEARANCE_WRAPPER_PATH = resolveSafehouseClearancePath();
  * Per-repo setup hook: if `.groundcrew/setup.sh` exists, run it with
  * `--deps-only`; otherwise no-op.
  */
-export const SETUP_COMMAND = "[ -f .groundcrew/setup.sh ] && bash .groundcrew/setup.sh --deps-only";
+export const SETUP_COMMAND =
+  "if [ -f .groundcrew/setup.sh ]; then bash .groundcrew/setup.sh --deps-only; fi";
 
 function renderAgentCommand(arguments_: {
   agentCmd: string;


### PR DESCRIPTION
## Summary

Fixes groundcrew launches in repos without `.groundcrew/setup.sh` by making the optional setup hook a successful no-op when absent. Real hook failures still propagate their status so the launch script only warns for actual setup failures.

## Validation

- `node --run verify`

Agent session: codex resume 019e50e4-d184-7311-ba3b-deebf5efb792
<!-- commit-push-pr:created v1 core@3.4.0 -->