### PR TITLE
docs(adr): record sandbox-provisioning and ticket-source decisions

### DIFF
--- a/docs/adr/0001-groundcrew-uses-but-does-not-provision-sandboxes.md
+++ b/docs/adr/0001-groundcrew-uses-but-does-not-provision-sandboxes.md
@@ -1,5 +1,7 @@
 # Groundcrew uses sandboxes but does not provision them
 
+**Status:** Accepted; not yet implemented. Implementation is tracked under STAFF-1033 and its slices. The past tense below describes the decided end state, not the current code — at time of writing `lib/dockerSandbox.ts` and `crew sandbox` still exist.
+
 Groundcrew launches agent processes _inside_ an isolation backend (safehouse on macOS, sdx/Docker Sandboxes elsewhere, or `none`), but it no longer manages the lifecycle of those sandboxes. We removed `crew sandbox` (ensure/regenerate/auth/rm/list), the auth-recipe machinery, and `lib/dockerSandbox.ts` because they duplicated functionality `sbx` already provides — wrapping someone else's CLI to be marginally more ergonomic cost ~1100 LOC and pulled sandbox-provisioning concepts (templates, kits, auth recipes, git defaults) into groundcrew's config surface for no proportional benefit.
 
 ## Considered Options

--- a/docs/adr/0001-groundcrew-uses-but-does-not-provision-sandboxes.md
+++ b/docs/adr/0001-groundcrew-uses-but-does-not-provision-sandboxes.md
@@ -1,0 +1,15 @@
+# Groundcrew uses sandboxes but does not provision them
+
+Groundcrew launches agent processes _inside_ an isolation backend (safehouse on macOS, sdx/Docker Sandboxes elsewhere, or `none`), but it no longer manages the lifecycle of those sandboxes. We removed `crew sandbox` (ensure/regenerate/auth/rm/list), the auth-recipe machinery, and `lib/dockerSandbox.ts` because they duplicated functionality `sbx` already provides — wrapping someone else's CLI to be marginally more ergonomic cost ~1100 LOC and pulled sandbox-provisioning concepts (templates, kits, auth recipes, git defaults) into groundcrew's config surface for no proportional benefit.
+
+## Considered Options
+
+- **Keep the sdx lifecycle commands** — rejected: they reimplement `sbx run`/`sbx exec` setup flows, and every concept they expose (`authRecipes`, `template`, `kits`, `gitDefaults`) is a sandbox concern, not an orchestration concern.
+- **Generalize the launch wrap to a user-supplied template string** — rejected for now: the build-time-secrets and `.groundcrew/setup.sh` plumbing inside the sdx wrap is awkward to express in a user template. Kept a small `safehouse | sdx | none` WRAP enum in core instead.
+
+## Consequences
+
+- The launch **WRAP** stays in core (`launchCommand.ts`): given an agent command + worktree + secrets + sandbox name, produce the shell string that runs the agent under the chosen backend.
+- First-time sandbox setup is now a manual `sbx` workflow the user runs themselves; the README points to it. Groundcrew assumes the sandbox already exists at launch.
+- Linux/WSL users are unaffected at launch time — they keep the sdx WRAP — but no longer get groundcrew-driven provisioning.
+- Removed config keys (`sandbox.authRecipes`, `sandbox.gitDefaults`, sdx lifecycle fields like `template`/`kits`) hard-fail with an actionable message, matching the existing `config.ts` precedent for removed shapes.

--- a/docs/adr/0002-one-ticket-source-path-linear-is-an-adapter.md
+++ b/docs/adr/0002-one-ticket-source-path-linear-is-an-adapter.md
@@ -1,5 +1,7 @@
 # One ticket-source path; Linear is just an adapter
 
