### PR TITLE
feat: add 'crew upgrade' subcommand with availability nudge

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -10,6 +10,12 @@ import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import {
+  createDefaultUpgradeCliOptions,
+  upgradeCli,
+  type UpgradeCliOptions,
+} from "./commands/upgrade.ts";
+import { computeUpgradeNudge } from "./lib/upgrade.ts";
+import {
   captureConsoleError,
   captureConsoleLog,
   type ConsoleCapture,
@@ -36,6 +42,17 @@ vi.mock(import("./commands/setupWorkspace.ts"), () => ({
 vi.mock(import("./commands/setupRepos.ts"), () => ({
   setupReposCli: vi.fn<typeof setupReposCli>(),
 }));
+vi.mock(import("./commands/upgrade.ts"), () => ({
+  upgradeCli: vi.fn<typeof upgradeCli>(),
+  createDefaultUpgradeCliOptions: vi.fn<typeof createDefaultUpgradeCliOptions>(),
+}));
+vi.mock(import("./lib/upgrade.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    computeUpgradeNudge: vi.fn<typeof computeUpgradeNudge>(),
+  };
+});
 
 const orchestrateMock = vi.mocked(orchestrate);
 const doctorMock = vi.mocked(doctor);
@@ -44,6 +61,9 @@ const resumeMock = vi.mocked(resumeWorkspaceCli);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
+const upgradeCliMock = vi.mocked(upgradeCli);
+const createDefaultUpgradeCliOptionsMock = vi.mocked(createDefaultUpgradeCliOptions);
+const computeUpgradeNudgeMock = vi.mocked(computeUpgradeNudge);
 const requireFromTest = createRequire(import.meta.url);
 const PACKAGE_VERSION = readPackageVersion();
 const README_TEXT = readFileSync(new URL("../README.md", import.meta.url), "utf8");
@@ -65,6 +85,19 @@ function readPackageVersion(): string {
   return packageMetadata.version;
 }
 
+function makeFakeUpgradeOptions(currentVersion: string): UpgradeCliOptions {
+  return {
+    currentVersion,
+    packageName: "@clipboard-health/groundcrew",
+    installKind: "global",
+    installPath: "/install",
+    npmBin: "/usr/local/bin/npm",
+    fetcher: vi.fn<UpgradeCliOptions["fetcher"]>(),
+    runInstall: vi.fn<UpgradeCliOptions["runInstall"]>(),
+    fetchTimeoutMs: 5000,
+  };
+}
+
 describe(run, () => {
   let consoleLog: ConsoleCapture;
   let consoleError: ConsoleCapture;
@@ -80,6 +113,10 @@ describe(run, () => {
     setupMock.mockResolvedValue();
     setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
+    upgradeCliMock.mockResolvedValue();
+    createDefaultUpgradeCliOptionsMock.mockResolvedValue(makeFakeUpgradeOptions(PACKAGE_VERSION));
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the no-nudge branch
+    computeUpgradeNudgeMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -372,5 +409,68 @@ describe(run, () => {
 
     expect(consoleError.output()).toBe("boom");
     expect(process.exitCode).toBe(1);
+  });
+
+  it("dispatches `upgrade` to upgradeCli with the assembled options", async () => {
+    const assembled = makeFakeUpgradeOptions(PACKAGE_VERSION);
+    createDefaultUpgradeCliOptionsMock.mockResolvedValue(assembled);
+
+    await run(["upgrade", "3.2.0"]);
+
+    const call = createDefaultUpgradeCliOptionsMock.mock.calls[0]?.[0];
+    expect(call?.currentVersion).toBe(PACKAGE_VERSION);
+    expect(call?.cliMetaUrl).toMatch(/cli\.ts$/);
+    expect(upgradeCliMock).toHaveBeenCalledWith(["3.2.0"], assembled);
+  });
+
+  it("does not run the upgrade nudge when the subcommand is upgrade", async () => {
+    await run(["upgrade", "--check"]);
+
+    expect(computeUpgradeNudgeMock).not.toHaveBeenCalled();
+  });
+
+  it("prints the upgrade nudge to stderr before non-upgrade subcommands", async () => {
+    computeUpgradeNudgeMock.mockResolvedValue(
+      "[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)",
+    );
+    await run(["doctor"]);
+
+    expect(computeUpgradeNudgeMock).toHaveBeenCalledTimes(1);
+    expect(consoleError.output()).toContain("[crew] 3.2.0 available");
+    expect(doctorMock).toHaveBeenCalledWith();
+  });
+
+  it("skips the nudge message when no upgrade is available", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the no-nudge branch
+    computeUpgradeNudgeMock.mockResolvedValue(undefined);
+    await run(["doctor"]);
+
+    expect(computeUpgradeNudgeMock).toHaveBeenCalledTimes(1);
+    expect(consoleError.calls).toStrictEqual([]);
+  });
+
+  it("forwards npm_config_registry and the env opt-out flag to the nudge", async () => {
+    vi.stubEnv("npm_config_registry", "https://npm.mirror.example");
+    vi.stubEnv("GROUNDCREW_NO_UPGRADE_CHECK", "1");
+    try {
+      await run(["doctor"]);
+      expect(computeUpgradeNudgeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          packageName: "@clipboard-health/groundcrew",
+          ttlMs: 6 * 60 * 60 * 1000,
+          fetchTimeoutMs: 300,
+          registry: "https://npm.mirror.example",
+          noUpgradeCheck: true,
+        }),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("does not run the nudge for unknown subcommands", async () => {
+    await run(["bogus"]);
+
+    expect(computeUpgradeNudgeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -475,4 +475,12 @@ describe(run, () => {
 
     expect(computeUpgradeNudgeMock).not.toHaveBeenCalled();
   });
+
+  it("still runs the requested subcommand when the nudge throws", async () => {
+    computeUpgradeNudgeMock.mockRejectedValueOnce(new Error("nudge boom"));
+    await run(["doctor"]);
+
+    expect(doctorMock).toHaveBeenCalledWith();
+    expect(process.exitCode).toBeUndefined();
+  });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -95,6 +95,8 @@ function makeFakeUpgradeOptions(currentVersion: string): UpgradeCliOptions {
     fetcher: vi.fn<UpgradeCliOptions["fetcher"]>(),
     runInstall: vi.fn<UpgradeCliOptions["runInstall"]>(),
     fetchTimeoutMs: 5000,
+    cachePath: "/tmp/cli-test-upgrade-cache.json",
+    now: () => 1_700_000_000_000,
   };
 }
 
@@ -458,7 +460,7 @@ describe(run, () => {
         expect.objectContaining({
           packageName: "@clipboard-health/groundcrew",
           ttlMs: 6 * 60 * 60 * 1000,
-          fetchTimeoutMs: 300,
+          fetchTimeoutMs: 1000,
           registry: "https://npm.mirror.example",
           noUpgradeCheck: true,
         }),

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -13,6 +13,7 @@ import {
   createDefaultUpgradeCliOptions,
   upgradeCli,
   type UpgradeCliOptions,
+  type UpgradeCliOptionsInput,
 } from "./commands/upgrade.ts";
 import { computeUpgradeNudge } from "./lib/upgrade.ts";
 import {
@@ -89,15 +90,26 @@ function makeFakeUpgradeOptions(currentVersion: string): UpgradeCliOptions {
   return {
     currentVersion,
     packageName: "@clipboard-health/groundcrew",
-    installKind: "global",
-    installPath: "/install",
-    npmBin: "/usr/local/bin/npm",
+    resolveInstall: async () => ({
+      installKind: "global",
+      installPath: "/install",
+      npmBin: "/usr/local/bin/npm",
+    }),
     fetcher: vi.fn<UpgradeCliOptions["fetcher"]>(),
     runInstall: vi.fn<UpgradeCliOptions["runInstall"]>(),
     fetchTimeoutMs: 5000,
     cachePath: "/tmp/cli-test-upgrade-cache.json",
     now: () => 1_700_000_000_000,
   };
+}
+
+function expectUpgradeOptionsFactory(
+  optionsInput: UpgradeCliOptionsInput,
+): () => Promise<UpgradeCliOptions> {
+  if (typeof optionsInput !== "function") {
+    throw new TypeError("expected lazy upgrade options factory");
+  }
+  return optionsInput;
 }
 
 describe(run, () => {
@@ -413,16 +425,22 @@ describe(run, () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("dispatches `upgrade` to upgradeCli with the assembled options", async () => {
+  it("dispatches `upgrade` to upgradeCli with lazy default options", async () => {
     const assembled = makeFakeUpgradeOptions(PACKAGE_VERSION);
     createDefaultUpgradeCliOptionsMock.mockResolvedValue(assembled);
+    upgradeCliMock.mockImplementationOnce(async (_argv, optionsInput) => {
+      const optionsFactory = expectUpgradeOptionsFactory(optionsInput);
+      const options = await optionsFactory();
+      expect(options).toBe(assembled);
+    });
 
     await run(["upgrade", "3.2.0"]);
 
     const call = createDefaultUpgradeCliOptionsMock.mock.calls[0]?.[0];
     expect(call?.currentVersion).toBe(PACKAGE_VERSION);
+    expect(call?.packageName).toBe("@clipboard-health/groundcrew");
     expect(call?.cliMetaUrl).toMatch(/cli\.ts$/);
-    expect(upgradeCliMock).toHaveBeenCalledWith(["3.2.0"], assembled);
+    expect(upgradeCliMock).toHaveBeenCalledWith(["3.2.0"], expect.any(Function));
   });
 
   it("does not run the upgrade nudge when the subcommand is upgrade", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,23 @@ import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
-import { errorMessage, readTicketArgument, writeError, writeOutput } from "./lib/util.ts";
+import { createDefaultUpgradeCliOptions, upgradeCli } from "./commands/upgrade.ts";
+import {
+  computeUpgradeNudge,
+  defaultUpgradeCheckCachePath,
+  fetchLatestVersion,
+} from "./lib/upgrade.ts";
+import {
+  errorMessage,
+  readEnvironmentVariable,
+  readTicketArgument,
+  writeError,
+  writeOutput,
+} from "./lib/util.ts";
+
+const UPGRADE_PACKAGE_NAME = "@clipboard-health/groundcrew";
+const NUDGE_TTL_MS = 6 * 60 * 60 * 1000;
+const NUDGE_FETCH_TIMEOUT_MS = 300;
 
 interface PackageMetadata {
   version: string;
@@ -66,6 +82,31 @@ async function runCli(argv: string[]): Promise<void> {
     return;
   }
   await setupWorkspaceCli(ticket, { dryRun });
+}
+
+async function upgradeCliInvoke(argv: string[]): Promise<void> {
+  const options = await createDefaultUpgradeCliOptions({
+    currentVersion: packageVersion(),
+    cliMetaUrl: import.meta.url,
+  });
+  await upgradeCli(argv, options);
+}
+
+async function maybeRunUpgradeNudge(currentVersion: string): Promise<void> {
+  const message = await computeUpgradeNudge({
+    currentVersion,
+    packageName: UPGRADE_PACKAGE_NAME,
+    cachePath: defaultUpgradeCheckCachePath(),
+    ttlMs: NUDGE_TTL_MS,
+    fetchTimeoutMs: NUDGE_FETCH_TIMEOUT_MS,
+    registry: readEnvironmentVariable("npm_config_registry"),
+    noUpgradeCheck: readEnvironmentVariable("GROUNDCREW_NO_UPGRADE_CHECK") === "1",
+    now: Date.now,
+    fetcher: fetchLatestVersion,
+  });
+  if (message !== undefined) {
+    writeError(message);
+  }
 }
 
 async function doctorCli(argv: string[]): Promise<void> {
@@ -132,6 +173,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     usage: "repos [--dry-run] [<repo>...]",
     invoke: setupCli,
   },
+  upgrade: {
+    summary: "Install the latest version of crew (or pin to a specific version)",
+    usage: "[<version>] [--check]",
+    invoke: upgradeCliInvoke,
+  },
 };
 
 function printHelp(): void {
@@ -177,6 +223,10 @@ export async function run(argv: string[]): Promise<void> {
     printHelp();
     process.exitCode = 1;
     return;
+  }
+
+  if (subcommand !== "upgrade") {
+    await maybeRunUpgradeNudge(packageVersion());
   }
 
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import {
 
 const UPGRADE_PACKAGE_NAME = "@clipboard-health/groundcrew";
 const NUDGE_TTL_MS = 6 * 60 * 60 * 1000;
-const NUDGE_FETCH_TIMEOUT_MS = 300;
+const NUDGE_FETCH_TIMEOUT_MS = 1000;
 
 interface PackageMetadata {
   version: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,11 +21,11 @@ import {
   writeOutput,
 } from "./lib/util.ts";
 
-const UPGRADE_PACKAGE_NAME = "@clipboard-health/groundcrew";
 const NUDGE_TTL_MS = 6 * 60 * 60 * 1000;
 const NUDGE_FETCH_TIMEOUT_MS = 1000;
 
 interface PackageMetadata {
+  name: string;
   version: string;
 }
 
@@ -85,17 +85,22 @@ async function runCli(argv: string[]): Promise<void> {
 }
 
 async function upgradeCliInvoke(argv: string[]): Promise<void> {
-  const options = await createDefaultUpgradeCliOptions({
-    currentVersion: packageVersion(),
-    cliMetaUrl: import.meta.url,
-  });
-  await upgradeCli(argv, options);
+  const metadata = packageMetadata();
+  await upgradeCli(
+    argv,
+    async () =>
+      await createDefaultUpgradeCliOptions({
+        currentVersion: metadata.version,
+        packageName: metadata.name,
+        cliMetaUrl: import.meta.url,
+      }),
+  );
 }
 
-async function maybeRunUpgradeNudge(currentVersion: string): Promise<void> {
+async function maybeRunUpgradeNudge(metadata: PackageMetadata): Promise<void> {
   const message = await computeUpgradeNudge({
-    currentVersion,
-    packageName: UPGRADE_PACKAGE_NAME,
+    currentVersion: metadata.version,
+    packageName: metadata.name,
     cachePath: defaultUpgradeCheckCachePath(),
     ttlMs: NUDGE_TTL_MS,
     fetchTimeoutMs: NUDGE_FETCH_TIMEOUT_MS,
@@ -195,10 +200,14 @@ function printHelp(): void {
   writeOutput("\nSee README.md for full configuration and behavior.");
 }
 
+function packageMetadata(): PackageMetadata {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment -- package.json is shipped with this package and is the metadata source of truth.
+  const metadata: PackageMetadata = requireFromCli("../package.json");
+  return metadata;
+}
+
 function packageVersion(): string {
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment -- package.json is shipped with this package and is the version source of truth.
-  const packageMetadata: PackageMetadata = requireFromCli("../package.json");
-  return packageMetadata.version;
+  return packageMetadata().version;
 }
 
 export async function run(argv: string[]): Promise<void> {
@@ -227,7 +236,7 @@ export async function run(argv: string[]): Promise<void> {
 
   if (subcommand !== "upgrade") {
     try {
-      await maybeRunUpgradeNudge(packageVersion());
+      await maybeRunUpgradeNudge(packageMetadata());
     } catch {
       // Passive nudge is never load-bearing; never block the user's command.
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -226,7 +226,11 @@ export async function run(argv: string[]): Promise<void> {
   }
 
   if (subcommand !== "upgrade") {
-    await maybeRunUpgradeNudge(packageVersion());
+    try {
+      await maybeRunUpgradeNudge(packageVersion());
+    } catch {
+      // Passive nudge is never load-bearing; never block the user's command.
+    }
   }
 
   try {

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -1,0 +1,325 @@
+import { pathToFileURL } from "node:url";
+
+import { runCommand, type RunCommandOptions } from "../lib/commandRunner.ts";
+import { which } from "../lib/host.ts";
+import { createDefaultNpmSpawner, type NpmSpawner, runNpmInstallGlobal } from "../lib/npmGlobal.ts";
+import { captureConsoleError, captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+
+import { createDefaultUpgradeCliOptions, upgradeCli, type UpgradeCliOptions } from "./upgrade.ts";
+
+type RunCommandFn = (
+  command: string,
+  args: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- overload-collapsing cast; tests only exercise the captured-stdio signature
+    runCommand: vi.fn<RunCommandFn>() as unknown as typeof actual.runCommand,
+  };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, which: vi.fn<typeof which>() };
+});
+vi.mock(import("../lib/npmGlobal.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runNpmInstallGlobal: vi.fn<typeof runNpmInstallGlobal>(),
+    createDefaultNpmSpawner: vi.fn<typeof createDefaultNpmSpawner>(),
+  };
+});
+
+const runCommandMock = vi.mocked(runCommand);
+const whichMock = vi.mocked(which);
+const runNpmInstallGlobalMock = vi.mocked(runNpmInstallGlobal);
+const createDefaultNpmSpawnerMock = vi.mocked(createDefaultNpmSpawner);
+
+const PACKAGE_NAME = "@clipboard-health/groundcrew";
+
+type FetcherFn = UpgradeCliOptions["fetcher"];
+type RunInstallFn = UpgradeCliOptions["runInstall"];
+
+function makeOptions(overrides: Partial<UpgradeCliOptions> = {}): UpgradeCliOptions {
+  return {
+    currentVersion: "3.1.8",
+    packageName: PACKAGE_NAME,
+    installKind: "global",
+    installPath: "/usr/local/lib/node_modules/@clipboard-health/groundcrew",
+    npmBin: "/usr/local/bin/npm",
+    fetcher: vi.fn<FetcherFn>().mockResolvedValue("3.1.8"),
+    runInstall: vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false }),
+    fetchTimeoutMs: 5000,
+    ...overrides,
+  };
+}
+
+describe(upgradeCli, () => {
+  let consoleLog: ReturnType<typeof captureConsoleLog>;
+  let consoleErr: ReturnType<typeof captureConsoleError>;
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+    consoleErr = captureConsoleError();
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    consoleErr.restore();
+    process.exitCode = undefined;
+  });
+
+  it("prints help and exits 0 on --help", async () => {
+    await upgradeCli(["--help"], makeOptions());
+    expect(consoleLog.output()).toMatch(/Usage: crew upgrade/);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("refuses when not globally installed", async () => {
+    const runInstall = vi.fn<RunInstallFn>();
+    await upgradeCli([], makeOptions({ installKind: "project", runInstall }));
+    expect(consoleErr.output()).toMatch(/not installed globally/i);
+    expect(consoleErr.output()).toContain(PACKAGE_NAME);
+    expect(runInstall).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses when installation is a dev symlink (npm link)", async () => {
+    await upgradeCli([], makeOptions({ installKind: "linked" }));
+    expect(consoleErr.output()).toMatch(/npm link/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses when running from an npx temp install", async () => {
+    await upgradeCli([], makeOptions({ installKind: "npx" }));
+    expect(consoleErr.output()).toMatch(/npx/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses when install kind cannot be determined", async () => {
+    await upgradeCli([], makeOptions({ installKind: "unknown", installPath: "/some/weird/place" }));
+    expect(consoleErr.output()).toContain("/some/weird/place");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses when npm is not on PATH", async () => {
+    await upgradeCli([], makeOptions({ npmBin: undefined }));
+    expect(consoleErr.output()).toMatch(/npm/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints 'up to date' and skips install when already on latest", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.1.8");
+    const runInstall = vi.fn<RunInstallFn>();
+    await upgradeCli([], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    expect(consoleLog.output()).toMatch(/up to date.*3\.1\.8/i);
+    expect(runInstall).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("installs the latest version when behind", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    await upgradeCli([], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    expect(runInstall).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      version: "3.2.0",
+      npmBin: "/usr/local/bin/npm",
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("forwards a non-zero install exit code", async () => {
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 7, sawEacces: false });
+    await upgradeCli(
+      [],
+      makeOptions({
+        currentVersion: "3.1.8",
+        fetcher: vi.fn<FetcherFn>().mockResolvedValue("3.2.0"),
+        runInstall,
+      }),
+    );
+    expect(process.exitCode).toBe(7);
+  });
+
+  it("appends an EACCES hint when install fails with EACCES", async () => {
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 243, sawEacces: true });
+    await upgradeCli(
+      [],
+      makeOptions({
+        currentVersion: "3.1.8",
+        fetcher: vi.fn<FetcherFn>().mockResolvedValue("3.2.0"),
+        runInstall,
+      }),
+    );
+    expect(consoleErr.output()).toMatch(/EACCES/i);
+    expect(consoleErr.output()).toMatch(/permission/i);
+    expect(process.exitCode).toBe(243);
+  });
+
+  it("installs a pinned version when given explicitly (upgrade)", async () => {
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    const fetcher = vi.fn<FetcherFn>();
+    await upgradeCli(["3.2.0"], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(runInstall).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      version: "3.2.0",
+      npmBin: "/usr/local/bin/npm",
+    });
+  });
+
+  it("prints downgrade notice and installs when pinned version is lower", async () => {
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    await upgradeCli(["3.1.5"], makeOptions({ currentVersion: "3.1.8", runInstall }));
+    expect(consoleLog.output()).toMatch(/downgrading.*3\.1\.8.*3\.1\.5/i);
+    expect(runInstall).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      version: "3.1.5",
+      npmBin: "/usr/local/bin/npm",
+    });
+  });
+
+  it("skips install when pinned version equals current", async () => {
+    const runInstall = vi.fn<RunInstallFn>();
+    await upgradeCli(["3.1.8"], makeOptions({ currentVersion: "3.1.8", runInstall }));
+    expect(consoleLog.output()).toMatch(/already on 3\.1\.8/i);
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed pinned version", async () => {
+    await upgradeCli(["not.a.version"], makeOptions());
+    expect(consoleErr.output()).toMatch(/invalid version/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an unknown flag", async () => {
+    await upgradeCli(["--bogus"], makeOptions());
+    expect(consoleErr.output()).toMatch(/unknown argument/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects two positional arguments", async () => {
+    await upgradeCli(["3.1.5", "3.2.0"], makeOptions());
+    expect(consoleErr.output()).toMatch(/too many positional arguments/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects --check combined with a version argument", async () => {
+    await upgradeCli(["--check", "3.1.5"], makeOptions());
+    expect(consoleErr.output()).toMatch(/--check does not accept a version/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("--check prints availability and never installs (behind)", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    const runInstall = vi.fn<RunInstallFn>();
+    await upgradeCli(["--check"], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    expect(consoleLog.output()).toMatch(/3\.2\.0 available/);
+    expect(runInstall).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("--check prints up-to-date and never installs (current)", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.1.8");
+    const runInstall = vi.fn<RunInstallFn>();
+    await upgradeCli(["--check"], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    expect(consoleLog.output()).toMatch(/up to date.*3\.1\.8/i);
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("exits non-zero on registry failure during fetch", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockRejectedValue(new Error("network down"));
+    await upgradeCli([], makeOptions({ fetcher }));
+    expect(consoleErr.output()).toMatch(/registry/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("exits non-zero on registry failure during --check", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockRejectedValue(new Error("network down"));
+    await upgradeCli(["--check"], makeOptions({ fetcher }));
+    expect(consoleErr.output()).toMatch(/registry/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("forwards the configured registry to the fetcher", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.1.8");
+    await upgradeCli(["--check"], makeOptions({ fetcher, registry: "https://my.mirror.example" }));
+    expect(fetcher).toHaveBeenCalledWith(PACKAGE_NAME, {
+      timeoutMs: 5000,
+      registry: "https://my.mirror.example",
+    });
+  });
+});
+
+describe(createDefaultUpgradeCliOptions, () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("wires real implementations when npm is on PATH", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+    vi.stubEnv("npm_config_registry", "https://npm.mirror.example");
+
+    const options = await createDefaultUpgradeCliOptions({
+      currentVersion: "3.1.8",
+      cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+    });
+
+    expect(options.currentVersion).toBe("3.1.8");
+    expect(options.packageName).toBe(PACKAGE_NAME);
+    expect(options.installPath).toBe("/opt/pkg");
+    expect(options.npmBin).toBe("/usr/local/bin/npm");
+    expect(options.registry).toBe("https://npm.mirror.example");
+    expect(options.fetchTimeoutMs).toBe(5000);
+    expect(whichMock).toHaveBeenCalledWith("npm");
+    expect(runCommandMock).toHaveBeenCalledWith("/usr/local/bin/npm", ["root", "-g"]);
+  });
+
+  it("returns npmBin=undefined and skips npm root -g when npm is missing", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the npmBin === undefined branch
+    whichMock.mockResolvedValue(undefined);
+
+    const options = await createDefaultUpgradeCliOptions({
+      currentVersion: "3.1.8",
+      cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+    });
+
+    expect(options.npmBin).toBeUndefined();
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("wires runInstall to runNpmInstallGlobal with the default spawner", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+    const fakeSpawner = vi.fn<NpmSpawner>();
+    createDefaultNpmSpawnerMock.mockReturnValue(fakeSpawner);
+    runNpmInstallGlobalMock.mockResolvedValue({ exitCode: 0, sawEacces: false });
+
+    const options = await createDefaultUpgradeCliOptions({
+      currentVersion: "3.1.8",
+      cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+    });
+    const result = await options.runInstall({
+      packageName: PACKAGE_NAME,
+      version: "3.2.0",
+      npmBin: "/usr/local/bin/npm",
+    });
+
+    expect(createDefaultNpmSpawnerMock).toHaveBeenCalledWith(process.stderr);
+    expect(runNpmInstallGlobalMock).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      version: "3.2.0",
+      npmBin: "/usr/local/bin/npm",
+      spawner: fakeSpawner,
+    });
+    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false });
+  });
+});

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -141,27 +141,6 @@ describe(upgradeCli, () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("refuses when installation is a dev symlink (npm link)", async () => {
-    await upgradeCli(["3.2.0"], makeOptions({ installKind: "linked" }));
-    expect(consoleErr.output()).toMatch(/npm link/i);
-    expect(process.exitCode).toBe(1);
-  });
-
-  it("refuses when running from an npx temp install", async () => {
-    await upgradeCli(["3.2.0"], makeOptions({ installKind: "npx" }));
-    expect(consoleErr.output()).toMatch(/npx/i);
-    expect(process.exitCode).toBe(1);
-  });
-
-  it("refuses when install kind cannot be determined", async () => {
-    await upgradeCli(
-      ["3.2.0"],
-      makeOptions({ installKind: "unknown", installPath: "/some/weird/place" }),
-    );
-    expect(consoleErr.output()).toContain("/some/weird/place");
-    expect(process.exitCode).toBe(1);
-  });
-
   it("refuses when npm is not on PATH", async () => {
     await upgradeCli(["3.2.0"], makeOptions({ npmBin: undefined }));
     expect(consoleErr.output()).toMatch(/npm/i);
@@ -255,17 +234,6 @@ describe(upgradeCli, () => {
     expect(consoleLog.output()).toMatch(/already on 3\.1\.8/i);
     expect(resolveInstall).not.toHaveBeenCalled();
     expect(runInstall).not.toHaveBeenCalled();
-  });
-
-  it("installs a distinct prerelease pin with the same numeric version", async () => {
-    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
-    await upgradeCli(["3.2.0-beta.2"], makeOptions({ currentVersion: "3.2.0-beta.1", runInstall }));
-    expect(consoleLog.output()).toBe("");
-    expect(runInstall).toHaveBeenCalledWith({
-      packageName: PACKAGE_NAME,
-      version: "3.2.0-beta.2",
-      npmBin: "/usr/local/bin/npm",
-    });
   });
 
   it("rejects a malformed pinned version", async () => {

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -8,7 +8,12 @@ import { which } from "../lib/host.ts";
 import { createDefaultNpmSpawner, type NpmSpawner, runNpmInstallGlobal } from "../lib/npmGlobal.ts";
 import { captureConsoleError, captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 
-import { createDefaultUpgradeCliOptions, upgradeCli, type UpgradeCliOptions } from "./upgrade.ts";
+import {
+  createDefaultUpgradeCliOptions,
+  upgradeCli,
+  type UpgradeCliOptions,
+  type UpgradeInstallDetails,
+} from "./upgrade.ts";
 
 type RunCommandFn = (
   command: string,
@@ -46,23 +51,34 @@ const PACKAGE_NAME = "@clipboard-health/groundcrew";
 
 type FetcherFn = UpgradeCliOptions["fetcher"];
 type RunInstallFn = UpgradeCliOptions["runInstall"];
+type ResolveInstallFn = UpgradeCliOptions["resolveInstall"];
+type MakeOptionsOverrides = Partial<Omit<UpgradeCliOptions, "resolveInstall">> &
+  Partial<UpgradeInstallDetails> & {
+    resolveInstall?: ResolveInstallFn;
+  };
 
 let testCacheDir: string;
 let testCachePath: string;
 
-function makeOptions(overrides: Partial<UpgradeCliOptions> = {}): UpgradeCliOptions {
+function makeOptions(overrides: MakeOptionsOverrides = {}): UpgradeCliOptions {
+  const { installKind, installPath, npmBin, resolveInstall, ...optionOverrides } = overrides;
+  const resolvedInstall =
+    resolveInstall ??
+    vi.fn<ResolveInstallFn>().mockResolvedValue({
+      installKind: installKind ?? "global",
+      installPath: installPath ?? "/usr/local/lib/node_modules/@clipboard-health/groundcrew",
+      npmBin: Object.hasOwn(overrides, "npmBin") ? npmBin : "/usr/local/bin/npm",
+    });
   return {
     currentVersion: "3.1.8",
     packageName: PACKAGE_NAME,
-    installKind: "global",
-    installPath: "/usr/local/lib/node_modules/@clipboard-health/groundcrew",
-    npmBin: "/usr/local/bin/npm",
+    resolveInstall: resolvedInstall,
     fetcher: vi.fn<FetcherFn>().mockResolvedValue("3.1.8"),
     runInstall: vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false }),
     fetchTimeoutMs: 5000,
     cachePath: testCachePath,
     now: () => 1_700_000_000_000,
-    ...overrides,
+    ...optionOverrides,
   };
 }
 
@@ -91,9 +107,34 @@ describe(upgradeCli, () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("does not resolve default options on --help", async () => {
+    const optionsFactory = vi.fn<() => Promise<UpgradeCliOptions>>();
+    await upgradeCli(["--help"], optionsFactory);
+    expect(optionsFactory).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve default options for argument errors", async () => {
+    const optionsFactory = vi.fn<() => Promise<UpgradeCliOptions>>();
+    await upgradeCli(["--bogus"], optionsFactory);
+    expect(optionsFactory).not.toHaveBeenCalled();
+  });
+
+  it("resolves lazy options only after parsing succeeds", async () => {
+    const options = makeOptions({ currentVersion: "3.1.8" });
+    const optionsFactory = vi.fn<() => Promise<UpgradeCliOptions>>().mockResolvedValue(options);
+    await upgradeCli(["--check"], optionsFactory);
+    expect(optionsFactory).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resolve install details for --check", async () => {
+    const resolveInstall = vi.fn<ResolveInstallFn>();
+    await upgradeCli(["--check"], makeOptions({ resolveInstall }));
+    expect(resolveInstall).not.toHaveBeenCalled();
+  });
+
   it("refuses when not globally installed", async () => {
     const runInstall = vi.fn<RunInstallFn>();
-    await upgradeCli([], makeOptions({ installKind: "project", runInstall }));
+    await upgradeCli(["3.2.0"], makeOptions({ installKind: "project", runInstall }));
     expect(consoleErr.output()).toMatch(/not installed globally/i);
     expect(consoleErr.output()).toContain(PACKAGE_NAME);
     expect(runInstall).not.toHaveBeenCalled();
@@ -101,25 +142,28 @@ describe(upgradeCli, () => {
   });
 
   it("refuses when installation is a dev symlink (npm link)", async () => {
-    await upgradeCli([], makeOptions({ installKind: "linked" }));
+    await upgradeCli(["3.2.0"], makeOptions({ installKind: "linked" }));
     expect(consoleErr.output()).toMatch(/npm link/i);
     expect(process.exitCode).toBe(1);
   });
 
   it("refuses when running from an npx temp install", async () => {
-    await upgradeCli([], makeOptions({ installKind: "npx" }));
+    await upgradeCli(["3.2.0"], makeOptions({ installKind: "npx" }));
     expect(consoleErr.output()).toMatch(/npx/i);
     expect(process.exitCode).toBe(1);
   });
 
   it("refuses when install kind cannot be determined", async () => {
-    await upgradeCli([], makeOptions({ installKind: "unknown", installPath: "/some/weird/place" }));
+    await upgradeCli(
+      ["3.2.0"],
+      makeOptions({ installKind: "unknown", installPath: "/some/weird/place" }),
+    );
     expect(consoleErr.output()).toContain("/some/weird/place");
     expect(process.exitCode).toBe(1);
   });
 
   it("refuses when npm is not on PATH", async () => {
-    await upgradeCli([], makeOptions({ npmBin: undefined }));
+    await upgradeCli(["3.2.0"], makeOptions({ npmBin: undefined }));
     expect(consoleErr.output()).toMatch(/npm/i);
     expect(process.exitCode).toBe(1);
   });
@@ -127,8 +171,13 @@ describe(upgradeCli, () => {
   it("prints 'up to date' and skips install when already on latest", async () => {
     const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.1.8");
     const runInstall = vi.fn<RunInstallFn>();
-    await upgradeCli([], makeOptions({ currentVersion: "3.1.8", fetcher, runInstall }));
+    const resolveInstall = vi.fn<ResolveInstallFn>();
+    await upgradeCli(
+      [],
+      makeOptions({ currentVersion: "3.1.8", fetcher, resolveInstall, runInstall }),
+    );
     expect(consoleLog.output()).toMatch(/up to date.*3\.1\.8/i);
+    expect(resolveInstall).not.toHaveBeenCalled();
     expect(runInstall).not.toHaveBeenCalled();
     expect(process.exitCode).toBeUndefined();
   });
@@ -197,10 +246,26 @@ describe(upgradeCli, () => {
   });
 
   it("skips install when pinned version equals current", async () => {
+    const resolveInstall = vi.fn<ResolveInstallFn>();
     const runInstall = vi.fn<RunInstallFn>();
-    await upgradeCli(["3.1.8"], makeOptions({ currentVersion: "3.1.8", runInstall }));
+    await upgradeCli(
+      ["3.1.8"],
+      makeOptions({ currentVersion: "3.1.8", resolveInstall, runInstall }),
+    );
     expect(consoleLog.output()).toMatch(/already on 3\.1\.8/i);
+    expect(resolveInstall).not.toHaveBeenCalled();
     expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("installs a distinct prerelease pin with the same numeric version", async () => {
+    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    await upgradeCli(["3.2.0-beta.2"], makeOptions({ currentVersion: "3.2.0-beta.1", runInstall }));
+    expect(consoleLog.output()).toBe("");
+    expect(runInstall).toHaveBeenCalledWith({
+      packageName: PACKAGE_NAME,
+      version: "3.2.0-beta.2",
+      npmBin: "/usr/local/bin/npm",
+    });
   });
 
   it("rejects a malformed pinned version", async () => {
@@ -276,6 +341,7 @@ describe(upgradeCli, () => {
     expect(JSON.parse(readFileSync(testCachePath, "utf8"))).toStrictEqual({
       latest: "3.2.0",
       fetchedAt: 12_345,
+      registry: "https://registry.npmjs.org",
     });
   });
 
@@ -285,6 +351,25 @@ describe(upgradeCli, () => {
     expect(JSON.parse(readFileSync(testCachePath, "utf8"))).toStrictEqual({
       latest: "3.2.0",
       fetchedAt: 99_999,
+      registry: "https://registry.npmjs.org",
+    });
+  });
+
+  it("records the normalized configured registry when priming the cache", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    await upgradeCli(
+      ["--check"],
+      makeOptions({
+        currentVersion: "3.1.8",
+        fetcher,
+        now: () => 12_345,
+        registry: "https://npm.mirror.example/",
+      }),
+    );
+    expect(JSON.parse(readFileSync(testCachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 12_345,
+      registry: "https://npm.mirror.example",
     });
   });
 
@@ -328,31 +413,37 @@ describe(createDefaultUpgradeCliOptions, () => {
 
     const options = await createDefaultUpgradeCliOptions({
       currentVersion: "3.1.8",
+      packageName: PACKAGE_NAME,
       cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
     });
 
     expect(options.currentVersion).toBe("3.1.8");
     expect(options.packageName).toBe(PACKAGE_NAME);
-    expect(options.installPath).toBe("/opt/pkg");
-    expect(options.npmBin).toBe("/usr/local/bin/npm");
     expect(options.registry).toBe("https://npm.mirror.example");
     expect(options.fetchTimeoutMs).toBe(5000);
     expect(options.cachePath).toMatch(/groundcrew[/\\]upgrade-check\.json$/);
     expect(options.now()).toBeGreaterThan(1_700_000_000_000);
+    expect(whichMock).not.toHaveBeenCalled();
+
+    const install = await options.resolveInstall();
+    expect(install.installPath).toBe("/opt/pkg");
+    expect(install.npmBin).toBe("/usr/local/bin/npm");
+    expect(install.installKind).toBe("unknown");
     expect(whichMock).toHaveBeenCalledWith("npm");
     expect(runCommandMock).toHaveBeenCalledWith("/usr/local/bin/npm", ["root", "-g"]);
   });
 
-  it("returns npmBin=undefined and skips npm root -g when npm is missing", async () => {
+  it("resolves npmBin=undefined and skips npm root -g when npm is missing", async () => {
     // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the npmBin === undefined branch
     whichMock.mockResolvedValue(undefined);
 
     const options = await createDefaultUpgradeCliOptions({
       currentVersion: "3.1.8",
+      packageName: PACKAGE_NAME,
       cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
     });
 
-    expect(options.npmBin).toBeUndefined();
+    await expect(options.resolveInstall()).resolves.toMatchObject({ npmBin: undefined });
     expect(runCommandMock).not.toHaveBeenCalled();
   });
 
@@ -365,6 +456,7 @@ describe(createDefaultUpgradeCliOptions, () => {
 
     const options = await createDefaultUpgradeCliOptions({
       currentVersion: "3.1.8",
+      packageName: PACKAGE_NAME,
       cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
     });
     const result = await options.runInstall({

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { runCommand, type RunCommandOptions } from "../lib/commandRunner.ts";
@@ -44,6 +47,9 @@ const PACKAGE_NAME = "@clipboard-health/groundcrew";
 type FetcherFn = UpgradeCliOptions["fetcher"];
 type RunInstallFn = UpgradeCliOptions["runInstall"];
 
+let testCacheDir: string;
+let testCachePath: string;
+
 function makeOptions(overrides: Partial<UpgradeCliOptions> = {}): UpgradeCliOptions {
   return {
     currentVersion: "3.1.8",
@@ -54,6 +60,8 @@ function makeOptions(overrides: Partial<UpgradeCliOptions> = {}): UpgradeCliOpti
     fetcher: vi.fn<FetcherFn>().mockResolvedValue("3.1.8"),
     runInstall: vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false }),
     fetchTimeoutMs: 5000,
+    cachePath: testCachePath,
+    now: () => 1_700_000_000_000,
     ...overrides,
   };
 }
@@ -63,6 +71,8 @@ describe(upgradeCli, () => {
   let consoleErr: ReturnType<typeof captureConsoleError>;
 
   beforeEach(() => {
+    testCacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cli-"));
+    testCachePath = join(testCacheDir, "upgrade-check.json");
     consoleLog = captureConsoleLog();
     consoleErr = captureConsoleError();
     process.exitCode = undefined;
@@ -72,6 +82,7 @@ describe(upgradeCli, () => {
     consoleLog.restore();
     consoleErr.restore();
     process.exitCode = undefined;
+    rmSync(testCacheDir, { recursive: true, force: true });
   });
 
   it("prints help and exits 0 on --help", async () => {
@@ -255,6 +266,40 @@ describe(upgradeCli, () => {
       registry: "https://my.mirror.example",
     });
   });
+
+  it("primes the upgrade-check cache after a successful --check", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    await upgradeCli(
+      ["--check"],
+      makeOptions({ currentVersion: "3.1.8", fetcher, now: () => 12_345 }),
+    );
+    expect(JSON.parse(readFileSync(testCachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 12_345,
+    });
+  });
+
+  it("primes the upgrade-check cache after a successful no-arg install fetch", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    await upgradeCli([], makeOptions({ currentVersion: "3.1.8", fetcher, now: () => 99_999 }));
+    expect(JSON.parse(readFileSync(testCachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 99_999,
+    });
+  });
+
+  it("does not prime the cache when the registry fetch fails", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockRejectedValue(new Error("network down"));
+    await upgradeCli(["--check"], makeOptions({ fetcher }));
+    expect(() => readFileSync(testCachePath, "utf8")).toThrow(/ENOENT/);
+  });
+
+  it("does not touch the cache when a pinned version skips the fetch", async () => {
+    const fetcher = vi.fn<FetcherFn>();
+    await upgradeCli(["3.2.0"], makeOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(() => readFileSync(testCachePath, "utf8")).toThrow(/ENOENT/);
+  });
 });
 
 describe(createDefaultUpgradeCliOptions, () => {
@@ -279,6 +324,8 @@ describe(createDefaultUpgradeCliOptions, () => {
     expect(options.npmBin).toBe("/usr/local/bin/npm");
     expect(options.registry).toBe("https://npm.mirror.example");
     expect(options.fetchTimeoutMs).toBe(5000);
+    expect(options.cachePath).toMatch(/groundcrew[/\\]upgrade-check\.json$/);
+    expect(options.now()).toBeGreaterThan(1_700_000_000_000);
     expect(whichMock).toHaveBeenCalledWith("npm");
     expect(runCommandMock).toHaveBeenCalledWith("/usr/local/bin/npm", ["root", "-g"]);
   });

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -299,6 +299,19 @@ describe(upgradeCli, () => {
     await upgradeCli(["3.2.0"], makeOptions({ currentVersion: "3.1.8", fetcher }));
     expect(fetcher).not.toHaveBeenCalled();
     expect(() => readFileSync(testCachePath, "utf8")).toThrow(/ENOENT/);
+  });
+
+  it("succeeds when cache priming fails (best-effort write)", async () => {
+    // Point cachePath under a regular file so mkdirSync inside writeUpgradeCheckCache throws.
+    const blocker = join(testCacheDir, "blocker");
+    writeFileSync(blocker, "");
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+    await upgradeCli(
+      ["--check"],
+      makeOptions({ currentVersion: "3.1.8", fetcher, cachePath: join(blocker, "cache.json") }),
+    );
+    expect(consoleLog.output()).toMatch(/3\.2\.0 available/);
+    expect(process.exitCode).toBeUndefined();
   });
 });
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,261 @@
+import { runCommand } from "../lib/commandRunner.ts";
+import { which } from "../lib/host.ts";
+import {
+  classifyInstall,
+  createDefaultNpmSpawner,
+  detectInstallPath,
+  detectIsSymlink,
+  detectNpmRootGlobal,
+  type InstallKind,
+  type NpmRunResult,
+  runNpmInstallGlobal,
+} from "../lib/npmGlobal.ts";
+import { compareVersions, fetchLatestVersion, parseVersion } from "../lib/upgrade.ts";
+import { readEnvironmentVariable, writeError, writeOutput } from "../lib/util.ts";
+
+const PACKAGE_NAME = "@clipboard-health/groundcrew";
+const EXPLICIT_FETCH_TIMEOUT_MS = 5000;
+
+interface FetchOptions {
+  timeoutMs: number;
+  registry?: string | undefined;
+}
+
+export interface UpgradeCliOptions {
+  currentVersion: string;
+  packageName: string;
+  installKind: InstallKind;
+  installPath: string;
+  npmBin: string | undefined;
+  fetcher: (packageName: string, options: FetchOptions) => Promise<string>;
+  runInstall: (options: {
+    packageName: string;
+    version: string;
+    npmBin: string;
+  }) => Promise<NpmRunResult>;
+  registry?: string | undefined;
+  fetchTimeoutMs: number;
+}
+
+interface ParsedArgs {
+  kind: "help" | "check" | "install";
+  pinnedVersion?: string | undefined;
+  error?: string | undefined;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let check = false;
+  let pinnedVersion: string | undefined;
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      return { kind: "help" };
+    }
+    if (arg === "--check") {
+      check = true;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      return { kind: "install", error: `crew upgrade: unknown argument: ${arg}` };
+    }
+    if (pinnedVersion !== undefined) {
+      return { kind: "install", error: "crew upgrade: too many positional arguments" };
+    }
+    pinnedVersion = arg;
+  }
+  if (check && pinnedVersion !== undefined) {
+    return { kind: "install", error: "crew upgrade: --check does not accept a version argument" };
+  }
+  if (check) {
+    return { kind: "check" };
+  }
+  return { kind: "install", pinnedVersion };
+}
+
+function printHelp(): void {
+  writeOutput("Usage: crew upgrade [<version>] [--check]");
+  writeOutput("");
+  writeOutput("Install the latest version of crew (npm @clipboard-health/groundcrew).");
+  writeOutput("");
+  writeOutput("Arguments:");
+  writeOutput("  <version>      Install an exact version (upgrade or downgrade)");
+  writeOutput("");
+  writeOutput("Options:");
+  writeOutput("  --check        Report availability without installing");
+  writeOutput("  -h, --help     Show this help");
+}
+
+function refusalMessage(
+  kind: Exclude<InstallKind, "global">,
+  installPath: string,
+  packageName: string,
+): string {
+  switch (kind) {
+    case "linked": {
+      return `crew is installed via 'npm link' at ${installPath}. Use 'node --run' from the source checkout instead of 'crew upgrade'.`;
+    }
+    case "npx": {
+      return `crew is running from an npx temp install. Run 'npm install -g ${packageName}' for a stable global install before using 'crew upgrade'.`;
+    }
+    case "project": {
+      return `crew is installed as a project dependency at ${installPath}, not installed globally. Run 'npm install -g ${packageName}' to use 'crew upgrade'.`;
+    }
+    case "unknown": {
+      return `crew is not installed globally — detected at ${installPath}. Run 'npm install -g ${packageName}' to use 'crew upgrade'.`;
+    }
+    /* v8 ignore next 3 @preserve */
+    default: {
+      throw new Error(`unhandled install kind: ${kind as string}`);
+    }
+  }
+}
+
+export async function upgradeCli(argv: string[], options: UpgradeCliOptions): Promise<void> {
+  const parsed = parseArgs(argv);
+  if (parsed.error !== undefined) {
+    writeError(parsed.error);
+    process.exitCode = 1;
+    return;
+  }
+  if (parsed.kind === "help") {
+    printHelp();
+    return;
+  }
+  if (options.installKind !== "global") {
+    writeError(refusalMessage(options.installKind, options.installPath, options.packageName));
+    process.exitCode = 1;
+    return;
+  }
+  const { npmBin } = options;
+  if (npmBin === undefined) {
+    writeError("crew upgrade: npm is required on PATH but was not found.");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (parsed.kind === "check") {
+    await runCheck(options);
+    return;
+  }
+
+  let targetVersion: string;
+  if (parsed.pinnedVersion === undefined) {
+    const fetched = await fetchOrFail(options);
+    if (fetched === undefined) {
+      return;
+    }
+    if (compareVersions(options.currentVersion, fetched) >= 0) {
+      writeOutput(`crew is up to date (${fetched})`);
+      return;
+    }
+    targetVersion = fetched;
+  } else {
+    const resolved = resolvePinnedVersion(options, parsed.pinnedVersion);
+    if (resolved === undefined) {
+      return;
+    }
+    targetVersion = resolved;
+  }
+
+  await runInstallAndReport(options, npmBin, targetVersion);
+}
+
+async function runCheck(options: UpgradeCliOptions): Promise<void> {
+  const latest = await fetchOrFail(options);
+  if (latest === undefined) {
+    return;
+  }
+  if (compareVersions(options.currentVersion, latest) >= 0) {
+    writeOutput(`crew is up to date (${latest})`);
+    return;
+  }
+  writeOutput(`${latest} available (you are on ${options.currentVersion}); run \`crew upgrade\``);
+}
+
+async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefined> {
+  try {
+    return await options.fetcher(options.packageName, {
+      timeoutMs: options.fetchTimeoutMs,
+      registry: options.registry,
+    });
+  } catch (error) {
+    writeError(`crew upgrade: could not reach npm registry: ${String(error)}`);
+    process.exitCode = 1;
+    return undefined;
+  }
+}
+
+function resolvePinnedVersion(
+  options: UpgradeCliOptions,
+  pinnedVersion: string,
+): string | undefined {
+  try {
+    parseVersion(pinnedVersion);
+  } catch (error) {
+    writeError(`crew upgrade: ${String(error)}`);
+    process.exitCode = 1;
+    return undefined;
+  }
+  const cmp = compareVersions(options.currentVersion, pinnedVersion);
+  if (cmp === 0) {
+    writeOutput(`crew is already on ${pinnedVersion}`);
+    return undefined;
+  }
+  if (cmp > 0) {
+    writeOutput(`downgrading ${options.currentVersion} → ${pinnedVersion}`);
+  }
+  return pinnedVersion;
+}
+
+async function runInstallAndReport(
+  options: UpgradeCliOptions,
+  npmBin: string,
+  version: string,
+): Promise<void> {
+  const result = await options.runInstall({
+    packageName: options.packageName,
+    version,
+    npmBin,
+  });
+  if (result.exitCode === 0) {
+    return;
+  }
+  if (result.sawEacces) {
+    writeError(
+      "crew upgrade: install failed with EACCES (permission denied). Your global npm prefix may require elevated permissions — see https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally",
+    );
+  }
+  process.exitCode = result.exitCode;
+}
+
+export interface CreateUpgradeOptionsArgs {
+  currentVersion: string;
+  cliMetaUrl: string;
+}
+
+export async function createDefaultUpgradeCliOptions(
+  args: CreateUpgradeOptionsArgs,
+): Promise<UpgradeCliOptions> {
+  const installPath = detectInstallPath(args.cliMetaUrl);
+  const npmBin = await which("npm");
+  const npmRootGlobal = npmBin === undefined ? undefined : detectNpmRootGlobal(npmBin, runCommand);
+  const installKind = classifyInstall({
+    installPath,
+    npmRootGlobal,
+    isSymlink: detectIsSymlink,
+  });
+  return {
+    currentVersion: args.currentVersion,
+    packageName: PACKAGE_NAME,
+    installKind,
+    installPath,
+    npmBin,
+    fetcher: fetchLatestVersion,
+    runInstall: async (options) =>
+      await runNpmInstallGlobal({
+        ...options,
+        spawner: createDefaultNpmSpawner(process.stderr),
+      }),
+    fetchTimeoutMs: EXPLICIT_FETCH_TIMEOUT_MS,
+    registry: readEnvironmentVariable("npm_config_registry"),
+  };
+}

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -101,24 +101,7 @@ function refusalMessage(
   installPath: string,
   packageName: string,
 ): string {
-  switch (kind) {
-    case "linked": {
-      return `crew is installed via 'npm link' at ${installPath}. Use 'node --run' from the source checkout instead of 'crew upgrade'.`;
-    }
-    case "npx": {
-      return `crew is running from an npx temp install. Run 'npm install -g ${packageName}' for a stable global install before using 'crew upgrade'.`;
-    }
-    case "project": {
-      return `crew is installed as a project dependency at ${installPath}, not installed globally. Run 'npm install -g ${packageName}' to use 'crew upgrade'.`;
-    }
-    case "unknown": {
-      return `crew is not installed globally — detected at ${installPath}. Run 'npm install -g ${packageName}' to use 'crew upgrade'.`;
-    }
-    /* v8 ignore next 3 @preserve */
-    default: {
-      throw new Error(`unhandled install kind: ${kind as string}`);
-    }
-  }
+  return `crew is not installed globally (${kind} at ${installPath}). Run 'npm install -g ${packageName}' to use 'crew upgrade'.`;
 }
 
 async function resolveOptions(options: UpgradeCliOptionsInput): Promise<UpgradeCliOptions> {
@@ -202,9 +185,8 @@ async function runCheck(options: UpgradeCliOptions): Promise<void> {
 }
 
 async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefined> {
-  let latest: string;
   try {
-    latest = await fetchAndPrimeUpgradeCheckCache({
+    return await fetchAndPrimeUpgradeCheckCache({
       packageName: options.packageName,
       cachePath: options.cachePath,
       fetchTimeoutMs: options.fetchTimeoutMs,
@@ -217,7 +199,6 @@ async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefin
     process.exitCode = 1;
     return undefined;
   }
-  return latest;
 }
 
 function resolvePinnedVersion(

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -13,27 +13,20 @@ import {
 import {
   compareVersions,
   defaultUpgradeCheckCachePath,
+  fetchAndPrimeUpgradeCheckCache,
   fetchLatestVersion,
   parseVersion,
-  writeUpgradeCheckCache,
+  type VersionFetcher,
 } from "../lib/upgrade.ts";
-import { readEnvironmentVariable, writeError, writeOutput } from "../lib/util.ts";
+import { errorMessage, readEnvironmentVariable, writeError, writeOutput } from "../lib/util.ts";
 
-const PACKAGE_NAME = "@clipboard-health/groundcrew";
 const EXPLICIT_FETCH_TIMEOUT_MS = 5000;
-
-interface FetchOptions {
-  timeoutMs: number;
-  registry?: string | undefined;
-}
 
 export interface UpgradeCliOptions {
   currentVersion: string;
   packageName: string;
-  installKind: InstallKind;
-  installPath: string;
-  npmBin: string | undefined;
-  fetcher: (packageName: string, options: FetchOptions) => Promise<string>;
+  resolveInstall: () => Promise<UpgradeInstallDetails>;
+  fetcher: VersionFetcher;
   runInstall: (options: {
     packageName: string;
     version: string;
@@ -48,11 +41,19 @@ export interface UpgradeCliOptions {
   now: () => number;
 }
 
-interface ParsedArgs {
-  kind: "help" | "check" | "install";
-  pinnedVersion?: string | undefined;
-  error?: string | undefined;
+export interface UpgradeInstallDetails {
+  installKind: InstallKind;
+  installPath: string;
+  npmBin: string | undefined;
 }
+
+type ParsedArgs =
+  | { kind: "help" }
+  | { kind: "check" }
+  | { kind: "install"; pinnedVersion?: string | undefined }
+  | { kind: "error"; message: string };
+
+export type UpgradeCliOptionsInput = UpgradeCliOptions | (() => Promise<UpgradeCliOptions>);
 
 function parseArgs(argv: string[]): ParsedArgs {
   let check = false;
@@ -66,15 +67,15 @@ function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
     if (arg.startsWith("-")) {
-      return { kind: "install", error: `crew upgrade: unknown argument: ${arg}` };
+      return { kind: "error", message: `crew upgrade: unknown argument: ${arg}` };
     }
     if (pinnedVersion !== undefined) {
-      return { kind: "install", error: "crew upgrade: too many positional arguments" };
+      return { kind: "error", message: "crew upgrade: too many positional arguments" };
     }
     pinnedVersion = arg;
   }
   if (check && pinnedVersion !== undefined) {
-    return { kind: "install", error: "crew upgrade: --check does not accept a version argument" };
+    return { kind: "error", message: "crew upgrade: --check does not accept a version argument" };
   }
   if (check) {
     return { kind: "check" };
@@ -85,7 +86,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 function printHelp(): void {
   writeOutput("Usage: crew upgrade [<version>] [--check]");
   writeOutput("");
-  writeOutput("Install the latest version of crew (npm @clipboard-health/groundcrew).");
+  writeOutput("Install the latest version of crew.");
   writeOutput("");
   writeOutput("Arguments:");
   writeOutput("  <version>      Install an exact version (upgrade or downgrade)");
@@ -120,10 +121,20 @@ function refusalMessage(
   }
 }
 
-export async function upgradeCli(argv: string[], options: UpgradeCliOptions): Promise<void> {
+async function resolveOptions(options: UpgradeCliOptionsInput): Promise<UpgradeCliOptions> {
+  if (typeof options === "function") {
+    return await options();
+  }
+  return options;
+}
+
+export async function upgradeCli(
+  argv: string[],
+  optionsInput: UpgradeCliOptionsInput,
+): Promise<void> {
   const parsed = parseArgs(argv);
-  if (parsed.error !== undefined) {
-    writeError(parsed.error);
+  if (parsed.kind === "error") {
+    writeError(parsed.message);
     process.exitCode = 1;
     return;
   }
@@ -131,18 +142,7 @@ export async function upgradeCli(argv: string[], options: UpgradeCliOptions): Pr
     printHelp();
     return;
   }
-  if (options.installKind !== "global") {
-    writeError(refusalMessage(options.installKind, options.installPath, options.packageName));
-    process.exitCode = 1;
-    return;
-  }
-  const { npmBin } = options;
-  if (npmBin === undefined) {
-    writeError("crew upgrade: npm is required on PATH but was not found.");
-    process.exitCode = 1;
-    return;
-  }
-
+  const options = await resolveOptions(optionsInput);
   if (parsed.kind === "check") {
     await runCheck(options);
     return;
@@ -167,7 +167,26 @@ export async function upgradeCli(argv: string[], options: UpgradeCliOptions): Pr
     targetVersion = resolved;
   }
 
+  const npmBin = await resolveGlobalNpmBin(options);
+  if (npmBin === undefined) {
+    return;
+  }
   await runInstallAndReport(options, npmBin, targetVersion);
+}
+
+async function resolveGlobalNpmBin(options: UpgradeCliOptions): Promise<string | undefined> {
+  const install = await options.resolveInstall();
+  if (install.installKind !== "global") {
+    writeError(refusalMessage(install.installKind, install.installPath, options.packageName));
+    process.exitCode = 1;
+    return undefined;
+  }
+  if (install.npmBin === undefined) {
+    writeError("crew upgrade: npm is required on PATH but was not found.");
+    process.exitCode = 1;
+    return undefined;
+  }
+  return install.npmBin;
 }
 
 async function runCheck(options: UpgradeCliOptions): Promise<void> {
@@ -185,19 +204,18 @@ async function runCheck(options: UpgradeCliOptions): Promise<void> {
 async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefined> {
   let latest: string;
   try {
-    latest = await options.fetcher(options.packageName, {
-      timeoutMs: options.fetchTimeoutMs,
+    latest = await fetchAndPrimeUpgradeCheckCache({
+      packageName: options.packageName,
+      cachePath: options.cachePath,
+      fetchTimeoutMs: options.fetchTimeoutMs,
       registry: options.registry,
+      now: options.now,
+      fetcher: options.fetcher,
     });
   } catch (error) {
-    writeError(`crew upgrade: could not reach npm registry: ${String(error)}`);
+    writeError(`crew upgrade: could not reach npm registry: ${errorMessage(error)}`);
     process.exitCode = 1;
     return undefined;
-  }
-  try {
-    writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
-  } catch {
-    // Cache priming is best-effort; do not fail the command on disk errors.
   }
   return latest;
 }
@@ -209,15 +227,15 @@ function resolvePinnedVersion(
   try {
     parseVersion(pinnedVersion);
   } catch (error) {
-    writeError(`crew upgrade: ${String(error)}`);
+    writeError(`crew upgrade: ${errorMessage(error)}`);
     process.exitCode = 1;
     return undefined;
   }
-  const cmp = compareVersions(options.currentVersion, pinnedVersion);
-  if (cmp === 0) {
+  if (options.currentVersion === pinnedVersion) {
     writeOutput(`crew is already on ${pinnedVersion}`);
     return undefined;
   }
+  const cmp = compareVersions(options.currentVersion, pinnedVersion);
   if (cmp > 0) {
     writeOutput(`downgrading ${options.currentVersion} → ${pinnedVersion}`);
   }
@@ -247,26 +265,28 @@ async function runInstallAndReport(
 
 export interface CreateUpgradeOptionsArgs {
   currentVersion: string;
+  packageName: string;
   cliMetaUrl: string;
 }
 
 export async function createDefaultUpgradeCliOptions(
   args: CreateUpgradeOptionsArgs,
 ): Promise<UpgradeCliOptions> {
-  const installPath = detectInstallPath(args.cliMetaUrl);
-  const npmBin = await which("npm");
-  const npmRootGlobal = npmBin === undefined ? undefined : detectNpmRootGlobal(npmBin, runCommand);
-  const installKind = classifyInstall({
-    installPath,
-    npmRootGlobal,
-    isSymlink: detectIsSymlink,
-  });
   return {
     currentVersion: args.currentVersion,
-    packageName: PACKAGE_NAME,
-    installKind,
-    installPath,
-    npmBin,
+    packageName: args.packageName,
+    resolveInstall: async () => {
+      const installPath = detectInstallPath(args.cliMetaUrl);
+      const npmBin = await which("npm");
+      const npmRootGlobal =
+        npmBin === undefined ? undefined : detectNpmRootGlobal(npmBin, runCommand);
+      const installKind = classifyInstall({
+        installPath,
+        npmRootGlobal,
+        isSymlink: detectIsSymlink,
+      });
+      return { installKind, installPath, npmBin };
+    },
     fetcher: fetchLatestVersion,
     runInstall: async (options) =>
       await runNpmInstallGlobal({

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -10,7 +10,13 @@ import {
   type NpmRunResult,
   runNpmInstallGlobal,
 } from "../lib/npmGlobal.ts";
-import { compareVersions, fetchLatestVersion, parseVersion } from "../lib/upgrade.ts";
+import {
+  compareVersions,
+  defaultUpgradeCheckCachePath,
+  fetchLatestVersion,
+  parseVersion,
+  writeUpgradeCheckCache,
+} from "../lib/upgrade.ts";
 import { readEnvironmentVariable, writeError, writeOutput } from "../lib/util.ts";
 
 const PACKAGE_NAME = "@clipboard-health/groundcrew";
@@ -35,6 +41,11 @@ export interface UpgradeCliOptions {
   }) => Promise<NpmRunResult>;
   registry?: string | undefined;
   fetchTimeoutMs: number;
+  /** Path of the upgrade-availability cache that the nudge reads. We prime
+   * it from `--check` and the default install path so the next non-upgrade
+   * subcommand can render the nudge without paying the network cost. */
+  cachePath: string;
+  now: () => number;
 }
 
 interface ParsedArgs {
@@ -172,8 +183,9 @@ async function runCheck(options: UpgradeCliOptions): Promise<void> {
 }
 
 async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefined> {
+  let latest: string;
   try {
-    return await options.fetcher(options.packageName, {
+    latest = await options.fetcher(options.packageName, {
       timeoutMs: options.fetchTimeoutMs,
       registry: options.registry,
     });
@@ -182,6 +194,8 @@ async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefin
     process.exitCode = 1;
     return undefined;
   }
+  writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+  return latest;
 }
 
 function resolvePinnedVersion(
@@ -257,5 +271,7 @@ export async function createDefaultUpgradeCliOptions(
       }),
     fetchTimeoutMs: EXPLICIT_FETCH_TIMEOUT_MS,
     registry: readEnvironmentVariable("npm_config_registry"),
+    cachePath: defaultUpgradeCheckCachePath(),
+    now: Date.now,
   };
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -194,7 +194,11 @@ async function fetchOrFail(options: UpgradeCliOptions): Promise<string | undefin
     process.exitCode = 1;
     return undefined;
   }
-  writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+  try {
+    writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+  } catch {
+    // Cache priming is best-effort; do not fail the command on disk errors.
+  }
   return latest;
 }
 

--- a/src/lib/npmGlobal.test.ts
+++ b/src/lib/npmGlobal.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { PassThrough } from "node:stream";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  classifyInstall,
+  createDefaultNpmSpawner,
+  detectInstallPath,
+  detectIsSymlink,
+  detectNpmRootGlobal,
+  type NpmRootRunner,
+  type NpmSpawner,
+  runNpmInstallGlobal,
+} from "./npmGlobal.ts";
+
+const NOT_SYMLINK = () => false;
+const IS_SYMLINK = () => true;
+
+describe(classifyInstall, () => {
+  it("returns 'global' when the install path is under npm root -g and is not a symlink", () => {
+    const result = classifyInstall({
+      installPath: `${sep}usr${sep}local${sep}lib${sep}node_modules${sep}@scope${sep}pkg`,
+      npmRootGlobal: `${sep}usr${sep}local${sep}lib${sep}node_modules`,
+      isSymlink: NOT_SYMLINK,
+    });
+    expect(result).toBe("global");
+  });
+
+  it("returns 'linked' when the install path is under npm root -g and is a symlink", () => {
+    const result = classifyInstall({
+      installPath: `${sep}usr${sep}local${sep}lib${sep}node_modules${sep}@scope${sep}pkg`,
+      npmRootGlobal: `${sep}usr${sep}local${sep}lib${sep}node_modules`,
+      isSymlink: IS_SYMLINK,
+    });
+    expect(result).toBe("linked");
+  });
+
+  it("returns 'npx' when the install path is under the npm _npx cache", () => {
+    const result = classifyInstall({
+      installPath: `${sep}home${sep}u${sep}.npm${sep}_npx${sep}abc${sep}node_modules${sep}@scope${sep}pkg`,
+      npmRootGlobal: `${sep}usr${sep}local${sep}lib${sep}node_modules`,
+      isSymlink: NOT_SYMLINK,
+    });
+    expect(result).toBe("npx");
+  });
+
+  it("returns 'project' for an arbitrary node_modules outside npm root -g", () => {
+    const result = classifyInstall({
+      installPath: `${sep}home${sep}u${sep}proj${sep}node_modules${sep}@scope${sep}pkg`,
+      npmRootGlobal: `${sep}usr${sep}local${sep}lib${sep}node_modules`,
+      isSymlink: NOT_SYMLINK,
+    });
+    expect(result).toBe("project");
+  });
+
+  it("returns 'unknown' when no path heuristic matches", () => {
+    const result = classifyInstall({
+      installPath: `${sep}opt${sep}weird${sep}place${sep}pkg`,
+      npmRootGlobal: `${sep}usr${sep}local${sep}lib${sep}node_modules`,
+      isSymlink: NOT_SYMLINK,
+    });
+    expect(result).toBe("unknown");
+  });
+
+  it("treats npmRootGlobal=undefined as 'no global match' and falls through", () => {
+    const result = classifyInstall({
+      installPath: `${sep}home${sep}u${sep}proj${sep}node_modules${sep}@scope${sep}pkg`,
+      npmRootGlobal: undefined,
+      isSymlink: NOT_SYMLINK,
+    });
+    expect(result).toBe("project");
+  });
+});
+
+describe(runNpmInstallGlobal, () => {
+  it("invokes npm install -g <package>@<version> and forwards the exit code", async () => {
+    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 0, stderrText: "" });
+    const result = await runNpmInstallGlobal({
+      packageName: "@scope/pkg",
+      version: "3.2.0",
+      npmBin: "/usr/local/bin/npm",
+      spawner,
+    });
+    expect(spawner).toHaveBeenCalledWith("/usr/local/bin/npm", [
+      "install",
+      "-g",
+      "@scope/pkg@3.2.0",
+    ]);
+    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false });
+  });
+
+  it("forwards a non-zero exit code", async () => {
+    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 1, stderrText: "boom" });
+    const result = await runNpmInstallGlobal({
+      packageName: "@scope/pkg",
+      version: "3.2.0",
+      npmBin: "npm",
+      spawner,
+    });
+    expect(result).toStrictEqual({ exitCode: 1, sawEacces: false });
+  });
+
+  it("flags sawEacces when stderr contains EACCES", async () => {
+    const spawner = vi
+      .fn<NpmSpawner>()
+      .mockResolvedValueOnce({ exitCode: 243, stderrText: "npm ERR! EACCES: permission denied" });
+    const result = await runNpmInstallGlobal({
+      packageName: "@scope/pkg",
+      version: "3.2.0",
+      npmBin: "npm",
+      spawner,
+    });
+    expect(result).toStrictEqual({ exitCode: 243, sawEacces: true });
+  });
+});
+
+describe(createDefaultNpmSpawner, () => {
+  it("captures stderr text and exit code from a real subprocess", async () => {
+    const passthrough = new PassThrough();
+    const chunks: Buffer[] = [];
+    passthrough.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+
+    const spawner = createDefaultNpmSpawner(passthrough);
+    const result = await spawner(process.execPath, [
+      "--eval",
+      String.raw`process.stderr.write('EACCES: permission denied\n'); process.exit(2);`,
+    ]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderrText).toContain("EACCES");
+    expect(Buffer.concat(chunks).toString("utf8")).toContain("EACCES");
+  });
+
+  it("reports exit code 0 for a successful subprocess", async () => {
+    const spawner = createDefaultNpmSpawner(new PassThrough());
+    const result = await spawner(process.execPath, ["--eval", "process.exit(0)"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderrText).toBe("");
+  });
+
+  it("reports exit code 1 when the subprocess is terminated by a signal", async () => {
+    const spawner = createDefaultNpmSpawner(new PassThrough());
+    const result = await spawner(process.execPath, [
+      "--eval",
+      "process.kill(process.pid, 'SIGTERM')",
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe(detectInstallPath, () => {
+  it("returns the parent of the directory containing the CLI file", () => {
+    const fakeUrl = pathToFileURL("/opt/pkg/dist/cli.js").toString();
+    expect(detectInstallPath(fakeUrl)).toBe(`${sep}opt${sep}pkg`);
+  });
+});
+
+describe(detectNpmRootGlobal, () => {
+  it("returns the runner output on success", () => {
+    const runner = vi.fn<NpmRootRunner>().mockReturnValue("/usr/local/lib/node_modules");
+    expect(detectNpmRootGlobal("npm", runner)).toBe("/usr/local/lib/node_modules");
+    expect(runner).toHaveBeenCalledWith("npm", ["root", "-g"]);
+  });
+
+  it("returns undefined when the runner throws", () => {
+    const runner = vi.fn<NpmRootRunner>().mockImplementation(() => {
+      throw new Error("npm not found");
+    });
+    expect(detectNpmRootGlobal("npm", runner)).toBeUndefined();
+  });
+});
+
+describe(detectIsSymlink, () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "groundcrew-symlink-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns true for a symlink", () => {
+    const target = join(tmp, "target");
+    writeFileSync(target, "");
+    const link = join(tmp, "link");
+    symlinkSync(target, link);
+    expect(detectIsSymlink(link)).toBe(true);
+  });
+
+  it("returns false for a regular file", () => {
+    const file = join(tmp, "file");
+    writeFileSync(file, "");
+    expect(detectIsSymlink(file)).toBe(false);
+  });
+
+  it("returns false when the path does not exist", () => {
+    expect(detectIsSymlink(join(tmp, "missing"))).toBe(false);
+  });
+});
+
+describe("detection helpers (smoke)", () => {
+  it("the test process's own meta-url-based install path is the project root", () => {
+    const meta = import.meta.url;
+    const root = detectInstallPath(meta);
+    // npmGlobal.test.ts lives at <root>/src/lib/, so dirname dirname = <root>/src — confirm structure.
+    expect(fileURLToPath(meta)).toContain(root);
+  });
+});

--- a/src/lib/npmGlobal.test.ts
+++ b/src/lib/npmGlobal.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
-import { PassThrough, Writable } from "node:stream";
+import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -133,97 +133,6 @@ describe(createDefaultNpmSpawner, () => {
     expect(result.exitCode).toBe(2);
     expect(result.stderrText).toContain("EACCES");
     expect(Buffer.concat(chunks).toString("utf8")).toContain("EACCES");
-  });
-
-  it("caps captured stderr while still passing all stderr through", async () => {
-    const passthrough = new PassThrough();
-    const chunks: Buffer[] = [];
-    passthrough.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-
-    const spawner = createDefaultNpmSpawner(passthrough);
-    const result = await spawner(process.execPath, [
-      "--eval",
-      "process.stderr.write('x'.repeat(70 * 1024), () => process.exit(1));",
-    ]);
-
-    expect(result.stderrText.length).toBeLessThan(70 * 1024);
-    expect(Buffer.concat(chunks).toString("utf8")).toHaveLength(70 * 1024);
-  });
-
-  it("pauses stderr while the passthrough stream applies backpressure", async () => {
-    class SlowWritable extends Writable {
-      public readonly chunks: Buffer[] = [];
-      public readonly callbacks: (() => void)[] = [];
-
-      public override _write(
-        chunk: Buffer,
-        _encoding: BufferEncoding,
-        callback: (error?: Error | null) => void,
-      ): void {
-        this.chunks.push(Buffer.from(chunk));
-        this.callbacks.push(() => {
-          callback();
-        });
-      }
-
-      public flush(): void {
-        for (const callback of this.callbacks.splice(0)) {
-          callback();
-        }
-      }
-    }
-
-    const passthrough = new SlowWritable({ highWaterMark: 1 });
-    const spawner = createDefaultNpmSpawner(passthrough);
-    const resultPromise = spawner(process.execPath, [
-      "--eval",
-      "process.stderr.write('first'); process.stderr.write('second', () => process.exit(3));",
-    ]);
-
-    const flusher = setInterval(() => {
-      passthrough.flush();
-    }, 5);
-    const result = await resultPromise.finally(() => {
-      clearInterval(flusher);
-      passthrough.flush();
-    });
-    expect(result.exitCode).toBe(3);
-    expect(Buffer.concat(passthrough.chunks).toString("utf8")).toBe(["first", "second"].join(""));
-  });
-
-  it("resumes stderr when the passthrough stream drains", async () => {
-    class DrainingWritable extends Writable {
-      public drained = false;
-
-      public override write(_chunk: Uint8Array | string): boolean {
-        queueMicrotask(() => {
-          this.drained = true;
-          this.emit("drain");
-        });
-        return false;
-      }
-
-      public override _write(
-        _chunk: Buffer,
-        _encoding: BufferEncoding,
-        callback: (error?: Error | null) => void,
-      ): void {
-        callback();
-      }
-    }
-
-    const passthrough = new DrainingWritable();
-
-    const spawner = createDefaultNpmSpawner(passthrough);
-    const result = await spawner(process.execPath, [
-      "--eval",
-      "process.stderr.write('drain', () => process.exit(4));",
-    ]);
-
-    expect(result).toStrictEqual({ exitCode: 4, stderrText: "drain" });
-    expect(passthrough.drained).toBe(true);
   });
 
   it("rejects when the subprocess cannot be spawned", async () => {

--- a/src/lib/npmGlobal.test.ts
+++ b/src/lib/npmGlobal.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
-import { PassThrough } from "node:stream";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { PassThrough, Writable } from "node:stream";
+import { pathToFileURL } from "node:url";
 
 import {
   classifyInstall,
@@ -135,6 +135,102 @@ describe(createDefaultNpmSpawner, () => {
     expect(Buffer.concat(chunks).toString("utf8")).toContain("EACCES");
   });
 
+  it("caps captured stderr while still passing all stderr through", async () => {
+    const passthrough = new PassThrough();
+    const chunks: Buffer[] = [];
+    passthrough.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+
+    const spawner = createDefaultNpmSpawner(passthrough);
+    const result = await spawner(process.execPath, [
+      "--eval",
+      "process.stderr.write('x'.repeat(70 * 1024), () => process.exit(1));",
+    ]);
+
+    expect(result.stderrText.length).toBeLessThan(70 * 1024);
+    expect(Buffer.concat(chunks).toString("utf8")).toHaveLength(70 * 1024);
+  });
+
+  it("pauses stderr while the passthrough stream applies backpressure", async () => {
+    class SlowWritable extends Writable {
+      public readonly chunks: Buffer[] = [];
+      public readonly callbacks: (() => void)[] = [];
+
+      public override _write(
+        chunk: Buffer,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+      ): void {
+        this.chunks.push(Buffer.from(chunk));
+        this.callbacks.push(() => {
+          callback();
+        });
+      }
+
+      public flush(): void {
+        for (const callback of this.callbacks.splice(0)) {
+          callback();
+        }
+      }
+    }
+
+    const passthrough = new SlowWritable({ highWaterMark: 1 });
+    const spawner = createDefaultNpmSpawner(passthrough);
+    const resultPromise = spawner(process.execPath, [
+      "--eval",
+      "process.stderr.write('first'); process.stderr.write('second', () => process.exit(3));",
+    ]);
+
+    const flusher = setInterval(() => {
+      passthrough.flush();
+    }, 5);
+    const result = await resultPromise.finally(() => {
+      clearInterval(flusher);
+      passthrough.flush();
+    });
+    expect(result.exitCode).toBe(3);
+    expect(Buffer.concat(passthrough.chunks).toString("utf8")).toBe(["first", "second"].join(""));
+  });
+
+  it("resumes stderr when the passthrough stream drains", async () => {
+    class DrainingWritable extends Writable {
+      public drained = false;
+
+      public override write(_chunk: Uint8Array | string): boolean {
+        queueMicrotask(() => {
+          this.drained = true;
+          this.emit("drain");
+        });
+        return false;
+      }
+
+      public override _write(
+        _chunk: Buffer,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+      ): void {
+        callback();
+      }
+    }
+
+    const passthrough = new DrainingWritable();
+
+    const spawner = createDefaultNpmSpawner(passthrough);
+    const result = await spawner(process.execPath, [
+      "--eval",
+      "process.stderr.write('drain', () => process.exit(4));",
+    ]);
+
+    expect(result).toStrictEqual({ exitCode: 4, stderrText: "drain" });
+    expect(passthrough.drained).toBe(true);
+  });
+
+  it("rejects when the subprocess cannot be spawned", async () => {
+    const spawner = createDefaultNpmSpawner(new PassThrough());
+    await expect(spawner("/definitely/missing/npm", [])).rejects.toThrow(/ENOENT/);
+  });
+
   it("reports exit code 0 for a successful subprocess", async () => {
     const spawner = createDefaultNpmSpawner(new PassThrough());
     const result = await spawner(process.execPath, ["--eval", "process.exit(0)"]);
@@ -201,14 +297,5 @@ describe(detectIsSymlink, () => {
 
   it("returns false when the path does not exist", () => {
     expect(detectIsSymlink(join(tmp, "missing"))).toBe(false);
-  });
-});
-
-describe("detection helpers (smoke)", () => {
-  it("the test process's own meta-url-based install path is the project root", () => {
-    const meta = import.meta.url;
-    const root = detectInstallPath(meta);
-    // npmGlobal.test.ts lives at <root>/src/lib/, so dirname dirname = <root>/src — confirm structure.
-    expect(fileURLToPath(meta)).toContain(root);
   });
 });

--- a/src/lib/npmGlobal.ts
+++ b/src/lib/npmGlobal.ts
@@ -3,8 +3,6 @@ import { lstatSync } from "node:fs";
 import { dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const STDERR_CAPTURE_MAX_BYTES = 64 * 1024;
-
 export type InstallKind = "global" | "linked" | "npx" | "project" | "unknown";
 
 export interface ClassifyInstallOptions {
@@ -83,45 +81,17 @@ export function createDefaultNpmSpawner(passthroughStderr: NodeJS.WritableStream
       const child = spawn(command, [...args], { stdio: ["inherit", "inherit", "pipe"] });
       const { stderr } = child;
       const chunks: Buffer[] = [];
-      let capturedBytes = 0;
-      let closeCode: number | null | undefined;
-      let stderrEnded = false;
-      let settled = false;
-
-      function maybeResolve(): void {
-        if (settled || closeCode === undefined || !stderrEnded) {
-          return;
-        }
-        settled = true;
-        resolve({
-          exitCode: closeCode ?? 1,
-          stderrText: Buffer.concat(chunks).toString("utf8"),
-        });
-      }
 
       stderr.on("data", (chunk: Buffer) => {
-        const remainingBytes = STDERR_CAPTURE_MAX_BYTES - capturedBytes;
-        if (remainingBytes > 0) {
-          const captured = Buffer.from(chunk.subarray(0, remainingBytes));
-          chunks.push(captured);
-          capturedBytes += captured.length;
-        }
-        if (!passthroughStderr.write(chunk)) {
-          stderr.pause();
-          passthroughStderr.once("drain", () => {
-            stderr.resume();
-          });
-        }
-      });
-      stderr.on("end", () => {
-        stderrEnded = true;
-        maybeResolve();
+        chunks.push(chunk);
+        passthroughStderr.write(chunk);
       });
       child.on("error", reject);
       child.on("close", (code) => {
-        closeCode = code;
-        stderr.resume();
-        maybeResolve();
+        resolve({
+          exitCode: code ?? 1,
+          stderrText: Buffer.concat(chunks).toString("utf8"),
+        });
       });
     });
 }

--- a/src/lib/npmGlobal.ts
+++ b/src/lib/npmGlobal.ts
@@ -1,0 +1,95 @@
+import { spawn } from "node:child_process";
+import { lstatSync } from "node:fs";
+import { dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type InstallKind = "global" | "linked" | "npx" | "project" | "unknown";
+
+export interface ClassifyInstallOptions {
+  installPath: string;
+  npmRootGlobal: string | undefined;
+  isSymlink: (path: string) => boolean;
+}
+
+export function classifyInstall(options: ClassifyInstallOptions): InstallKind {
+  const { installPath, npmRootGlobal, isSymlink } = options;
+  if (npmRootGlobal !== undefined && installPath.startsWith(`${npmRootGlobal}${sep}`)) {
+    return isSymlink(installPath) ? "linked" : "global";
+  }
+  if (installPath.includes(`${sep}_npx${sep}`)) {
+    return "npx";
+  }
+  if (installPath.includes(`${sep}node_modules${sep}`)) {
+    return "project";
+  }
+  return "unknown";
+}
+
+export interface NpmSpawnerResult {
+  exitCode: number;
+  stderrText: string;
+}
+
+export type NpmSpawner = (command: string, args: readonly string[]) => Promise<NpmSpawnerResult>;
+
+export interface NpmRunResult {
+  exitCode: number;
+  sawEacces: boolean;
+}
+
+export interface RunNpmInstallOptions {
+  packageName: string;
+  version: string;
+  npmBin: string;
+  spawner: NpmSpawner;
+}
+
+export async function runNpmInstallGlobal(options: RunNpmInstallOptions): Promise<NpmRunResult> {
+  const args = ["install", "-g", `${options.packageName}@${options.version}`];
+  const result = await options.spawner(options.npmBin, args);
+  return {
+    exitCode: result.exitCode,
+    sawEacces: result.stderrText.includes("EACCES"),
+  };
+}
+
+export function detectInstallPath(cliMetaUrl: string): string {
+  return dirname(dirname(fileURLToPath(cliMetaUrl)));
+}
+
+export type NpmRootRunner = (command: string, args: readonly string[]) => string;
+
+export function detectNpmRootGlobal(npmBin: string, runner: NpmRootRunner): string | undefined {
+  try {
+    return runner(npmBin, ["root", "-g"]);
+  } catch {
+    return undefined;
+  }
+}
+
+export function detectIsSymlink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+export function createDefaultNpmSpawner(passthroughStderr: NodeJS.WritableStream): NpmSpawner {
+  return async (command, args) =>
+    await new Promise<NpmSpawnerResult>((resolve, reject) => {
+      const child = spawn(command, [...args], { stdio: ["inherit", "inherit", "pipe"] });
+      const chunks: Buffer[] = [];
+      child.stderr.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        passthroughStderr.write(chunk);
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        resolve({
+          exitCode: code ?? 1,
+          stderrText: Buffer.concat(chunks).toString("utf8"),
+        });
+      });
+    });
+}

--- a/src/lib/npmGlobal.ts
+++ b/src/lib/npmGlobal.ts
@@ -3,6 +3,8 @@ import { lstatSync } from "node:fs";
 import { dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const STDERR_CAPTURE_MAX_BYTES = 64 * 1024;
+
 export type InstallKind = "global" | "linked" | "npx" | "project" | "unknown";
 
 export interface ClassifyInstallOptions {
@@ -79,17 +81,47 @@ export function createDefaultNpmSpawner(passthroughStderr: NodeJS.WritableStream
   return async (command, args) =>
     await new Promise<NpmSpawnerResult>((resolve, reject) => {
       const child = spawn(command, [...args], { stdio: ["inherit", "inherit", "pipe"] });
+      const { stderr } = child;
       const chunks: Buffer[] = [];
-      child.stderr.on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-        passthroughStderr.write(chunk);
+      let capturedBytes = 0;
+      let closeCode: number | null | undefined;
+      let stderrEnded = false;
+      let settled = false;
+
+      function maybeResolve(): void {
+        if (settled || closeCode === undefined || !stderrEnded) {
+          return;
+        }
+        settled = true;
+        resolve({
+          exitCode: closeCode ?? 1,
+          stderrText: Buffer.concat(chunks).toString("utf8"),
+        });
+      }
+
+      stderr.on("data", (chunk: Buffer) => {
+        const remainingBytes = STDERR_CAPTURE_MAX_BYTES - capturedBytes;
+        if (remainingBytes > 0) {
+          const captured = Buffer.from(chunk.subarray(0, remainingBytes));
+          chunks.push(captured);
+          capturedBytes += captured.length;
+        }
+        if (!passthroughStderr.write(chunk)) {
+          stderr.pause();
+          passthroughStderr.once("drain", () => {
+            stderr.resume();
+          });
+        }
+      });
+      stderr.on("end", () => {
+        stderrEnded = true;
+        maybeResolve();
       });
       child.on("error", reject);
       child.on("close", (code) => {
-        resolve({
-          exitCode: code ?? 1,
-          stderrText: Buffer.concat(chunks).toString("utf8"),
-        });
+        closeCode = code;
+        stderr.resume();
+        maybeResolve();
       });
     });
 }

--- a/src/lib/upgrade.test.ts
+++ b/src/lib/upgrade.test.ts
@@ -18,15 +18,39 @@ type FetcherFn = ComputeUpgradeNudgeOptions["fetcher"];
 
 describe(parseVersion, () => {
   it("parses major.minor.patch", () => {
-    expect(parseVersion("3.1.8")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+    expect(parseVersion("3.1.8")).toStrictEqual({
+      major: 3,
+      minor: 1,
+      patch: 8,
+      prerelease: undefined,
+    });
   });
 
-  it("ignores prerelease suffix", () => {
-    expect(parseVersion("3.1.8-beta.1")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+  it("captures the prerelease suffix", () => {
+    expect(parseVersion("3.1.8-beta.1")).toStrictEqual({
+      major: 3,
+      minor: 1,
+      patch: 8,
+      prerelease: "beta.1",
+    });
   });
 
-  it("ignores build metadata", () => {
-    expect(parseVersion("3.1.8+sha.abc")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+  it("strips build metadata after the +", () => {
+    expect(parseVersion("3.1.8+sha.abc")).toStrictEqual({
+      major: 3,
+      minor: 1,
+      patch: 8,
+      prerelease: undefined,
+    });
+  });
+
+  it("captures prerelease and strips build metadata together", () => {
+    expect(parseVersion("3.1.8-beta+sha.abc")).toStrictEqual({
+      major: 3,
+      minor: 1,
+      patch: 8,
+      prerelease: "beta",
+    });
   });
 
   it("throws on missing components", () => {
@@ -63,8 +87,20 @@ describe(compareVersions, () => {
     expect(compareVersions("4.0.0", "3.99.99")).toBe(1);
   });
 
-  it("treats versions with same numeric parts as equal regardless of suffix", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8")).toBe(0);
+  it("ranks a prerelease lower than the stable of the same numeric", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8")).toBe(-1);
+  });
+
+  it("ranks the stable higher than a prerelease of the same numeric", () => {
+    expect(compareVersions("3.1.8", "3.1.8-beta.1")).toBe(1);
+  });
+
+  it("treats two identical prerelease strings as equal", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.1")).toBe(0);
+  });
+
+  it("treats two distinct prereleases of the same numeric as equal (coarse comparison)", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.2")).toBe(0);
   });
 });
 

--- a/src/lib/upgrade.test.ts
+++ b/src/lib/upgrade.test.ts
@@ -13,29 +13,17 @@ import {
   parseVersion,
   primeUpgradeCheckCache,
   readUpgradeCheckCache,
-  recordUpgradeCheckFailure,
   type UpgradeCheckCacheEntry,
-  type UpgradeCheckFailureCacheEntry,
   writeUpgradeCheckCache,
 } from "./upgrade.ts";
 
 type FetcherFn = ComputeUpgradeNudgeOptions["fetcher"];
+
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
 function cacheEntry(overrides: Partial<UpgradeCheckCacheEntry> = {}): UpgradeCheckCacheEntry {
   return {
     latest: "3.1.8",
-    fetchedAt: 1000,
-    registry: DEFAULT_REGISTRY,
-    ...overrides,
-  };
-}
-
-function failureCacheEntry(
-  overrides: Partial<UpgradeCheckFailureCacheEntry> = {},
-): UpgradeCheckFailureCacheEntry {
-  return {
-    status: "failure",
     fetchedAt: 1000,
     registry: DEFAULT_REGISTRY,
     ...overrides,
@@ -52,141 +40,26 @@ function readCacheEntry(path: string): unknown {
 
 describe(parseVersion, () => {
   it("parses major.minor.patch", () => {
-    expect(parseVersion("3.1.8")).toStrictEqual({
-      major: 3,
-      minor: 1,
-      patch: 8,
-      prerelease: undefined,
-    });
+    expect(parseVersion("3.1.8")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
   });
 
-  it("captures the prerelease suffix", () => {
-    expect(parseVersion("3.1.8-beta.1")).toStrictEqual({
-      major: 3,
-      minor: 1,
-      patch: 8,
-      prerelease: "beta.1",
-    });
-  });
-
-  it("strips build metadata after the +", () => {
-    expect(parseVersion("3.1.8+sha.abc")).toStrictEqual({
-      major: 3,
-      minor: 1,
-      patch: 8,
-      prerelease: undefined,
-    });
-  });
-
-  it("captures prerelease and strips build metadata together", () => {
-    expect(parseVersion("3.1.8-beta+sha.abc")).toStrictEqual({
-      major: 3,
-      minor: 1,
-      patch: 8,
-      prerelease: "beta",
-    });
-  });
-
-  it("throws on missing components", () => {
-    expect(() => parseVersion("3.1")).toThrow(/invalid version/i);
-  });
-
-  it("throws on non-numeric components", () => {
-    expect(() => parseVersion("3.x.8")).toThrow(/invalid version/i);
-  });
-
-  it("throws on empty string", () => {
-    expect(() => parseVersion("")).toThrow(/invalid version/i);
-  });
-
-  it("throws on leading-zero numeric components", () => {
-    expect(() => parseVersion("01.2.3")).toThrow(/invalid version/i);
-  });
-
-  it("throws on empty prerelease identifiers", () => {
-    expect(() => parseVersion("1.2.3-alpha..1")).toThrow(/invalid version/i);
-  });
-
-  it("throws on empty build identifiers", () => {
-    expect(() => parseVersion("1.2.3+build..1")).toThrow(/invalid version/i);
-  });
+  it.each(["3.1", "3.x.8", "", "01.2.3", "3.1.8-beta.1", "3.1.8+sha.abc"])(
+    "throws on invalid version %s",
+    (version) => {
+      expect(() => parseVersion(version)).toThrow(/invalid version/i);
+    },
+  );
 });
 
 describe(compareVersions, () => {
-  it("returns 0 for equal versions", () => {
-    expect(compareVersions("3.1.8", "3.1.8")).toBe(0);
-  });
-
-  it("returns -1 when first is older by patch", () => {
-    expect(compareVersions("3.1.7", "3.1.8")).toBe(-1);
-  });
-
-  it("returns 1 when first is newer by patch", () => {
-    expect(compareVersions("3.1.9", "3.1.8")).toBe(1);
-  });
-
-  it("returns 1 when first is newer by minor (minor outranks patch)", () => {
-    expect(compareVersions("3.2.0", "3.1.99")).toBe(1);
-  });
-
-  it("returns 1 when first is newer by major (major outranks minor)", () => {
-    expect(compareVersions("4.0.0", "3.99.99")).toBe(1);
-  });
-
-  it("ranks a prerelease lower than the stable of the same numeric", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8")).toBe(-1);
-  });
-
-  it("ranks the stable higher than a prerelease of the same numeric", () => {
-    expect(compareVersions("3.1.8", "3.1.8-beta.1")).toBe(1);
-  });
-
-  it("treats two identical prerelease strings as equal", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.1")).toBe(0);
-  });
-
-  it("orders prerelease identifiers numerically", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.2")).toBe(-1);
-  });
-
-  it("orders larger numeric prerelease identifiers higher", () => {
-    expect(compareVersions("3.1.8-beta.2", "3.1.8-beta.1")).toBe(1);
-  });
-
-  it("orders numeric prerelease identifiers without losing precision", () => {
-    expect(compareVersions("3.1.8-beta.9007199254740993", "3.1.8-beta.9007199254740992")).toBe(1);
-  });
-
-  it("orders numeric prerelease identifiers by length before lexical order", () => {
-    expect(compareVersions("3.1.8-beta.10", "3.1.8-beta.9")).toBe(1);
-  });
-
-  it("orders shorter numeric prerelease identifiers lower by length", () => {
-    expect(compareVersions("3.1.8-beta.9", "3.1.8-beta.10")).toBe(-1);
-  });
-
-  it("orders non-numeric prerelease identifiers lexically", () => {
-    expect(compareVersions("3.1.8-alpha", "3.1.8-beta")).toBe(-1);
-  });
-
-  it("orders later lexical prerelease identifiers higher", () => {
-    expect(compareVersions("3.1.8-beta", "3.1.8-alpha")).toBe(1);
-  });
-
-  it("ranks numeric prerelease identifiers lower than non-numeric ones", () => {
-    expect(compareVersions("3.1.8-1", "3.1.8-alpha")).toBe(-1);
-  });
-
-  it("ranks non-numeric prerelease identifiers higher than numeric ones", () => {
-    expect(compareVersions("3.1.8-alpha", "3.1.8-1")).toBe(1);
-  });
-
-  it("ranks a longer prerelease higher when all preceding identifiers match", () => {
-    expect(compareVersions("3.1.8-beta.1.1", "3.1.8-beta.1")).toBe(1);
-  });
-
-  it("ranks a shorter prerelease lower when all preceding identifiers match", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.1.1")).toBe(-1);
+  it.each([
+    ["3.1.8", "3.1.8", 0],
+    ["3.1.7", "3.1.8", -1],
+    ["3.1.9", "3.1.8", 1],
+    ["3.2.0", "3.1.99", 1],
+    ["4.0.0", "3.99.99", 1],
+  ])("compares %s to %s", (left, right, expected) => {
+    expect(compareVersions(left, right)).toBe(expected);
   });
 });
 
@@ -195,61 +68,73 @@ describe(fetchLatestVersion, () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns the version field from a 200 response", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ version: "3.1.8" })),
-    );
-    const result = await fetchLatestVersion("@clipboard-health/groundcrew", { timeoutMs: 1000 });
-    expect(result).toBe("3.1.8");
-  });
-
-  it("hits the default npm registry when none is supplied", async () => {
+  it("returns the version field from the registry", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(Response.json({ version: "1.0.0" }));
+      .mockResolvedValueOnce(Response.json({ version: "3.1.8" }));
     vi.stubGlobal("fetch", fetchMock);
-    await fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 });
+
+    const result = await fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 });
+
+    expect(result).toBe("3.1.8");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://registry.npmjs.org/@scope%2Fpkg/latest",
       expect.any(Object),
     );
   });
 
-  it("uses a custom registry and strips a trailing slash", async () => {
+  it("uses a custom registry", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(Response.json({ version: "1.0.0" }));
     vi.stubGlobal("fetch", fetchMock);
+
     await fetchLatestVersion("@scope/pkg", {
       timeoutMs: 1000,
       registry: "https://npm.mirror.example/",
     });
+
     expect(fetchMock).toHaveBeenCalledWith(
       "https://npm.mirror.example/@scope%2Fpkg/latest",
       expect.any(Object),
     );
   });
 
-  it("throws when the registry responds with a non-2xx status", async () => {
+  it("throws when the registry cannot return a usable version", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 503 })),
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response("nope", { status: 503 }))
+        .mockResolvedValueOnce(Response.json(null))
+        .mockResolvedValueOnce(Response.json(5))
+        .mockResolvedValueOnce(Response.json({ name: "x" }))
+        .mockResolvedValueOnce(Response.json({ version: 123 }))
+        .mockResolvedValueOnce(Response.json({ version: "3.1.8-beta.1" })),
     );
+
     await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/503/);
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(
+      /invalid version/,
+    );
   });
 
-  it("wraps network failures with a registry-context message", async () => {
+  it("wraps fetch failures", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>().mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND")),
     );
+
     await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(
       /registry request failed/,
     );
   });
 
-  it("throws when the timeout elapses before the registry responds", async () => {
+  it("times out the registry request", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>().mockImplementation(
@@ -261,59 +146,19 @@ describe(fetchLatestVersion, () => {
           }),
       ),
     );
+
     await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 5 })).rejects.toThrow(
       /registry request failed/,
     );
   });
-
-  it("keeps the timeout active while reading the response body", async () => {
-    let abortBody: ((error: Error) => void) | undefined;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>().mockImplementation(async (_input, init) => {
-        init?.signal?.addEventListener("abort", () => {
-          abortBody?.(new Error("body aborted"));
-        });
-        const response = new Response("{}", { status: 200 });
-        vi.spyOn(response, "json").mockImplementation(
-          async () =>
-            await new Promise<unknown>((_resolve, reject) => {
-              abortBody = reject;
-            }),
-        );
-        return response;
-      }),
-    );
-    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 5 })).rejects.toThrow(
-      /body aborted/,
-    );
-  });
-
-  it("throws when the response body lacks a version field entirely", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ name: "x" })),
-    );
-    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
-  });
-
-  it("throws when the version field is present but not a string", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ version: 123 })),
-    );
-    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
-  });
 });
 
 describe(normalizeRegistry, () => {
-  it("returns the default npm registry when no registry is configured", () => {
-    const input: { registry?: string } = {};
-    expect(normalizeRegistry(input.registry)).toBe(DEFAULT_REGISTRY);
-  });
-
-  it("strips one trailing slash from a configured registry", () => {
-    expect(normalizeRegistry("https://npm.mirror.example/")).toBe("https://npm.mirror.example");
+  it.each([
+    [undefined, DEFAULT_REGISTRY],
+    ["https://npm.mirror.example/", "https://npm.mirror.example"],
+  ])("normalizes %s", (input: string | undefined, expected) => {
+    expect(normalizeRegistry(input)).toBe(expected);
   });
 });
 
@@ -324,26 +169,20 @@ describe(defaultUpgradeCheckCachePath, () => {
 
   it("uses XDG_CACHE_HOME when set", () => {
     vi.stubEnv("XDG_CACHE_HOME", "/var/cache/example");
+
     expect(defaultUpgradeCheckCachePath()).toBe("/var/cache/example/groundcrew/upgrade-check.json");
   });
 
-  it("falls back to ~/.cache when XDG_CACHE_HOME is unset", () => {
-    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the unset-env fallback
-    vi.stubEnv("XDG_CACHE_HOME", undefined);
-    expect(defaultUpgradeCheckCachePath()).toBe(
-      join(homedir(), ".cache", "groundcrew", "upgrade-check.json"),
-    );
-  });
+  it.each([undefined, ""])("falls back to ~/.cache when XDG_CACHE_HOME is %s", (value) => {
+    vi.stubEnv("XDG_CACHE_HOME", value);
 
-  it("falls back to ~/.cache when XDG_CACHE_HOME is empty", () => {
-    vi.stubEnv("XDG_CACHE_HOME", "");
     expect(defaultUpgradeCheckCachePath()).toBe(
       join(homedir(), ".cache", "groundcrew", "upgrade-check.json"),
     );
   });
 });
 
-describe(readUpgradeCheckCache, () => {
+describe("upgrade-check cache", () => {
   let cacheDir: string;
   let cachePath: string;
 
@@ -356,144 +195,49 @@ describe(readUpgradeCheckCache, () => {
     rmSync(cacheDir, { recursive: true, force: true });
   });
 
-  it("returns 'missing' when the file does not exist", () => {
-    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
+  it("reads missing, invalid, fresh, stale, and wrong-registry cache entries", () => {
+    expect(readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 })).toStrictEqual({
+      kind: "missing",
+    });
 
-  it("returns 'missing' when the file contains invalid JSON", () => {
-    writeFileSync(cachePath, "{not json");
-    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
+    for (const content of [
+      "{not json",
+      "null",
+      "5",
+      JSON.stringify({ latest: "3.1.8" }),
+      JSON.stringify({ latest: 5, fetchedAt: 1000, registry: DEFAULT_REGISTRY }),
+      JSON.stringify({ latest: "3.1.8", fetchedAt: "soon", registry: DEFAULT_REGISTRY }),
+      JSON.stringify({ latest: "3.1.8", fetchedAt: 1000, registry: 5 }),
+      JSON.stringify({ latest: "3.1.8-beta.1", fetchedAt: 1000, registry: DEFAULT_REGISTRY }),
+      JSON.stringify({ latest: "9.9.9", fetchedAt: 1000, registry: "https://mirror.example" }),
+    ]) {
+      writeFileSync(cachePath, content);
+      expect(readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 })).toStrictEqual({
+        kind: "missing",
+      });
+    }
 
-  it("returns 'missing' when the JSON parses to null", () => {
-    writeFileSync(cachePath, "null");
-    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'missing' when the JSON is not an object", () => {
-    writeFileSync(cachePath, "5");
-    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'missing' when the object lacks required fields", () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8" }));
-    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'missing' when the cache entry lacks the registry field", () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1000 }));
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'missing' when a non-failure cache entry lacks latest", () => {
-    writeFileSync(cachePath, JSON.stringify({ fetchedAt: 1000, registry: DEFAULT_REGISTRY }));
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'fresh' when the entry is within the TTL", () => {
     writeCacheEntry(cachePath);
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({
+    expect(readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 })).toStrictEqual({
       kind: "fresh",
       entry: cacheEntry(),
     });
-  });
-
-  it("returns 'stale' when the entry is older than the TTL", () => {
-    writeCacheEntry(cachePath);
-    const result = readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 });
-    expect(result).toStrictEqual({
+    expect(readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 })).toStrictEqual({
       kind: "stale",
       entry: cacheEntry(),
     });
   });
 
-  it("returns 'missing' when the cache entry was fetched from a different registry", () => {
-    writeCacheEntry(cachePath, { latest: "9.9.9", registry: "https://npm.mirror.example" });
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-
-  it("returns 'recentFailure' for a fresh failed check marker", () => {
-    const entry = failureCacheEntry();
-    writeUpgradeCheckCache(cachePath, entry);
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "recentFailure", entry });
-  });
-
-  it("preserves latest on a fresh failed check marker", () => {
-    const entry = failureCacheEntry({ latest: "3.2.0" });
-    writeUpgradeCheckCache(cachePath, entry);
-    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "recentFailure", entry });
-  });
-
-  it("returns 'missing' for a stale failed check marker", () => {
-    writeUpgradeCheckCache(cachePath, failureCacheEntry());
-    const result = readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "missing" });
-  });
-});
-
-describe(writeUpgradeCheckCache, () => {
-  let cacheDir: string;
-
-  beforeEach(() => {
-    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
-  });
-
-  afterEach(() => {
-    rmSync(cacheDir, { recursive: true, force: true });
-  });
-
-  it("creates intermediate directories and writes the entry", () => {
-    const cachePath = join(cacheDir, "nested", "upgrade-check.json");
+  it("writes cache entries", () => {
+    const nestedPath = join(cacheDir, "nested", "upgrade-check.json");
     const entry = cacheEntry({ latest: "3.2.0", fetchedAt: 42 });
-    writeUpgradeCheckCache(cachePath, entry);
-    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
+
+    writeUpgradeCheckCache(nestedPath, entry);
+
+    expect(readCacheEntry(nestedPath)).toStrictEqual(entry);
   });
 
-  it("overwrites an existing cache file", () => {
-    const cachePath = join(cacheDir, "upgrade-check.json");
-    writeUpgradeCheckCache(cachePath, cacheEntry({ fetchedAt: 1 }));
-    const entry = cacheEntry({
-      latest: "3.2.0",
-      fetchedAt: 2,
-      registry: "https://npm.mirror.example",
-    });
-    writeUpgradeCheckCache(cachePath, entry);
-    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
-  });
-
-  it("writes a failed check marker", () => {
-    const cachePath = join(cacheDir, "upgrade-check.json");
-    const entry = failureCacheEntry({ fetchedAt: 2 });
-    writeUpgradeCheckCache(cachePath, entry);
-    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
-  });
-});
-
-describe(primeUpgradeCheckCache, () => {
-  let cacheDir: string;
-  let cachePath: string;
-
-  beforeEach(() => {
-    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
-    cachePath = join(cacheDir, "upgrade-check.json");
-  });
-
-  afterEach(() => {
-    rmSync(cacheDir, { recursive: true, force: true });
-  });
-
-  it("writes a normalized registry cache entry", () => {
+  it("primes cache entries best-effort", () => {
     primeUpgradeCheckCache({
       path: cachePath,
       latest: "3.2.0",
@@ -505,9 +249,7 @@ describe(primeUpgradeCheckCache, () => {
       fetchedAt: 42,
       registry: "https://npm.mirror.example",
     });
-  });
 
-  it("swallows cache write failures", () => {
     const blocker = join(cacheDir, "blocker");
     writeFileSync(blocker, "");
     expect(() => {
@@ -520,71 +262,13 @@ describe(primeUpgradeCheckCache, () => {
   });
 });
 
-describe(recordUpgradeCheckFailure, () => {
-  let cacheDir: string;
-  let cachePath: string;
-
-  beforeEach(() => {
-    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
-    cachePath = join(cacheDir, "upgrade-check.json");
-  });
-
-  afterEach(() => {
-    rmSync(cacheDir, { recursive: true, force: true });
-  });
-
-  it("writes a normalized registry failure marker", () => {
-    recordUpgradeCheckFailure({
-      path: cachePath,
-      now: () => 42,
-      registry: "https://npm.mirror.example/",
-    });
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      status: "failure",
-      fetchedAt: 42,
-      registry: "https://npm.mirror.example",
-    });
-  });
-
-  it("preserves a stale latest version while recording a failure marker", () => {
-    recordUpgradeCheckFailure({
-      path: cachePath,
-      latest: "3.2.0",
-      now: () => 42,
-    });
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      status: "failure",
-      latest: "3.2.0",
-      fetchedAt: 42,
-      registry: DEFAULT_REGISTRY,
-    });
-  });
-
-  it("swallows cache write failures", () => {
-    const blocker = join(cacheDir, "blocker");
-    writeFileSync(blocker, "");
-    expect(() => {
-      recordUpgradeCheckFailure({
-        path: join(blocker, "cache.json"),
-        now: () => 42,
-      });
-    }).not.toThrow();
-  });
-});
-
 describe(composeNudgeMessage, () => {
-  it("returns a one-line message when latest is newer than current", () => {
-    expect(composeNudgeMessage("3.1.8", "3.2.0")).toBe(
-      "[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)",
-    );
-  });
-
-  it("returns undefined when current equals latest", () => {
-    expect(composeNudgeMessage("3.1.8", "3.1.8")).toBeUndefined();
-  });
-
-  it("returns undefined when current is newer than latest", () => {
-    expect(composeNudgeMessage("3.2.0", "3.1.8")).toBeUndefined();
+  it.each([
+    ["3.1.8", "3.2.0", "[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)"],
+    ["3.1.8", "3.1.8", undefined],
+    ["3.2.0", "3.1.8", undefined],
+  ])("composes a nudge from %s to %s", (current, latest, expected) => {
+    expect(composeNudgeMessage(current, latest)).toBe(expected);
   });
 });
 
@@ -623,31 +307,26 @@ describe(computeUpgradeNudge, () => {
     };
   }
 
-  it("returns undefined when noUpgradeCheck is true (env opt-out)", async () => {
-    writeCacheEntry(cachePath, { latest: "9.9.9", fetchedAt: 1_000_000 });
-    const result = await computeUpgradeNudge(
-      baseOptions({ currentVersion: "1.0.0", noUpgradeCheck: true }),
-    );
-    expect(result).toBeUndefined();
-  });
-
-  it("returns a nudge using a fresh cache entry when newer", async () => {
+  it("uses a fresh cache entry and honors opt-out", async () => {
     writeCacheEntry(cachePath, { latest: "3.2.0", fetchedAt: 1_000_000 });
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
-    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+
+    await expect(computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }))).resolves.toBe(
+      "[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)",
+    );
+    await expect(
+      computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", noUpgradeCheck: true })),
+    ).resolves.toBeUndefined();
   });
 
-  it("returns undefined when fresh cache equals current", async () => {
-    writeCacheEntry(cachePath, { fetchedAt: 1_000_000 });
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
-    expect(result).toBeUndefined();
-  });
-
-  it("fetches when cache is stale, writes new cache, returns nudge", async () => {
-    const stale = 1_000_000 - 100 * 60 * 60 * 1000; // 100h ago, beyond 6h TTL
+  it("fetches and caches when the cache is missing or stale", async () => {
+    const stale = 1_000_000 - 100 * 60 * 60 * 1000;
     writeCacheEntry(cachePath, { fetchedAt: stale });
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValue("3.2.0");
+
+    const result = await computeUpgradeNudge(
+      baseOptions({ currentVersion: "3.1.8", fetcher, now: () => 1_000_000 }),
+    );
+
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
     expect(fetcher).toHaveBeenCalledWith("@clipboard-health/groundcrew", {
       timeoutMs: 300,
@@ -660,104 +339,45 @@ describe(computeUpgradeNudge, () => {
     });
   });
 
-  it("falls back to stale cache entry when fetch fails", async () => {
+  it("falls back to stale cache when fetch fails", async () => {
     const stale = 1_000_000 - 100 * 60 * 60 * 1000;
     writeCacheEntry(cachePath, { latest: "3.2.0", fetchedAt: stale });
     const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
+
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
     expect(readCacheEntry(cachePath)).toStrictEqual({
-      status: "failure",
       latest: "3.2.0",
-      fetchedAt: 1_000_000,
+      fetchedAt: stale,
       registry: DEFAULT_REGISTRY,
     });
   });
 
-  it("returns undefined when fetch fails and no cache exists", async () => {
+  it("returns undefined when fetch fails without cache", async () => {
     const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
+
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+
     expect(result).toBeUndefined();
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      status: "failure",
-      fetchedAt: 1_000_000,
-      registry: DEFAULT_REGISTRY,
-    });
+    expect(() => readCacheEntry(cachePath)).toThrow(/ENOENT/);
   });
 
-  it("skips fetching during the failed-check backoff window", async () => {
-    writeUpgradeCheckCache(cachePath, failureCacheEntry({ fetchedAt: 1_000_000 }));
+  it("forwards registry and still returns when cache write fails", async () => {
+    const blocker = join(cacheDir, "blocker");
+    writeFileSync(blocker, "");
     const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
-    expect(result).toBeUndefined();
-    expect(fetcher).not.toHaveBeenCalled();
-  });
 
-  it("uses a failed-check marker with latest during the backoff window", async () => {
-    writeUpgradeCheckCache(cachePath, failureCacheEntry({ latest: "3.2.0", fetchedAt: 1_000_000 }));
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("9.9.9");
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
-    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
-    expect(fetcher).not.toHaveBeenCalled();
-  });
-
-  it("fetches again after a failed-check marker expires", async () => {
-    const stale = 1_000_000 - 100 * 60 * 60 * 1000;
-    writeUpgradeCheckCache(cachePath, failureCacheEntry({ fetchedAt: stale }));
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
-    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      latest: "3.2.0",
-      fetchedAt: 1_000_000,
-      registry: DEFAULT_REGISTRY,
-    });
-  });
-
-  it("fetches when cache is missing and writes the cache on success", async () => {
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
-    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
-    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      latest: "3.2.0",
-      fetchedAt: 1_000_000,
-      registry: DEFAULT_REGISTRY,
-    });
-  });
-
-  it("ignores a fresh cache entry from a different registry and refreshes it", async () => {
-    writeCacheEntry(cachePath, {
-      latest: "9.9.9",
-      fetchedAt: 1_000_000,
-      registry: "https://npm.mirror.example",
-    });
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
     const result = await computeUpgradeNudge({
       ...baseOptions({ currentVersion: "3.1.8", fetcher }),
+      cachePath: join(blocker, "cache.json"),
       registry: "https://registry.npmjs.org/",
     });
+
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
     expect(fetcher).toHaveBeenCalledWith("@clipboard-health/groundcrew", {
       timeoutMs: 300,
       registry: "https://registry.npmjs.org/",
     });
-    expect(readCacheEntry(cachePath)).toStrictEqual({
-      latest: "3.2.0",
-      fetchedAt: 1_000_000,
-      registry: DEFAULT_REGISTRY,
-    });
-  });
-
-  it("returns the fresh nudge even when cache write throws", async () => {
-    // Point cachePath under a regular file so mkdirSync inside writeUpgradeCheckCache throws.
-    const blocker = join(cacheDir, "blocker");
-    writeFileSync(blocker, "");
-    const unreachableCachePath = join(blocker, "cache.json");
-    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
-    const result = await computeUpgradeNudge({
-      ...baseOptions({ currentVersion: "3.1.8", fetcher }),
-      cachePath: unreachableCachePath,
-    });
-    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
   });
 });

--- a/src/lib/upgrade.test.ts
+++ b/src/lib/upgrade.test.ts
@@ -1,0 +1,383 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  compareVersions,
+  composeNudgeMessage,
+  type ComputeUpgradeNudgeOptions,
+  computeUpgradeNudge,
+  defaultUpgradeCheckCachePath,
+  fetchLatestVersion,
+  parseVersion,
+  readUpgradeCheckCache,
+  writeUpgradeCheckCache,
+} from "./upgrade.ts";
+
+type FetcherFn = ComputeUpgradeNudgeOptions["fetcher"];
+
+describe(parseVersion, () => {
+  it("parses major.minor.patch", () => {
+    expect(parseVersion("3.1.8")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+  });
+
+  it("ignores prerelease suffix", () => {
+    expect(parseVersion("3.1.8-beta.1")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+  });
+
+  it("ignores build metadata", () => {
+    expect(parseVersion("3.1.8+sha.abc")).toStrictEqual({ major: 3, minor: 1, patch: 8 });
+  });
+
+  it("throws on missing components", () => {
+    expect(() => parseVersion("3.1")).toThrow(/invalid version/i);
+  });
+
+  it("throws on non-numeric components", () => {
+    expect(() => parseVersion("3.x.8")).toThrow(/invalid version/i);
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseVersion("")).toThrow(/invalid version/i);
+  });
+});
+
+describe(compareVersions, () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareVersions("3.1.8", "3.1.8")).toBe(0);
+  });
+
+  it("returns -1 when first is older by patch", () => {
+    expect(compareVersions("3.1.7", "3.1.8")).toBe(-1);
+  });
+
+  it("returns 1 when first is newer by patch", () => {
+    expect(compareVersions("3.1.9", "3.1.8")).toBe(1);
+  });
+
+  it("returns 1 when first is newer by minor (minor outranks patch)", () => {
+    expect(compareVersions("3.2.0", "3.1.99")).toBe(1);
+  });
+
+  it("returns 1 when first is newer by major (major outranks minor)", () => {
+    expect(compareVersions("4.0.0", "3.99.99")).toBe(1);
+  });
+
+  it("treats versions with same numeric parts as equal regardless of suffix", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8")).toBe(0);
+  });
+});
+
+describe(fetchLatestVersion, () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the version field from a 200 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ version: "3.1.8" })),
+    );
+    const result = await fetchLatestVersion("@clipboard-health/groundcrew", { timeoutMs: 1000 });
+    expect(result).toBe("3.1.8");
+  });
+
+  it("hits the default npm registry when none is supplied", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ version: "1.0.0" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@scope/pkg/latest",
+      expect.any(Object),
+    );
+  });
+
+  it("uses a custom registry and strips a trailing slash", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ version: "1.0.0" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchLatestVersion("@scope/pkg", {
+      timeoutMs: 1000,
+      registry: "https://npm.mirror.example/",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://npm.mirror.example/@scope/pkg/latest",
+      expect.any(Object),
+    );
+  });
+
+  it("throws when the registry responds with a non-2xx status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 503 })),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/503/);
+  });
+
+  it("wraps network failures with a registry-context message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND")),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(
+      /registry request failed/,
+    );
+  });
+
+  it("throws when the timeout elapses before the registry responds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockImplementation(
+        async (_input, init) =>
+          await new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(new Error("aborted"));
+            });
+          }),
+      ),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 5 })).rejects.toThrow(
+      /registry request failed/,
+    );
+  });
+
+  it("throws when the response body lacks a version field entirely", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ name: "x" })),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+  });
+
+  it("throws when the version field is present but not a string", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValueOnce(Response.json({ version: 123 })),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 })).rejects.toThrow(/version/);
+  });
+});
+
+describe(defaultUpgradeCheckCachePath, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses XDG_CACHE_HOME when set", () => {
+    vi.stubEnv("XDG_CACHE_HOME", "/var/cache/example");
+    expect(defaultUpgradeCheckCachePath()).toBe("/var/cache/example/groundcrew/upgrade-check.json");
+  });
+
+  it("falls back to ~/.cache when XDG_CACHE_HOME is unset", () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the unset-env fallback
+    vi.stubEnv("XDG_CACHE_HOME", undefined);
+    expect(defaultUpgradeCheckCachePath()).toBe(
+      join(homedir(), ".cache", "groundcrew", "upgrade-check.json"),
+    );
+  });
+});
+
+describe(readUpgradeCheckCache, () => {
+  let cacheDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
+    cachePath = join(cacheDir, "upgrade-check.json");
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("returns 'missing' when the file does not exist", () => {
+    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'missing' when the file contains invalid JSON", () => {
+    writeFileSync(cachePath, "{not json");
+    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'missing' when the JSON parses to null", () => {
+    writeFileSync(cachePath, "null");
+    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'missing' when the JSON is not an object", () => {
+    writeFileSync(cachePath, "5");
+    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'missing' when the object lacks required fields", () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8" }));
+    const result = readUpgradeCheckCache(cachePath, { now: () => 0, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'fresh' when the entry is within the TTL", () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1000 }));
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "fresh", entry: { latest: "3.1.8", fetchedAt: 1000 } });
+  });
+
+  it("returns 'stale' when the entry is older than the TTL", () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1000 }));
+    const result = readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "stale", entry: { latest: "3.1.8", fetchedAt: 1000 } });
+  });
+});
+
+describe(writeUpgradeCheckCache, () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("creates intermediate directories and writes the entry", () => {
+    const cachePath = join(cacheDir, "nested", "upgrade-check.json");
+    writeUpgradeCheckCache(cachePath, { latest: "3.2.0", fetchedAt: 42 });
+    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 42,
+    });
+  });
+
+  it("overwrites an existing cache file", () => {
+    const cachePath = join(cacheDir, "upgrade-check.json");
+    writeUpgradeCheckCache(cachePath, { latest: "3.1.8", fetchedAt: 1 });
+    writeUpgradeCheckCache(cachePath, { latest: "3.2.0", fetchedAt: 2 });
+    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 2,
+    });
+  });
+});
+
+describe(composeNudgeMessage, () => {
+  it("returns a one-line message when latest is newer than current", () => {
+    expect(composeNudgeMessage("3.1.8", "3.2.0")).toBe(
+      "[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)",
+    );
+  });
+
+  it("returns undefined when current equals latest", () => {
+    expect(composeNudgeMessage("3.1.8", "3.1.8")).toBeUndefined();
+  });
+
+  it("returns undefined when current is newer than latest", () => {
+    expect(composeNudgeMessage("3.2.0", "3.1.8")).toBeUndefined();
+  });
+});
+
+describe(computeUpgradeNudge, () => {
+  let cacheDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-nudge-"));
+    cachePath = join(cacheDir, "upgrade-check.json");
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  function baseOptions(overrides: {
+    currentVersion: string;
+    fetcher?: FetcherFn;
+    noUpgradeCheck?: boolean;
+    now?: () => number;
+  }): ComputeUpgradeNudgeOptions {
+    return {
+      currentVersion: overrides.currentVersion,
+      packageName: "@clipboard-health/groundcrew",
+      cachePath,
+      ttlMs: 6 * 60 * 60 * 1000,
+      fetchTimeoutMs: 300,
+      noUpgradeCheck: overrides.noUpgradeCheck ?? false,
+      now: overrides.now ?? (() => 1_000_000),
+      fetcher:
+        overrides.fetcher ??
+        (async () => {
+          throw new Error("fetcher should not have been called");
+        }),
+    };
+  }
+
+  it("returns undefined when noUpgradeCheck is true (env opt-out)", async () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "9.9.9", fetchedAt: 1_000_000 }));
+    const result = await computeUpgradeNudge(
+      baseOptions({ currentVersion: "1.0.0", noUpgradeCheck: true }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns a nudge using a fresh cache entry when newer", async () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.2.0", fetchedAt: 1_000_000 }));
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+  });
+
+  it("returns undefined when fresh cache equals current", async () => {
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1_000_000 }));
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
+    expect(result).toBeUndefined();
+  });
+
+  it("fetches when cache is stale, writes new cache, returns nudge", async () => {
+    const stale = 1_000_000 - 100 * 60 * 60 * 1000; // 100h ago, beyond 6h TTL
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: stale }));
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(fetcher).toHaveBeenCalledWith("@clipboard-health/groundcrew", {
+      timeoutMs: 300,
+      registry: undefined,
+    });
+    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 1_000_000,
+    });
+  });
+
+  it("falls back to stale cache entry when fetch fails", async () => {
+    const stale = 1_000_000 - 100 * 60 * 60 * 1000;
+    writeFileSync(cachePath, JSON.stringify({ latest: "3.2.0", fetchedAt: stale }));
+    const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: stale,
+    });
+  });
+
+  it("returns undefined when fetch fails and no cache exists", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBeUndefined();
+  });
+
+  it("fetches when cache is missing and writes the cache on success", async () => {
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 1_000_000,
+    });
+  });
+});

