### PR TITLE
feat: add crew init for scaffolding crew.config.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Installs the `crew` binary. `@clipboard-health/clearance` is pulled in transitiv
 4. **Configure.** Create a `crew.config.ts` you can edit:
 
    ```bash
-   crew init            # write ./crew.config.ts in the current folder
-   crew init --global   # write ${XDG_CONFIG_HOME:-~/.config}/groundcrew/crew.config.ts
-   $EDITOR crew.config.ts
+   # Write into the current folder:
+   crew init && $EDITOR crew.config.ts
+
+   # ...or into the XDG config dir:
+   crew init --global && $EDITOR "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts"
    ```
 
    `crew init` refuses to overwrite an existing config; pass `--force` to replace it, or `--dry-run` to preview the destination path.

--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ Installs the `crew` binary. `@clipboard-health/clearance` is pulled in transitiv
 
 3. **Create a Linear project to scope your work.** Any team works — make a project inside it and drop tickets in. The orchestrator polls by project, not by team.
 
-4. **Configure.** Copy the shipped example into XDG config and edit:
+4. **Configure.** Create a `crew.config.ts` you can edit:
 
    ```bash
-   mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew"
-   cp "$(npm root -g)/@clipboard-health/groundcrew/crew.config.example.ts" \
-      "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts"
-   $EDITOR "${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts"
+   crew init            # write ./crew.config.ts in the current folder
+   crew init --global   # write ${XDG_CONFIG_HOME:-~/.config}/groundcrew/crew.config.ts
+   $EDITOR crew.config.ts
    ```
 
-   Or drop `crew.config.ts` at the root of any repo you run `crew` from — `crew` discovers it via cosmiconfig project-walk. Any of `crew.config.{ts,mjs,js,json}`, `.crewrc{,.json,.ts}`, `.config/crew.config.{ts,json}`, or `.config/crewrc{,.json}` work.
+   `crew init` refuses to overwrite an existing config; pass `--force` to replace it, or `--dry-run` to preview the destination path.
+
+   `crew` discovers the config via cosmiconfig project-walk, so dropping it at the root of any repo you run `crew` from works too. Any of `crew.config.{ts,mjs,js,json}`, `.crewrc{,.json,.ts}`, `.config/crew.config.{ts,json}`, or `.config/crewrc{,.json}` are recognized.
 
    Set `linear.projects[].projectSlug` (paste the trailing slug of your Linear project URL, e.g. `ai-strategy-5152195762f3`), `workspace.projectDir`, and `workspace.knownRepositories`. Defaults cover everything else. To watch multiple projects from one `crew` instance, add more entries to `linear.projects`; they all share the same `orchestrator.maximumInProgress` budget.
 
@@ -359,6 +360,7 @@ To have a coding agent (Claude Code, Cursor, etc.) scaffold `.groundcrew/setup.s
 ## Commands
 
 ```bash
+crew init [--global | --local] [--force] [--dry-run] # create a crew.config.ts (cwd by default)
 crew doctor                                              # full setup check
 crew doctor --ticket <TICKET> [--no-linear] [--no-fetch] # full ticket lifecycle (dispatch + recovery)
 crew run                                                 # one-shot dispatch

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 
 import { cleanupWorkspaceCli } from "./commands/cleanupWorkspace.ts";
 import { doctor } from "./commands/doctor.ts";
