### PR TITLE
feat(cli): split run/start/stop verbs with deprecation aliases (staff-1040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ In Linear, assign tickets to yourself and add an `agent-*` label (`agent-claude`
 crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.ts
 crew doctor                                              # check setup
 crew status [<TICKET>]                                   # inspect current state or one ticket
-crew run                                                 # one-shot dispatch
+crew run                                                 # one-shot orchestration
 crew run --watch                                         # poll forever
-crew run --ticket <TICKET>                               # dispatch one ticket
+crew start <TICKET>                                      # provision + launch one ticket now
 crew setup repos [<repo>...] [--dry-run]                 # clone known repos via gh
-crew interrupt <TICKET> [--reason <text>]                # stop workspace, keep worktree
+crew stop <TICKET> [--reason <text>]                     # stop workspace, keep worktree
 crew resume <TICKET>                                     # reopen a paused ticket
 crew cleanup <TICKET>                                    # tear down every worktree for a ticket
 ```
+
+Deprecated aliases still work but print a warning and will be removed in the next major version: `crew interrupt` → `crew stop`, `crew run --ticket <TICKET>` → `crew start <TICKET>`, `crew doctor --ticket <TICKET>` → `crew status <TICKET>`.
 
 ## Configuration
 
@@ -109,7 +111,7 @@ The branch prefix (`<prefix>-<TICKET>`) is derived from `os.userInfo().username`
 - `agent-claude`, `agent-codex`, `agent-<name>` → that model.
 - `agent-any` → the model with the most available session capacity.
 - Unknown `agent-<name>` → falls back to `models.default` with a warning.
-- No `agent-*` label → ignored by `crew run`. Dispatch on demand with `crew run --ticket <TICKET>` (also falls back to `models.default`).
+- No `agent-*` label → ignored by `crew run`. Dispatch on demand with `crew start <TICKET>` (also falls back to `models.default`).
 - Todo tickets blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
 
 Status classification uses Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so renamed status columns work without configuration. Parent issues with children are ignored — sub-issues are the work items.
@@ -136,7 +138,7 @@ Resolution order: `GROUNDCREW_CONFIG` → cosmiconfig project-walk from cwd (any
 | `orchestrator.maximumInProgress`        | `4`                 | Cap on in-progress tickets at once for this `crew` instance.                                                                                                                                                                                                                                                                                                            |
 | `orchestrator.pollIntervalMilliseconds` | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                                                                                                                                        |
 | `orchestrator.sessionLimitPercentage`   | `85`                | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick.                                                                                                                                                                                                                                                               |
-| `models.default`                        | `"claude"`          | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew run --ticket <TICKET>` for unlabeled tickets. `crew run` without `--ticket` ignores unlabeled tickets and does not apply this default. Must exist in `models.definitions`.                                                                               |
+| `models.default`                        | `"claude"`          | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew start <TICKET>` for unlabeled tickets. `crew run` ignores unlabeled tickets and does not apply this default. Must exist in `models.definitions`.                                                                                                         |
 | `models.definitions`                    | `{ claude, codex }` | Agent definitions. Additive merge with shipped defaults.                                                                                                                                                                                                                                                                                                                |
 | `models.definitions.<name>.cmd`         | —                   | Shell command launched for the model. Runs in the worktree through the resolved `local.runner`. `{{worktree}}` is replaced before launch; `{{sandbox}}` expands to the sbx sandbox name under the sdx runner and an empty string otherwise.                                                                                                                             |
 | `models.definitions.<name>.color`       | —                   | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                                                                                                                                                |
@@ -234,21 +236,30 @@ In Progress (state.type=started) — Multi-event extractor: year inference can p
 
 </details>
 
-### `crew interrupt <TICKET>`
+### `crew start <TICKET>`
 
-Stops a live workspace pane while preserving the ticket worktree and branch. The manual pause button for cases where you need terminal capacity back, want to stop an agent that's going in the wrong direction, or need to inspect the diff before letting another agent continue.
+Provisions and launches one ticket immediately, bypassing orchestrator eligibility. Use it to dispatch a specific ticket on demand — including unlabeled tickets that `crew run` ignores. (Replaces the deprecated `crew run --ticket <TICKET>`.)
 
 ```bash
-crew interrupt HRD-442 --reason "wrong implementation direction"
+crew start HRD-442
+crew start HRD-442 --dry-run
+```
+
+### `crew stop <TICKET>`
+
+Stops a live workspace pane while preserving the ticket worktree and branch. The manual pause button for cases where you need terminal capacity back, want to stop an agent that's going in the wrong direction, or need to inspect the diff before letting another agent continue. (Replaces the deprecated `crew interrupt <TICKET>`.)
+
+```bash
+crew stop HRD-442 --reason "wrong implementation direction"
 crew status HRD-442
 crew resume HRD-442
 ```
 
-The command closes the cmux/tmux workspace if present, records local run state, and never tears down the worktree. If the workspace was already gone but the worktree is still present, interrupt records that fact so status can show the preserved branch.
+The command closes the cmux/tmux workspace if present, records local run state, and never tears down the worktree. If the workspace was already gone but the worktree is still present, stop records that fact so status can show the preserved branch.
 
 ### `crew resume <TICKET>`
 
-Reopens an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew run --ticket <ticket>`.
+Reopens an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew start <ticket>`.
 
 The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and ticket context.
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -243,15 +243,18 @@ describe(run, () => {
     expect(orchestrateMock).toHaveBeenCalledWith({ watch: true, dryRun: true });
   });
 
-  it("dispatches `run --ticket <id>` to setupWorkspaceCli", async () => {
+  it("dispatches the deprecated `run --ticket <id>` alias to setupWorkspaceCli with a warning", async () => {
     await run(["run", "--ticket", "team-220"]);
 
     expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: false });
     expect(orchestrateMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("crew run --ticket is deprecated");
+    expect(consoleError.output()).toContain("use crew start");
+    expect(consoleError.output()).toContain("next major");
   });
 
-  it("documents `run --ticket <TICKET>` as the manual ticket setup command", () => {
-    expect(README_TEXT).toContain("crew run --ticket <TICKET>");
+  it("documents `crew start <TICKET>` as the manual ticket setup command", () => {
+    expect(README_TEXT).toContain("crew start <TICKET>");
     expect(README_TEXT).not.toContain("crew setup <TICKET>");
   });
 
@@ -312,6 +315,51 @@ describe(run, () => {
     expect(setupMock).not.toHaveBeenCalled();
   });
 
+  it("dispatches `start <ticket>` to setupWorkspaceCli with no deprecation warning", async () => {
+    await run(["start", "team-220"]);
+
+    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: false });
+    expect(orchestrateMock).not.toHaveBeenCalled();
+    expect(consoleError.calls).toStrictEqual([]);
+  });
+
+  it("forwards --dry-run to setupWorkspaceCli under `start`", async () => {
+    await run(["start", "team-220", "--dry-run"]);
+
+    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: true });
+  });
+
+  it("rejects `start` with no ticket", async () => {
+    await run(["start"]);
+
+    expect(consoleError.output()).toContain("Usage: crew start <ticket>");
+    expect(process.exitCode).toBe(1);
+    expect(setupMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown flags under `start`", async () => {
+    await run(["start", "team-220", "--watch"]);
+
+    expect(consoleError.output()).toContain("Unknown option: --watch");
+    expect(process.exitCode).toBe(1);
+    expect(setupMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects extra positional args under `start`", async () => {
+    await run(["start", "team-220", "extra"]);
+
+    expect(consoleError.output()).toContain("Usage: crew start <ticket>");
+    expect(process.exitCode).toBe(1);
+    expect(setupMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches `stop` to interruptWorkspaceCli with no deprecation warning", async () => {
+    await run(["stop", "TEAM-1", "--reason", "wrong direction"]);
+
+    expect(interruptMock).toHaveBeenCalledWith(["TEAM-1", "--reason", "wrong direction"]);
+    expect(consoleError.calls).toStrictEqual([]);
+  });
+
   it("calls doctor and leaves exit code untouched on success", async () => {
     doctorMock.mockResolvedValue(true);
 
@@ -335,11 +383,32 @@ describe(run, () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("rejects legacy doctor ticket mode", async () => {
+  it("routes the deprecated `doctor --ticket <id>` alias to status with a warning", async () => {
     await run(["doctor", "--ticket", "team-220"]);
 
-    expect(consoleError.output()).toContain("Usage: crew doctor");
+    expect(statusMock).toHaveBeenCalledWith(["team-220"]);
+    expect(doctorMock).not.toHaveBeenCalled();
+    expect(consoleError.output()).toContain("crew doctor --ticket is deprecated");
+    expect(consoleError.output()).toContain("use crew status");
+    expect(consoleError.output()).toContain("next major");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("rejects `doctor --ticket` with no value", async () => {
+    await run(["doctor", "--ticket"]);
+
+    expect(consoleError.output()).toContain("ticket id is required");
     expect(process.exitCode).toBe(1);
+    expect(statusMock).not.toHaveBeenCalled();
+    expect(doctorMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects extra args after `doctor --ticket <id>`", async () => {
+    await run(["doctor", "--ticket", "team-220", "extra"]);
+
+    expect(consoleError.output()).toContain("Usage: crew status");
+    expect(process.exitCode).toBe(1);
+    expect(statusMock).not.toHaveBeenCalled();
     expect(doctorMock).not.toHaveBeenCalled();
   });
 
@@ -373,10 +442,13 @@ describe(run, () => {
     expect(cleanupMock).toHaveBeenCalledWith(["--force", "TEAM-1"]);
   });
 
-  it("dispatches interrupt to interruptWorkspaceCli with the remaining argv", async () => {
+  it("routes the deprecated `interrupt` alias to interruptWorkspaceCli with a warning", async () => {
     await run(["interrupt", "TEAM-1", "--reason", "wrong direction"]);
 
     expect(interruptMock).toHaveBeenCalledWith(["TEAM-1", "--reason", "wrong direction"]);
+    expect(consoleError.output()).toContain("crew interrupt is deprecated");
+    expect(consoleError.output()).toContain("use crew stop");
+    expect(consoleError.output()).toContain("next major");
   });
 
   it("dispatches resume to resumeWorkspaceCli with the remaining argv", async () => {
@@ -415,7 +487,7 @@ describe(run, () => {
   it("prints the error message and sets exit code 1 when a subcommand throws", async () => {
     setupMock.mockRejectedValue(new Error("boom"));
 
-    await run(["run", "--ticket", "team-1"]);
+    await run(["start", "team-1"]);
 
     expect(consoleError.output()).toBe("boom");
     expect(process.exitCode).toBe(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
 } from "./lib/upgrade.ts";
 import {
   errorMessage,
+  parseDryRunPositionals,
   readEnvironmentVariable,
   readTicketArgument,
   writeError,
@@ -36,9 +37,21 @@ interface Subcommand {
   summary: string;
   usage: string;
   invoke: (argv: string[]) => Promise<void>;
+  // Deprecated aliases keep working but are hidden from `crew --help`.
+  deprecated?: boolean;
 }
 
 const requireFromCli = createRequire(import.meta.url);
+
+/**
+ * Prints a deprecation warning to stderr naming the canonical command and that
+ * the old form is removed in the next major, then lets the caller proceed.
+ */
+function warnDeprecated(forms: { oldForm: string; newForm: string }): void {
+  writeError(
+    `crew ${forms.oldForm} is deprecated and will be removed in the next major version; use crew ${forms.newForm} instead.`,
+  );
+}
 
 function setupUsage(): string {
   return "Usage: crew setup repos [--dry-run] [<repo>...]";
@@ -84,6 +97,18 @@ async function runCli(argv: string[]): Promise<void> {
     await orchestrate({ watch, dryRun });
     return;
   }
+  warnDeprecated({ oldForm: "run --ticket", newForm: "start" });
+  await setupWorkspaceCli(ticket, { dryRun });
+}
+
+const START_USAGE = "crew start <ticket> [--dry-run]";
+
+async function startCli(argv: string[]): Promise<void> {
+  const { dryRun, positionals } = parseDryRunPositionals(argv, START_USAGE);
+  const [ticket, ...extras] = positionals;
+  if (ticket === undefined || ticket.length === 0 || extras.length > 0) {
+    throw new Error(`Usage: ${START_USAGE}`);
+  }
   await setupWorkspaceCli(ticket, { dryRun });
 }
 
@@ -117,7 +142,24 @@ async function maybeRunUpgradeNudge(metadata: PackageMetadata): Promise<void> {
   }
 }
 
+function doctorTicketAlias(argv: string[]): string | undefined {
+  if (argv[0] !== "--ticket") {
+    return undefined;
+  }
+  const ticket = readTicketArgument(argv, 0, "doctor");
+  if (argv.length > 2) {
+    throw new Error("Usage: crew status [<ticket>]");
+  }
+  return ticket;
+}
+
 async function doctorCli(argv: string[]): Promise<void> {
+  const aliasTicket = doctorTicketAlias(argv);
+  if (aliasTicket !== undefined) {
+    warnDeprecated({ oldForm: "doctor --ticket", newForm: "status" });
+    await statusCli([aliasTicket]);
+    return;
+  }
   if (argv.length > 0) {
     throw new Error("Usage: crew doctor");
   }
@@ -132,9 +174,14 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: initConfigCli,
   },
   run: {
-    summary: "Run the orchestrator (one-shot by default), or provision one ticket with --ticket",
-    usage: "[--watch] [--dry-run] [--ticket <ticket>]",
+    summary: "Run the orchestrator: poll sources and start eligible tickets (one-shot by default)",
+    usage: "[--watch] [--dry-run]",
     invoke: runCli,
+  },
+  start: {
+    summary: "Provision and launch one ticket immediately, bypassing eligibility",
+    usage: "<ticket> [--dry-run]",
+    invoke: startCli,
   },
   doctor: {
     summary: "Verify host prerequisites (PATH tools, config validity, Linear reachability)",
@@ -151,10 +198,19 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     usage: "[--force] <ticket>",
     invoke: cleanupWorkspaceCli,
   },
-  interrupt: {
+  stop: {
     summary: "Stop a live ticket workspace while preserving its worktree",
     usage: "<ticket> [--reason <text>]",
     invoke: interruptWorkspaceCli,
+  },
+  interrupt: {
+    summary: "Deprecated alias for `crew stop`",
+    usage: "<ticket> [--reason <text>]",
+    deprecated: true,
+    invoke: async (argv) => {
+      warnDeprecated({ oldForm: "interrupt", newForm: "stop" });
+      await interruptWorkspaceCli(argv);
+    },
   },
   resume: {
     summary: "Reopen an existing ticket worktree with a continuation prompt",
@@ -187,6 +243,9 @@ function printHelp(): void {
   writeOutput("");
   writeOutput("Commands:");
   for (const [name, command] of Object.entries(SUBCOMMANDS)) {
+    if (command.deprecated === true) {
+      continue;
+    }
     writeOutput(`  ${name.padEnd(width)}  ${command.summary}`);
     writeOutput(`  ${" ".repeat(width)}  → crew ${name} ${command.usage}`);
   }

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -213,7 +213,7 @@ describe(interruptWorkspaceCli, () => {
   });
 
   it("rejects missing ticket", async () => {
-    await expect(interruptWorkspaceCli([])).rejects.toThrow(/Usage: crew interrupt/);
+    await expect(interruptWorkspaceCli([])).rejects.toThrow(/Usage: crew stop/);
   });
 
   it("rejects missing reason text", async () => {

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -31,22 +31,20 @@ function parseArguments(argv: string[]): InterruptWorkspaceOptions {
     if (argument === "--reason") {
       const value = argv[index + 1];
       if (value === undefined || value.length === 0 || value.startsWith("-")) {
-        throw new Error("crew interrupt --reason: reason text is required");
+        throw new Error("crew stop --reason: reason text is required");
       }
       reason = value;
       index += 1;
       continue;
     }
     if (argument.startsWith("-")) {
-      throw new Error(
-        `Unknown option: ${argument}\nUsage: crew interrupt <ticket> [--reason <text>]`,
-      );
+      throw new Error(`Unknown option: ${argument}\nUsage: crew stop <ticket> [--reason <text>]`);
     }
     positionals.push(argument);
   }
   const [ticket, ...extras] = positionals;
   if (ticket === undefined || ticket.length === 0 || extras.length > 0) {
-    throw new Error("Usage: crew interrupt <ticket> [--reason <text>]");
+    throw new Error("Usage: crew stop <ticket> [--reason <text>]");
   }
   return { ticket: ticket.toLowerCase(), ...(reason === undefined ? {} : { reason }) };
 }

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -12,7 +12,7 @@ import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { runCommandAsync } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { which } from "../lib/host.ts";
-import { errorMessage, log, writeOutput } from "../lib/util.ts";
+import { errorMessage, log, parseDryRunPositionals, writeOutput } from "../lib/util.ts";
 
 export interface SetupReposOptions {
   /** Print the plan without running any clone. */
@@ -267,20 +267,10 @@ export async function setupRepos(
 }
 
 function parseArguments(argv: string[]): SetupReposOptions {
-  let dryRun = false;
-  const positionals: string[] = [];
-  for (const argument of argv) {
-    if (argument === "--dry-run") {
-      dryRun = true;
-      continue;
-    }
-    if (argument.startsWith("-")) {
-      throw new Error(
-        `Unknown option: ${argument}\nUsage: crew setup repos [--dry-run] [<repo>...]`,
-      );
-    }
-    positionals.push(argument);
-  }
+  const { dryRun, positionals } = parseDryRunPositionals(
+    argv,
+    "crew setup repos [--dry-run] [<repo>...]",
+  );
   const options: SetupReposOptions = { dryRun };
   if (positionals.length > 0) {
     options.only = positionals;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -173,6 +173,33 @@ export function readTicketArgument(argv: string[], index: number, command: strin
   return value;
 }
 
+export interface DryRunPositionals {
+  dryRun: boolean;
+  positionals: string[];
+}
+
+/**
+ * Parses an argv that accepts an optional `--dry-run` flag plus free
+ * positionals, rejecting any other dash-prefixed token. Shared by the
+ * subcommands whose only flag is `--dry-run` so each parser stays DRY; pass the
+ * command's `usage` string for the "Unknown option" error.
+ */
+export function parseDryRunPositionals(argv: string[], usage: string): DryRunPositionals {
+  let dryRun = false;
+  const positionals: string[] = [];
+  for (const argument of argv) {
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(`Unknown option: ${argument}\nUsage: ${usage}`);
+    }
+    positionals.push(argument);
+  }
+  return { dryRun, positionals };
+}
+
 export function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
## What

Reworks the CLI so one verb means one behavior, with working deprecation aliases for the renamed forms.

Canonical lifecycle verbs are now: `init`, `run`, `start`, `resume`, `stop`, `cleanup`, `status`, `doctor`, `upgrade`.

- **`crew run [--watch] [--dry-run]`** — orchestrates only: polls Sources and starts eligible tickets. It no longer provisions a single ticket.
- **`crew start <ticket> [--dry-run]`** — provisions and launches one ticket immediately, bypassing eligibility (this is the old `run --ticket` behavior, extracted into its own verb).
- **`crew stop <ticket> [--reason <text>]`** — halts the running agent while preserving the worktree (this is the old `interrupt`).

### Deprecation aliases

Each old form still works but prints a warning naming the new command and that the old form is removed in the next major version, then proceeds:

- `crew interrupt <ticket>` → `crew stop <ticket>`
- `crew run --ticket <ticket>` → `crew start <ticket>`
- `crew doctor --ticket <ticket>` → `crew status <ticket>`

Deprecated aliases are hidden from `crew --help` but remain dispatchable.

## Why

Part of [STAFF-1033](https://linear.app/clipboardhealth/issue/STAFF-1033) (simplify groundcrew: rethink CLI). Overloaded verbs (`run` doing both orchestration and single-ticket provisioning; `doctor` doing both host checks and per-ticket diagnostics) made the surface confusing. Splitting them gives one verb per behavior while keeping muscle memory working through aliases for one more major.

## Implementation notes / decisions

- The canonical `stop` invokes the existing `interruptWorkspaceCli`; its user-facing usage strings were updated from `crew interrupt` to `crew stop`. Internal function names and the persisted `state: "interrupted"` run-state enum are unchanged (renaming them would be churn with no user-visible benefit and would break existing run-state files).
- `crew run --watch --ticket` still errors on mutual exclusivity *before* emitting a deprecation warning.
- Extracted the duplicated `--dry-run`+positionals parser into `parseDryRunPositionals` (`src/lib/util.ts`), now shared by `start` and `setup repos`, to satisfy the zero-duplication `cpd` guardrail.

## Tests

Alias deprecation behavior is covered by tests asserting the warning fires (names the new command + "next major") *and* that the new behavior runs, for all three aliases. Added dispatch/usage tests for `start` and `stop`.

`node --run verify` passes; coverage guardrail satisfied (100% statements/branches/functions/lines).

## Continuation

To reattach to this workspace (tmux backend): `tmux attach -t groundcrew:staff-1040`

Closes staff-1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)