--- a/src/lib/upgrade.test.ts
+++ b/src/lib/upgrade.test.ts
@@ -416,4 +416,17 @@ describe(computeUpgradeNudge, () => {
       fetchedAt: 1_000_000,
     });
   });
+
+  it("returns the fresh nudge even when cache write throws", async () => {
+    // Point cachePath under a regular file so mkdirSync inside writeUpgradeCheckCache throws.
+    const blocker = join(cacheDir, "blocker");
+    writeFileSync(blocker, "");
+    const unreachableCachePath = join(blocker, "cache.json");
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge({
+      ...baseOptions({ currentVersion: "3.1.8", fetcher }),
+      cachePath: unreachableCachePath,
+    });
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+  });
 });

--- a/src/lib/upgrade.test.ts
+++ b/src/lib/upgrade.test.ts
@@ -9,12 +9,46 @@ import {
   computeUpgradeNudge,
   defaultUpgradeCheckCachePath,
   fetchLatestVersion,
+  normalizeRegistry,
   parseVersion,
+  primeUpgradeCheckCache,
   readUpgradeCheckCache,
+  recordUpgradeCheckFailure,
+  type UpgradeCheckCacheEntry,
+  type UpgradeCheckFailureCacheEntry,
   writeUpgradeCheckCache,
 } from "./upgrade.ts";
 
 type FetcherFn = ComputeUpgradeNudgeOptions["fetcher"];
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
+
+function cacheEntry(overrides: Partial<UpgradeCheckCacheEntry> = {}): UpgradeCheckCacheEntry {
+  return {
+    latest: "3.1.8",
+    fetchedAt: 1000,
+    registry: DEFAULT_REGISTRY,
+    ...overrides,
+  };
+}
+
+function failureCacheEntry(
+  overrides: Partial<UpgradeCheckFailureCacheEntry> = {},
+): UpgradeCheckFailureCacheEntry {
+  return {
+    status: "failure",
+    fetchedAt: 1000,
+    registry: DEFAULT_REGISTRY,
+    ...overrides,
+  };
+}
+
+function writeCacheEntry(path: string, overrides: Partial<UpgradeCheckCacheEntry> = {}): void {
+  writeUpgradeCheckCache(path, cacheEntry(overrides));
+}
+
+function readCacheEntry(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
 
 describe(parseVersion, () => {
   it("parses major.minor.patch", () => {
@@ -64,6 +98,18 @@ describe(parseVersion, () => {
   it("throws on empty string", () => {
     expect(() => parseVersion("")).toThrow(/invalid version/i);
   });
+
+  it("throws on leading-zero numeric components", () => {
+    expect(() => parseVersion("01.2.3")).toThrow(/invalid version/i);
+  });
+
+  it("throws on empty prerelease identifiers", () => {
+    expect(() => parseVersion("1.2.3-alpha..1")).toThrow(/invalid version/i);
+  });
+
+  it("throws on empty build identifiers", () => {
+    expect(() => parseVersion("1.2.3+build..1")).toThrow(/invalid version/i);
+  });
 });
 
 describe(compareVersions, () => {
@@ -99,8 +145,48 @@ describe(compareVersions, () => {
     expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.1")).toBe(0);
   });
 
-  it("treats two distinct prereleases of the same numeric as equal (coarse comparison)", () => {
-    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.2")).toBe(0);
+  it("orders prerelease identifiers numerically", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.2")).toBe(-1);
+  });
+
+  it("orders larger numeric prerelease identifiers higher", () => {
+    expect(compareVersions("3.1.8-beta.2", "3.1.8-beta.1")).toBe(1);
+  });
+
+  it("orders numeric prerelease identifiers without losing precision", () => {
+    expect(compareVersions("3.1.8-beta.9007199254740993", "3.1.8-beta.9007199254740992")).toBe(1);
+  });
+
+  it("orders numeric prerelease identifiers by length before lexical order", () => {
+    expect(compareVersions("3.1.8-beta.10", "3.1.8-beta.9")).toBe(1);
+  });
+
+  it("orders shorter numeric prerelease identifiers lower by length", () => {
+    expect(compareVersions("3.1.8-beta.9", "3.1.8-beta.10")).toBe(-1);
+  });
+
+  it("orders non-numeric prerelease identifiers lexically", () => {
+    expect(compareVersions("3.1.8-alpha", "3.1.8-beta")).toBe(-1);
+  });
+
+  it("orders later lexical prerelease identifiers higher", () => {
+    expect(compareVersions("3.1.8-beta", "3.1.8-alpha")).toBe(1);
+  });
+
+  it("ranks numeric prerelease identifiers lower than non-numeric ones", () => {
+    expect(compareVersions("3.1.8-1", "3.1.8-alpha")).toBe(-1);
+  });
+
+  it("ranks non-numeric prerelease identifiers higher than numeric ones", () => {
+    expect(compareVersions("3.1.8-alpha", "3.1.8-1")).toBe(1);
+  });
+
+  it("ranks a longer prerelease higher when all preceding identifiers match", () => {
+    expect(compareVersions("3.1.8-beta.1.1", "3.1.8-beta.1")).toBe(1);
+  });
+
+  it("ranks a shorter prerelease lower when all preceding identifiers match", () => {
+    expect(compareVersions("3.1.8-beta.1", "3.1.8-beta.1.1")).toBe(-1);
   });
 });
 
@@ -125,7 +211,7 @@ describe(fetchLatestVersion, () => {
     vi.stubGlobal("fetch", fetchMock);
     await fetchLatestVersion("@scope/pkg", { timeoutMs: 1000 });
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/@scope/pkg/latest",
+      "https://registry.npmjs.org/@scope%2Fpkg/latest",
       expect.any(Object),
     );
   });
@@ -140,7 +226,7 @@ describe(fetchLatestVersion, () => {
       registry: "https://npm.mirror.example/",
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://npm.mirror.example/@scope/pkg/latest",
+      "https://npm.mirror.example/@scope%2Fpkg/latest",
       expect.any(Object),
     );
   });
@@ -180,6 +266,29 @@ describe(fetchLatestVersion, () => {
     );
   });
 
+  it("keeps the timeout active while reading the response body", async () => {
+    let abortBody: ((error: Error) => void) | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockImplementation(async (_input, init) => {
+        init?.signal?.addEventListener("abort", () => {
+          abortBody?.(new Error("body aborted"));
+        });
+        const response = new Response("{}", { status: 200 });
+        vi.spyOn(response, "json").mockImplementation(
+          async () =>
+            await new Promise<unknown>((_resolve, reject) => {
+              abortBody = reject;
+            }),
+        );
+        return response;
+      }),
+    );
+    await expect(fetchLatestVersion("@scope/pkg", { timeoutMs: 5 })).rejects.toThrow(
+      /body aborted/,
+    );
+  });
+
   it("throws when the response body lacks a version field entirely", async () => {
     vi.stubGlobal(
       "fetch",
@@ -197,6 +306,17 @@ describe(fetchLatestVersion, () => {
   });
 });
 
+describe(normalizeRegistry, () => {
+  it("returns the default npm registry when no registry is configured", () => {
+    const input: { registry?: string } = {};
+    expect(normalizeRegistry(input.registry)).toBe(DEFAULT_REGISTRY);
+  });
+
+  it("strips one trailing slash from a configured registry", () => {
+    expect(normalizeRegistry("https://npm.mirror.example/")).toBe("https://npm.mirror.example");
+  });
+});
+
 describe(defaultUpgradeCheckCachePath, () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -210,6 +330,13 @@ describe(defaultUpgradeCheckCachePath, () => {
   it("falls back to ~/.cache when XDG_CACHE_HOME is unset", () => {
     // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the unset-env fallback
     vi.stubEnv("XDG_CACHE_HOME", undefined);
+    expect(defaultUpgradeCheckCachePath()).toBe(
+      join(homedir(), ".cache", "groundcrew", "upgrade-check.json"),
+    );
+  });
+
+  it("falls back to ~/.cache when XDG_CACHE_HOME is empty", () => {
+    vi.stubEnv("XDG_CACHE_HOME", "");
     expect(defaultUpgradeCheckCachePath()).toBe(
       join(homedir(), ".cache", "groundcrew", "upgrade-check.json"),
     );
@@ -258,16 +385,60 @@ describe(readUpgradeCheckCache, () => {
     expect(result).toStrictEqual({ kind: "missing" });
   });
 
-  it("returns 'fresh' when the entry is within the TTL", () => {
+  it("returns 'missing' when the cache entry lacks the registry field", () => {
     writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1000 }));
     const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "fresh", entry: { latest: "3.1.8", fetchedAt: 1000 } });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'missing' when a non-failure cache entry lacks latest", () => {
+    writeFileSync(cachePath, JSON.stringify({ fetchedAt: 1000, registry: DEFAULT_REGISTRY }));
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'fresh' when the entry is within the TTL", () => {
+    writeCacheEntry(cachePath);
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({
+      kind: "fresh",
+      entry: cacheEntry(),
+    });
   });
 
   it("returns 'stale' when the entry is older than the TTL", () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1000 }));
+    writeCacheEntry(cachePath);
     const result = readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 });
-    expect(result).toStrictEqual({ kind: "stale", entry: { latest: "3.1.8", fetchedAt: 1000 } });
+    expect(result).toStrictEqual({
+      kind: "stale",
+      entry: cacheEntry(),
+    });
+  });
+
+  it("returns 'missing' when the cache entry was fetched from a different registry", () => {
+    writeCacheEntry(cachePath, { latest: "9.9.9", registry: "https://npm.mirror.example" });
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
+  });
+
+  it("returns 'recentFailure' for a fresh failed check marker", () => {
+    const entry = failureCacheEntry();
+    writeUpgradeCheckCache(cachePath, entry);
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "recentFailure", entry });
+  });
+
+  it("preserves latest on a fresh failed check marker", () => {
+    const entry = failureCacheEntry({ latest: "3.2.0" });
+    writeUpgradeCheckCache(cachePath, entry);
+    const result = readUpgradeCheckCache(cachePath, { now: () => 1500, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "recentFailure", entry });
+  });
+
+  it("returns 'missing' for a stale failed check marker", () => {
+    writeUpgradeCheckCache(cachePath, failureCacheEntry());
+    const result = readUpgradeCheckCache(cachePath, { now: () => 5000, ttlMs: 1000 });
+    expect(result).toStrictEqual({ kind: "missing" });
   });
 });
 
