### PR TITLE
chore: allow docs.datadoghq.com and fastdl.mongodb.org egress

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -29,6 +29,7 @@ slack.com
 api.datadoghq.com
 app.datadoghq.com
 datadoghq.com
+docs.datadoghq.com
 
 # GitHub + GHA artifact storage (Azure blobs)
 api.github.com
@@ -68,6 +69,7 @@ www.npmjs.com
 app.terraform.io
 buf.build
 cdn.playwright.dev
+fastdl.mongodb.org
 formulae.brew.sh
 hub.docker.com
 index.docker.io

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "embedex",
     "ensurecli",
     "esac",
+    "fastdl",
     "groundcrew",
     "defence",
     "discriminable",


### PR DESCRIPTION
## Summary

Adds two hosts to the clearance egress allowlist so agent runs aren't blocked when they need them:

- `docs.datadoghq.com` — Datadog's public documentation site (used by the `dd-docs` skill).
- `fastdl.mongodb.org` — MongoDB's official binary CDN, used by `mongodb-memory-server` and similar tooling to download MongoDB binaries.

Also adds `fastdl` to `cspell.json` since the hostname tripped the spellchecker.

## Validation

- `node --run verify` — 995 tests pass, 100% coverage.
- cspell now accepts `fastdl` (pre-commit hook ran cleanly on the second attempt).

Agent session: claude --resume 05cc52a8-ddae-46ce-ae07-57185936e9a1
<!-- commit-push-pr:created v1 core@3.4.1 -->