### PR TITLE
feat(sandbox): apply gh-auth git defaults inside every sandbox

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -68,6 +68,7 @@
     "Safehouse",
     "bubblewrap",
     "dockersandbox",
+    "gpgsign",
     "normalises",
     "sandboxed",
     "sandboxing",

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -56,7 +56,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -65,7 +65,7 @@ const config: ResolvedConfig = {
   prompts: { initial: "x" },
   workspaceKind: "auto",
   local: { runner: "auto" },
-  sandbox: { authRecipes: {} },
+  sandbox: { authRecipes: {}, gitDefaults: false },
   logging: { file: "/tmp/groundcrew-test.log" },
 };
 

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -65,7 +65,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -122,7 +122,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -45,7 +45,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -81,7 +81,7 @@ function makeConfig(): ResolvedConfig {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -117,7 +117,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto", ...overrides.local },
-    sandbox: { authRecipes: {}, ...overrides.sandbox },
+    sandbox: { authRecipes: {}, gitDefaults: false, ...overrides.sandbox },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -154,7 +154,7 @@ function makeConfig(): ResolvedConfig {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/sandbox/auth.test.ts
+++ b/src/commands/sandbox/auth.test.ts
@@ -45,6 +45,21 @@ function isStatusExec(call: SbxCall): boolean {
   return call[0] === "sbx" && call[1][0] === "exec" && call[1][1] !== "-it";
 }
 
+function isStatusProbe(arguments_: readonly string[]): boolean {
+  // Status probes shell out to `sh -c '<binary> <args> 2>&1'`; the 2>&1
+  // suffix differentiates them from other non-interactive exec calls
+  // (applyGitDefaults' `sh -c 'git config ...'` and the post-login
+  // `gh auth setup-git`).
+  const tail = arguments_.at(-1);
+  return typeof tail === "string" && tail.endsWith("2>&1");
+}
+
+function findSetupGitCall(calls: readonly SbxCall[]): SbxCall | undefined {
+  return calls.find(
+    (call) => call[0] === "sbx" && call[1][0] === "exec" && call[1].includes("setup-git"),
+  );
+}
+
 interface MockAuthFlowOptions {
   /** Status outputs in call order. Last one repeats if more calls happen. */
   statusOutputs: readonly string[];
@@ -62,6 +77,11 @@ function mockAuthFlow(opts: MockAuthFlowOptions): void {
       return "NAME\n";
     }
     if (arguments_[0] === "exec" && arguments_[1] !== "-it") {
+      if (!isStatusProbe(arguments_)) {
+        // Side-effect exec (applyGitDefaults / gh auth setup-git) — return
+        // empty so the call succeeds without consuming a status slot.
+        return "";
+      }
       if (opts.statusThrows === true) {
         throw new Error("sbx exec failed");
       }
@@ -71,6 +91,42 @@ function mockAuthFlow(opts: MockAuthFlowOptions): void {
     }
     return "";
   });
+}
+
+interface MockGithubLoginOptions {
+  /** Result of the `gh auth setup-git` call: "ok" or an error to throw. */
+  setupGit: "ok" | Error;
+}
+
+function mockGithubLoginWithSetupGit(opts: MockGithubLoginOptions): {
+  setupGitCalls: () => number;
+} {
+  let setupGitCalls = 0;
+  runCommandMock.mockImplementation(async (command, arguments_) => {
+    const isSbx = command === "sbx";
+    const isLs = isSbx && arguments_[0] === "ls";
+    const isExec = isSbx && arguments_[0] === "exec";
+    const isLogin = isExec && arguments_[1] === "-it";
+    const isSetupGit = isExec && arguments_.includes("setup-git");
+    if (isLs) {
+      return "NAME\n";
+    }
+    if (isLogin) {
+      return "";
+    }
+    if (isSetupGit) {
+      setupGitCalls += 1;
+      if (opts.setupGit instanceof Error) {
+        throw opts.setupGit;
+      }
+      return "";
+    }
+    if (isExec) {
+      return "Logged in to github.com";
+    }
+    return "";
+  });
+  return { setupGitCalls: () => setupGitCalls };
 }
 
 function mockClaudeLoggedInOnly(): void {
@@ -322,6 +378,7 @@ describe("crew sandbox auth", () => {
           // kind omitted on purpose — defaults to "tool"
         },
       },
+      gitDefaults: false,
     };
     loadConfigMock.mockResolvedValue(customConfig);
 
@@ -344,6 +401,96 @@ describe("crew sandbox auth", () => {
     expect(output).toContain("cursor (3/3)");
   });
 
+  it("runs 'gh auth setup-git' after a successful github login when gitDefaults is on", async () => {
+    const config = makeSandboxConfig();
+    config.sandbox.gitDefaults = true;
+    loadConfigMock.mockResolvedValue(config);
+    pickToolsMock.mockResolvedValueOnce(["github"]);
+    mockAuthFlow({ statusOutputs: ["", "Logged in to github.com"] });
+
+    await sandboxCli(["auth", "claude"]);
+
+    const setupGitCall = findSetupGitCall(runCommandMock.mock.calls);
+    expect(setupGitCall?.[1]).toStrictEqual([
+      "exec",
+      "groundcrew-claude",
+      "gh",
+      "auth",
+      "setup-git",
+    ]);
+  });
+
+  it("does not run 'gh auth setup-git' when github login verification fails", async () => {
+    const config = makeSandboxConfig();
+    config.sandbox.gitDefaults = true;
+    loadConfigMock.mockResolvedValue(config);
+    pickToolsMock.mockResolvedValueOnce(["github"]);
+    mockAuthFlow({ statusOutputs: ["", "Not logged in"] });
+
+    await sandboxCli(["auth", "claude"]);
+
+    expect(findSetupGitCall(runCommandMock.mock.calls)).toBeUndefined();
+  });
+
+  it("does not run 'gh auth setup-git' for non-github recipes", async () => {
+    const config = makeSandboxConfig();
+    config.sandbox.gitDefaults = true;
+    loadConfigMock.mockResolvedValue(config);
+    pickToolsMock.mockResolvedValueOnce(["claude"]);
+    mockAuthFlow({ statusOutputs: ["", '{"loggedIn": true}'] });
+
+    await sandboxCli(["auth", "claude"]);
+
+    expect(findSetupGitCall(runCommandMock.mock.calls)).toBeUndefined();
+  });
+
+  it("warns but does not abort when 'gh auth setup-git' fails", async () => {
+    const config = makeSandboxConfig();
+    config.sandbox.gitDefaults = true;
+    loadConfigMock.mockResolvedValue(config);
+    pickToolsMock.mockResolvedValueOnce(["github"]);
+    const { setupGitCalls } = mockGithubLoginWithSetupGit({
+      setupGit: new Error("setup-git boom"),
+    });
+
+    await expect(sandboxCli(["auth", "claude"])).resolves.toBeUndefined();
+
+    expect(setupGitCalls()).toBe(1);
+    expect(consoleLog.output()).toContain("'gh auth setup-git' failed:");
+    expect(consoleLog.output()).toContain("setup-git boom");
+  });
+
+  it("skips 'gh auth setup-git' when gitDefaults is off", async () => {
+    pickToolsMock.mockResolvedValueOnce(["github"]);
+    mockAuthFlow({ statusOutputs: ["", "Logged in to github.com"] });
+
+    await sandboxCli(["auth", "claude"]);
+
+    expect(findSetupGitCall(runCommandMock.mock.calls)).toBeUndefined();
+  });
+
+  it("skips 'gh auth setup-git' when a custom github recipe overrides the binary", async () => {
+    const config = makeSandboxConfig();
+    config.sandbox.gitDefaults = true;
+    config.sandbox.authRecipes = {
+      github: {
+        displayName: "GitHub (custom)",
+        binary: "gh-custom",
+        loginArgs: ["login"],
+        statusArgs: ["status"],
+        authenticatedPattern: /Logged in/,
+        kind: "tool",
+      },
+    };
+    loadConfigMock.mockResolvedValue(config);
+    pickToolsMock.mockResolvedValueOnce(["github"]);
+    mockAuthFlow({ statusOutputs: ["", "Logged in"] });
+
+    await sandboxCli(["auth", "claude"]);
+
+    expect(findSetupGitCall(runCommandMock.mock.calls)).toBeUndefined();
+  });
+
   it("user-config recipe overrides the built-in for the same key", async () => {
     const customConfig = makeSandboxConfig();
     customConfig.sandbox = {
@@ -357,6 +504,7 @@ describe("crew sandbox auth", () => {
           kind: "tool",
         },
       },
+      gitDefaults: false,
     };
     loadConfigMock.mockResolvedValue(customConfig);
     pickToolsMock.mockResolvedValueOnce(["github"]);

--- a/src/commands/sandbox/auth.ts
+++ b/src/commands/sandbox/auth.ts
@@ -98,8 +98,9 @@ async function loginAndVerify(input: {
   toolKey: string;
   recipe: AuthRecipe;
   modelName: string;
+  gitDefaults: boolean;
 }): Promise<void> {
-  const { sandboxName, toolKey, recipe, modelName } = input;
+  const { sandboxName, toolKey, recipe, modelName, gitDefaults } = input;
   const binary = binaryFor(toolKey, recipe);
   writeOutput(`${sandboxName}: launching '${recipe.displayName}' login...`);
   writeOutput("Complete the login flow in the prompts/browser, then return here.");
@@ -114,11 +115,29 @@ async function loginAndVerify(input: {
   const authenticated = await probeAuthStatus(sandboxName, toolKey, recipe);
   if (authenticated) {
     writeOutput(`${sandboxName}: '${recipe.displayName}' authenticated.`);
+    if (gitDefaults && toolKey === "github" && binary === "gh") {
+      await runGhSetupGit(sandboxName);
+    }
     return;
   }
   writeOutput(
     `${sandboxName}: could not confirm '${recipe.displayName}' authentication — re-run 'crew sandbox auth ${modelName}' to retry.`,
   );
+}
+
+/**
+ * Register `gh` as git's credential helper inside the sandbox so HTTPS
+ * pushes succeed without prompting. Best-effort — a failure here doesn't
+ * undo the login itself, so we warn and move on.
+ */
+async function runGhSetupGit(sandboxName: string): Promise<void> {
+  writeOutput(`${sandboxName}: wiring 'gh' as git credential helper...`);
+  try {
+    await runCommandAsync("sbx", ["exec", sandboxName, "gh", "auth", "setup-git"]);
+    writeOutput(`${sandboxName}: 'gh auth setup-git' done.`);
+  } catch (error) {
+    writeOutput(`${sandboxName}: warning — 'gh auth setup-git' failed: ${String(error)}`);
+  }
 }
 
 interface RecipeEntry {
@@ -245,6 +264,7 @@ async function runAuthInteractive(
       toolKey: key,
       recipe,
       modelName,
+      gitDefaults: config.sandbox.gitDefaults,
     });
   }
 }

--- a/src/commands/sandbox/lifecycle.ts
+++ b/src/commands/sandbox/lifecycle.ts
@@ -11,6 +11,7 @@ export async function ensureOne(config: ResolvedConfig, model: SandboxModel): Pr
     sandboxName: model.sandboxName,
     sandbox: model.sandbox,
     mountPath: resolve(config.workspace.projectDir),
+    gitDefaults: config.sandbox.gitDefaults,
   });
 }
 

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -68,7 +68,7 @@ function makeConfig(overrides: {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -218,7 +218,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
     },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/ticketDoctor.test.ts
+++ b/src/commands/ticketDoctor.test.ts
@@ -69,7 +69,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto", ...overrides.local },
-    sandbox: { authRecipes: {}, ...overrides.sandbox },
+    sandbox: { authRecipes: {}, gitDefaults: false, ...overrides.sandbox },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -63,6 +63,7 @@ export async function ensureAgentSandbox(input: {
         sandboxName: input.sandboxName,
         sandbox: input.definition.sandbox,
         mountPath: resolve(input.config.workspace.projectDir),
+        gitDefaults: input.config.sandbox.gitDefaults,
       },
       input.signal,
     );

--- a/src/lib/boardSource.test.ts
+++ b/src/lib/boardSource.test.ts
@@ -83,7 +83,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -601,6 +601,59 @@ describe("loadConfig", () => {
     );
   });
 