@@ -284,21 +455,120 @@ describe(writeUpgradeCheckCache, () => {
 
   it("creates intermediate directories and writes the entry", () => {
     const cachePath = join(cacheDir, "nested", "upgrade-check.json");
-    writeUpgradeCheckCache(cachePath, { latest: "3.2.0", fetchedAt: 42 });
-    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
-      latest: "3.2.0",
-      fetchedAt: 42,
-    });
+    const entry = cacheEntry({ latest: "3.2.0", fetchedAt: 42 });
+    writeUpgradeCheckCache(cachePath, entry);
+    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
   });
 
   it("overwrites an existing cache file", () => {
     const cachePath = join(cacheDir, "upgrade-check.json");
-    writeUpgradeCheckCache(cachePath, { latest: "3.1.8", fetchedAt: 1 });
-    writeUpgradeCheckCache(cachePath, { latest: "3.2.0", fetchedAt: 2 });
-    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+    writeUpgradeCheckCache(cachePath, cacheEntry({ fetchedAt: 1 }));
+    const entry = cacheEntry({
       latest: "3.2.0",
       fetchedAt: 2,
+      registry: "https://npm.mirror.example",
     });
+    writeUpgradeCheckCache(cachePath, entry);
+    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
+  });
+
+  it("writes a failed check marker", () => {
+    const cachePath = join(cacheDir, "upgrade-check.json");
+    const entry = failureCacheEntry({ fetchedAt: 2 });
+    writeUpgradeCheckCache(cachePath, entry);
+    expect(readCacheEntry(cachePath)).toStrictEqual(entry);
+  });
+});
+
+describe(primeUpgradeCheckCache, () => {
+  let cacheDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
+    cachePath = join(cacheDir, "upgrade-check.json");
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("writes a normalized registry cache entry", () => {
+    primeUpgradeCheckCache({
+      path: cachePath,
+      latest: "3.2.0",
+      now: () => 42,
+      registry: "https://npm.mirror.example/",
+    });
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 42,
+      registry: "https://npm.mirror.example",
+    });
+  });
+
+  it("swallows cache write failures", () => {
+    const blocker = join(cacheDir, "blocker");
+    writeFileSync(blocker, "");
+    expect(() => {
+      primeUpgradeCheckCache({
+        path: join(blocker, "cache.json"),
+        latest: "3.2.0",
+        now: () => 42,
+      });
+    }).not.toThrow();
+  });
+});
+
+describe(recordUpgradeCheckFailure, () => {
+  let cacheDir: string;
+  let cachePath: string;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-cache-"));
+    cachePath = join(cacheDir, "upgrade-check.json");
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("writes a normalized registry failure marker", () => {
+    recordUpgradeCheckFailure({
+      path: cachePath,
+      now: () => 42,
+      registry: "https://npm.mirror.example/",
+    });
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      status: "failure",
+      fetchedAt: 42,
+      registry: "https://npm.mirror.example",
+    });
+  });
+
+  it("preserves a stale latest version while recording a failure marker", () => {
+    recordUpgradeCheckFailure({
+      path: cachePath,
+      latest: "3.2.0",
+      now: () => 42,
+    });
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      status: "failure",
+      latest: "3.2.0",
+      fetchedAt: 42,
+      registry: DEFAULT_REGISTRY,
+    });
+  });
+
+  it("swallows cache write failures", () => {
+    const blocker = join(cacheDir, "blocker");
+    writeFileSync(blocker, "");
+    expect(() => {
+      recordUpgradeCheckFailure({
+        path: join(blocker, "cache.json"),
+        now: () => 42,
+      });
+    }).not.toThrow();
   });
 });
 
