### PR TITLE
fix(init): point example config at package import and tidy commands block

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ To have a coding agent (Claude Code, Cursor, etc.) scaffold `.groundcrew/setup.s
 ## Commands
 
 ```bash
-crew init [--global | --local] [--force] [--dry-run] # create a crew.config.ts (cwd by default)
+crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.ts
 crew doctor                                              # full setup check
 crew doctor --ticket <TICKET> [--no-linear] [--no-fetch] # full ticket lifecycle (dispatch + recovery)
 crew run                                                 # one-shot dispatch

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -1,4 +1,4 @@
-import type { Config } from "./src/lib/config.js";
+import type { Config } from "@clipboard-health/groundcrew";
 // import { readFileSync } from "node:fs";
 
 export default {


### PR DESCRIPTION
## Summary

Two followups to #102 (`crew init`): the scaffolded example now imports from the package name so it works in any project, and the new `crew init` row in the README's Commands block re-aligns with the rest of the table.

## Why

The example shipped with `import type { Config } from "./src/lib/config.js";`, which only resolved inside this repo. Anywhere `crew init` wrote it, the import broke immediately. Pointing at `@clipboard-health/groundcrew` works in user projects and still resolves locally via the `paths` mapping in `tsconfig.base.json`.

The new `crew init` row broke the comment-alignment column in the Commands block, and `(cwd by default)` was redundant since `--local` is already the default.

## What

- `crew.config.example.ts`: import `Config` from `@clipboard-health/groundcrew` instead of the in-repo relative path
- `README.md`: pad the `crew init` row so its `#` aligns with the rest of the Commands block, and drop the redundant `(cwd by default)` tail