### PR TITLE
feat(sandbox): mirror curated host ~/.claude into the claude sandbox

### DIFF
--- a/src/commands/sandbox/auth.test.ts
+++ b/src/commands/sandbox/auth.test.ts
@@ -42,7 +42,9 @@ function isLoginExec(call: SbxCall): boolean {
 }
 
 function isStatusExec(call: SbxCall): boolean {
-  return call[0] === "sbx" && call[1][0] === "exec" && call[1][1] !== "-it";
+  return (
+    call[0] === "sbx" && call[1][0] === "exec" && call[1][1] !== "-it" && isStatusProbe(call[1])
+  );
 }
 
 function isStatusProbe(arguments_: readonly string[]): boolean {

--- a/src/commands/sandbox/index.ts
+++ b/src/commands/sandbox/index.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from "../../lib/config.ts";
 import { runAuth } from "./auth.ts";
 import { runList } from "./inspect.ts";
-import { runEnsure, runRegenerate, runRemove } from "./lifecycle.ts";
+import { runEnsure, runRegenerate, runRemove, runSync } from "./lifecycle.ts";
 
 const USAGE = [
   "Usage: crew sandbox <verb> [...args]",
@@ -10,6 +10,8 @@ const USAGE = [
   "  list                      Show every groundcrew-owned sandbox known to sbx",
   "  ensure [<model>]          Provision the sandbox for one model, or all when omitted",
   "  regenerate <model>|--all  Tear down and recreate from current template/kits",
+  "  sync <model>|--all        Mirror a curated subset of host ~/.claude (skills, agents,",
+  "                            commands, memory, CLAUDE.md) into the claude sandbox",
   "  auth <model>|--all        Open a checkbox picker of every tool available in <model>'s",
   "                            sandbox and run the login flow for each one you select;",
   "                            --all loops through every configured sandbox in turn",
@@ -32,6 +34,10 @@ export async function sandboxCli(argv: string[]): Promise<void> {
     }
     case "regenerate": {
       await runRegenerate(await loadConfig(), rest);
+      return;
+    }
+    case "sync": {
+      await runSync(await loadConfig(), rest);
       return;
     }
     case "auth": {

--- a/src/commands/sandbox/lifecycle.test.ts
+++ b/src/commands/sandbox/lifecycle.test.ts
@@ -175,6 +175,38 @@ describe("crew sandbox ensure / regenerate / rm", () => {
     });
   });
 
+  describe("sync", () => {
+    it("syncs a single claude sandbox by name", async () => {
+      await sandboxCli(["sync", "claude"]);
+
+      const cpCalls = sbxCallsForVerb(runCommandMock, "cp");
+      expect(cpCalls.length).toBeGreaterThan(0);
+      expect(cpCalls.every((arguments_) => arguments_[2]?.startsWith("groundcrew-claude:"))).toBe(
+        true,
+      );
+    });
+
+    it("skips non-claude sandboxes with a clear notice", async () => {
+      await sandboxCli(["sync", "codex"]);
+
+      expect(consoleLog.output()).toContain("groundcrew-codex: skipped (claude-only)");
+      expect(sbxCallsForVerb(runCommandMock, "cp")).toHaveLength(0);
+    });
+
+    it("walks every sandbox model with --all, syncing only claude", async () => {
+      await sandboxCli(["sync", "--all"]);
+
+      const output = consoleLog.output();
+      expect(output).toContain("groundcrew-claude: synced");
+      expect(output).toContain("groundcrew-codex: skipped (claude-only)");
+      expect(output).toContain("groundcrew-cursor: skipped (claude-only)");
+    });
+
+    it("rejects sync without a target", async () => {
+      await expect(sandboxCli(["sync"])).rejects.toThrow(/Usage: crew sandbox sync <model>/);
+    });
+  });
+
   describe("rm", () => {
     it("invokes sbx rm --force <name> for the resolved model", async () => {
       await sandboxCli(["rm", "claude"]);

--- a/src/commands/sandbox/lifecycle.test.ts
+++ b/src/commands/sandbox/lifecycle.test.ts
@@ -1,4 +1,7 @@
+import { homedir } from "node:os";
+
 import { loadConfig } from "../../lib/config.ts";
+import { injectClaudeConfig } from "../../lib/sandboxClaudeInjection.ts";
 import {
   captureConsoleError,
   captureConsoleLog,
@@ -29,7 +32,13 @@ vi.mock(import("../../lib/config.ts"), async (importOriginal) => {
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
 
+vi.mock(import("../../lib/sandboxClaudeInjection.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, injectClaudeConfig: vi.fn<typeof actual.injectClaudeConfig>() };
+});
+
 const loadConfigMock = vi.mocked(loadConfig);
+const injectClaudeConfigMock = vi.mocked(injectClaudeConfig);
 
 describe("crew sandbox ensure / regenerate / rm", () => {
   let consoleLog: ConsoleCapture;
@@ -40,6 +49,7 @@ describe("crew sandbox ensure / regenerate / rm", () => {
     consoleError = captureConsoleError();
     loadConfigMock.mockResolvedValue(makeSandboxConfig());
     mockSbxLs(runCommandMock, []);
+    injectClaudeConfigMock.mockResolvedValue();
   });
 
   afterEach(() => {
@@ -176,21 +186,22 @@ describe("crew sandbox ensure / regenerate / rm", () => {
   });
 
   describe("sync", () => {
-    it("syncs a single claude sandbox by name", async () => {
+    it("invokes injectClaudeConfig for a claude sandbox by name", async () => {
       await sandboxCli(["sync", "claude"]);
 
-      const cpCalls = sbxCallsForVerb(runCommandMock, "cp");
-      expect(cpCalls.length).toBeGreaterThan(0);
-      expect(cpCalls.every((arguments_) => arguments_[2]?.startsWith("groundcrew-claude:"))).toBe(
-        true,
-      );
+      expect(injectClaudeConfigMock).toHaveBeenCalledTimes(1);
+      expect(injectClaudeConfigMock).toHaveBeenCalledWith({
+        sandboxName: "groundcrew-claude",
+        hostHome: homedir(),
+      });
+      expect(consoleLog.output()).toContain("groundcrew-claude: synced");
     });
 
     it("skips non-claude sandboxes with a clear notice", async () => {
       await sandboxCli(["sync", "codex"]);
 
       expect(consoleLog.output()).toContain("groundcrew-codex: skipped (claude-only)");
-      expect(sbxCallsForVerb(runCommandMock, "cp")).toHaveLength(0);
+      expect(injectClaudeConfigMock).not.toHaveBeenCalled();
     });
 
     it("walks every sandbox model with --all, syncing only claude", async () => {
@@ -200,6 +211,7 @@ describe("crew sandbox ensure / regenerate / rm", () => {
       expect(output).toContain("groundcrew-claude: synced");
       expect(output).toContain("groundcrew-codex: skipped (claude-only)");
       expect(output).toContain("groundcrew-cursor: skipped (claude-only)");
+      expect(injectClaudeConfigMock).toHaveBeenCalledTimes(1);
     });
 
     it("rejects sync without a target", async () => {

--- a/src/commands/sandbox/lifecycle.ts
+++ b/src/commands/sandbox/lifecycle.ts
@@ -1,8 +1,10 @@
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 
 import { runCommandAsync } from "../../lib/commandRunner.ts";
 import type { ResolvedConfig } from "../../lib/config.ts";
 import { ensureSandbox, sandboxExists } from "../../lib/dockerSandbox.ts";
+import { injectClaudeConfig } from "../../lib/sandboxClaudeInjection.ts";
 import { writeOutput } from "../../lib/util.ts";
 import { requireOnePositional, resolveModel, type SandboxModel, sandboxModels } from "./model.ts";
 
@@ -16,8 +18,32 @@ export async function ensureOne(
     sandbox: model.sandbox,
     mountPath: resolve(config.workspace.projectDir),
     gitDefaults: config.sandbox.gitDefaults,
+    hostHome: homedir(),
     ...(alreadyExists === undefined ? {} : { alreadyExists }),
   });
+}
+
+function syncTargets(config: ResolvedConfig, argv: string[]): SandboxModel[] {
+  const target = requireOnePositional(argv, "Usage: crew sandbox sync <model>|--all");
+  if (target === "--all") {
+    return sandboxModels(config);
+  }
+  return [resolveModel(config, target)];
+}
+
+export async function runSync(config: ResolvedConfig, argv: string[]): Promise<void> {
+  const targets = syncTargets(config, argv);
+  const hostHome = homedir();
+  for (const model of targets) {
+    if (model.sandbox.agent !== "claude") {
+      writeOutput(`${model.sandboxName}: skipped (claude-only)`);
+      continue;
+    }
+    writeOutput(`${model.sandboxName}: syncing host ~/.claude...`);
+    // oxlint-disable-next-line no-await-in-loop -- sandboxes are synced one at a time.
+    await injectClaudeConfig({ sandboxName: model.sandboxName, hostHome });
+    writeOutput(`${model.sandboxName}: synced`);
+  }
 }
 
 async function removeOne(model: SandboxModel): Promise<void> {

--- a/src/lib/dockerSandbox.ts
+++ b/src/lib/dockerSandbox.ts
@@ -1,5 +1,6 @@
 import { runCommandAsync } from "./commandRunner.ts";
 import type { SandboxDefinition } from "./config.ts";
+import { injectClaudeConfig } from "./sandboxClaudeInjection.ts";
 import { applyGitDefaults } from "./sandboxGitDefaults.ts";
 
 /**
@@ -52,6 +53,13 @@ interface EnsureSandboxArguments {
    * probe on its own.
    */
   alreadyExists?: boolean;
+  /**
+   * Host directory containing the `.claude` subtree. Used by the
+   * claude-only injection step to mirror skills, agents, commands,
+   * memory, and `CLAUDE.md` into the sandbox. Defaults to `homedir()`.
+   * Override in tests to point at a fixture without a real `.claude`.
+   */
+  hostHome?: string;
 }
 
 /**
@@ -99,5 +107,11 @@ export async function ensureSandbox(
   }
   if (arguments_.gitDefaults) {
     await applyGitDefaults({ sandboxName: arguments_.sandboxName }, signal);
+  }
+  if (arguments_.sandbox.agent === "claude" && arguments_.hostHome !== undefined) {
+    await injectClaudeConfig(
+      { sandboxName: arguments_.sandboxName, hostHome: arguments_.hostHome },
+      signal,
+    );
   }
 }

--- a/src/lib/sandboxClaudeInjection.test.ts
+++ b/src/lib/sandboxClaudeInjection.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { RunCommandOptions } from "./commandRunner.ts";
+import { CLAUDE_CONFIG_ALLOWLIST, injectClaudeConfig } from "./sandboxClaudeInjection.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test mock intentionally shares one recorder across sync and async command APIs.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+
+describe(injectClaudeConfig, () => {
+  let hostHome: string;
+
+  beforeEach(() => {
+    runCommandMock.mockReset();
+    runCommandMock.mockReturnValue("");
+    hostHome = mkdtempSync(join(tmpdir(), "groundcrew-injection-"));
+  });
+
+  afterEach(() => {
+    rmSync(hostHome, { recursive: true, force: true });
+  });
+
+  function seedHostEntry(entry: string, kind: "file" | "dir"): void {
+    const path = join(hostHome, ".claude", entry);
+    if (kind === "dir") {
+      mkdirSync(path, { recursive: true });
+      return;
+    }
+    mkdirSync(join(hostHome, ".claude"), { recursive: true });
+    writeFileSync(path, "stub");
+  }
+
+  it("returns without touching the sandbox when ~/.claude is missing on the host", async () => {
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome });
+
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("creates the sandbox .claude directory before copying entries", async () => {
+    seedHostEntry("CLAUDE.md", "file");
+
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome });
+
+    const [firstCall] = runCommandMock.mock.calls;
+    expect(firstCall?.[0]).toBe("sbx");
+    expect(firstCall?.[1]).toStrictEqual([
+      "exec",
+      "groundcrew-claude",
+      "mkdir",
+      "-p",
+      "/home/agent/.claude",
+    ]);
+  });
+
+  it("removes then copies each present allowlist entry", async () => {
+    seedHostEntry("CLAUDE.md", "file");
+    seedHostEntry("skills", "dir");
+
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome });
+
+    const afterMkdir = runCommandMock.mock.calls.slice(1);
+    expect(afterMkdir).toHaveLength(4);
+    expect(afterMkdir[0]?.[1].slice(0, 4)).toStrictEqual([
+      "exec",
+      "groundcrew-claude",
+      "rm",
+      "-rf",
+    ]);
+    expect(afterMkdir[1]?.[1][0]).toBe("cp");
+    expect(afterMkdir[2]?.[1].slice(0, 4)).toStrictEqual([
+      "exec",
+      "groundcrew-claude",
+      "rm",
+      "-rf",
+    ]);
+    expect(afterMkdir[3]?.[1][0]).toBe("cp");
+  });
+
+  it("skips entries that don't exist on the host", async () => {
+    seedHostEntry("CLAUDE.md", "file");
+
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome });
+
+    const cpCalls = runCommandMock.mock.calls.filter((call) => call[1][0] === "cp");
+    expect(cpCalls).toHaveLength(1);
+    expect(cpCalls[0]?.[1][1]).toBe(join(hostHome, ".claude", "CLAUDE.md"));
+    expect(cpCalls[0]?.[1][2]).toBe("groundcrew-claude:/home/agent/.claude/CLAUDE.md");
+  });
+
+  it("removes the in-sandbox path before copying so directories don't nest on re-sync", async () => {
+    seedHostEntry("skills", "dir");
+
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome });
+
+    expect(runCommandMock.mock.calls[1]?.[1]).toStrictEqual([
+      "exec",
+      "groundcrew-claude",
+      "rm",
+      "-rf",
+      "/home/agent/.claude/skills",
+    ]);
+  });
+
+  it("honours a custom sandboxHome", async () => {
+    seedHostEntry("CLAUDE.md", "file");
+
+    await injectClaudeConfig({
+      sandboxName: "groundcrew-claude",
+      hostHome,
+      sandboxHome: "/root",
+    });
+
+    const cpCall = runCommandMock.mock.calls.find((call) => call[1][0] === "cp");
+    expect(cpCall?.[1][2]).toBe("groundcrew-claude:/root/.claude/CLAUDE.md");
+  });
+
+  it("passes the AbortSignal through to every sbx call", async () => {
+    seedHostEntry("CLAUDE.md", "file");
+    const controller = new AbortController();
+
+    await injectClaudeConfig({ sandboxName: "groundcrew-claude", hostHome }, controller.signal);
+
+    for (const call of runCommandMock.mock.calls) {
+      expect(call[2]).toMatchObject({ signal: controller.signal });
+    }
+  });
+
+  it("exports the documented allowlist set", () => {
+    expect(CLAUDE_CONFIG_ALLOWLIST).toStrictEqual([
+      "CLAUDE.md",
+      "MEMORY.md",
+      "skills",
+      "commands",
+      "agents",
+      "memory",
+    ]);
+  });
+});

--- a/src/lib/sandboxClaudeInjection.ts
+++ b/src/lib/sandboxClaudeInjection.ts
@@ -1,0 +1,82 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { runCommandAsync } from "./commandRunner.ts";
+
+/**
+ * Curated subset of the host `~/.claude` mirrored into the `claude`
+ * sandbox during `ensureSandbox` and refreshed by `crew sandbox sync`.
+ *
+ * Identity, session, and host-only state are deliberately excluded:
+ * `settings.json`, `.credentials.json`, `sessions/`, `projects/`,
+ * `plugins/`, `hooks/`, `daemon*`, `cache/`, telemetry, history.
+ */
+export const CLAUDE_CONFIG_ALLOWLIST: readonly string[] = [
+  "CLAUDE.md",
+  "MEMORY.md",
+  "skills",
+  "commands",
+  "agents",
+  "memory",
+];
+
+const DEFAULT_SANDBOX_HOME = "/home/agent";
+
+interface InjectClaudeConfigArguments {
+  /** Sandbox container name, e.g. `groundcrew-claude`. */
+  sandboxName: string;
+  /** Host directory containing the `.claude` subtree (typically `os.homedir()`). */
+  hostHome: string;
+  /** Home directory inside the sandbox. Defaults to `/home/agent`. */
+  sandboxHome?: string;
+}
+
+/**
+ * Refresh the curated subset of the host `~/.claude` inside `sandboxName`.
+ * Each allowlist entry is removed from the sandbox (if present) and
+ * re-copied from the host with `sbx cp`. Missing host entries are skipped
+ * silently so a partial host config doesn't fail the run.
+ *
+ * `sbx cp` "places source inside destination when destination exists",
+ * so the `rm -rf` step is required to keep `skills/` from nesting into
+ * `skills/skills/` on the second sync.
+ */
+export async function injectClaudeConfig(
+  arguments_: InjectClaudeConfigArguments,
+  signal?: AbortSignal,
+): Promise<void> {
+  const sandboxHome = arguments_.sandboxHome ?? DEFAULT_SANDBOX_HOME;
+  const sandboxConfig = `${sandboxHome}/.claude`;
+  const hostConfig = join(arguments_.hostHome, ".claude");
+  const options = signal === undefined ? {} : { signal };
+
+  if (!existsSync(hostConfig)) {
+    return;
+  }
+
+  await runCommandAsync(
+    "sbx",
+    ["exec", arguments_.sandboxName, "mkdir", "-p", sandboxConfig],
+    options,
+  );
+
+  for (const entry of CLAUDE_CONFIG_ALLOWLIST) {
+    const hostPath = join(hostConfig, entry);
+    if (!existsSync(hostPath)) {
+      continue;
+    }
+    const sandboxPath = `${sandboxConfig}/${entry}`;
+    // oxlint-disable-next-line no-await-in-loop -- one sbx call at a time keeps ordering deterministic.
+    await runCommandAsync(
+      "sbx",
+      ["exec", arguments_.sandboxName, "rm", "-rf", sandboxPath],
+      options,
+    );
+    // oxlint-disable-next-line no-await-in-loop -- sequential sbx cp avoids racing the rm above.
+    await runCommandAsync(
+      "sbx",
+      ["cp", hostPath, `${arguments_.sandboxName}:${sandboxPath}`],
+      options,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- The `groundcrew-claude` sandbox boots with a vanilla `~/.claude`, so the host's `CLAUDE.md`, `skills/`, `agents/`, `commands/`, and `memory/` are invisible inside — the in-sandbox agent loses skills, custom subagents, and persistent memory.
- Mirrors that allowlisted subset from host → sandbox after `applyGitDefaults` inside `ensureSandbox`, gated to the `claude` agent only.
- Adds `crew sandbox sync <model>|--all` to refresh the mirror on demand without recreating the container; non-`claude` targets are skipped with a clear notice.

## Why

`settings.json`, `.credentials.json`, `sessions/`, `projects/`, `plugins/`, and `hooks/` are deliberately excluded — they carry identity, session, or host-only state that does not belong in the sandbox. The user can iterate on host skills and run `crew sandbox sync` to pick up changes without paying the cost of a full `regenerate`.