@@ -354,7 +624,7 @@ describe(computeUpgradeNudge, () => {
   }
 
   it("returns undefined when noUpgradeCheck is true (env opt-out)", async () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "9.9.9", fetchedAt: 1_000_000 }));
+    writeCacheEntry(cachePath, { latest: "9.9.9", fetchedAt: 1_000_000 });
     const result = await computeUpgradeNudge(
       baseOptions({ currentVersion: "1.0.0", noUpgradeCheck: true }),
     );
@@ -362,20 +632,20 @@ describe(computeUpgradeNudge, () => {
   });
 
   it("returns a nudge using a fresh cache entry when newer", async () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.2.0", fetchedAt: 1_000_000 }));
+    writeCacheEntry(cachePath, { latest: "3.2.0", fetchedAt: 1_000_000 });
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
   });
 
   it("returns undefined when fresh cache equals current", async () => {
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: 1_000_000 }));
+    writeCacheEntry(cachePath, { fetchedAt: 1_000_000 });
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8" }));
     expect(result).toBeUndefined();
   });
 
   it("fetches when cache is stale, writes new cache, returns nudge", async () => {
     const stale = 1_000_000 - 100 * 60 * 60 * 1000; // 100h ago, beyond 6h TTL
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.1.8", fetchedAt: stale }));
+    writeCacheEntry(cachePath, { fetchedAt: stale });
     const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
@@ -383,21 +653,24 @@ describe(computeUpgradeNudge, () => {
       timeoutMs: 300,
       registry: undefined,
     });
-    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+    expect(readCacheEntry(cachePath)).toStrictEqual({
       latest: "3.2.0",
       fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
     });
   });
 
   it("falls back to stale cache entry when fetch fails", async () => {
     const stale = 1_000_000 - 100 * 60 * 60 * 1000;
-    writeFileSync(cachePath, JSON.stringify({ latest: "3.2.0", fetchedAt: stale }));
+    writeCacheEntry(cachePath, { latest: "3.2.0", fetchedAt: stale });
     const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
-    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      status: "failure",
       latest: "3.2.0",
-      fetchedAt: stale,
+      fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
     });
   });
 
