### PR TITLE
fix: warn-and-skip instead of crashing on tickets with no parseable repo

### DIFF
--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -430,7 +430,7 @@ describe(orchestrate, () => {
     );
   });
 
-  it("fails fast when the description has no known repo", async () => {
+  it("warns and skips dispatch when the description has no known repo", async () => {
     const client = makeClient({
       pages: [
         [
@@ -445,14 +445,12 @@ describe(orchestrate, () => {
     });
     mockLinearClient(client);
 
-    await expect(orchestrate({ watch: false, dryRun: false })).rejects.toThrow(
-      /No known repository found in ticket TEAM-3 description/,
-    );
+    await orchestrate({ watch: false, dryRun: false });
 
     expect(setupMock).not.toHaveBeenCalled();
-    expect(
-      client.client.rawRequest.mock.calls.filter(([query]) => query.includes("BoardIssues")),
-    ).toHaveLength(1);
+    expect(consoleLog.output()).toMatch(
+      /TEAM-3 has an agent-\* label but no known repository in its description/,
+    );
   });
 
   it("resolves the model from an agent-* label", async () => {
@@ -1456,7 +1454,10 @@ describe(orchestrate, () => {
     expect(out).toContain("Error: network down");
   });
 
-  it("fails fast on repository resolution errors in watch mode", async () => {
+  it("keeps polling when a labeled ticket has no parseable repository in watch mode", async () => {
+    // A single broken ticket previously aborted the entire watch loop. Now
+    // the orchestrator warns and continues to the next tick so the rest of
+    // the board still gets serviced.
     const client = makeClient({
       pages: [
         [
@@ -1470,13 +1471,14 @@ describe(orchestrate, () => {
       ],
     });
     mockLinearClient(client);
-    sleepMock.mockRejectedValue(new Error("__stop__"));
+    stopAfterMoreThanSleepCalls(1);
 
-    await expect(orchestrate({ watch: true, dryRun: false })).rejects.toThrow(
-      /No known repository found in ticket TEAM-3 description/,
+    await expect(orchestrate({ watch: true, dryRun: false })).rejects.toThrow("__stop__");
+
+    expect(setupMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toMatch(
+      /TEAM-3 has an agent-\* label but no known repository in its description/,
     );
-
-    expect(sleepMock).not.toHaveBeenCalled();
   });
 
   it("ignores models whose session window is null", async () => {

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -5,12 +5,7 @@
  * orchestrator's user-facing output.
  */
 
-import {
-  type BoardSource,
-  type BoardState,
-  createBoardSource,
-  RepositoryResolutionError,
-} from "../lib/boardSource.ts";
+import { type BoardSource, type BoardState, createBoardSource } from "../lib/boardSource.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -36,9 +31,6 @@ async function withRetry<T>(
       // oxlint-disable-next-line no-await-in-loop -- retry loop sequences attempts deliberately
       return await function_();
     } catch (error) {
-      if (error instanceof RepositoryResolutionError) {
-        throw error;
-      }
       if (attempt === maxRetries) {
         throw error;
       }
@@ -185,9 +177,6 @@ async function runWatchLoop(
       } catch (error) {
         if (error instanceof WatchLoopShutdownError) {
           break;
-        }
-        if (error instanceof RepositoryResolutionError) {
-          throw error;
         }
         const message = errorMessage(error);
         if (message.includes("Signal: SIGINT")) {

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -420,7 +420,7 @@ describe(createBoardSource, () => {
       expect(first?.repository).toBe("ClipboardHealth/security-alerts-agent");
     });
 
-    it("rejects when a bare repo name is ambiguous across multiple orgs", async () => {
+    it("warns and yields a non-eligible issue when a bare repo name is ambiguous across multiple orgs", async () => {
       const { source } = makeBoardSource(
         makeClient({
           pages: [
@@ -439,8 +439,12 @@ describe(createBoardSource, () => {
           },
         }),
       );
-      await expect(source.fetch()).rejects.toThrow(
-        /No known repository found in ticket TEAM-1 description/,
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.repository).toBeUndefined();
+      expect(first?.model).toBeUndefined();
+      expect(consoleLog.output()).toMatch(
+        /TEAM-1 has an agent-\* label but no known repository in its description/,
       );
     });
 
@@ -463,7 +467,10 @@ describe(createBoardSource, () => {
       expect(first?.repository).toBe("api-admin");
     });
 
-    it("rejects when a labeled ticket has no known repo in its description", async () => {
+    it("warns and yields a non-eligible issue when a labeled ticket has no known repo in its description", async () => {
+      // Regression guard: a single broken ticket used to abort the entire
+      // `crew run` loop. Now it's surfaced as a warning and treated as
+      // not-eligible so the rest of the board still ticks.
       const { source } = makeBoardSource(
         makeClient({
           pages: [
@@ -477,12 +484,16 @@ describe(createBoardSource, () => {
         }),
       );
 
-      await expect(source.fetch()).rejects.toThrow(
-        /No known repository found in ticket TEAM-1 description/,
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.repository).toBeUndefined();
+      expect(first?.model).toBeUndefined();
+      expect(consoleLog.output()).toMatch(
+        /TEAM-1 has an agent-\* label but no known repository in its description/,
       );
     });
 
-    it("rejects when a labeled ticket has a missing description", async () => {
+    it("warns and yields a non-eligible issue when a labeled ticket has a missing description", async () => {
       const { source } = makeBoardSource(
         makeClient({
           pages: [
@@ -496,8 +507,12 @@ describe(createBoardSource, () => {
         }),
       );
 
-      await expect(source.fetch()).rejects.toThrow(
-        /No known repository found in ticket TEAM-1 description/,
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.repository).toBeUndefined();
+      expect(first?.model).toBeUndefined();
+      expect(consoleLog.output()).toMatch(
+        /TEAM-1 has an agent-\* label but no known repository in its description/,
       );
     });
 

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -516,6 +516,55 @@ describe(createBoardSource, () => {
       );
     });
 
+    it("does not warn or parse a repo for a labeled Done ticket whose description has no known repo", async () => {
+      // The dispatcher never reads `Issue.repository` on non-Todo tickets, so
+      // parsing a Done ticket's description only invites tick-spam warnings if
+      // its description was edited (or knownRepositories changed) after the
+      // ticket was originally dispatched. Cleaner still sees the ticket by id.
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                description: "nothing parseable here",
+                state: { id: "state-done", name: "Done" },
+                labels: { nodes: [{ name: "agent-claude" }] },
+              }),
+            ],
+          ],
+        }),
+      );
+
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.id).toBe("team-1");
+      expect(first?.repository).toBeUndefined();
+      expect(first?.model).toBeUndefined();
+      expect(consoleLog.output()).not.toMatch(/no known repository/);
+    });
+
+    it("does not warn or parse a repo for a labeled In Progress ticket whose description has no known repo", async () => {
+      const { source } = makeBoardSource(
+        makeClient({
+          pages: [
+            [
+              issueNode({
+                description: "nothing parseable here",
+                state: { id: "state-ip", name: "In Progress" },
+                labels: { nodes: [{ name: "agent-claude" }] },
+              }),
+            ],
+          ],
+        }),
+      );
+
+      const state = await source.fetch();
+      const [first] = state.issues;
+      expect(first?.repository).toBeUndefined();
+      expect(first?.model).toBeUndefined();
+      expect(consoleLog.output()).not.toMatch(/no known repository/);
+    });
+
     it("does not reject when an unlabeled ticket has no parseable repo", async () => {
       // Regression guard: previously aborted the whole board load on any
       // human-owned ticket whose description happened not to mention one

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -339,15 +339,13 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
     after = page.pageInfo.endCursor;
   }
 
-  const repositoryRegex = buildRepositoryRegex(config);
-
   // Only parse `repository` for tickets that opted in via an `agent-*` label.
-  // Without this gate, a single human-owned ticket without a parseable repo
-  // would abort the whole `crew run` before the Todo filter ever runs.
+  // Unlabeled tickets are not groundcrew's concern even when they share a
+  // configured state name with one that is.
   const issues: Issue[] = nodes
     .filter((node) => node.children.nodes.length === 0)
     .filter((node) => issueStatusBelongsToOwnProject(node, config))
-    .map((node) => issueFromNode(node, config, repositoryRegex));
+    .map((node) => issueFromNode(node, config));
 
   const parentSkips: ParentSkip[] = nodes
     .filter((node) => node.children.nodes.length > 0)
@@ -393,18 +391,31 @@ function modelForResolution(resolution: ModelResolution): string | undefined {
   return undefined;
 }
 
-function issueFromNode(node: IssueNode, config: ResolvedConfig, repositoryRegex: RegExp): Issue {
+function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
   const modelResolution = resolveModelFor({ labels: node.labels.nodes, config });
   warnIfDisabledFallback(node.identifier, modelResolution, config);
-  const repository =
-    modelResolution.kind === "no-label"
-      ? undefined
-      : parseRepository({
-          description: node.description ?? undefined,
-          config,
-          repositoryRegex,
-          ticket: node.identifier,
-        });
+  let repository: string | undefined;
+  let model = modelForResolution(modelResolution);
+  if (modelResolution.kind !== "no-label") {
+    const resolution = resolveRepositoryFor({
+      description: node.description ?? undefined,
+      config,
+      ticket: node.identifier,
+    });
+    if (resolution.kind === "ok") {
+      ({ repository } = resolution);
+    } else {
+      // A labeled ticket with no parseable repository is the operator's bug, not
+      // a fatal one — fixing the description (or removing the label) is the
+      // user action. Surface it loudly and treat the ticket as not-eligible so
+      // a single broken ticket doesn't kill the watch loop. Done tickets stay
+      // in the board state for the cleaner to act on their worktrees.
+      log(
+        `WARNING: ${node.identifier} has an ${AGENT_LABEL_PREFIX}* label but no known repository in its description; skipping dispatch. Add one of workspace.knownRepositories to the description, or remove the ${AGENT_LABEL_PREFIX}* label: ${config.workspace.knownRepositories.join(", ")}`,
+      );
+      model = undefined;
+    }
+  }
   // `issueStatusBelongsToOwnProject` drops nodes whose `state` or `project`
   // is missing, so by the time we land here both are defined. The nullish
   // coalescing on those fields is belt-and-suspenders for type narrowing.
@@ -419,7 +430,7 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig, repositoryRegex:
     assignee: node.assignee?.name ?? "Unassigned",
     updatedAt: node.updatedAt,
     repository,
-    model: modelForResolution(modelResolution),
+    model,
     teamId: node.team?.id ?? "",
     /* v8 ignore next @preserve -- post-filter guarantees `project` is defined */
     projectSlugId: node.project?.slugId?.toLowerCase() ?? "",
@@ -827,48 +838,6 @@ export async function fetchResolvedIssue(arguments_: {
     teamId: raw.teamId,
     projectSlugId: project.slugId,
   };
-}
-
-interface ParseRepositoryArguments {
-  description: string | undefined;
-  config: ResolvedConfig;
-  repositoryRegex: RegExp;
-  ticket: string;
-}
-
-function parseRepository(arguments_: ParseRepositoryArguments): string {
-  const { description, config, repositoryRegex, ticket } = arguments_;
-  if (description === undefined || description.length === 0) {
-    throw new RepositoryResolutionError({
-      ticket,
-      repositories: config.workspace.knownRepositories,
-    });
-  }
-  const matched = repositoryRegex.exec(description)?.[1];
-  if (matched === undefined) {
-    throw new RepositoryResolutionError({
-      ticket,
-      repositories: config.workspace.knownRepositories,
-    });
-  }
-  // Resolve the match to a known repo. The regex may capture a bare repo name
-  // (no org prefix) when only that appears in the description; the filter
-  // handles both full "owner/repo" and bare "repo" matches. Reject if
-  // ambiguous (same bare name under multiple orgs).
-  const candidates = config.workspace.knownRepositories.filter(
-    (r) => r === matched || r.endsWith(`/${matched}`),
-  );
-  if (candidates.length !== 1) {
-    throw new RepositoryResolutionError({
-      ticket,
-      repositories: config.workspace.knownRepositories,
-    });
-  }
-  /* v8 ignore next 3 @preserve -- candidates.length===1 guarantees [0] is defined */
-  if (candidates[0] === undefined) {
-    throw new Error("unreachable");
-  }
-  return candidates[0];
 }
 
 /**

--- a/src/lib/boardSource.ts
+++ b/src/lib/boardSource.ts
@@ -42,9 +42,14 @@ export interface Issue {
   statusId: string;
   assignee: string;
   updatedAt: string;
-  /** `undefined` when the ticket has no `agent-*` label — i.e. not groundcrew's concern. */
+  /**
+   * `undefined` unless the ticket is in Todo with a parseable `agent-*` label
+   * and a known-repo reference in its description — i.e. the dispatcher would
+   * actually pick it up. Resolving on non-Todo statuses would just invite
+   * tick-spam warnings on already-finished work.
+   */
   repository: string | undefined;
-  /** `undefined` when the ticket has no `agent-*` label — i.e. not groundcrew's concern. */
+  /** `undefined` whenever `repository` is — the two are populated together. */
   model: string | undefined;
   teamId: string;
   /** SlugId of the Linear project the issue belongs to — always one of `linear.projects[*].slugId`. */
@@ -349,7 +354,7 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
 
   const parentSkips: ParentSkip[] = nodes
     .filter((node) => node.children.nodes.length > 0)
-    .filter((node) => isTodoParentForOwnProject(node, config))
+    .filter((node) => isTodoStatusForOwnProject(node, config))
     .map((node) => ({
       id: node.identifier.toLowerCase(),
       title: node.title,
@@ -360,11 +365,15 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
 }
 
 /**
- * Narrows parent tickets to those the dispatcher would otherwise pick up —
- * Todo status under their own project's configured status names. Done /
- * In Progress parents aren't surprising drops, so we don't log them.
+ * Checks whether the node sits in Todo under its own project's configured
+ * status names. Used to narrow parent skips (Done / In Progress parents
+ * aren't surprising drops, so we don't log them) and to gate the repository
+ * parse on the only status the dispatcher acts on — In Progress / Done
+ * tickets never read `Issue.repository` so parsing it for them just creates
+ * tick-spamming warnings when an operator already-finished ticket can't be
+ * re-parsed.
  */
-function isTodoParentForOwnProject(node: IssueNode, config: ResolvedConfig): boolean {
+function isTodoStatusForOwnProject(node: IssueNode, config: ResolvedConfig): boolean {
   const slugId = node.project?.slugId?.toLowerCase();
   /* v8 ignore next 3 @preserve -- GraphQL slugId filter scopes results to configured projects */
   if (slugId === undefined) {
@@ -378,25 +387,31 @@ function isTodoParentForOwnProject(node: IssueNode, config: ResolvedConfig): boo
   return node.state?.name === project.statuses.todo;
 }
 
-function modelForResolution(resolution: ModelResolution): string | undefined {
+function modelForResolution(resolution: Exclude<ModelResolution, { kind: "no-label" }>): string {
   if (resolution.kind === "matched") {
     return resolution.model;
   }
   if (resolution.kind === "disabled-fallback") {
     return resolution.fallbackModel;
   }
-  if (resolution.kind === "agent-any") {
-    return AGENT_ANY_MODEL;
-  }
-  return undefined;
+  return AGENT_ANY_MODEL;
 }
 
 function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
   const modelResolution = resolveModelFor({ labels: node.labels.nodes, config });
   warnIfDisabledFallback(node.identifier, modelResolution, config);
   let repository: string | undefined;
-  let model = modelForResolution(modelResolution);
-  if (modelResolution.kind !== "no-label") {
+  let model: string | undefined;
+  // Only the dispatcher reads `Issue.repository` / `Issue.model`, and only on
+  // tickets in the Todo column it's about to pick up. Resolving them for In
+  // Progress (already running) or Done (cleaner only needs the id) would just
+  // invite tick-spam warnings on already-finished tickets — e.g. when a
+  // description was edited or knownRepositories changed after dispatch. A
+  // ticket sitting in Todo with no parseable repo is still the operator's
+  // bug, so surface it loudly there and treat it as not-eligible so the rest
+  // of the board still ticks instead of the whole watch loop crashing on
+  // one bad ticket.
+  if (modelResolution.kind !== "no-label" && isTodoStatusForOwnProject(node, config)) {
     const resolution = resolveRepositoryFor({
       description: node.description ?? undefined,
       config,
@@ -404,16 +419,11 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
     });
     if (resolution.kind === "ok") {
       ({ repository } = resolution);
+      model = modelForResolution(modelResolution);
     } else {
-      // A labeled ticket with no parseable repository is the operator's bug, not
-      // a fatal one — fixing the description (or removing the label) is the
-      // user action. Surface it loudly and treat the ticket as not-eligible so
-      // a single broken ticket doesn't kill the watch loop. Done tickets stay
-      // in the board state for the cleaner to act on their worktrees.
       log(
         `WARNING: ${node.identifier} has an ${AGENT_LABEL_PREFIX}* label but no known repository in its description; skipping dispatch. Add one of workspace.knownRepositories to the description, or remove the ${AGENT_LABEL_PREFIX}* label: ${config.workspace.knownRepositories.join(", ")}`,
       );
-      model = undefined;
     }
   }
   // `issueStatusBelongsToOwnProject` drops nodes whose `state` or `project`


### PR DESCRIPTION
## Summary

An agent-labeled ticket whose description lacked a known repository (e.g. STAFF-720, which was in Done status with no parseable repo) used to throw `RepositoryResolutionError` from inside `fetchBoard`. The watch loop deliberately re-threw the error rather than retrying — so one bad ticket killed the whole orchestrator on every poll.

Two changes:

1. **Repository parse is now best-effort and gated on Todo status.** Only the dispatcher reads `Issue.repository` / `Issue.model`, and only on tickets in the Todo column it's about to pick up. In Progress (already running) and Done (cleaner only needs the id) tickets no longer get their description re-parsed every tick — that's what was causing the warnings on already-finished work whose description was edited or whose repo had been removed from `knownRepositories`.
2. **A Todo ticket that fails the parse now logs a warning and is treated as not-groundcrew-eligible** instead of throwing. The dispatcher's `isGroundcrewIssue` filter skips it; the cleaner still sees Done tickets in `BoardState` (it keys off `issue.id` + on-disk worktrees, not `repository`) so worktree teardown still works; the rest of the board keeps ticking.

The explicit single-ticket path through `fetchResolvedIssue` (used by `setup`, `doctor`, `resume`) still throws — there, fixing the description is the user's job, so fail-fast is right.

Also renamed `isTodoParentForOwnProject` → `isTodoStatusForOwnProject` (the function never actually knew about parents; it always just checked Todo status under the node's own project).

## Validation

- `node --run verify` — 995 tests pass, 100% statement/branch/function/line coverage.

Agent session: claude --resume 95e1fe03-fafc-4e90-b176-ce9fef17a6d3
<!-- commit-push-pr:created v1 core@3.4.1 -->