### PR TITLE
feat(dispatcher): show slot usage and active tickets in heartbeat

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,6 +9,13 @@ export default defineConfig(
         typeAware: true,
         typeCheck: true,
       },
+      // `crew.config.example.ts` is a template the `crew init` command writes
+      // into user projects. It imports from `@clipboard-health/groundcrew` so
+      // it resolves there, but locally that path lives only in
+      // `tsconfig.base.json`'s `paths` mapping — and the file isn't included
+      // in any leaf tsconfig project, so oxlint's typeAware pass can't apply
+      // the mapping. The file isn't internal source, so exclude it from lint.
+      ignorePatterns: ["crew.config.example.ts"],
       overrides: [
         {
           files: ["**/bin/**/*.js", "**/bin/**/*.cjs"],

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -6,7 +6,7 @@ import { EXHAUSTED_USAGE } from "../lib/usage.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
-import { createDispatcher } from "./dispatcher.ts";
+import { createDispatcher, formatActiveSlotList } from "./dispatcher.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
 vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
@@ -153,7 +153,104 @@ describe(createDispatcher, () => {
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("At capacity");
+      expect(consoleLog.output()).toContain(
+        "At capacity (1/1) [team-a(claude)], no new work to start",
+      );
+    });
+
+    it("enumerates all in-progress tickets in the `At capacity` line, sorted by id", async () => {
+      const config = makeConfig({
+        orchestrator: {
+          maximumInProgress: 2,
+          pollIntervalMilliseconds: 1,
+          sessionLimitPercentage: 85,
+        },
+      });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config, board });
+
+      await dispatcher.runOnce({
+        // Deliberately reverse-ordered to prove the dispatcher sorts.
+        state: boardOf([
+          activeIssue({ id: "linear:team-b", model: "codex" }),
+          activeIssue({ id: "linear:team-a", model: "claude" }),
+        ]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(consoleLog.output()).toContain(
+        "At capacity (2/2) [team-a(claude), team-b(codex)], no new work to start",
+      );
+    });
+
+    it("logs `Slots 0/N used` on the happy path when no slots are occupied", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue()]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: true,
+      });
+
+      expect(consoleLog.output()).toContain("Slots 0/2 used, starting 1 ticket(s): team-1(claude)");
+    });
+
+    it("enumerates already-running tickets when some slots are occupied", async () => {
+      const config = makeConfig({
+        orchestrator: {
+          maximumInProgress: 3,
+          pollIntervalMilliseconds: 1,
+          sessionLimitPercentage: 85,
+        },
+      });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config, board });
+
+      await dispatcher.runOnce({
+        state: boardOf([
+          activeIssue({ id: "linear:team-running-b", model: "codex" }),
+          activeIssue({ id: "linear:team-running-a", model: "claude" }),
+          todoIssue({ id: "linear:team-new" }),
+        ]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: true,
+      });
+
+      expect(consoleLog.output()).toContain(
+        "Slots 2/3 used [team-running-a(claude), team-running-b(codex)], starting 1 ticket(s): team-new(claude)",
+      );
+    });
+
+    it("includes in-progress issues with undefined model in the slot list as `id(?)`", async () => {
+      const config = makeConfig({
+        orchestrator: {
+          maximumInProgress: 2,
+          pollIntervalMilliseconds: 1,
+          sessionLimitPercentage: 85,
+        },
+      });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config, board });
+
+      await dispatcher.runOnce({
+        state: boardOf([
+          // Active issue whose `agent-*` label is gone — model resolves to undefined.
+          activeIssue({ id: "linear:team-stale", model: undefined }),
+          todoIssue({ id: "linear:team-new" }),
+        ]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: true,
+      });
+
+      expect(consoleLog.output()).toContain(
+        "Slots 1/2 used [team-stale(?)], starting 1 ticket(s): team-new(claude)",
+      );
     });
 
     it("logs `No Todo tickets` when nothing is queued", async () => {
@@ -850,5 +947,27 @@ describe(createDispatcher, () => {
 
       expect(consoleLog.output()).not.toContain("reason=parent_with_children");
     });
+  });
+});
+
+describe(formatActiveSlotList, () => {
+  it("returns an empty string when no slots are used", () => {
+    expect(formatActiveSlotList([])).toBe("");
+  });
+
+  it("formats a single in-progress ticket as ` [id(model)]`", () => {
+    const issue = activeIssue({ id: "linear:hrd-1", model: "claude" });
+    expect(formatActiveSlotList([issue])).toBe(" [hrd-1(claude)]");
+  });
+
+  it("joins multiple tickets with `, ` and preserves caller-supplied order", () => {
+    const a = activeIssue({ id: "linear:hrd-1", model: "claude" });
+    const b = activeIssue({ id: "linear:hrd-2", model: "codex" });
+    expect(formatActiveSlotList([a, b])).toBe(" [hrd-1(claude), hrd-2(codex)]");
+  });
+
+  it("renders an undefined model as `?`", () => {
+    const issue = activeIssue({ id: "linear:hrd-9", model: undefined });
+    expect(formatActiveSlotList([issue])).toBe(" [hrd-9(?)]");
   });
 });

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -239,7 +239,7 @@ describe(createDispatcher, () => {
 
       await dispatcher.runOnce({
         state: boardOf([
-          // Active issue whose `agent-*` label is gone — model resolves to undefined.
+          // Defensive fallback for a source that cannot resolve model metadata.
           activeIssue({ id: "linear:team-stale", model: undefined }),
           todoIssue({ id: "linear:team-new" }),
         ]),

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -14,6 +14,7 @@ import {
   type BoardState,
   type GroundcrewIssue,
   isGroundcrewIssue,
+  type Issue,
   naturalIdFromCanonical,
 } from "../lib/ticketSource.ts";
 import type { UsageByModel } from "../lib/usage.ts";
@@ -160,7 +161,10 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       });
     }
 
-    const activeCount = state.issues.filter((issue) => issue.status === "in-progress").length;
+    const active = state.issues
+      .filter((issue) => issue.status === "in-progress")
+      .toSorted((a, b) => a.id.localeCompare(b.id));
+    const activeCount = active.length;
     const slots = config.orchestrator.maximumInProgress - activeCount;
     // Narrow Todo to tickets that opted in via an `agent-*` label.
     // Unlabeled tickets are not groundcrew's concern even when in Todo.
@@ -170,7 +174,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
 
     if (slots <= 0) {
       log(
-        `At capacity (${activeCount}/${config.orchestrator.maximumInProgress}), no new work to start${idleSuffix}`,
+        `At capacity (${activeCount}/${config.orchestrator.maximumInProgress})${formatActiveSlotList(active)}, no new work to start${idleSuffix}`,
       );
       return;
     }
@@ -253,7 +257,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     const dispatchable = starts;
 
     log(
-      `${slots} slot(s) available, starting ${dispatchable.length} ticket(s): ${dispatchable.map(({ issue }) => `${naturalIdFromCanonical(issue.id)}(${issue.model})`).join(", ")}`,
+      `Slots ${activeCount}/${config.orchestrator.maximumInProgress} used${formatActiveSlotList(active)}, starting ${dispatchable.length} ticket(s): ${dispatchable.map(({ issue }) => `${naturalIdFromCanonical(issue.id)}(${issue.model})`).join(", ")}`,
     );
     logEvent("dispatch", {
       outcome: "starting",
@@ -277,4 +281,14 @@ function formatUsageExhaustion(exhaustion: ModelUsageExhaustion): string {
     return `${exhaustion.model} session at ${exhaustion.usedPercentage.toFixed(0)}% (> ${exhaustion.limitPercentage}%), resets in ${mins}m — skipping its tickets`;
   }
   return `${exhaustion.model} weekly at ${exhaustion.usedPercentage.toFixed(1)}% (> ${exhaustion.allowedPercentage.toFixed(1)}% paced budget), resets in ${exhaustion.resetMinutes}m — skipping its tickets`;
+}
+
+export function formatActiveSlotList(active: readonly Issue[]): string {
+  if (active.length === 0) {
+    return "";
+  }
+  const entries = active
+    .map((issue) => `${naturalIdFromCanonical(issue.id)}(${issue.model ?? "?"})`)
+    .join(", ");
+  return ` [${entries}]`;
 }

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -320,7 +320,7 @@ describe(createBoardSource, () => {
       expect(boardCalls).toHaveLength(2);
     });
 
-    it("only resolves repository on Todo tickets with an agent-* label", async () => {
+    it("resolves model on in-progress tickets but only resolves repository on Todo tickets", async () => {
       const todo = issueNode({
         identifier: "TEAM-1",
         labels: { nodes: [{ name: "agent-claude" }] },
@@ -337,7 +337,7 @@ describe(createBoardSource, () => {
       expect(first?.repository).toBe("repo-a");
       expect(first?.model).toBe("claude");
       expect(second?.repository).toBeUndefined();
-      expect(second?.model).toBeUndefined();
+      expect(second?.model).toBe("claude");
     });
 
     it("falls back to models.default when a Todo's agent-* label refers to a disabled shipped default", async () => {

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -59,11 +59,11 @@ export interface Issue {
   /**
    * `undefined` unless the ticket is in Todo with a parseable `agent-*` label
    * and a known-repo reference in its description — i.e. the dispatcher would
-   * actually pick it up. Resolving on non-Todo statuses would just invite
-   * tick-spam warnings on already-finished work.
+   * actually pick it up. Non-Todo tickets do not resolve repositories because
+   * that would invite tick-spam warnings on already-finished work.
    */
   repository: string | undefined;
-  /** `undefined` whenever `repository` is — the two are populated together. */
+  /** Parsed from the `agent-*` label when present, including non-Todo tickets for slot logs. */
   model: string | undefined;
   teamId: string;
   blockers: Blocker[];
@@ -283,7 +283,7 @@ export function modelForResolution(
   return "any";
 }
 
-function resolveTodoAgentMetadata(arguments_: {
+function resolveAgentMetadata(arguments_: {
   ticket: string;
   description: string | undefined;
   modelResolution: ModelResolution;
@@ -293,12 +293,17 @@ function resolveTodoAgentMetadata(arguments_: {
   const { ticket, description, modelResolution, config, isTodo } = arguments_;
   let repository: string | undefined;
   let model: string | undefined;
-  if (modelResolution.kind !== "no-label" && isTodo) {
+  if (modelResolution.kind === "no-label") {
+    return { repository, model };
+  }
+
+  model = modelForResolution(modelResolution);
+  if (isTodo) {
     const resolution = resolveRepositoryFor({ description, config });
     if (resolution.kind === "ok") {
       ({ repository } = resolution);
-      model = modelForResolution(modelResolution);
     } else {
+      model = undefined;
       log(
         `WARNING: ${ticket} has an ${AGENT_LABEL_PREFIX}* label but no known repository in its description; skipping dispatch. Add one of workspace.knownRepositories to the description, or remove the ${AGENT_LABEL_PREFIX}* label: ${config.workspace.knownRepositories.join(", ")}`,
       );
@@ -344,7 +349,7 @@ function buildLinearIssue(input: {
 function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
   const modelResolution = resolveModelFor({ labels: node.labels.nodes, config });
   warnIfDisabledFallback(node.identifier, modelResolution, config);
-  const { repository, model } = resolveTodoAgentMetadata({
+  const { repository, model } = resolveAgentMetadata({
     ticket: node.identifier,
     /* v8 ignore next @preserve -- BoardIssues query selects description; the ?? guard normalises a null vs undefined edge */
     description: node.description ?? undefined,

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -62,9 +62,9 @@ export interface Issue {
   title: string;
   description: string;
   status: CanonicalStatus;
-  /** `undefined` when the ticket isn't groundcrew-eligible (no agent label / no repo match). */
+  /** `undefined` when the ticket is not dispatchable to a repository. */
   repository: string | undefined;
-  /** `undefined` when the ticket isn't groundcrew-eligible. */
+  /** Parsed agent model when the source can resolve one; may be present on non-Todo tickets for logs. */
   model: string | undefined;
   assignee: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

- `crew run`'s per-tick heartbeat now reports slot usage and lists the in-progress tickets occupying each used slot.
- Two log lines change in `src/commands/dispatcher.ts`:
  - Happy path: `2 slot(s) available, starting 1 ticket(s): hrd-456(claude)` → `Slots 2/4 used [hrd-123(claude), hrd-789(codex)], starting 1 ticket(s): hrd-456(claude)`
  - At capacity: `At capacity (4/4), no new work to start` → `At capacity (4/4) [hrd-123(claude), hrd-456(claude), hrd-789(codex), hrd-790(claude)], no new work to start`
- The bracketed list is omitted when no slots are used (`Slots 0/4 used, starting ...`), so the format scales down gracefully.
- Linear in-progress tickets now keep their parsed `agent-*` model metadata, so active slot logs can render `id(model)` instead of `id(?)` for normal Linear tickets.

## Why

The heartbeat previously hid two things you usually want at a glance:

1. **Total capacity.** `2 slot(s) available` doesn't say `2 of how many?` -- the operator can't tell whether more concurrency is configured. The at-capacity branch already used `(X/N)`; the happy path now matches, so the denominator is no longer asymmetric across branches.
2. **What's filling the used slots.** Once a ticket left Todo, the line gave no signal about what was actually consuming capacity. Both branches now enumerate the active tickets in `id(model)` form so a single tick of the log answers "why are slots used?" without bouncing to Linear.

Both lines route through one formatter (`formatActiveSlotList`) so the shape can't drift apart over time.

## What

Notable changes:

- `chore(lint)`: exclude `crew.config.example.ts` from oxlint. The file imports `@clipboard-health/groundcrew` (resolved via the `tsconfig.base.json` paths mapping in user projects after `crew init`) but isn't in any leaf tsconfig project here, so oxlint's `typeAware` pass reports TS2307 on a clean checkout. Treat it as a user-facing template, not internal source.
- `refactor(dispatcher)`: capture the in-progress issues (sorted by id with `.toSorted`), not just the count.
- `feat(dispatcher)`: add `formatActiveSlotList(active: readonly Issue[]): string` -- single source of truth for the bracketed `[id(model), ...]` shape. Returns `""` when empty; renders `undefined` model as `?`.
- `feat(dispatcher)`: wire the helper into the at-capacity and happy-path log lines.
- `fix(linear)`: resolve `Issue.model` from `agent-*` labels for non-Todo Linear tickets while keeping repository resolution Todo-only to avoid noisy repository warnings for completed or already-running work.
- `test`: lock in dispatcher slot-list output and Linear's active-ticket model resolution behavior.

## Validation

- `npx vitest run --config ./vitest.config.ts src/lib/adapters/linear/fetch.test.ts src/commands/dispatcher.test.ts`: 85 tests pass.
- `node --run verify`: all checks pass (lint, format, build, knip, spell, syncpack, markdown, architecture, cpd, test); full suite reports 916 tests and 100% coverage.
- Pre-push hook reran `node --run verify` successfully before pushing `78d8206`.

## Notes

`agent-any` active tickets still render as `id(any)` because Linear stores the original label, not the concrete model chosen by the dispatcher at start time.

Agent session: codex resume 019e6a04-f29b-7b33-b00e-2b1d8a28c112
<!-- commit-push-pr:created v1 core@3.4.1 -->