@@ -405,15 +678,73 @@ describe(computeUpgradeNudge, () => {
     const fetcher = vi.fn<FetcherFn>().mockRejectedValueOnce(new Error("network down"));
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
     expect(result).toBeUndefined();
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      status: "failure",
+      fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
+    });
+  });
+
+  it("skips fetching during the failed-check backoff window", async () => {
+    writeUpgradeCheckCache(cachePath, failureCacheEntry({ fetchedAt: 1_000_000 }));
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBeUndefined();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("uses a failed-check marker with latest during the backoff window", async () => {
+    writeUpgradeCheckCache(cachePath, failureCacheEntry({ latest: "3.2.0", fetchedAt: 1_000_000 }));
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("9.9.9");
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("fetches again after a failed-check marker expires", async () => {
+    const stale = 1_000_000 - 100 * 60 * 60 * 1000;
+    writeUpgradeCheckCache(cachePath, failureCacheEntry({ fetchedAt: stale }));
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
+    });
   });
 
   it("fetches when cache is missing and writes the cache on success", async () => {
     const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
     const result = await computeUpgradeNudge(baseOptions({ currentVersion: "3.1.8", fetcher }));
     expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
-    expect(JSON.parse(readFileSync(cachePath, "utf8"))).toStrictEqual({
+    expect(readCacheEntry(cachePath)).toStrictEqual({
       latest: "3.2.0",
       fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
+    });
+  });
+
+  it("ignores a fresh cache entry from a different registry and refreshes it", async () => {
+    writeCacheEntry(cachePath, {
+      latest: "9.9.9",
+      fetchedAt: 1_000_000,
+      registry: "https://npm.mirror.example",
+    });
+    const fetcher = vi.fn<FetcherFn>().mockResolvedValueOnce("3.2.0");
+    const result = await computeUpgradeNudge({
+      ...baseOptions({ currentVersion: "3.1.8", fetcher }),
+      registry: "https://registry.npmjs.org/",
+    });
+    expect(result).toBe("[crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)");
+    expect(fetcher).toHaveBeenCalledWith("@clipboard-health/groundcrew", {
+      timeoutMs: 300,
+      registry: "https://registry.npmjs.org/",
+    });
+    expect(readCacheEntry(cachePath)).toStrictEqual({
+      latest: "3.2.0",
+      fetchedAt: 1_000_000,
+      registry: DEFAULT_REGISTRY,
     });
   });
 

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { readEnvironmentVariable } from "./util.ts";
+
+interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+export function parseVersion(version: string): Version {
+  const match = VERSION_RE.exec(version);
+  if (!match) {
+    throw new Error(`invalid version: ${JSON.stringify(version)}`);
+  }
+  return {
+    // oxlint-disable typescript/no-non-null-assertion -- VERSION_RE guarantees all three capture groups on match.
+    major: Number.parseInt(match[1]!, 10),
+    minor: Number.parseInt(match[2]!, 10),
+    patch: Number.parseInt(match[3]!, 10),
+    // oxlint-enable typescript/no-non-null-assertion
+  };
+}
+
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (left[key] !== right[key]) {
+      return left[key] > right[key] ? 1 : -1;
+    }
+  }
+  return 0;
+}
+
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
+
+interface FetchOptions {
+  timeoutMs: number;
+  registry?: string | undefined;
+}
+
+export async function fetchLatestVersion(
+  packageName: string,
+  options: FetchOptions,
+): Promise<string> {
+  const registry = (options.registry ?? DEFAULT_REGISTRY).replace(/\/$/, "");
+  const url = `${registry}/${packageName}/latest`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, options.timeoutMs);
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    throw new Error(`registry request failed: ${String(error)}`, { cause: error });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!response.ok) {
+    throw new Error(`registry returned ${response.status} for ${url}`);
+  }
+  const body: unknown = await response.json();
+  if (typeof body !== "object" || body === null || !("version" in body)) {
+    throw new TypeError(`registry response missing 'version' field`);
+  }
+  const { version } = body;
+  if (typeof version !== "string") {
+    throw new TypeError(`registry response missing 'version' field`);
+  }
+  return version;
+}
+
+export interface UpgradeCheckCacheEntry {
+  latest: string;
+  fetchedAt: number;
+}
+
+export type UpgradeCheckCacheResult =
+  | { kind: "missing" }
+  | { kind: "fresh"; entry: UpgradeCheckCacheEntry }
+  | { kind: "stale"; entry: UpgradeCheckCacheEntry };
+
+export function defaultUpgradeCheckCachePath(): string {
+  const base = readEnvironmentVariable("XDG_CACHE_HOME") ?? join(homedir(), ".cache");
+  return join(base, "groundcrew", "upgrade-check.json");
+}
+
+function parseCacheEntry(value: unknown): UpgradeCheckCacheEntry | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const candidate = value as { latest?: unknown; fetchedAt?: unknown };
+  if (typeof candidate.latest !== "string" || typeof candidate.fetchedAt !== "number") {
+    return undefined;
+  }
+  return { latest: candidate.latest, fetchedAt: candidate.fetchedAt };
+}
+
+export function readUpgradeCheckCache(
+  path: string,
+  options: { now: () => number; ttlMs: number },
+): UpgradeCheckCacheResult {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return { kind: "missing" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: "missing" };
+  }
+  const entry = parseCacheEntry(parsed);
+  if (!entry) {
+    return { kind: "missing" };
+  }
+  const ageMs = options.now() - entry.fetchedAt;
+  return ageMs >= options.ttlMs ? { kind: "stale", entry } : { kind: "fresh", entry };
+}
+
+export function writeUpgradeCheckCache(path: string, entry: UpgradeCheckCacheEntry): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(entry));
+}
+
+export function composeNudgeMessage(current: string, latest: string): string | undefined {
+  if (compareVersions(current, latest) >= 0) {
+    return undefined;
+  }
+  return `[crew] ${latest} available — run \`crew upgrade\` (you have ${current})`;
+}
+
+type VersionFetcher = (packageName: string, options: FetchOptions) => Promise<string>;
+
+export interface ComputeUpgradeNudgeOptions {
+  currentVersion: string;
+  packageName: string;
+  cachePath: string;
+  ttlMs: number;
+  fetchTimeoutMs: number;
+  registry?: string | undefined;
+  noUpgradeCheck: boolean;
+  now: () => number;
+  fetcher: VersionFetcher;
+}
+
+export async function computeUpgradeNudge(
+  options: ComputeUpgradeNudgeOptions,
+): Promise<string | undefined> {
+  if (options.noUpgradeCheck) {
+    return undefined;
+  }
+  const cacheResult = readUpgradeCheckCache(options.cachePath, {
+    now: options.now,
+    ttlMs: options.ttlMs,
+  });
+  if (cacheResult.kind === "fresh") {
+    return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
+  }
+  try {
+    const latest = await options.fetcher(options.packageName, {
+      timeoutMs: options.fetchTimeoutMs,
+      registry: options.registry,
+    });
+    writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+    return composeNudgeMessage(options.currentVersion, latest);
+  } catch {
+    if (cacheResult.kind === "stale") {
+      return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
+    }
+    return undefined;
+  }
+}

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -8,15 +8,11 @@ interface Version {
   major: number;
   minor: number;
   patch: number;
-  prerelease: string | undefined;
 }
 
 const NUMERIC_IDENTIFIER_PATTERN = String.raw`0|[1-9]\d*`;