+import { initConfigCli } from "./commands/init.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
@@ -101,6 +102,11 @@ async function doctorCli(argv: string[]): Promise<void> {
 }
 
 const SUBCOMMANDS: Record<string, Subcommand> = {
+  init: {
+    summary: "Create a crew.config.ts in the cwd (or --global into the XDG config dir)",
+    usage: "[--global | --local] [--force] [--dry-run]",
+    invoke: initConfigCli,
+  },
   run: {
     summary: "Run the orchestrator (one-shot by default), or provision one ticket with --ticket",
     usage: "[--watch] [--dry-run] [--ticket <ticket>]",

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -78,6 +78,15 @@ describe("crew init", () => {
       expect(result.destination).toContain(join(".config", "groundcrew", "crew.config.ts"));
     });
 
+    it("ignores a relative XDG_CONFIG_HOME per the XDG spec", () => {
+      setEnvironmentVariable("XDG_CONFIG_HOME", "relative/path");
+
+      const result = initConfig({ scope: "global", dryRun: true });
+
+      expect(result.destination).toContain(join(".config", "groundcrew", "crew.config.ts"));
+      expect(result.destination).not.toContain("relative/path");
+    });
+
     it("refuses to overwrite an existing destination without --force", () => {
       const destination = join(cwd, "crew.config.ts");
       writeFileSync(destination, "existing content");
@@ -182,6 +191,12 @@ describe("crew init", () => {
     it("rejects an unknown flag with a helpful usage line", async () => {
       await expect(initConfigCli(["--what"])).rejects.toThrow(
         /Unknown option: --what[\s\S]*Usage: crew init/,
+      );
+    });
+
+    it("rejects --global and --local passed together", async () => {
+      await expect(initConfigCli(["--global", "--local"])).rejects.toThrow(
+        /--global and --local are mutually exclusive/,
       );
     });
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+import { initConfig, initConfigCli } from "./init.ts";
+
+const EXAMPLE_PATH = join(import.meta.dirname, "..", "..", "crew.config.example.ts");
+const exampleContents = readFileSync(EXAMPLE_PATH, "utf8");
+
+async function withCwd(directory: string, fn: () => Promise<void>): Promise<void> {
+  const original = process.cwd();
+  process.chdir(directory);
+  try {
+    await fn();
+  } finally {
+    process.chdir(original);
+  }
+}
+
+describe("crew init", () => {
+  let cwd: string;
+  let xdgHome: string;
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "groundcrew-init-cwd-"));
+    xdgHome = mkdtempSync(join(tmpdir(), "groundcrew-init-xdg-"));
+    setEnvironmentVariable("XDG_CONFIG_HOME", xdgHome);
+    consoleLog = captureConsoleLog();
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(xdgHome, { recursive: true, force: true });
+    deleteEnvironmentVariable("XDG_CONFIG_HOME");
+    process.exitCode = 0;
+  });
+
+  describe(initConfig, () => {
+    it("writes the example to <cwd>/crew.config.ts by default", () => {
+      const result = initConfig({ cwd });
+
+      const destination = join(cwd, "crew.config.ts");
+      expect(result.outcome).toBe("wrote");
+      expect(result.destination).toBe(destination);
+      expect(readFileSync(destination, "utf8")).toBe(exampleContents);
+      expect(consoleLog.output()).toContain(`[wrote] ${destination}`);
+    });
+
+    it("writes to the XDG groundcrew dir when scope is global", () => {
+      const result = initConfig({ scope: "global" });
+
+      const destination = join(xdgHome, "groundcrew", "crew.config.ts");
+      expect(result.outcome).toBe("wrote");
+      expect(result.destination).toBe(destination);
+      expect(readFileSync(destination, "utf8")).toBe(exampleContents);
+    });
+
+    it("creates the groundcrew parent directory under XDG when missing", () => {
+      expect(existsSync(join(xdgHome, "groundcrew"))).toBe(false);
+
+      initConfig({ scope: "global" });
+
+      expect(existsSync(join(xdgHome, "groundcrew"))).toBe(true);
+    });
+
+    it("falls back to ~/.config when XDG_CONFIG_HOME is unset", () => {
+      deleteEnvironmentVariable("XDG_CONFIG_HOME");
+
+      // Dry-run keeps the test off the real home dir — we only need the
+      // resolved destination path, not the side effect.
+      const result = initConfig({ scope: "global", dryRun: true });
+
+      expect(result.destination).toContain(join(".config", "groundcrew", "crew.config.ts"));
+    });
+
+    it("refuses to overwrite an existing destination without --force", () => {
+      const destination = join(cwd, "crew.config.ts");
+      writeFileSync(destination, "existing content");
+
+      const result = initConfig({ cwd });
+
+      expect(result.outcome).toBe("exists");
+      expect(readFileSync(destination, "utf8")).toBe("existing content");
+      expect(consoleLog.output()).toContain(`[exists] ${destination}`);
+      expect(consoleLog.output()).toContain("--force to overwrite");
+    });
+
+    it("overwrites an existing destination when --force is passed", () => {
+      const destination = join(cwd, "crew.config.ts");
+      writeFileSync(destination, "existing content");
+
+      const result = initConfig({ cwd, force: true });
+
+      expect(result.outcome).toBe("wrote");
+      expect(readFileSync(destination, "utf8")).toBe(exampleContents);
+    });
+
+    it("reports the planned write without touching disk in --dry-run", () => {
+      const destination = join(cwd, "crew.config.ts");
+
+      const result = initConfig({ cwd, dryRun: true });
+
+      expect(result.outcome).toBe("dry-run-would-write");
+      expect(existsSync(destination)).toBe(false);
+      expect(consoleLog.output()).toContain(`[dry-run] would write ${destination}`);
+    });
+
+    it("treats an existing destination as exists even in --dry-run without --force", () => {
+      const destination = join(cwd, "crew.config.ts");
+      writeFileSync(destination, "existing content");
+
+      const result = initConfig({ cwd, dryRun: true });
+
+      expect(result.outcome).toBe("exists");
+      expect(readFileSync(destination, "utf8")).toBe("existing content");
+    });
+
+    it("reports the planned overwrite when --dry-run and --force combine", () => {
+      const destination = join(cwd, "crew.config.ts");
+      writeFileSync(destination, "existing content");
+
+      const result = initConfig({ cwd, dryRun: true, force: true });
+
+      expect(result.outcome).toBe("dry-run-would-write");
+      expect(readFileSync(destination, "utf8")).toBe("existing content");
+    });
+  });
+
+  describe(initConfigCli, () => {
+    it("writes the config and prints next-step guidance with no flags", async () => {
+      await withCwd(cwd, async () => {
+        await initConfigCli([]);
+      });
+
+      expect(existsSync(join(cwd, "crew.config.ts"))).toBe(true);
+      const output = consoleLog.output();
+      expect(output).toContain("Next steps:");
+      expect(output).toContain("crew doctor");
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("sets exit code 1 when destination exists and --force is absent", async () => {
+      writeFileSync(join(cwd, "crew.config.ts"), "existing content");
+
+      await withCwd(cwd, async () => {
+        await initConfigCli([]);
+      });
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("routes --global to the XDG path", async () => {
+      await initConfigCli(["--global"]);
+
+      expect(existsSync(join(xdgHome, "groundcrew", "crew.config.ts"))).toBe(true);
+    });
+
+    it("accepts an explicit --local flag (cwd default)", async () => {
+      await withCwd(cwd, async () => {
+        await initConfigCli(["--local"]);
+      });
+
+      expect(existsSync(join(cwd, "crew.config.ts"))).toBe(true);
+    });
+
+    it("overwrites an existing config when --force is in argv", async () => {
+      const destination = join(cwd, "crew.config.ts");
+      writeFileSync(destination, "existing content");
+
+      await withCwd(cwd, async () => {
+        await initConfigCli(["--force"]);
+      });
+
+      expect(readFileSync(destination, "utf8")).toBe(exampleContents);
+    });
+
+    it("rejects an unknown flag with a helpful usage line", async () => {
+      await expect(initConfigCli(["--what"])).rejects.toThrow(
+        /Unknown option: --what[\s\S]*Usage: crew init/,
+      );
+    });
+
+    it("does not print next-step guidance in --dry-run", async () => {
+      await withCwd(cwd, async () => {
+        await initConfigCli(["--dry-run"]);
+      });
+
+      expect(consoleLog.output()).not.toContain("Next steps:");
+    });
+  });
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -77,17 +77,19 @@ export async function initConfigCli(argv: string[]): Promise<void> {
 }
 
 function parseArguments(argv: string[]): InitConfigOptions {
-  let scope: InitConfigScope = "local";
+  let scope: InitConfigScope | undefined;
   let force = false;
   let dryRun = false;
 
   for (const argument of argv) {
-    if (argument === "--global") {
-      scope = "global";
-      continue;
-    }
-    if (argument === "--local") {
-      scope = "local";
+    if (argument === "--global" || argument === "--local") {
+      const next: InitConfigScope = argument === "--global" ? "global" : "local";
+      if (scope !== undefined && scope !== next) {
+        throw new Error(
+          "crew init: --global and --local are mutually exclusive.\nUsage: crew init [--global | --local] [--force] [--dry-run]",
+        );
+      }
+      scope = next;
       continue;
     }
     if (argument === "--force") {
@@ -103,7 +105,7 @@ function parseArguments(argv: string[]): InitConfigOptions {
     );
   }
 
-  return { scope, force, dryRun };
+  return { scope: scope ?? "local", force, dryRun };
 }
 
 function destinationFor(args: { scope: InitConfigScope; cwd: string }): string {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,120 @@
+/**
+ * `crew init` — create a `crew.config.ts` in the current working directory or,
+ * with `--global`, in the XDG groundcrew config dir. The contents come from
+ * the shipped `crew.config.example.ts` so a fresh install skips the manual
+ * `cp` dance documented in the README.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { log, writeOutput } from "../lib/util.ts";
+import { xdgConfigPath } from "../lib/xdg.ts";
+
+const CONFIG_FILE_NAME = "crew.config.ts";
+const EXAMPLE_FILE_NAME = "crew.config.example.ts";
+
+type InitConfigScope = "global" | "local";
+
+interface InitConfigOptions {
+  /** Where to write the config. Defaults to "local" (cwd). */
+  scope?: InitConfigScope;
+  /** Overwrite an existing destination. */
+  force?: boolean;
+  /** Report the planned action without touching the filesystem. */
+  dryRun?: boolean;
+  /** Override for the working directory; defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+type InitConfigOutcome = "dry-run-would-write" | "exists" | "wrote";
+
+interface InitConfigResult {
+  destination: string;
+  outcome: InitConfigOutcome;
+}
+
+export function initConfig(options: InitConfigOptions = {}): InitConfigResult {
+  const scope = options.scope ?? "local";
+  const cwd = options.cwd ?? process.cwd();
+  const source = resolveExamplePath();
+  const destination = destinationFor({ scope, cwd });
+
+  if (existsSync(destination) && options.force !== true) {
+    log(`[exists] ${destination} — pass --force to overwrite`);
+    return { destination, outcome: "exists" };
+  }
+
+  if (options.dryRun === true) {
+    log(`[dry-run] would write ${destination}`);
+    return { destination, outcome: "dry-run-would-write" };
+  }
+
+  mkdirSync(dirname(destination), { recursive: true });
+  copyFileSync(source, destination);
+  log(`[wrote] ${destination}`);
+  return { destination, outcome: "wrote" };
+}
+
+export async function initConfigCli(argv: string[]): Promise<void> {
+  const options = parseArguments(argv);
+  const result = initConfig(options);
+
+  if (result.outcome === "exists") {
+    process.exitCode = 1;
+    return;
+  }
+  if (result.outcome === "wrote") {
+    writeOutput("");
+    writeOutput("Next steps:");
+    writeOutput(`  - Edit ${result.destination}`);
+    writeOutput(
+      "  - Set linear.projects[].projectSlug, workspace.projectDir, workspace.knownRepositories",
+    );
+    writeOutput("  - Export GROUNDCREW_LINEAR_API_KEY (or LINEAR_API_KEY)");
+    writeOutput("  - Verify with `crew doctor`");
+  }
+}
+
+function parseArguments(argv: string[]): InitConfigOptions {
+  let scope: InitConfigScope = "local";
+  let force = false;
+  let dryRun = false;
+
+  for (const argument of argv) {
+    if (argument === "--global") {
+      scope = "global";
+      continue;
+    }
+    if (argument === "--local") {
+      scope = "local";
+      continue;
+    }
+    if (argument === "--force") {
+      force = true;
+      continue;
+    }
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    throw new Error(
+      `Unknown option: ${argument}\nUsage: crew init [--global | --local] [--force] [--dry-run]`,
+    );
+  }
+
+  return { scope, force, dryRun };
+}
+
+function destinationFor(args: { scope: InitConfigScope; cwd: string }): string {
+  if (args.scope === "global") {
+    return xdgConfigPath("groundcrew", CONFIG_FILE_NAME);
+  }
+  return resolve(args.cwd, CONFIG_FILE_NAME);
+}
+
+function resolveExamplePath(): string {
+  // `init.ts` lives at src/commands/init.ts in source and dist/commands/init.js
+  // after build; the example ships at the package root in both cases.
+  return resolve(import.meta.dirname, "..", "..", EXAMPLE_FILE_NAME);
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,7 @@ import { cosmiconfig, type CosmiconfigResult, type Loader } from "cosmiconfig";
 import type { LinearAdapterConfig } from "./adapters/linear/schema.ts";
 import type { ShellAdapterConfig } from "./adapters/shell/schema.ts";
 import { log, readEnvironmentVariable, setLogFile } from "./util.ts";
+import { xdgConfigPath, xdgStatePath } from "./xdg.ts";
 
 export { BUILD_SECRET_NAMES } from "./buildSecrets.ts";
 
@@ -358,22 +359,6 @@ const PROMPT_PLACEHOLDER_RE = /{{[^{}]*}}/g;
 
 const PERCENT_MIN_EXCLUSIVE = 0;
 const PERCENT_MAX = 100;
-
-function xdgBase(envName: string, fallbackSegments: readonly string[]): string {
-  const override = readEnvironmentVariable(envName);
-  if (override !== undefined && override.length > 0) {
-    return override;
-  }
-  return resolve(homedir(), ...fallbackSegments);
-}
-
-function xdgConfigPath(...segments: string[]): string {
-  return resolve(xdgBase("XDG_CONFIG_HOME", [".config"]), ...segments);
-}
-
-function xdgStatePath(...segments: string[]): string {
-  return resolve(xdgBase("XDG_STATE_HOME", [".local", "state"]), ...segments);
-}
 
 function defaultLogFile(): string {
   return xdgStatePath("groundcrew", "groundcrew.log");

--- a/src/lib/xdg.ts
+++ b/src/lib/xdg.ts
@@ -1,11 +1,14 @@
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 import { readEnvironmentVariable } from "./util.ts";
 
+// Per the XDG Base Directory spec, relative override paths are invalid and
+// must be ignored — without this guard, a relative override would anchor to
+// the cwd via `resolve` instead of falling back to $HOME.
 function xdgBase(envName: string, fallbackSegments: readonly string[]): string {
   const override = readEnvironmentVariable(envName);
-  if (override !== undefined && override.length > 0) {
+  if (override !== undefined && override.length > 0 && isAbsolute(override)) {
     return override;
   }
   return resolve(homedir(), ...fallbackSegments);

--- a/src/lib/xdg.ts
+++ b/src/lib/xdg.ts
@@ -1,0 +1,20 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+import { readEnvironmentVariable } from "./util.ts";
+
+function xdgBase(envName: string, fallbackSegments: readonly string[]): string {
+  const override = readEnvironmentVariable(envName);
+  if (override !== undefined && override.length > 0) {
+    return override;
+  }
+  return resolve(homedir(), ...fallbackSegments);
+}
+
+export function xdgConfigPath(...segments: string[]): string {
+  return resolve(xdgBase("XDG_CONFIG_HOME", [".config"]), ...segments);
+}
+
+export function xdgStatePath(...segments: string[]): string {
+  return resolve(xdgBase("XDG_STATE_HOME", [".local", "state"]), ...segments);
+}


### PR DESCRIPTION
## Summary

- `crew init` writes a fresh `crew.config.ts` to the cwd, or `--global` into `${XDG_CONFIG_HOME:-~/.config}/groundcrew/`.
- Replaces the manual `cp $(npm root -g)/.../crew.config.example.ts ...` dance in the README's setup step.

## Why

First-run setup required users to know where the example config ships inside the npm install, what the XDG conventions are, and to `mkdir -p` the parent before the `cp`. That's three bash facts to get right before they can run `crew doctor`. A single `crew init` collapses it.