+  it("defaults sandbox.gitDefaults to true when omitted", async () => {
+    const path = writeConfigFile(
+      temporary,
+      configSource({
+        linear: { ...VALID_LINEAR },
+        workspace: VALID_WORKSPACE(temporary),
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.sandbox.gitDefaults).toBe(true);
+  });
+
+  it("threads an explicit sandbox.gitDefaults: false through to the resolved config", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  sandbox: { gitDefaults: false },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.sandbox.gitDefaults).toBe(false);
+  });
+
+  it("rejects a non-boolean sandbox.gitDefaults", async () => {
+    const path = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  linear: ${JSON.stringify(VALID_LINEAR)},`,
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        "  sandbox: { gitDefaults: 'yes' },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", path);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/sandbox\.gitDefaults must be a boolean/);
+  });
+
   it("rejects an invalid local.runner value", async () => {
     const path = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -240,6 +240,21 @@ export interface Config {
    */
   sandbox?: {
     authRecipes?: Record<string, AuthRecipe>;
+    /**
+     * When true (default), every `crew sandbox ensure` / `auth` run applies
+     * a small set of git defaults inside the sandbox so robot commits push
+     * over `gh`-managed HTTPS regardless of how the user cloned the repo:
+     *
+     *   - disable GPG signing for commits and tags
+     *   - rewrite `git@github.com:` and `ssh://git@github.com/` URLs to
+     *     `https://github.com/` so push uses gh's credential helper
+     *   - after a successful `github` auth recipe login, run
+     *     `gh auth setup-git` inside the sandbox
+     *
+     * Set `false` to skip both the git-config block and the post-login
+     * `gh auth setup-git` step.
+     */
+    gitDefaults?: boolean;
   };
   logging?: {
     /**
@@ -311,6 +326,7 @@ export interface ResolvedConfig {
    */
   sandbox: {
     authRecipes: Record<string, AuthRecipe>;
+    gitDefaults: boolean;
   };
   logging: {
     file: string;
@@ -456,6 +472,16 @@ function normalizeOptionalString(value: unknown, path: string): string | undefin
     fail(`${path} must be a non-empty string`);
   }
   return value.trim();
+}
+
+function normalizeOptionalBoolean(value: unknown, path: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    fail(`${path} must be a boolean`);
+  }
+  return value;
 }
 
 function normalizeOptionalStringArray(value: unknown, path: string): string[] | undefined {
@@ -830,6 +856,8 @@ function applyDefaults(user: Config): ResolvedConfig {
     },
     sandbox: {
       authRecipes: user.sandbox?.authRecipes ?? {},
+      gitDefaults:
+        normalizeOptionalBoolean(user.sandbox?.gitDefaults, "sandbox.gitDefaults") ?? true,
     },
     logging: {
       file: expandHome(

--- a/src/lib/dockerSandbox.test.ts
+++ b/src/lib/dockerSandbox.test.ts
@@ -83,6 +83,7 @@ describe(ensureSandbox, () => {
       sandboxName: "groundcrew-claude",
       sandbox: { agent: "claude" },
       mountPath: "/home/user/dev",
+      gitDefaults: false,
     });
 
     expect(runCommandMock).toHaveBeenCalledTimes(1);
@@ -97,6 +98,7 @@ describe(ensureSandbox, () => {
       sandboxName: "groundcrew-claude",
       sandbox: { agent: "claude" },
       mountPath: "/home/user/dev",
+      gitDefaults: false,
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
@@ -113,6 +115,7 @@ describe(ensureSandbox, () => {
       sandboxName: "groundcrew-claude",
       sandbox: { agent: "claude", template: "node-22" },
       mountPath: "/home/user/dev",
+      gitDefaults: false,
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
@@ -137,6 +140,7 @@ describe(ensureSandbox, () => {
       sandboxName: "groundcrew-claude",
       sandbox: { agent: "claude", kits: ["npm-cache", "tools"] },
       mountPath: "/home/user/dev",
+      gitDefaults: false,
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
@@ -165,6 +169,7 @@ describe(ensureSandbox, () => {
         sandboxName: "groundcrew-claude",
         sandbox: { agent: "claude" },
         mountPath: "/home/user/dev",
+        gitDefaults: false,
       },
       controller.signal,
     );
@@ -182,6 +187,7 @@ describe(ensureSandbox, () => {
         sandboxName: "groundcrew-claude",
         sandbox: { agent: "claude" },
         mountPath: "/home/user/dev",
+        gitDefaults: false,
       }),
     ).resolves.toBeUndefined();
     expect(counters.createCalls).toBe(1);
@@ -196,10 +202,83 @@ describe(ensureSandbox, () => {
         sandboxName: "groundcrew-claude",
         sandbox: { agent: "claude" },
         mountPath: "/home/user/dev",
+        gitDefaults: false,
       }),
     ).rejects.toThrow(/sbx daemon unreachable/);
   });
+
+  it("applies git defaults inside an existing sandbox when gitDefaults is true", async () => {
+    mockExisting(["groundcrew-claude"]);
+
+    await ensureSandbox({
+      sandboxName: "groundcrew-claude",
+      sandbox: { agent: "claude" },
+      mountPath: "/home/user/dev",
+      gitDefaults: true,
+    });
+
+    const gitDefaultsCall = findGitDefaultsCall(runCommandMock.mock.calls);
+    expect(gitDefaultsCall).toBeDefined();
+    expect(gitDefaultsCall?.[1]?.[1]).toBe("groundcrew-claude");
+  });
+
+  it("applies git defaults after creating a missing sandbox", async () => {
+    mockExisting([]);
+
+    await ensureSandbox({
+      sandboxName: "groundcrew-claude",
+      sandbox: { agent: "claude" },
+      mountPath: "/home/user/dev",
+      gitDefaults: true,
+    });
+
+    const verbs = runCommandMock.mock.calls.map(([, arguments_]) => arguments_[0]);
+    expect(verbs).toStrictEqual(["ls", "create", "exec"]);
+  });
+
+  it("passes the AbortSignal through to applyGitDefaults", async () => {
+    const controller = new AbortController();
+    mockExisting(["groundcrew-claude"]);
+
+    await ensureSandbox(
+      {
+        sandboxName: "groundcrew-claude",
+        sandbox: { agent: "claude" },
+        mountPath: "/home/user/dev",
+        gitDefaults: true,
+      },
+      controller.signal,
+    );
+
+    const gitDefaultsCall = findGitDefaultsCall(runCommandMock.mock.calls);
+    expect(gitDefaultsCall?.[2]).toMatchObject({ signal: controller.signal });
+  });
+
+  it("skips git defaults when gitDefaults is false", async () => {
+    mockExisting(["groundcrew-claude"]);
+
+    await ensureSandbox({
+      sandboxName: "groundcrew-claude",
+      sandbox: { agent: "claude" },
+      mountPath: "/home/user/dev",
+      gitDefaults: false,
+    });
+
+    expect(findGitDefaultsCall(runCommandMock.mock.calls)).toBeUndefined();
+  });
 });
+
+function findGitDefaultsCall(
+  calls: readonly Parameters<RunCommandMock>[],
+): Parameters<RunCommandMock> | undefined {
+  return calls.find(([command, arguments_]) => {
+    if (command !== "sbx" || arguments_[0] !== "exec") {
+      return false;
+    }
+    const script = arguments_.at(4);
+    return typeof script === "string" && script.includes("commit.gpgsign false");
+  });
+}
 
 interface SbxCallCounters {
   readonly lsCalls: number;

--- a/src/lib/dockerSandbox.ts
+++ b/src/lib/dockerSandbox.ts
@@ -1,5 +1,6 @@
 import { runCommandAsync } from "./commandRunner.ts";
 import type { SandboxDefinition } from "./config.ts";
+import { applyGitDefaults } from "./sandboxGitDefaults.ts";
 
 /**
  * Derive a deterministic sbx sandbox name from the sbx agent so every
@@ -39,38 +40,47 @@ interface EnsureSandboxArguments {
    * clone) are visible to `sbx exec -w <worktreeDir>` after creation.
    */
   mountPath: string;
+  /**
+   * When true, apply the standard git defaults inside the sandbox after
+   * it exists (idempotent, runs whether the sandbox was just created or
+   * already there). See `sandboxGitDefaults.ts` for what gets set.
+   */
+  gitDefaults: boolean;
 }
 
 /**
  * Idempotent guard: ensure a Docker Sandboxes container exists for the
  * given repository + model. Probes `sbx ls`; if `sandboxName` is missing,
  * calls `sbx create --name <name> [--template <t>] [--kit <k>]... <agent>
- * <mountPath>` to provision it. First-time agent auth still happens inside
- * the sandbox the first time `sbx exec` runs the agent — `create` only
- * provisions the container, it does not attach.
+ * <mountPath>` to provision it. Once the container exists (newly created
+ * or pre-existing), applies the standard git defaults when enabled.
+ * First-time agent auth still happens inside the sandbox the first time
+ * `sbx exec` runs the agent — `create` only provisions the container, it
+ * does not attach.
  */
 export async function ensureSandbox(
   arguments_: EnsureSandboxArguments,
   signal?: AbortSignal,
 ): Promise<void> {
-  if (await sandboxExists(arguments_.sandboxName, signal)) {
-    return;
-  }
-  const createArguments: string[] = ["create", "--name", arguments_.sandboxName];
-  if (arguments_.sandbox.template !== undefined) {
-    createArguments.push("--template", arguments_.sandbox.template);
-  }
-  for (const kit of arguments_.sandbox.kits ?? []) {
-    createArguments.push("--kit", kit);
-  }
-  createArguments.push(arguments_.sandbox.agent, arguments_.mountPath);
-  const options = signal === undefined ? {} : { signal };
-  try {
-    await runCommandAsync("sbx", createArguments, options);
-  } catch (error) {
-    if (await sandboxExists(arguments_.sandboxName, signal)) {
-      return;
+  if (!(await sandboxExists(arguments_.sandboxName, signal))) {
+    const createArguments: string[] = ["create", "--name", arguments_.sandboxName];
+    if (arguments_.sandbox.template !== undefined) {
+      createArguments.push("--template", arguments_.sandbox.template);
     }
-    throw error;
+    for (const kit of arguments_.sandbox.kits ?? []) {
+      createArguments.push("--kit", kit);
+    }
+    createArguments.push(arguments_.sandbox.agent, arguments_.mountPath);
+    const options = signal === undefined ? {} : { signal };
+    try {
+      await runCommandAsync("sbx", createArguments, options);
+    } catch (error) {
+      if (!(await sandboxExists(arguments_.sandboxName, signal))) {
+        throw error;
+      }
+    }
+  }
+  if (arguments_.gitDefaults) {
+    await applyGitDefaults({ sandboxName: arguments_.sandboxName }, signal);
   }
 }

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -41,7 +41,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: join(stateRoot, "groundcrew.log") },
   };
 }

--- a/src/lib/sandboxGitDefaults.ts
+++ b/src/lib/sandboxGitDefaults.ts
@@ -1,0 +1,44 @@
+import { runCommandAsync } from "./commandRunner.ts";
+
+/**
+ * Git defaults applied inside every sandbox when `sandbox.gitDefaults`
+ * is enabled (the default).
+ *
+ * - Disable GPG signing — robot commits inside the sandbox have no key
+ *   and would otherwise fail or end up unsigned silently.
+ * - Rewrite GitHub SSH URLs to HTTPS so push/fetch go through the `gh`
+ *   credential helper (wired by `gh auth setup-git` after a successful
+ *   `crew sandbox auth` github login), regardless of how the user
+ *   originally cloned the repo on the host.
+ *
+ * `url.<base>.insteadOf` is multi-valued in git; `--unset-all` before
+ * `--add` keeps the set identical across repeated runs instead of
+ * appending duplicates.
+ */
+const GIT_DEFAULT_COMMANDS = [
+  "git config --global commit.gpgsign false",
+  "git config --global tag.gpgsign false",
+  'git config --global --unset-all url."https://github.com/".insteadOf 2>/dev/null || true',
+  'git config --global --add url."https://github.com/".insteadOf "git@github.com:"',
+  'git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"',
+].join(" && ");
+
+interface ApplyGitDefaultsArguments {
+  sandboxName: string;
+}
+
+/**
+ * Apply the standard git defaults inside `sandboxName`. Idempotent —
+ * safe to call on every `ensure`/`auth` run to repair drift.
+ */
+export async function applyGitDefaults(
+  arguments_: ApplyGitDefaultsArguments,
+  signal?: AbortSignal,
+): Promise<void> {
+  const options = signal === undefined ? {} : { signal };
+  await runCommandAsync(
+    "sbx",
+    ["exec", arguments_.sandboxName, "sh", "-c", GIT_DEFAULT_COMMANDS],
+    options,
+  );
+}

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -86,7 +86,7 @@ function makeConfig(
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -93,7 +93,7 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
     prompts: { initial: "x" },
     workspaceKind,
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -95,7 +95,7 @@ function makeConfig(overrides: {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/testHelpers/sandboxFixtures.ts
+++ b/src/testHelpers/sandboxFixtures.ts
@@ -59,7 +59,7 @@ export function makeSandboxConfig(): ResolvedConfig {
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
-    sandbox: { authRecipes: {} },
+    sandbox: { authRecipes: {}, gitDefaults: false },
     logging: { file: "/tmp/groundcrew-sandbox-test.log" },
   };
 }


### PR DESCRIPTION
## Summary

- Sandboxes now default to git config that lets robot commits push through `gh` CLI auth regardless of how the host cloned: GPG signing off, GitHub SSH URLs rewritten to HTTPS, and `gh auth setup-git` runs after a successful `crew sandbox auth` github login.
- Idempotent — re-applies on every `ensure`/`auth` run, repairing drift.
- Opt out per project with `sandbox.gitDefaults: false` in `crew.config.ts`.

## Why

Sandboxes don't have the host's SSH key or GPG key. SSH-cloned repos fail to push from inside the container even after `gh auth login`, and GPG-signed commits either fail or end up unsigned silently. Making `gh`-HTTPS the default removes both classes of footgun for the agent flows.