### PR TITLE
chore: allow google apis and cloud.nx.app egress hosts

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -67,10 +67,17 @@ api.npmjs.org
 registry.npmjs.org
 www.npmjs.com
 
+# Google APIs
+developers.google.com
+drive.googleapis.com
+forms.googleapis.com
+www.googleapis.com
+
 # Developer tooling
 app.terraform.io
 buf.build
 cdn.playwright.dev
+cloud.nx.app
 fastdl.mongodb.org
 formulae.brew.sh
 hub.docker.com


### PR DESCRIPTION
## Summary

Extend the starter egress allowlist with hosts the agents need for Google Workspace integrations (Forms, Drive, generic googleapis) and Nx Cloud (`cloud.nx.app`). Adds a new `# Google APIs` section and slots `cloud.nx.app` into `# Developer tooling` in alphabetical order.

## Validation

- Not run: config-only change to an allowlist file; no tests cover its contents.

Agent session: claude --resume b83e792c-15d9-4dcc-80ab-8685f6595c28
<!-- commit-push-pr:created v1 core@3.4.1 -->