+**Status:** Accepted; not yet implemented. Implementation is tracked under STAFF-1033 / STAFF-1034 (lands PR #89). The past/present tense below describes the decided end state, not the current code — at time of writing `orchestrator.ts` still calls `boardSource.fetch()` and `boardSource.ts` still exists.
+
 There is a single path from board state to dispatch: `Source[] → Board → Dispatcher`. Linear is a `TicketSource` adapter like any other; the dispatcher and eligibility code never import Linear-specific logic. We deleted the legacy `boardSource.ts → dispatcher` path (which made Linear the only source that could actually start agents) and moved the live Linear logic into `src/lib/adapters/linear/`, because the half-wired parallel architecture meant declared shell sources validated at startup but contributed zero tickets to dispatch — defeating the entire pluggable-source point.
 
 ## Considered Options

--- a/docs/adr/0002-one-ticket-source-path-linear-is-an-adapter.md
+++ b/docs/adr/0002-one-ticket-source-path-linear-is-an-adapter.md
@@ -1,0 +1,15 @@
+# One ticket-source path; Linear is just an adapter
+
+There is a single path from board state to dispatch: `Source[] → Board → Dispatcher`. Linear is a `TicketSource` adapter like any other; the dispatcher and eligibility code never import Linear-specific logic. We deleted the legacy `boardSource.ts → dispatcher` path (which made Linear the only source that could actually start agents) and moved the live Linear logic into `src/lib/adapters/linear/`, because the half-wired parallel architecture meant declared shell sources validated at startup but contributed zero tickets to dispatch — defeating the entire pluggable-source point.
+
+## Considered Options
+
+- **Keep `boardSource.ts` as a Linear fast-path and wire extras alongside it** — rejected: two paths from board to dispatch is exactly the coupling that let Linear concepts leak into the dispatcher. The whole value is symmetry — every source, including Linear, reaches dispatch the same way.
+
+## Consequences
+
+- The canonical seam is the `Issue` contract: a source emits `model` and `repository`, or the ticket is ignored (`isGroundcrewIssue` keys off exactly that). Consumers branch on the canonical `CanonicalStatus` enum, never on a source's native status names.
+- **Linear-specific** concepts live in the adapter: `agent-*` label parsing, `agent-any` routing, sub-issue/parent detection, assigned-to-viewer + label selection policy.
+- **Canonical** concepts stay in eligibility so every source benefits: blocker classification (sources populate `blockers[]`) and exhausted-model gating (sources pick a `model`).
+- This was a pure internal refactor with no user-visible change — Linear keeps working identically — so it carried no migration cost and landed before the breaking v5 cuts.
+- Changing the Linear selection mechanism (assigned + labeled) is now an adapter-local change that does not touch the engine.


### PR DESCRIPTION
## Summary

Adds two architecture decision records under `docs/adr/` to capture the hard-to-reverse decisions behind the groundcrew simplification effort (parent: STAFF-1033), so future readers don't reverse them by accident:

- **ADR 0001 — Groundcrew uses sandboxes but does not provision them.** Records why the sdx lifecycle (`crew sandbox`, auth recipes, Docker-Sandbox helpers, git defaults) is being removed while the launch WRAP for safehouse/sdx/none stays in core.
- **ADR 0002 — One ticket-source path; Linear is just an adapter.** Records the unification onto `Source[] → Board → Dispatcher`, the deletion of the legacy `boardSource` path, and the canonical `Issue` seam.

Documentation only — no code or behavior change.

## Validation

- Not run: docs-only change; the pre-commit markdownlint hook ran and reformatted on commit.

## Notes

- Decisions trace to Linear STAFF-1033 (simplification PRD) and its slices STAFF-1034 (lands #89) / STAFF-1035 / STAFF-1036 / STAFF-1037 / STAFF-1038 / STAFF-1040.
- The CONTEXT.md glossary delta referenced in ADR 0002 is intentionally deferred until the unification lands (rides along with STAFF-1034), so the glossary stays in sync with the code.

Agent session: claude --resume 9c88afec-b1b4-4619-af4f-40c8ba6627bf
<!-- commit-push-pr:created v1 core@3.4.1 -->