-const PRERELEASE_IDENTIFIER_PATTERN = String.raw`(?:${NUMERIC_IDENTIFIER_PATTERN}|\d*[A-Za-z-][0-9A-Za-z-]*)`;
-const PRERELEASE_PATTERN = String.raw`${PRERELEASE_IDENTIFIER_PATTERN}(?:\.${PRERELEASE_IDENTIFIER_PATTERN})*`;
-const BUILD_PATTERN = String.raw`[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`;
 const VERSION_RE = new RegExp(
-  String.raw`^(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})(?:-(${PRERELEASE_PATTERN}))?(?:\+${BUILD_PATTERN})?$`,
+  String.raw`^(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})$`,
 );
 
 export function parseVersion(version: string): Version {
@@ -30,7 +26,6 @@ export function parseVersion(version: string): Version {
     minor: Number.parseInt(match[2]!, 10),
     patch: Number.parseInt(match[3]!, 10),
     // oxlint-enable typescript/no-non-null-assertion
-    prerelease: match[4],
   };
 }
 
@@ -42,60 +37,7 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
       return left[key] > right[key] ? 1 : -1;
     }
   }
-  // Numeric parts equal. Per SemVer 11.3, a stable version outranks any
-  // prerelease of the same numeric.
-  if (left.prerelease === undefined && right.prerelease === undefined) {
-    return 0;
-  }
-  if (left.prerelease === undefined) {
-    return 1;
-  }
-  if (right.prerelease === undefined) {
-    return -1;
-  }
-  return comparePrereleases(left.prerelease, right.prerelease);
-}
-
-function comparePrereleases(a: string, b: string): -1 | 0 | 1 {
-  const left = a.split(".");
-  const right = b.split(".");
-  const length = Math.max(left.length, right.length);
-  for (let index = 0; index < length; index += 1) {
-    const leftPart = left[index];
-    const rightPart = right[index];
-    if (leftPart === undefined) {
-      return -1;
-    }
-    if (rightPart === undefined) {
-      return 1;
-    }
-    const comparison = comparePrereleaseIdentifier(leftPart, rightPart);
-    if (comparison !== 0) {
-      return comparison;
-    }
-  }
   return 0;
-}
-
-function comparePrereleaseIdentifier(a: string, b: string): -1 | 0 | 1 {
-  if (a === b) {
-    return 0;
-  }
-  const leftNumeric = /^\d+$/.test(a);
-  const rightNumeric = /^\d+$/.test(b);
-  if (leftNumeric && rightNumeric) {
-    if (a.length !== b.length) {
-      return a.length > b.length ? 1 : -1;
-    }
-    return a > b ? 1 : -1;
-  }
-  if (leftNumeric) {
-    return -1;
-  }
-  if (rightNumeric) {
-    return 1;
-  }
-  return a > b ? 1 : -1;
 }
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
@@ -141,6 +83,7 @@ export async function fetchLatestVersion(
     if (typeof version !== "string") {
       throw new TypeError(`registry response 'version' field is not a string`);
     }
+    parseVersion(version);
     return version;
   } finally {
     clearTimeout(timer);
@@ -153,13 +96,6 @@ export interface UpgradeCheckCacheEntry {
   registry: string;
 }
 
-export interface UpgradeCheckFailureCacheEntry {
-  status: "failure";
-  fetchedAt: number;
-  registry: string;
-  latest?: string | undefined;
-}
-
 export interface PrimeUpgradeCheckCacheOptions {
   path: string;
   latest: string;
@@ -167,18 +103,10 @@ export interface PrimeUpgradeCheckCacheOptions {
   now: () => number;
 }
 
-export interface RecordUpgradeCheckFailureOptions {
-  path: string;
-  registry?: string | undefined;
-  latest?: string | undefined;
-  now: () => number;
-}
-
 export type UpgradeCheckCacheResult =
   | { kind: "missing" }
   | { kind: "fresh"; entry: UpgradeCheckCacheEntry }
-  | { kind: "stale"; entry: UpgradeCheckCacheEntry }
-  | { kind: "recentFailure"; entry: UpgradeCheckFailureCacheEntry };
+  | { kind: "stale"; entry: UpgradeCheckCacheEntry };
 
 export function defaultUpgradeCheckCachePath(): string {
   const override = readEnvironmentVariable("XDG_CACHE_HOME");
@@ -187,9 +115,7 @@ export function defaultUpgradeCheckCachePath(): string {
   return join(base, "groundcrew", "upgrade-check.json");
 }
 
-function parseCacheEntry(
-  value: unknown,
-): UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry | undefined {
+function parseCacheEntry(value: unknown): UpgradeCheckCacheEntry | undefined {
   if (typeof value !== "object" || value === null) {
     return undefined;
   }
@@ -197,20 +123,17 @@ function parseCacheEntry(
     latest?: unknown;
     fetchedAt?: unknown;
     registry?: unknown;
-    status?: unknown;
   };
-  if (typeof candidate.fetchedAt !== "number" || typeof candidate.registry !== "string") {
+  if (
+    typeof candidate.latest !== "string" ||
+    typeof candidate.fetchedAt !== "number" ||
+    typeof candidate.registry !== "string"
+  ) {
     return undefined;
   }
-  if (candidate.status === "failure") {
-    const entry: UpgradeCheckFailureCacheEntry = {
-      status: "failure",
-      fetchedAt: candidate.fetchedAt,
-      registry: candidate.registry,
-    };
-    return typeof candidate.latest === "string" ? { ...entry, latest: candidate.latest } : entry;
-  }
-  if (typeof candidate.latest !== "string") {
+  try {
+    parseVersion(candidate.latest);
+  } catch {
     return undefined;
   }
   return { latest: candidate.latest, fetchedAt: candidate.fetchedAt, registry: candidate.registry };
@@ -240,24 +163,15 @@ export function readUpgradeCheckCache(
     return { kind: "missing" };
   }
   const ageMs = options.now() - entry.fetchedAt;
-  if ("status" in entry) {
-    return ageMs >= options.ttlMs ? { kind: "missing" } : { kind: "recentFailure", entry };
-  }
   return ageMs >= options.ttlMs ? { kind: "stale", entry } : { kind: "fresh", entry };
 }
 
-export function writeUpgradeCheckCache(
-  path: string,
-  entry: UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry,
-): void {
+export function writeUpgradeCheckCache(path: string, entry: UpgradeCheckCacheEntry): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(entry));
 }
 
-function writeUpgradeCheckCacheBestEffort(
-  path: string,
-  entry: UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry,
-): void {
+function writeUpgradeCheckCacheBestEffort(path: string, entry: UpgradeCheckCacheEntry): void {
   try {
     writeUpgradeCheckCache(path, entry);
   } catch {
@@ -270,15 +184,6 @@ export function primeUpgradeCheckCache(options: PrimeUpgradeCheckCacheOptions): 
     latest: options.latest,
     fetchedAt: options.now(),
     registry: normalizeRegistry(options.registry),
-  });
-}
-
-export function recordUpgradeCheckFailure(options: RecordUpgradeCheckFailureOptions): void {
-  writeUpgradeCheckCacheBestEffort(options.path, {
-    status: "failure",
-    fetchedAt: options.now(),
-    registry: normalizeRegistry(options.registry),
-    latest: options.latest,
   });
 }
 
@@ -342,25 +247,12 @@ export async function computeUpgradeNudge(
   if (cacheResult.kind === "fresh") {
     return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
   }
-  if (cacheResult.kind === "recentFailure") {
-    if (cacheResult.entry.latest !== undefined) {
-      return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
-    }
-    return undefined;
-  }
   try {
     const latest = await fetchAndPrimeUpgradeCheckCache(options);
     return composeNudgeMessage(options.currentVersion, latest);
   } catch {
-    const staleLatest = cacheResult.kind === "stale" ? cacheResult.entry.latest : undefined;
-    recordUpgradeCheckFailure({
-      path: options.cachePath,
-      registry: options.registry,
-      latest: staleLatest,
-      now: options.now,
-    });
-    if (staleLatest !== undefined) {
-      return composeNudgeMessage(options.currentVersion, staleLatest);
+    if (cacheResult.kind === "stale") {
+      return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
     }
     return undefined;
   }

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -8,9 +8,10 @@ interface Version {
   major: number;
   minor: number;
   patch: number;
+  prerelease: string | undefined;
 }
 
-const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?(?:\+.*)?$/;
 
 export function parseVersion(version: string): Version {
   const match = VERSION_RE.exec(version);
@@ -18,11 +19,12 @@ export function parseVersion(version: string): Version {
     throw new Error(`invalid version: ${JSON.stringify(version)}`);
   }
   return {
-    // oxlint-disable typescript/no-non-null-assertion -- VERSION_RE guarantees all three capture groups on match.
+    // oxlint-disable typescript/no-non-null-assertion -- VERSION_RE guarantees groups 1–3 on match; group 4 is optional.
     major: Number.parseInt(match[1]!, 10),
     minor: Number.parseInt(match[2]!, 10),
     patch: Number.parseInt(match[3]!, 10),
     // oxlint-enable typescript/no-non-null-assertion
+    prerelease: match[4],
   };
 }
 
@@ -33,6 +35,20 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
     if (left[key] !== right[key]) {
       return left[key] > right[key] ? 1 : -1;
     }
+  }
+  // Numeric parts equal. Per SemVer 11.3, a stable version outranks any
+  // prerelease of the same numeric. Two prereleases of the same numeric are
+  // treated as equal — we deliberately don't implement full per-identifier
+  // SemVer ordering, since the registry's `latest` dist-tag never points at
+  // a prerelease in npm convention.
+  if (left.prerelease === right.prerelease) {
+    return 0;
+  }
+  if (left.prerelease === undefined) {
+    return 1;
+  }
+  if (right.prerelease === undefined) {
+    return -1;
   }
   return 0;
 }

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -71,7 +71,7 @@ export async function fetchLatestVersion(
   }
   const { version } = body;
   if (typeof version !== "string") {
-    throw new TypeError(`registry response missing 'version' field`);
+    throw new TypeError(`registry response 'version' field is not a string`);
   }
   return version;
 }

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -186,7 +186,11 @@ export async function computeUpgradeNudge(
       timeoutMs: options.fetchTimeoutMs,
       registry: options.registry,
     });
-    writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+    try {
+      writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
+    } catch {
+      // Best-effort cache priming; don't lose a freshly-fetched value on disk error.
+    }
     return composeNudgeMessage(options.currentVersion, latest);
   } catch {
     if (cacheResult.kind === "stale") {

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { readEnvironmentVariable } from "./util.ts";
+import { errorMessage, readEnvironmentVariable } from "./util.ts";
 
 interface Version {
   major: number;
@@ -11,7 +11,13 @@ interface Version {
   prerelease: string | undefined;
 }
 
-const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([^+]+))?(?:\+.*)?$/;
+const NUMERIC_IDENTIFIER_PATTERN = String.raw`0|[1-9]\d*`;
+const PRERELEASE_IDENTIFIER_PATTERN = String.raw`(?:${NUMERIC_IDENTIFIER_PATTERN}|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const PRERELEASE_PATTERN = String.raw`${PRERELEASE_IDENTIFIER_PATTERN}(?:\.${PRERELEASE_IDENTIFIER_PATTERN})*`;
+const BUILD_PATTERN = String.raw`[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*`;
+const VERSION_RE = new RegExp(
+  String.raw`^(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})\.(${NUMERIC_IDENTIFIER_PATTERN})(?:-(${PRERELEASE_PATTERN}))?(?:\+${BUILD_PATTERN})?$`,
+);
 
 export function parseVersion(version: string): Version {
   const match = VERSION_RE.exec(version);
@@ -37,11 +43,8 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
     }
   }
   // Numeric parts equal. Per SemVer 11.3, a stable version outranks any
-  // prerelease of the same numeric. Two prereleases of the same numeric are
-  // treated as equal — we deliberately don't implement full per-identifier
-  // SemVer ordering, since the registry's `latest` dist-tag never points at
-  // a prerelease in npm convention.
-  if (left.prerelease === right.prerelease) {
+  // prerelease of the same numeric.
+  if (left.prerelease === undefined && right.prerelease === undefined) {
     return 0;
   }
   if (left.prerelease === undefined) {
@@ -50,12 +53,62 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
   if (right.prerelease === undefined) {
     return -1;
   }
+  return comparePrereleases(left.prerelease, right.prerelease);
+}
+
+function comparePrereleases(a: string, b: string): -1 | 0 | 1 {
+  const left = a.split(".");
+  const right = b.split(".");
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    const comparison = comparePrereleaseIdentifier(leftPart, rightPart);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
   return 0;
+}
+
+function comparePrereleaseIdentifier(a: string, b: string): -1 | 0 | 1 {
+  if (a === b) {
+    return 0;
+  }
+  const leftNumeric = /^\d+$/.test(a);
+  const rightNumeric = /^\d+$/.test(b);
+  if (leftNumeric && rightNumeric) {
+    if (a.length !== b.length) {
+      return a.length > b.length ? 1 : -1;
+    }
+    return a > b ? 1 : -1;
+  }
+  if (leftNumeric) {
+    return -1;
+  }
+  if (rightNumeric) {
+    return 1;
+  }
+  return a > b ? 1 : -1;
 }
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
-interface FetchOptions {
+export function normalizeRegistry(registry: string | undefined): string {
+  return (registry ?? DEFAULT_REGISTRY).replace(/\/$/, "");
+}
+
+function encodePackageNameForRegistry(packageName: string): string {
+  return encodeURIComponent(packageName).replace(/^%40/, "@");
+}
+
+export interface FetchOptions {
   timeoutMs: number;
   registry?: string | undefined;
 }
@@ -64,63 +117,108 @@ export async function fetchLatestVersion(
   packageName: string,
   options: FetchOptions,
 ): Promise<string> {
-  const registry = (options.registry ?? DEFAULT_REGISTRY).replace(/\/$/, "");
-  const url = `${registry}/${packageName}/latest`;
+  const registry = normalizeRegistry(options.registry);
+  const url = `${registry}/${encodePackageNameForRegistry(packageName)}/latest`;
   const controller = new AbortController();
   const timer = setTimeout(() => {
     controller.abort();
   }, options.timeoutMs);
-  let response: Response;
   try {
-    response = await fetch(url, { signal: controller.signal });
-  } catch (error) {
-    throw new Error(`registry request failed: ${String(error)}`, { cause: error });
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } catch (error) {
+      throw new Error(`registry request failed: ${errorMessage(error)}`, { cause: error });
+    }
+    if (!response.ok) {
+      throw new Error(`registry returned ${response.status} for ${url}`);
+    }
+    const body: unknown = await response.json();
+    if (typeof body !== "object" || body === null || !("version" in body)) {
+      throw new TypeError(`registry response missing 'version' field`);
+    }
+    const { version } = body;
+    if (typeof version !== "string") {
+      throw new TypeError(`registry response 'version' field is not a string`);
+    }
+    return version;
   } finally {
     clearTimeout(timer);
   }
-  if (!response.ok) {
-    throw new Error(`registry returned ${response.status} for ${url}`);
-  }
-  const body: unknown = await response.json();
-  if (typeof body !== "object" || body === null || !("version" in body)) {
-    throw new TypeError(`registry response missing 'version' field`);
-  }
-  const { version } = body;
-  if (typeof version !== "string") {
-    throw new TypeError(`registry response 'version' field is not a string`);
-  }
-  return version;
 }
 
 export interface UpgradeCheckCacheEntry {
   latest: string;
   fetchedAt: number;
+  registry: string;
+}
+
+export interface UpgradeCheckFailureCacheEntry {
+  status: "failure";
+  fetchedAt: number;
+  registry: string;
+  latest?: string | undefined;
+}
+
+export interface PrimeUpgradeCheckCacheOptions {
+  path: string;
+  latest: string;
+  registry?: string | undefined;
+  now: () => number;
+}
+
+export interface RecordUpgradeCheckFailureOptions {
+  path: string;
+  registry?: string | undefined;
+  latest?: string | undefined;
+  now: () => number;
 }
 
 export type UpgradeCheckCacheResult =
   | { kind: "missing" }
   | { kind: "fresh"; entry: UpgradeCheckCacheEntry }
-  | { kind: "stale"; entry: UpgradeCheckCacheEntry };
+  | { kind: "stale"; entry: UpgradeCheckCacheEntry }
+  | { kind: "recentFailure"; entry: UpgradeCheckFailureCacheEntry };
 
 export function defaultUpgradeCheckCachePath(): string {
-  const base = readEnvironmentVariable("XDG_CACHE_HOME") ?? join(homedir(), ".cache");
+  const override = readEnvironmentVariable("XDG_CACHE_HOME");
+  const base =
+    override === undefined || override.length === 0 ? join(homedir(), ".cache") : override;
   return join(base, "groundcrew", "upgrade-check.json");
 }
 
-function parseCacheEntry(value: unknown): UpgradeCheckCacheEntry | undefined {
+function parseCacheEntry(
+  value: unknown,
+): UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry | undefined {
   if (typeof value !== "object" || value === null) {
     return undefined;
   }
-  const candidate = value as { latest?: unknown; fetchedAt?: unknown };
-  if (typeof candidate.latest !== "string" || typeof candidate.fetchedAt !== "number") {
+  const candidate = value as {
+    latest?: unknown;
+    fetchedAt?: unknown;
+    registry?: unknown;
+    status?: unknown;
+  };
+  if (typeof candidate.fetchedAt !== "number" || typeof candidate.registry !== "string") {
     return undefined;
   }
-  return { latest: candidate.latest, fetchedAt: candidate.fetchedAt };
+  if (candidate.status === "failure") {
+    const entry: UpgradeCheckFailureCacheEntry = {
+      status: "failure",
+      fetchedAt: candidate.fetchedAt,
+      registry: candidate.registry,
+    };
+    return typeof candidate.latest === "string" ? { ...entry, latest: candidate.latest } : entry;
+  }
+  if (typeof candidate.latest !== "string") {
+    return undefined;
+  }
+  return { latest: candidate.latest, fetchedAt: candidate.fetchedAt, registry: candidate.registry };
 }
 
 export function readUpgradeCheckCache(
   path: string,
-  options: { now: () => number; ttlMs: number },
+  options: { now: () => number; ttlMs: number; registry?: string | undefined },
 ): UpgradeCheckCacheResult {
   let raw: string;
   try {
@@ -138,13 +236,50 @@ export function readUpgradeCheckCache(
   if (!entry) {
     return { kind: "missing" };
   }
+  if (entry.registry !== normalizeRegistry(options.registry)) {
+    return { kind: "missing" };
+  }
   const ageMs = options.now() - entry.fetchedAt;
+  if ("status" in entry) {
+    return ageMs >= options.ttlMs ? { kind: "missing" } : { kind: "recentFailure", entry };
+  }
   return ageMs >= options.ttlMs ? { kind: "stale", entry } : { kind: "fresh", entry };
 }
 
-export function writeUpgradeCheckCache(path: string, entry: UpgradeCheckCacheEntry): void {
+export function writeUpgradeCheckCache(
+  path: string,
+  entry: UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry,
+): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(entry));
+}
+
+function writeUpgradeCheckCacheBestEffort(
+  path: string,
+  entry: UpgradeCheckCacheEntry | UpgradeCheckFailureCacheEntry,
+): void {
+  try {
+    writeUpgradeCheckCache(path, entry);
+  } catch {
+    // Upgrade-check cache writes are best-effort; callers should keep using current data.
+  }
+}
+
+export function primeUpgradeCheckCache(options: PrimeUpgradeCheckCacheOptions): void {
+  writeUpgradeCheckCacheBestEffort(options.path, {
+    latest: options.latest,
+    fetchedAt: options.now(),
+    registry: normalizeRegistry(options.registry),
+  });
+}
+
+export function recordUpgradeCheckFailure(options: RecordUpgradeCheckFailureOptions): void {
+  writeUpgradeCheckCacheBestEffort(options.path, {
+    status: "failure",
+    fetchedAt: options.now(),
+    registry: normalizeRegistry(options.registry),
+    latest: options.latest,
+  });
 }
 
 export function composeNudgeMessage(current: string, latest: string): string | undefined {
@@ -154,7 +289,32 @@ export function composeNudgeMessage(current: string, latest: string): string | u
   return `[crew] ${latest} available — run \`crew upgrade\` (you have ${current})`;
 }
 
-type VersionFetcher = (packageName: string, options: FetchOptions) => Promise<string>;
+export type VersionFetcher = (packageName: string, options: FetchOptions) => Promise<string>;
+
+export interface FetchAndPrimeUpgradeCheckCacheOptions {
+  packageName: string;
+  cachePath: string;
+  fetchTimeoutMs: number;
+  registry?: string | undefined;
+  now: () => number;
+  fetcher: VersionFetcher;
+}
+
+export async function fetchAndPrimeUpgradeCheckCache(
+  options: FetchAndPrimeUpgradeCheckCacheOptions,
+): Promise<string> {
+  const latest = await options.fetcher(options.packageName, {
+    timeoutMs: options.fetchTimeoutMs,
+    registry: options.registry,
+  });
+  primeUpgradeCheckCache({
+    path: options.cachePath,
+    latest,
+    registry: options.registry,
+    now: options.now,
+  });
+  return latest;
+}
 
 export interface ComputeUpgradeNudgeOptions {
   currentVersion: string;
@@ -177,24 +337,30 @@ export async function computeUpgradeNudge(
   const cacheResult = readUpgradeCheckCache(options.cachePath, {
     now: options.now,
     ttlMs: options.ttlMs,
+    registry: options.registry,
   });
   if (cacheResult.kind === "fresh") {
     return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
   }
-  try {
-    const latest = await options.fetcher(options.packageName, {
-      timeoutMs: options.fetchTimeoutMs,
-      registry: options.registry,
-    });
-    try {
-      writeUpgradeCheckCache(options.cachePath, { latest, fetchedAt: options.now() });
-    } catch {
-      // Best-effort cache priming; don't lose a freshly-fetched value on disk error.
+  if (cacheResult.kind === "recentFailure") {
+    if (cacheResult.entry.latest !== undefined) {
+      return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
     }
+    return undefined;
+  }
+  try {
+    const latest = await fetchAndPrimeUpgradeCheckCache(options);
     return composeNudgeMessage(options.currentVersion, latest);
   } catch {
-    if (cacheResult.kind === "stale") {
-      return composeNudgeMessage(options.currentVersion, cacheResult.entry.latest);
+    const staleLatest = cacheResult.kind === "stale" ? cacheResult.entry.latest : undefined;
+    recordUpgradeCheckFailure({
+      path: options.cachePath,
+      registry: options.registry,
+      latest: staleLatest,
+      now: options.now,
+    });
+    if (staleLatest !== undefined) {
+      return composeNudgeMessage(options.currentVersion, staleLatest);
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary

Adds a self-upgrade command for `crew` so users don't have to remember `npm install -g @clipboard-health/groundcrew@latest`, plus a passive nudge on every other subcommand when a newer version is published.

- **`crew upgrade [<version>] [--check]`** — installs `@latest` by default, accepts an exact version (upgrade or downgrade), or reports status with `--check`. Refuses cleanly when not running from a global npm install (`npm link` dev, npx temp, project dependency, unknown location) — each refusal carries a tailored hint pointing at the right fix.
- **Passive nudge** prints a single line to **stderr** before every non-`upgrade` subcommand when the registry's `latest` exceeds the running version:
  ```
  [crew] 3.2.0 available — run `crew upgrade` (you have 3.1.8)
  ```
  Cached at `~/.cache/groundcrew/upgrade-check.json` with a 6 h TTL and a 1000 ms hard fetch timeout. Explicit `crew upgrade` / `crew upgrade --check` calls also prime the cache, so the next subcommand never pays a network call. Silenced by `GROUNDCREW_NO_UPGRADE_CHECK=1`; honors `npm_config_registry` for corporate mirrors.
- **No new runtime dependencies** — version compare, registry fetch, and cache are hand-rolled (~50 lines each) against the existing `host.ts` / `commandRunner.ts` helpers. No `semver`, no chalk.

## Design decisions

| Decision | Outcome |
|---|---|
| Distribution | npm self-upgrade only (Homebrew considered, rejected) |
| Channel | Stable `latest` dist-tag only (no `--beta` / pre-release) |
| Downgrade | `crew upgrade <ver>` where `<ver>` < current prints `"downgrading A → B"` and proceeds (no prompt, no `--force`) |
| Prereleases | SemVer 11.3 ordering: stable > prerelease of same numeric, so a beta build correctly sees the upgrade nudge. Coarse comparison only (two prereleases of same numeric are equal). |
| Nudge cadence | Every non-`upgrade` invocation (incl. `crew run`), cached |
| Nudge style | Plain text, stderr, single line, npm-style (top of output) |
| Non-global refusal | Hard refuse; each install-kind gets a tailored hint |
| Post-upgrade changelog | Out of scope for v1 |

## Files

- **New** `src/lib/upgrade.ts` (+ test) — `parseVersion`, `compareVersions`, `fetchLatestVersion`, cache helpers, `composeNudgeMessage`, `computeUpgradeNudge`.
- **New** `src/lib/npmGlobal.ts` (+ test) — `classifyInstall`, `runNpmInstallGlobal`, `createDefaultNpmSpawner`, plus `detectInstallPath` / `detectNpmRootGlobal` / `detectIsSymlink` helpers.
- **New** `src/commands/upgrade.ts` (+ test) — `upgradeCli(argv, options)` orchestration and `createDefaultUpgradeCliOptions` factory.
- **Modified** `src/cli.ts` — registers the `upgrade` subcommand and calls the nudge before dispatch.
- **Modified** `src/cli.test.ts` — verifies dispatch routing and nudge wiring.

## Test plan

- [x] `node --run verify` passes — 1094 tests, 100% coverage across statements, branches, functions, lines.
- [ ] Manual smoke against a published version mismatch:
  - [x] `crew upgrade --check` from a globally-installed `crew` on an older version → prints `"X.Y.Z available …"`.
  - [x] `crew upgrade --check` when current = latest → prints `"crew is up to date (X.Y.Z)"`.
  - [x] `crew doctor` from an older version → nudge appears once on stderr, doctor output unaffected.
  - [ ] `GROUNDCREW_NO_UPGRADE_CHECK=1 crew doctor` → no nudge.
  - [ ] `crew upgrade` from the dev checkout (`node --run crew -- upgrade`) → refuses with `"npm link"`/`"project dependency"` hint and exits 1.
  - [ ] `crew upgrade 3.1.5` from a 3.1.8 install → prints `"downgrading 3.1.8 → 3.1.5"` and downgrades.

## Notes for the reviewer

- The `runInstall` closure in `createDefaultUpgradeCliOptions` exists so tests can swap out the real `runNpmInstallGlobal` + `createDefaultNpmSpawner` plumbing without spawning real `npm` processes.
- I considered passing `now: Date.now` directly to `computeUpgradeNudge` vs. wrapping in an arrow; passing the reference avoids an extra arrow function (and an extra `v8` coverage point).
- The default-case branch in `refusalMessage` is unreachable given `Exclude<InstallKind, "global">`, but ESLint requires it; suppressed with `/* v8 ignore next 3 @preserve */` matching the codebase's convention in `ticketDoctor.ts`.