### PR TITLE
chore: add clearance docs hosts

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -12,6 +12,8 @@ ab.chatgpt.com
 api.anthropic.com
 api.openai.com
 chatgpt.com
+docs.anthropic.com
+docs.claude.com
 platform.claude.com
 
 # Hosted MCP servers + their auth/web hosts
@@ -73,6 +75,7 @@ fastdl.mongodb.org
 formulae.brew.sh
 hub.docker.com
 index.docker.io
+json.schemastore.org
 nx.dev
 sourcegraph.com
 vitest.dev


### PR DESCRIPTION
## Summary

Adds exact public documentation and schema hosts to the shipped Safehouse clearance starter allowlist so agents can access Anthropic/Claude docs and SchemaStore JSON schemas without expanding to wildcard egress.

## Validation

- `node --run verify`
- Pre-push hook ran `node --run verify`

<!-- commit-push-pr:created v1 core@3.4.0 -->