### PR TITLE
feat(tickets): unify on TicketSource (orchestrator + consumers canonical, delete boardSource)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "discriminable",
     "initialised",
     "dedup",
+    "dispatchable",
     "misconfig",
     "ticketsource",
     "writeback",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -18,6 +18,19 @@ export default defineConfig(
             "typescript/strict-boolean-expressions": "off",
           },
         },
+        {
+          // ticketDoctor.ts is a ~1500-line orchestrating command; the
+          // matching unit-test file is comprehensive (~2200 lines covering
+          // every probe, verdict path, and section, including non-Linear
+          // source path tests added in the source-agnostic doctor refactor).
+          // Splitting by describe block would create cross-file coupling on
+          // shared makeConfig / makeStubDependencies helpers without
+          // improving readability. Bump the cap for this one file.
+          files: ["**/ticketDoctor.test.ts"],
+          rules: {
+            "max-lines": ["error", 2500],
+          },
+        },
       ],
     },
     presets: [base, vitest],

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -1,6 +1,7 @@
-import type { BoardState, Issue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
 import { removeRunState } from "../lib/runState.ts";
+import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import type { BoardState } from "../lib/ticketSource.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
@@ -51,35 +52,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   };
 }
 
-function doneIssue(id: string, overrides: Partial<Issue> = {}): Issue {
-  return {
-    id,
-    uuid: `uuid-${id}`,
-    title: "Title",
-    status: "Done",
-    statusId: "state-done",
-    stateType: "completed",
-    assignee: "Alice",
-    updatedAt: "2025-01-01T00:00:00.000Z",
-    repository: "repo-a",
-    model: "claude",
-    teamId: "team-1",
-    blockers: [],
-    hasMoreBlockers: false,
-    ...overrides,
-  };
-}
-
-function todoIssue(id: string, overrides: Partial<Issue> = {}): Issue {
-  return doneIssue(id, {
-    status: "Todo",
-    statusId: "state-todo",
-    stateType: "unstarted",
-    ...overrides,
-  });
-}
-
-function boardOf(issues: Issue[]): BoardState {
+function boardOf(issues: BoardState["issues"]): BoardState {
   return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
 }
 
@@ -106,13 +79,13 @@ describe(createCleaner, () => {
     vi.clearAllMocks();
   });
 
-  it("calls teardown for a Done ticket's worktree", async () => {
+  it("calls teardown for a done ticket's worktree", async () => {
     const cleaner = createCleaner({ config: makeConfig() });
     const entry = hostEntryFor("repo-a", "team-1");
     teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [entry] }));
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [entry],
       dryRun: false,
     });
@@ -122,11 +95,11 @@ describe(createCleaner, () => {
     expect(consoleLog.output()).toContain("event=cleanup outcome=cleaned ticket=team-1");
   });
 
-  it("ignores worktrees whose ticket is not in the board snapshot", async () => {
+  it("ignores worktrees whose ticket is not in the terminal set", async () => {
     const cleaner = createCleaner({ config: makeConfig() });
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [hostEntryFor("repo-a", "other-1")],
       dryRun: false,
     });
@@ -138,7 +111,7 @@ describe(createCleaner, () => {
     const cleaner = createCleaner({ config: makeConfig() });
 
     await cleaner.runOnce({
-      state: boardOf([todoIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "todo" })]),
       worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: false,
     });
@@ -146,23 +119,16 @@ describe(createCleaner, () => {
     expect(teardownMock).not.toHaveBeenCalled();
   });
 
-  it("treats canceled tickets as terminal regardless of status name", async () => {
+  it("treats in-progress tickets as non-terminal", async () => {
     const cleaner = createCleaner({ config: makeConfig() });
-    const entry = hostEntryFor("repo-a", "team-1");
 
     await cleaner.runOnce({
-      state: boardOf([
-        doneIssue("team-1", {
-          status: "Won't fix",
-          statusId: "state-wont-fix",
-          stateType: "canceled",
-        }),
-      ]),
-      worktreeEntries: [entry],
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "in-progress" })]),
+      worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: false,
     });
 
-    expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry]);
+    expect(teardownMock).not.toHaveBeenCalled();
   });
 
   it("logs workspace_closed events for tickets reported by teardown", async () => {
@@ -170,7 +136,7 @@ describe(createCleaner, () => {
     teardownMock.mockResolvedValue(emptyTeardownResult({ closed: ["team-1"] }));
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: false,
     });
@@ -185,7 +151,7 @@ describe(createCleaner, () => {
     );
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: false,
     });
@@ -204,7 +170,7 @@ describe(createCleaner, () => {
     );
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: false,
     });
@@ -224,7 +190,7 @@ describe(createCleaner, () => {
     );
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [entry],
       dryRun: false,
     });
@@ -245,7 +211,7 @@ describe(createCleaner, () => {
     );
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [entry],
       dryRun: false,
     });
@@ -257,7 +223,7 @@ describe(createCleaner, () => {
     const cleaner = createCleaner({ config: makeConfig() });
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [hostEntryFor("repo-a", "team-1")],
       dryRun: true,
     });
@@ -275,7 +241,7 @@ describe(createCleaner, () => {
     const cleaner = createCleaner({ config: makeConfig() });
 
     await cleaner.runOnce({
-      state: boardOf([doneIssue("team-1")]),
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
       worktreeEntries: [entry],
       dryRun: false,
       signal,

--- a/src/commands/cleaner.ts
+++ b/src/commands/cleaner.ts
@@ -4,9 +4,9 @@
  * invocation; stateless across iterations. Mirrors `Dispatcher`.
  */
 
-import { type BoardState, isTerminalStatusForIssue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
+import { naturalIdFromCanonical, type BoardState } from "../lib/ticketSource.ts";
 import { log, logEvent } from "../lib/util.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
@@ -36,7 +36,9 @@ export function createCleaner(deps: CleanerDeps): Cleaner {
     const { state, worktreeEntries, dryRun, signal } = arguments_;
 
     const terminalTickets = new Set(
-      state.issues.filter((issue) => isTerminalStatusForIssue(issue)).map((issue) => issue.id),
+      state.issues
+        .filter((issue) => issue.status === "done")
+        .map((issue) => naturalIdFromCanonical(issue.id)),
     );
     if (terminalTickets.size === 0) {
       return;

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -1,7 +1,7 @@
-import type { LinearClient } from "@linear/sdk";
-
-import type { BoardState, Issue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import { makeBoard } from "../testHelpers/boardFixtures.ts";
+import type { BoardState, Issue } from "../lib/ticketSource.ts";
 import { EXHAUSTED_USAGE } from "../lib/usage.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
@@ -61,35 +61,26 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
 }
 
 function todoIssue(overrides: Partial<Issue> = {}): Issue {
-  return {
-    id: "team-1",
-    uuid: "uuid-1",
-    title: "Title",
-    status: "Todo",
-    statusId: "state-todo",
-    stateType: "unstarted",
-    assignee: "Alice",
-    updatedAt: "2025-01-01T00:00:00.000Z",
+  return canonicalLinearIssue({
+    naturalId: "team-1",
+    status: "todo",
     repository: "repo-a",
     model: "claude",
-    teamId: "team-1",
-    blockers: [],
-    hasMoreBlockers: false,
-    ...overrides,
-  };
-}
-
-function activeIssue(overrides: Partial<Issue> = {}): Issue {
-  return todoIssue({
-    status: "In Progress",
-    statusId: "state-active",
-    stateType: "started",
+    title: "Title",
+    description: "",
     ...overrides,
   });
 }
 
-function boardOf(issues: Issue[]): BoardState {
-  return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
+function activeIssue(overrides: Partial<Issue> = {}): Issue {
+  return todoIssue({ status: "in-progress", ...overrides });
+}
+
+function boardOf(
+  issues: Issue[],
+  { parentSkips = [] }: { parentSkips?: BoardState["parentSkips"] } = {},
+): BoardState {
+  return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips };
 }
 
 function hostEntryFor(repository: string, ticket: string): WorktreeEntry {
@@ -100,37 +91,6 @@ function hostEntryFor(repository: string, ticket: string): WorktreeEntry {
     dir: `/work/${repository}-${ticket}`,
     kind: "host",
   };
-}
-
-interface ClientStub {
-  team: ReturnType<typeof vi.fn>;
-  updateIssue: ReturnType<typeof vi.fn>;
-}
-
-function makeClient(options: { omitInProgressState?: boolean } = {}): ClientStub {
-  const { omitInProgressState = false } = options;
-  interface StateNode {
-    id: string;
-    name: string;
-    type: string;
-  }
-  return {
-    team: vi
-      .fn<() => Promise<{ states: () => Promise<{ nodes: StateNode[] }> }>>()
-      .mockResolvedValue({
-        states: vi.fn<() => Promise<{ nodes: StateNode[] }>>().mockResolvedValue({
-          nodes: omitInProgressState
-            ? [{ id: "state-other", name: "Other", type: "unstarted" }]
-            : [{ id: "state-in-progress", name: "In Progress", type: "started" }],
-        }),
-      }),
-    updateIssue: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
-  };
-}
-
-function asLinearClient(stub: ClientStub): LinearClient {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests use the LinearClient surface consumed by dispatcher
-  return stub as unknown as LinearClient;
 }
 
 describe(createDispatcher, () => {
@@ -149,8 +109,8 @@ describe(createDispatcher, () => {
 
   describe("slot math", () => {
     it("starts a Todo ticket and marks it In Progress", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -165,9 +125,13 @@ describe(createDispatcher, () => {
           ticket: "team-1",
           repository: "repo-a",
           model: "claude",
+          details: { title: "Title", description: "" },
         }),
       );
-      expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-in-progress" });
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "linear:team-1" }),
+      );
     });
 
     it("logs `At capacity` when no slots remain", async () => {
@@ -178,14 +142,11 @@ describe(createDispatcher, () => {
           sessionLimitPercentage: 85,
         },
       });
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config, client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config, board });
 
       await dispatcher.runOnce({
-        state: boardOf([
-          activeIssue({ id: "team-a" }),
-          todoIssue({ id: "team-b", uuid: "uuid-b" }),
-        ]),
+        state: boardOf([activeIssue({ id: "linear:team-a" }), todoIssue({ id: "linear:team-b" })]),
         worktreeEntries: [],
         usage: async () => ({}),
         dryRun: false,
@@ -196,8 +157,8 @@ describe(createDispatcher, () => {
     });
 
     it("logs `No Todo tickets` when nothing is queued", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([activeIssue()]),
@@ -212,8 +173,8 @@ describe(createDispatcher, () => {
     it("ignores Todo tickets without an agent-* label (model: undefined)", async () => {
       // Unlabeled Todo tickets reach the dispatcher in the board snapshot
       // but should be filtered out via isGroundcrewIssue before eligibility.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue({ model: undefined, repository: undefined })]),
@@ -223,7 +184,8 @@ describe(createDispatcher, () => {
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      expect(client.updateIssue).not.toHaveBeenCalled();
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).not.toHaveBeenCalled();
       expect(consoleLog.output()).toContain("No Todo tickets");
     });
 
@@ -235,14 +197,11 @@ describe(createDispatcher, () => {
           sessionLimitPercentage: 85,
         },
       });
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config, client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config, board });
 
       await dispatcher.runOnce({
-        state: boardOf([
-          todoIssue({ id: "team-1", uuid: "uuid-1" }),
-          todoIssue({ id: "team-2", uuid: "uuid-2" }),
-        ]),
+        state: boardOf([todoIssue({ id: "linear:team-1" }), todoIssue({ id: "linear:team-2" })]),
         worktreeEntries: [],
         usage: async () => ({}),
         dryRun: false,
@@ -254,18 +213,17 @@ describe(createDispatcher, () => {
 
   describe("blocker classification", () => {
     it("skips a ticket whose blocker is not in a terminal state", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([
           todoIssue({
             blockers: [
               {
-                id: "team-0",
+                id: "linear:team-0",
                 title: "Blocker",
-                status: "In Progress",
-                stateType: "started",
+                status: "in-progress",
               },
             ],
           }),
@@ -282,13 +240,13 @@ describe(createDispatcher, () => {
     });
 
     it("dispatches a ticket whose blocker is terminal", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([
           todoIssue({
-            blockers: [{ id: "team-0", title: "Blocker", status: "Done", stateType: "completed" }],
+            blockers: [{ id: "linear:team-0", title: "Blocker", status: "done" }],
           }),
         ]),
         worktreeEntries: [],
@@ -303,8 +261,8 @@ describe(createDispatcher, () => {
     });
 
     it("conservatively skips a ticket when blocker pagination overflowed", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue({ hasMoreBlockers: true })]),
@@ -319,13 +277,13 @@ describe(createDispatcher, () => {
     });
 
     it("conservatively skips a ticket when a blocker state is missing", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([
           todoIssue({
-            blockers: [{ id: "team-0", title: "Blocker", status: undefined, stateType: undefined }],
+            blockers: [{ id: "linear:team-0", title: "Blocker", status: "other" }],
           }),
         ]),
         worktreeEntries: [],
@@ -334,38 +292,35 @@ describe(createDispatcher, () => {
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("blockers=team-0:missing");
+      expect(consoleLog.output()).toContain("blockers=linear:team-0:other");
     });
 
     // Regression: the lazy `usage` callback exists so all-blocked ticks don't
     // burn a codexbar HTTP call and a cmux/tmux shell-out for nothing.
     it("does not probe usage or workspaces when every Todo is blocked", async () => {
       const usageProbe = vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({});
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([
           todoIssue({
-            id: "team-1",
+            id: "linear:team-1",
             blockers: [
               {
-                id: "team-0",
+                id: "linear:team-0",
                 title: "Blocker",
-                status: "In Progress",
-                stateType: "started",
+                status: "in-progress",
               },
             ],
           }),
           todoIssue({
-            id: "team-2",
-            uuid: "uuid-2",
+            id: "linear:team-2",
             blockers: [
               {
-                id: "team-0",
+                id: "linear:team-0",
                 title: "Blocker",
-                status: "In Progress",
-                stateType: "started",
+                status: "in-progress",
               },
             ],
           }),
@@ -383,8 +338,8 @@ describe(createDispatcher, () => {
 
   describe("agent-any resolution", () => {
     it("picks the model with the lowest session-used percent", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue({ model: "any" })]),
@@ -404,8 +359,8 @@ describe(createDispatcher, () => {
     });
 
     it("skips agent-any when every model is exhausted", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue({ model: "any" })]),
@@ -425,8 +380,8 @@ describe(createDispatcher, () => {
   describe("eligibility", () => {
     it("resumes when worktree exists and a matching live workspace is present", async () => {
       workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -436,14 +391,17 @@ describe(createDispatcher, () => {
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-in-progress" });
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "linear:team-1" }),
+      );
       expect(consoleLog.output()).toContain("resuming with markInProgress");
     });
 
     it("skips when worktree exists but no live workspace matches", async () => {
       workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -453,14 +411,15 @@ describe(createDispatcher, () => {
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      expect(client.updateIssue).not.toHaveBeenCalled();
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).not.toHaveBeenCalled();
       expect(consoleLog.output()).toContain("Run `crew cleanup");
     });
 
     it("retries next iteration when the workspace list is unavailable", async () => {
       workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -474,8 +433,8 @@ describe(createDispatcher, () => {
     });
 
     it("dry-run logs `Would start` without invoking setupWorkspace", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -490,8 +449,8 @@ describe(createDispatcher, () => {
     });
 
     it("rethrows workspace probe failures after attaching a usage rejection handler", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
       const usageProbe = vi
         .fn<() => Promise<Record<string, never>>>()
         .mockRejectedValue(new Error("usage failed"));
@@ -510,8 +469,8 @@ describe(createDispatcher, () => {
 
   describe("session limits", () => {
     it("skips a Todo ticket whose model is over the session limit", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -527,7 +486,7 @@ describe(createDispatcher, () => {
     });
 
     it("treats EXHAUSTED_USAGE as exhausted at sessionLimitPercentage=100", async () => {
-      const client = makeClient();
+      const board = makeBoard();
       const dispatcher = createDispatcher({
         config: makeConfig({
           orchestrator: {
@@ -536,7 +495,7 @@ describe(createDispatcher, () => {
             sessionLimitPercentage: 100,
           },
         }),
-        client: asLinearClient(client),
+        board,
       });
 
       await dispatcher.runOnce({
@@ -561,8 +520,8 @@ describe(createDispatcher, () => {
 
     it("does not gate when weekly usage is below the current day budget", async () => {
       // End of day 3 → 3/7 = 42.86% allowed. Used 30% — well under the line.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -583,8 +542,8 @@ describe(createDispatcher, () => {
 
     it("allows the first-day budget immediately after weekly rollover", async () => {
       // 19 minutes after rollover is still day 1, so 1/7 = 14.29% is allowed.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue({ model: "codex" })]),
@@ -606,8 +565,8 @@ describe(createDispatcher, () => {
 
     it("gates when weekly usage exceeds the current day budget", async () => {
       // End of day 1 → 1/7 = 14.29% allowed. Used 20% — over the line.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -635,8 +594,8 @@ describe(createDispatcher, () => {
     // refactor to `>=` can't silently start benching models early.
     it("does not gate when weekly usage exactly equals the current day budget", async () => {
       // Mid-week (3.5 days in) is day 4's bucket, and used exactly 4/7.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -660,8 +619,8 @@ describe(createDispatcher, () => {
     // usage gives nightly agents the full 2/7 = 28.57% budget — i.e.,
     // catch-up usage is permitted when behind the pace.
     it("permits catch-up usage when behind the pace", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -682,8 +641,8 @@ describe(createDispatcher, () => {
     });
 
     it("ignores a null weekly value (no codexbar secondary window)", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -698,8 +657,8 @@ describe(createDispatcher, () => {
     });
 
     it("ignores a null weekEndDuration (can't compute pace this tick)", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -726,8 +685,8 @@ describe(createDispatcher, () => {
       // Anomalous weekEndDuration > MINUTES_PER_WEEK (e.g., codexbar
       // returned a value from before the window started). Elapsed should
       // clamp to the first day bucket, so usage over 1/7 trips the gate.
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -748,8 +707,8 @@ describe(createDispatcher, () => {
     });
 
     it("does not double-gate when weekly is Infinity (session gate handles EXHAUSTED_USAGE)", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -766,103 +725,11 @@ describe(createDispatcher, () => {
     });
   });
 
-  describe("team-state cache", () => {
-    it("fetches the In-Progress state once across multiple tickets in the same team", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
-
-      await dispatcher.runOnce({
-        state: boardOf([
-          todoIssue({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
-          todoIssue({ id: "team-2", uuid: "uuid-2", teamId: "shared" }),
-        ]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-
-      expect(client.team).toHaveBeenCalledTimes(1);
-    });
-
-    it("reuses the cached state across multiple runOnce invocations", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
-
-      await dispatcher.runOnce({
-        state: boardOf([todoIssue({ id: "team-1", uuid: "uuid-1", teamId: "shared" })]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-      await dispatcher.runOnce({
-        state: boardOf([todoIssue({ id: "team-2", uuid: "uuid-2", teamId: "shared" })]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-
-      expect(client.team).toHaveBeenCalledTimes(1);
-      expect(client.updateIssue).toHaveBeenCalledTimes(2);
-    });
-
-    it("logs and continues when the team has no In-Progress state", async () => {
-      const client = makeClient({ omitInProgressState: true });
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
-
-      await dispatcher.runOnce({
-        state: boardOf([todoIssue()]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-
-      expect(consoleLog.output()).toContain('Could not find a workflow state with type "started"');
-    });
-
-    it("dedupes a misconfigured-team lookup within an iteration", async () => {
-      const client = makeClient({ omitInProgressState: true });
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
-
-      await dispatcher.runOnce({
-        state: boardOf([
-          todoIssue({ id: "team-1", uuid: "uuid-1", teamId: "broken" }),
-          todoIssue({ id: "team-2", uuid: "uuid-2", teamId: "broken" }),
-          todoIssue({ id: "team-3", uuid: "uuid-3", teamId: "broken" }),
-        ]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-
-      expect(client.team).toHaveBeenCalledTimes(1);
-    });
-
-    it("re-fetches a misconfigured team next iteration so a Linear-side fix auto-recovers", async () => {
-      const client = makeClient({ omitInProgressState: true });
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
-
-      await dispatcher.runOnce({
-        state: boardOf([todoIssue({ id: "team-1", uuid: "uuid-1", teamId: "broken" })]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-      await dispatcher.runOnce({
-        state: boardOf([todoIssue({ id: "team-2", uuid: "uuid-2", teamId: "broken" })]),
-        worktreeEntries: [],
-        usage: async () => ({}),
-        dryRun: false,
-      });
-
-      expect(client.team).toHaveBeenCalledTimes(2);
-    });
-  });
-
   describe("setup failures", () => {
     it("logs setupWorkspace failures without crashing the loop", async () => {
       setupMock.mockRejectedValue(new Error("boom"));
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
@@ -875,24 +742,84 @@ describe(createDispatcher, () => {
     });
   });
 
-  // Without these logs, a parent Todo ticket disappears silently from the
-  // daemon log — operators see "No Todo tickets to pick up" and can't tell
-  // why. Surfacing each parent skip makes the silent fetchBoard filter
-  // visible.
-  describe("parent ticket logging", () => {
-    it("emits a dispatch skip event for every parent ticket in state.parentSkips", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+  describe("repository validation", () => {
+    it("WARN-skips an issue whose repository is not in knownRepositories", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
-        state: {
-          timestamp: "2025-01-01T00:00:00.000Z",
-          issues: [],
+        state: boardOf([todoIssue({ repository: "unknown-repo" })]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).not.toHaveBeenCalled();
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).not.toHaveBeenCalled();
+      expect(consoleLog.output()).toContain("references unknown repository unknown-repo");
+    });
+
+    it("short-circuits BEFORE usage() and workspaces.probe when every candidate has an unknown repo", async () => {
+      // Pins the ordering invariant: repository validation runs ahead of the
+      // expensive probes, so an all-unknown-repo tick doesn't pay the HTTP +
+      // shell-out cost just to drop every candidate afterward.
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+      const usageMock = vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({});
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue({ repository: "unknown-repo" })]),
+        worktreeEntries: [],
+        usage: usageMock,
+        dryRun: false,
+      });
+
+      expect(usageMock).not.toHaveBeenCalled();
+      expect(workspacesProbeMock).not.toHaveBeenCalled();
+      expect(consoleLog.output()).toContain("No eligible Todo tickets after repository validation");
+    });
+
+    it("dispatches issues whose repository is in knownRepositories", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue({ repository: "repo-b" })]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ repository: "repo-b" }),
+      );
+      // oxlint-disable-next-line typescript/unbound-method -- board is a plain vi.fn stub; markInProgress has no `this` binding
+      expect(board.markInProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "linear:team-1" }),
+      );
+    });
+  });
+
+  // Parent tickets are silently dropped by board.fetch (children filter).
+  // Surfacing each parent skip makes the silent filter visible so operators
+  // see WHY a Todo ticket isn't being picked up (PR #80 behavior).
+  describe("parent ticket logging", () => {
+    it("emits a dispatch skip event for every parent ticket in state.parentSkips", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      // ParentSkip.id is canonical (source-prefixed) per the contract in
+      // ticketSource.ts. The dispatcher strips the prefix before logging so
+      // operator output is uniform with the rest of the dispatcher's log lines.
+      await dispatcher.runOnce({
+        state: boardOf([], {
           parentSkips: [
-            { id: "team-9", title: "Umbrella epic", childCount: 3 },
-            { id: "team-10", title: "Another epic", childCount: 1 },
+            { id: "linear:team-9", title: "Umbrella epic", childCount: 3 },
+            { id: "linear:team-10", title: "Another epic", childCount: 1 },
           ],
-        },
+        }),
         worktreeEntries: [],
         usage: async () => ({}),
         dryRun: false,
@@ -905,12 +832,14 @@ describe(createDispatcher, () => {
       expect(output).toContain(
         "event=dispatch outcome=skipped reason=parent_with_children ticket=team-10",
       );
-      expect(output).toMatch(/team-9.*3 sub-issue/);
+      expect(output).toMatch(/Skipping team-9: parent ticket with 3 sub-issue/);
+      expect(output).not.toContain("linear:team-9");
+      expect(output).not.toContain("linear:team-10");
     });
 
     it("does not log parent skips when state.parentSkips is empty", async () => {
-      const client = makeClient();
-      const dispatcher = createDispatcher({ config: makeConfig(), client: asLinearClient(client) });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
 
       await dispatcher.runOnce({
         state: boardOf([]),

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -1,23 +1,21 @@
 /**
  * Per-iteration decider that picks Todo tickets to start and acts on the
- * picks. One per `orchestrate()` invocation; reuses its team-state cache
- * across iterations within an invocation.
+ * picks. Stateless across iterations. The Board adapter owns its own writeback
+ * caches (e.g., Linear's team-state cache lives in `src/lib/adapters/linear/writeback.ts`).
  *
  * Pure verdict logic lives in `eligibility.ts`; this module is responsible
- * for telemetry, Linear writes, and side-effecting setupWorkspace calls.
+ * for telemetry, writeback via Board, and side-effecting setupWorkspace calls.
  */
 
-import type { LinearClient } from "@linear/sdk";
-
+import type { Board } from "../lib/board.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
+import { dispatchableRepository } from "../lib/repositoryValidation.ts";
 import {
   type BoardState,
   type GroundcrewIssue,
   isGroundcrewIssue,
-  isIssueInProgress,
-  isIssueTodo,
-} from "../lib/boardSource.ts";
-import type { ResolvedConfig } from "../lib/config.ts";
-import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
+  naturalIdFromCanonical,
+} from "../lib/ticketSource.ts";
 import type { UsageByModel } from "../lib/usage.ts";
 import { errorMessage, log, logEvent } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
@@ -34,7 +32,7 @@ import { setupWorkspace } from "./setupWorkspace.ts";
 
 interface DispatcherDeps {
   config: ResolvedConfig;
-  client: LinearClient;
+  board: Board;
 }
 
 export interface Dispatcher {
@@ -59,15 +57,14 @@ function logSkip(verdict: SkipVerdict): void {
   logEvent("dispatch", {
     outcome: "skipped",
     reason: verdict.eventReason,
-    ticket: verdict.issue.id,
+    ticket: naturalIdFromCanonical(verdict.issue.id),
     blockers: verdict.blockers,
     model: verdict.model,
   });
 }
 
 export function createDispatcher(deps: DispatcherDeps): Dispatcher {
-  const { config, client } = deps;
-  const issueStatusUpdater = createLinearIssueStatusUpdater({ client });
+  const { config, board } = deps;
 
   function buildExhaustedSet(usage: UsageByModel): Set<string> {
     const exhausted = new Set<string>();
@@ -84,19 +81,20 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     signal?: AbortSignal,
   ): Promise<void> {
     const { issue, recovery } = start;
+    const ticketId = naturalIdFromCanonical(issue.id);
     if (start.resolvedFromAny) {
-      log(`Resolved agent-any for ${issue.id} → ${issue.model}`);
+      log(`Resolved agent-any for ${ticketId} → ${issue.model}`);
     }
 
     if (dryRun) {
       log(
         /* v8 ignore next @preserve -- classifyTodo forces recovery=false in dry-run, so the resume branch can't fire here */
-        `[dry-run] Would ${recovery ? "resume" : "start"} ${issue.id} in ${issue.repository} (${issue.model})`,
+        `[dry-run] Would ${recovery ? "resume" : "start"} ${ticketId} in ${issue.repository} (${issue.model})`,
       );
       logEvent("dispatch", {
         outcome: "skipped",
         reason: "dry_run",
-        ticket: issue.id,
+        ticket: ticketId,
         model: issue.model,
         repository: issue.repository,
       });
@@ -105,29 +103,30 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
 
     try {
       if (recovery) {
-        log(`Worktree and workspace already exist for ${issue.id}; resuming with markInProgress`);
+        log(`Worktree and workspace already exist for ${ticketId}; resuming with markInProgress`);
       } else {
         const setupOptions = {
           repository: issue.repository,
-          ticket: issue.id,
+          ticket: ticketId,
           model: issue.model,
+          details: { title: issue.title, description: issue.description },
         };
         await (signal === undefined
           ? setupWorkspace(config, setupOptions)
           : setupWorkspace(config, setupOptions, { signal }));
       }
-      await issueStatusUpdater.markInProgress(issue);
+      await board.markInProgress(issue);
       logEvent("dispatch", {
         outcome: recovery ? "resumed" : "started",
-        ticket: issue.id,
+        ticket: ticketId,
         model: issue.model,
         repository: issue.repository,
       });
     } catch (error) {
-      log(`Failed to start ${issue.id}: ${errorMessage(error)}`);
+      log(`Failed to start ${ticketId}: ${errorMessage(error)}`);
       logEvent("dispatch", {
         outcome: "failed",
-        ticket: issue.id,
+        ticket: ticketId,
         model: issue.model,
         repository: issue.repository,
         error: errorMessage(error),
@@ -144,29 +143,29 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     idleSuffix?: string;
   }): Promise<void> {
     const { state, worktreeEntries, usage, dryRun, signal, idleSuffix = "" } = arguments_;
-    issueStatusUpdater.resetMissingInProgressCache();
 
-    // Surface parent tickets that fetchBoard silently dropped. Without this
+    // Surface parent tickets that fetch silently dropped. Without this
     // an operator sees "No Todo tickets to pick up" with no signal that an
     // expected Todo+labelled ticket was skipped because it has sub-issues.
     for (const skip of state.parentSkips) {
+      const ticket = naturalIdFromCanonical(skip.id);
       log(
-        `Skipping ${skip.id}: parent ticket with ${skip.childCount} sub-issue(s) — groundcrew works sub-issues, not parents`,
+        `Skipping ${ticket}: parent ticket with ${skip.childCount} sub-issue(s) — groundcrew works sub-issues, not parents`,
       );
       logEvent("dispatch", {
         outcome: "skipped",
         reason: "parent_with_children",
-        ticket: skip.id,
+        ticket,
         children: skip.childCount,
       });
     }
 
-    const activeCount = state.issues.filter((issue) => isIssueInProgress(issue)).length;
+    const activeCount = state.issues.filter((issue) => issue.status === "in-progress").length;
     const slots = config.orchestrator.maximumInProgress - activeCount;
     // Narrow Todo to tickets that opted in via an `agent-*` label.
     // Unlabeled tickets are not groundcrew's concern even when in Todo.
     const todo: readonly GroundcrewIssue[] = state.issues.filter(
-      (issue): issue is GroundcrewIssue => isIssueTodo(issue) && isGroundcrewIssue(issue),
+      (issue): issue is GroundcrewIssue => issue.status === "todo" && isGroundcrewIssue(issue),
     );
 
     if (slots <= 0) {
@@ -192,6 +191,22 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       return;
     }
 
+    // Validate repositories BEFORE the expensive probes so a tick whose only
+    // candidates have unknown repos short-circuits without paying for the
+    // usage() HTTP call or the workspaces.probe shell-out. Doing this filter
+    // here also keeps an unknown-repo ticket at the head of the queue from
+    // consuming a slot in classifyEligibility and starving later valid
+    // tickets. Each unknown repo still emits a WARN via dispatchableRepository.
+    const dispatchableUnblocked = unblocked.filter((issue) => {
+      const repository = dispatchableRepository(issue, config.workspace.knownRepositories, log);
+      return repository !== undefined;
+    });
+
+    if (dispatchableUnblocked.length === 0) {
+      log(`No eligible Todo tickets after repository validation${idleSuffix}`);
+      return;
+    }
+
     // usage() is an HTTP call; workspaces.probe shells tmux/cmux. Kick off
     // usage first so the workspace probe can overlap with the in-flight request.
     const usagePromise = usage(signal);
@@ -214,7 +229,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
 
     const verdicts = classifyEligibility({
       config,
-      unblocked,
+      unblocked: dispatchableUnblocked,
       worktreeEntries,
       workspaceProbe,
       usage: fetchedUsage,
@@ -235,15 +250,19 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       return;
     }
 
+    const dispatchable = starts;
+
     log(
-      `${slots} slot(s) available, starting ${starts.length} ticket(s): ${starts.map(({ issue }) => `${issue.id}(${issue.model})`).join(", ")}`,
+      `${slots} slot(s) available, starting ${dispatchable.length} ticket(s): ${dispatchable.map(({ issue }) => `${naturalIdFromCanonical(issue.id)}(${issue.model})`).join(", ")}`,
     );
     logEvent("dispatch", {
       outcome: "starting",
-      tickets: starts.map(({ issue }) => `${issue.id}:${issue.model}`),
+      tickets: dispatchable.map(
+        ({ issue }) => `${naturalIdFromCanonical(issue.id)}:${issue.model}`,
+      ),
     });
 
-    for (const start of starts) {
+    for (const start of dispatchable) {
       // oxlint-disable-next-line no-await-in-loop -- one workspace at a time avoids racing on git
       await startEligibleIssue(start, dryRun, signal);
     }

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,12 +1,12 @@
 import { existsSync, statSync } from "node:fs";
 
-import { createBoardSource, type BoardSource } from "../lib/boardSource.ts";
+import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources, type sourcesFromConfig } from "../lib/buildSources.ts";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
-import { readEnvironmentVariable } from "../lib/util.ts";
+import type { TicketSource } from "../lib/ticketSource.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
-import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import { doctor } from "./doctor.ts";
 
 interface NodeFsMock {
@@ -29,10 +29,17 @@ vi.mock(import("../lib/host.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
 });
-vi.mock(import("../lib/boardSource.ts"), async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual, createBoardSource: vi.fn<typeof createBoardSource>() };
-});
+// Full replacements (no importOriginal): pulling in the real buildSources/board
+// would load the adapter registry, which scans the adapters directory and
+// imports each adapter — dragging the real config module into the graph and
+// defeating the config.ts mock when this suite runs alongside others.
+vi.mock(import("../lib/buildSources.ts"), () => ({
+  buildSources: vi.fn<typeof buildSources>(),
+  sourcesFromConfig: vi.fn<typeof sourcesFromConfig>(() => []),
+}));
+vi.mock(import("../lib/board.ts"), () => ({
+  createBoard: vi.fn<typeof createBoard>(),
+}));
 type RunCommandMock = (
   command: string,
   arguments_: readonly string[],
@@ -53,10 +60,34 @@ vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
 
 const existsMock = vi.mocked(existsSync);
 const statMock = vi.mocked(statSync);
-const createBoardSourceMock = vi.mocked(createBoardSource);
+const buildSourcesMock = vi.mocked(buildSources);
+const createBoardMock = vi.mocked(createBoard);
 const loadConfigMock = vi.mocked(loadConfig);
 const detectHostMock = vi.mocked(detectHostCapabilities);
-const linearVerifyMock = vi.fn<BoardSource["verify"]>();
+const boardVerifyMock = vi.fn<Board["verify"]>();
+
+/**
+ * A minimal Board whose `verify()` is the controllable mock. The other
+ * Board methods are unused by the source-probe check, so they're stubbed.
+ */
+function stubBoard(): Board {
+  return {
+    verify: boardVerifyMock,
+    fetch: vi.fn<Board["fetch"]>(),
+    resolveOne: vi.fn<Board["resolveOne"]>(),
+    markInProgress: vi.fn<Board["markInProgress"]>(),
+  };
+}
+
+function stubSource(name: string): TicketSource {
+  return {
+    name,
+    verify: vi.fn<TicketSource["verify"]>(),
+    fetch: vi.fn<TicketSource["fetch"]>(),
+    resolveOne: vi.fn<TicketSource["resolveOne"]>(),
+    markInProgress: vi.fn<TicketSource["markInProgress"]>(),
+  };
+}
 
 function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): ResolvedConfig {
   return {
@@ -140,20 +171,15 @@ function mockMissingPath(missingPath: string): void {
 
 describe(doctor, () => {
   let consoleLog: ConsoleCapture;
-  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
 
   beforeEach(() => {
     consoleLog = captureConsoleLog();
-    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-    setEnvironmentVariable("LINEAR_API_KEY", "lin_api_test");
     existsMock.mockReturnValue(true);
     statMock.mockReturnValue(statsWithDirectoryValue(true));
     detectHostMock.mockResolvedValue(host());
-    createBoardSourceMock.mockReturnValue({
-      verify: linearVerifyMock,
-      fetch: vi.fn<BoardSource["fetch"]>(),
-    });
+    buildSourcesMock.mockResolvedValue([stubSource("linear")]);
+    createBoardMock.mockReturnValue(stubBoard());
+    boardVerifyMock.mockResolvedValue();
     runCommandMock.mockImplementation((_cmd, arguments_) => {
       const target = firstArgument(arguments_);
       return `/usr/bin/${target}\n`;
@@ -162,16 +188,6 @@ describe(doctor, () => {
 
   afterEach(() => {
     consoleLog.restore();
-    if (originalGroundcrewKey === undefined) {
-      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-    } else {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
-    }
-    if (originalLinearKey === undefined) {
-      deleteEnvironmentVariable("LINEAR_API_KEY");
-    } else {
-      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
-    }
     vi.resetAllMocks();
   });
 
@@ -200,63 +216,23 @@ describe(doctor, () => {
     const actual = await doctor();
 
     expect(actual).toBe(true);
-    expect(createBoardSourceMock).toHaveBeenCalledTimes(1);
-    const createBoardSourceArguments = createBoardSourceMock.mock.calls[0]?.[0];
-    expect(createBoardSourceArguments?.config.workspace.projectDir).toBe("/work");
-    expect(createBoardSourceArguments?.client).toBeDefined();
-    expect(linearVerifyMock).toHaveBeenCalledTimes(1);
-    expect(consoleLog.output()).toContain("All required checks passed");
+    expect(buildSourcesMock).toHaveBeenCalledTimes(1);
+    expect(boardVerifyMock).toHaveBeenCalledTimes(1);
+    const output = consoleLog.output();
+    expect(output).toContain("[ok] source probe");
+    expect(output).toContain("1 source(s) verified");
+    expect(output).toContain("All required checks passed");
   });
 
-  it("returns false and reports both env var names when neither key is set", async () => {
-    deleteEnvironmentVariable("LINEAR_API_KEY");
+  it("reports a source probe failure when board verification throws", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
+    boardVerifyMock.mockRejectedValue(new Error("viewer lookup failed"));
 
     const actual = await doctor();
 
     expect(actual).toBe(false);
     const output = consoleLog.output();
-    expect(output).toContain("linear reachability");
-    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
-    expect(output).toContain("$LINEAR_API_KEY");
-    expect(linearVerifyMock).not.toHaveBeenCalled();
-  });
-
-  it("reports the resolved env var when only GROUNDCREW_LINEAR_API_KEY is set", async () => {
-    deleteEnvironmentVariable("LINEAR_API_KEY");
-    setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
-    loadConfigMock.mockResolvedValue(makeConfig());
-
-    const actual = await doctor();
-
-    expect(actual).toBe(true);
-    const output = consoleLog.output();
-    expect(output).toContain("linear reachability");
-    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
-  });
-
-  it("prefers GROUNDCREW_LINEAR_API_KEY in doctor output when both env vars are set", async () => {
-    setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
-    setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
-    loadConfigMock.mockResolvedValue(makeConfig());
-
-    const actual = await doctor();
-
-    expect(actual).toBe(true);
-    const output = consoleLog.output();
-    expect(output).toContain("$GROUNDCREW_LINEAR_API_KEY");
-    expect(output).not.toMatch(/set via \$LINEAR_API_KEY/);
-  });
-
-  it("returns false when Linear cannot be reached", async () => {
-    loadConfigMock.mockResolvedValue(makeConfig());
-    linearVerifyMock.mockRejectedValue(new Error("viewer lookup failed"));
-
-    const actual = await doctor();
-
-    expect(actual).toBe(false);
-    const output = consoleLog.output();
-    expect(output).toContain("[--] linear reachability");
+    expect(output).toContain("[--] source probe");
     expect(output).toContain("viewer lookup failed");
   });
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,17 +5,18 @@
 
 import { existsSync, statSync } from "node:fs";
 
+import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import {
   type LocalRunner,
   type LocalRunnerSetting,
   loadConfig,
   type ResolvedConfig,
 } from "../lib/config.ts";
-import { createBoardSource } from "../lib/boardSource.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
 import { gatedModels } from "../lib/usage.ts";
-import { errorMessage, getLinearClient, resolveLinearApiKey, writeOutput } from "../lib/util.ts";
+import { errorMessage, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
 
 // Tokenization stops after this many non-flag tokens. Two is enough to
@@ -43,31 +44,26 @@ async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<
   return result;
 }
 
-async function checkLinearReachability(config: ResolvedConfig): Promise<Check> {
-  const resolved = resolveLinearApiKey();
-  if (resolved === undefined) {
-    return {
-      name: "linear reachability",
-      ok: false,
-      required: true,
-      hint: "export $GROUNDCREW_LINEAR_API_KEY or $LINEAR_API_KEY",
-    };
-  }
+/**
+ * Source-agnostic reachability check: build every configured ticket source
+ * and run the Board's `verify()` fan-out. Replaces the old Linear-only
+ * "api key + reachability" probe so a misconfigured shell (or future Jira)
+ * source surfaces here too. A missing Linear API key still fails verify with
+ * its own user-facing message, so the prior behavior is preserved.
+ */
+async function checkSourceProbe(config: ResolvedConfig): Promise<Check> {
   try {
-    await createBoardSource({ config, client: getLinearClient() }).verify();
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+    const board: Board = createBoard(sources);
+    await board.verify();
     return {
-      name: "linear reachability",
+      name: "source probe",
       ok: true,
       required: true,
-      hint: `set via $${resolved.source}`,
+      hint: `${sources.length} source(s) verified`,
     };
   } catch (error) {
-    return {
-      name: "linear reachability",
-      ok: false,
-      required: true,
-      hint: errorMessage(error),
-    };
+    return { name: "source probe", ok: false, required: true, hint: errorMessage(error) };
   }
 }
 
@@ -181,7 +177,7 @@ export async function doctor(): Promise<boolean> {
   reportWorkspaceKind(config, workspaceOutcome);
 
   const checks: Check[] = [
-    await checkLinearReachability(config),
+    await checkSourceProbe(config),
     await checkCmd("git", true, "https://git-scm.com/"),
     ...(await workspaceChecks(workspaceOutcome)),
     checkDir(config.workspace.projectDir, "workspace.projectDir"),

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -1,5 +1,6 @@
-import type { GroundcrewIssue } from "../lib/boardSource.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { canonicalBlocker, canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import { isGroundcrewIssue, type GroundcrewIssue } from "../lib/ticketSource.ts";
 import type { UsageByModel } from "../lib/usage.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import {
@@ -8,7 +9,16 @@ import {
   classifyEligibility,
   classifyUsageExhaustion,
   pickBestModel,
+  type SkipVerdict,
 } from "./eligibility.ts";
+
+/** Assert an Issue is groundcrew-eligible (model + repository defined) and narrow the type. */
+function asGroundcrewIssue(issue: ReturnType<typeof canonicalLinearIssue>): GroundcrewIssue {
+  if (!isGroundcrewIssue(issue)) {
+    throw new Error("Expected a GroundcrewIssue (model and repository must be defined)");
+  }
+  return issue;
+}
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
@@ -41,22 +51,15 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
 }
 
 function todoIssue(overrides: Partial<GroundcrewIssue> = {}): GroundcrewIssue {
-  return {
-    id: "team-1",
-    uuid: "uuid-1",
-    title: "Title",
-    status: "Todo",
-    statusId: "state-todo",
-    stateType: "unstarted",
-    assignee: "Alice",
-    updatedAt: "2025-01-01T00:00:00.000Z",
-    repository: "repo-a",
-    model: "claude",
-    teamId: "team-1",
-    blockers: [],
-    hasMoreBlockers: false,
-    ...overrides,
-  };
+  return asGroundcrewIssue(
+    canonicalLinearIssue({
+      naturalId: "team-1",
+      status: "todo",
+      repository: "repo-a",
+      model: "claude",
+      ...overrides,
+    }),
+  );
 }
 
 function hostEntryFor(repository: string, ticket: string): WorktreeEntry {
@@ -87,7 +90,7 @@ describe(classifyBlockers, () => {
   it("emits a `blocked` skip when a blocker is in a non-terminal state", () => {
     const { unblocked, skips } = classifyBlockers([
       todoIssue({
-        blockers: [{ id: "team-0", title: "B", status: "In Progress", stateType: "started" }],
+        blockers: [canonicalBlocker({ naturalId: "team-0", status: "in-progress" })],
       }),
     ]);
 
@@ -96,7 +99,7 @@ describe(classifyBlockers, () => {
     expect(skips[0]).toMatchObject({
       kind: "skip",
       eventReason: "blocked",
-      blockers: ["team-0:In Progress"],
+      blockers: ["linear:team-0:in-progress"],
     });
   });
 
@@ -106,24 +109,24 @@ describe(classifyBlockers, () => {
     expect(skips[0]).toMatchObject({ kind: "skip", eventReason: "blockers_paginated" });
   });
 
-  it("emits a `blocked` skip when the blocker state is missing", () => {
+  it("emits a `blocked` skip when the blocker status is 'other' (unknown status)", () => {
     const { skips } = classifyBlockers([
       todoIssue({
-        blockers: [{ id: "team-0", title: "B", status: undefined, stateType: undefined }],
+        blockers: [canonicalBlocker({ naturalId: "team-0", status: "other" })],
       }),
     ]);
 
     expect(skips[0]).toMatchObject({
       kind: "skip",
       eventReason: "blocked",
-      blockers: ["team-0:missing"],
+      blockers: ["linear:team-0:other"],
     });
   });
 
-  it("returns the issue as unblocked when its blocker is already terminal", () => {
+  it("returns the issue as unblocked when its blocker status is 'done'", () => {
     const { unblocked, skips } = classifyBlockers([
       todoIssue({
-        blockers: [{ id: "team-0", title: "B", status: "Done", stateType: "completed" }],
+        blockers: [canonicalBlocker({ naturalId: "team-0", status: "done" })],
       }),
     ]);
 
@@ -133,17 +136,77 @@ describe(classifyBlockers, () => {
 
   it("partitions a mixed batch into unblocked and skip lists", () => {
     const { unblocked, skips } = classifyBlockers([
-      todoIssue({ id: "team-1", uuid: "uuid-1" }),
+      todoIssue({ id: "linear:team-1" }),
       todoIssue({
-        id: "team-2",
-        uuid: "uuid-2",
-        blockers: [{ id: "team-0", title: "B", status: "In Progress", stateType: "started" }],
+        id: "linear:team-2",
+        blockers: [canonicalBlocker({ naturalId: "team-0", status: "in-progress" })],
       }),
-      todoIssue({ id: "team-3", uuid: "uuid-3" }),
+      todoIssue({ id: "linear:team-3" }),
     ]);
 
-    expect(unblocked.map((issue) => issue.id)).toStrictEqual(["team-1", "team-3"]);
-    expect(skips.map((skip) => skip.issue.id)).toStrictEqual(["team-2"]);
+    expect(unblocked.map((issue) => issue.id)).toStrictEqual(["linear:team-1", "linear:team-3"]);
+    expect(skips.map((skip) => skip.issue.id)).toStrictEqual(["linear:team-2"]);
+  });
+
+  it("treats a 'done' blocker as cleared (canonical status)", () => {
+    const issue = asGroundcrewIssue(
+      canonicalLinearIssue({
+        naturalId: "eng-100",
+        blockers: [canonicalBlocker({ naturalId: "eng-90", status: "done" })],
+        repository: "repo-a",
+        model: "claude",
+      }),
+    );
+    const { unblocked, skips } = classifyBlockers([issue]);
+
+    expect(unblocked).toHaveLength(1);
+    expect(skips).toHaveLength(0);
+  });
+
+  it("treats an 'in-progress' blocker as blocking", () => {
+    const issue = asGroundcrewIssue(
+      canonicalLinearIssue({
+        naturalId: "eng-100",
+        blockers: [canonicalBlocker({ naturalId: "eng-90", status: "in-progress" })],
+        repository: "repo-a",
+        model: "claude",
+      }),
+    );
+    const { unblocked, skips } = classifyBlockers([issue]);
+
+    expect(unblocked).toHaveLength(0);
+    expect(skips).toHaveLength(1);
+  });
+
+  it("treats an 'other' (unknown-status) blocker as blocking", () => {
+    // Previously: status: undefined was blocking. Now: status: "other" represents the same.
+    const issue = asGroundcrewIssue(
+      canonicalLinearIssue({
+        naturalId: "eng-100",
+        blockers: [canonicalBlocker({ naturalId: "eng-90", status: "other" })],
+        repository: "repo-a",
+        model: "claude",
+      }),
+    );
+    const { unblocked, skips } = classifyBlockers([issue]);
+
+    expect(unblocked).toHaveLength(0);
+    expect(skips).toHaveLength(1);
+  });
+
+  it("treats a 'todo' blocker as blocking", () => {
+    const issue = asGroundcrewIssue(
+      canonicalLinearIssue({
+        naturalId: "eng-100",
+        blockers: [canonicalBlocker({ naturalId: "eng-90", status: "todo" })],
+        repository: "acme/web",
+        model: "claude",
+      }),
+    );
+    const { unblocked, skips } = classifyBlockers([issue]);
+
+    expect(unblocked).toHaveLength(0);
+    expect(skips).toHaveLength(1);
   });
 });
 
@@ -241,6 +304,21 @@ describe(classifyEligibility, () => {
       expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
     });
 
+    it("workspace_missing hint uses the natural id in the cleanup command", () => {
+      const verdicts = classifyEligibility(
+        defaultArguments({
+          worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+          workspaceProbe: { kind: "ok", names: new Set<string>() },
+        }),
+      );
+
+      expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
+      // The suggested `crew cleanup` command must use the natural id so it is actually runnable.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- verdict kind is asserted above
+      const { message } = verdicts[0] as SkipVerdict;
+      expect(message).toMatch(/crew cleanup team-1/);
+    });
+
     it("emits `workspace_list_unavailable` when the workspace adapter probe failed", () => {
       const verdicts = classifyEligibility(
         defaultArguments({
@@ -273,15 +351,12 @@ describe(classifyEligibility, () => {
       const verdicts = classifyEligibility(
         defaultArguments({
           slots: 1,
-          unblocked: [
-            todoIssue({ id: "team-1", uuid: "uuid-1" }),
-            todoIssue({ id: "team-2", uuid: "uuid-2" }),
-          ],
+          unblocked: [todoIssue({ id: "linear:team-1" }), todoIssue({ id: "linear:team-2" })],
         }),
       );
 
       expect(verdicts).toHaveLength(1);
-      expect(verdicts[0]).toMatchObject({ kind: "start", issue: { id: "team-1" } });
+      expect(verdicts[0]).toMatchObject({ kind: "start", issue: { id: "linear:team-1" } });
     });
   });
 });

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -7,12 +7,8 @@
  * effects.
  */
 
-import {
-  type Blocker,
-  type GroundcrewIssue,
-  isTerminalStatusForBlocker,
-} from "../lib/boardSource.ts";
 import { AGENT_ANY_MODEL, type ResolvedConfig } from "../lib/config.ts";
+import { naturalIdFromCanonical, type Blocker, type GroundcrewIssue } from "../lib/ticketSource.ts";
 import type { UsageByModel } from "../lib/usage.ts";
 import type { WorkspaceProbe } from "../lib/workspaces.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
@@ -99,7 +95,7 @@ interface BlockerClassification {
 }
 
 function blockerSummary(blocker: Blocker): string {
-  return `${blocker.id}:${blocker.status ?? "missing"}`;
+  return `${blocker.id}:${blocker.status}`;
 }
 
 function blockerVerdictFor(issue: GroundcrewIssue): SkipVerdict | undefined {
@@ -114,7 +110,7 @@ function blockerVerdictFor(issue: GroundcrewIssue): SkipVerdict | undefined {
     };
   }
 
-  const unresolved = issue.blockers.filter((blocker) => !isTerminalStatusForBlocker(blocker));
+  const unresolved = issue.blockers.filter((blocker) => blocker.status !== "done");
   if (unresolved.length === 0) {
     return undefined;
   }
@@ -225,8 +221,9 @@ function classifyRecovery(
     return { kind: "go", recovery: false };
   }
 
+  const naturalId = naturalIdFromCanonical(issue.id);
   const exists = worktreeEntries.some(
-    (entry) => entry.repository === issue.repository && entry.ticket === issue.id,
+    (entry) => entry.repository === issue.repository && entry.ticket === naturalId,
   );
   if (!exists) {
     return { kind: "go", recovery: false };
@@ -239,11 +236,11 @@ function classifyRecovery(
       eventReason: "workspace_list_unavailable",
     };
   }
-  if (!workspaceProbe.names.has(issue.id)) {
+  if (!workspaceProbe.names.has(naturalId)) {
     return {
       kind: "skip",
       issue,
-      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run \`crew cleanup ${issue.id}\` to allow re-provisioning.`,
+      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run \`crew cleanup ${naturalId}\` to allow re-provisioning.`,
       eventReason: "workspace_missing",
     };
   }

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -8,7 +8,8 @@ import type * as configModule from "../lib/config.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { getUsageByModel } from "../lib/usage.ts";
 import type * as utilModule from "../lib/util.ts";
-import { getLinearClient, sleep } from "../lib/util.ts";
+import { sleep } from "../lib/util.ts";
+import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -20,11 +21,14 @@ vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof configModule>();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
+vi.mock(import("../lib/adapters/linear/client.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
+});
 vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
     ...actual,
-    getLinearClient: vi.fn<typeof getLinearClient>(),
     sleep: vi.fn<typeof sleep>(),
     // log() is forwarded to stdout so test assertions on render output
     // can also see status/info lines emitted via log().
@@ -793,7 +797,7 @@ describe(orchestrate, () => {
             state: { id: "state-todo", name: "Todo", type: "unstarted" },
             labels: { nodes: [{ name: "agent-any" }] },
             inverseRelations: {
-              nodes: [blockingRelation("TEAM-0", "In Progress")],
+              nodes: [blockingRelation("TEAM-0", "In Progress", "started")],
               pageInfo: { hasNextPage: false },
             },
           }),
@@ -807,7 +811,8 @@ describe(orchestrate, () => {
     expect(setupMock).not.toHaveBeenCalled();
     const out = consoleLog.output();
     expect(out).toContain("event=dispatch outcome=skipped reason=blocked ticket=team-1");
-    expect(out).toContain('blockers="team-0:In Progress"');
+    // After main's #110: state.type drives classification; "started" maps to "in-progress".
+    expect(out).toContain("blockers=linear:team-0:in-progress");
   });
 
   it("dispatches Todo tickets whose blockers are terminal", async () => {
@@ -879,7 +884,8 @@ describe(orchestrate, () => {
     await orchestrate({ watch: false, dryRun: false });
 
     expect(setupMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("blockers=team-0:missing");
+    // After canonical migration: undefined status maps to "other"; id is source-prefixed.
+    expect(consoleLog.output()).toContain("blockers=linear:team-0:other");
   });
 
   it("ignores non-blocking relations and skips malformed blockers", async () => {
@@ -912,7 +918,8 @@ describe(orchestrate, () => {
     await orchestrate({ watch: false, dryRun: false });
 
     expect(setupMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("blockers=unknown:missing");
+    // After canonical migration: malformed blocker (null issue) maps to "linear:unknown:other".
+    expect(consoleLog.output()).toContain("blockers=linear:unknown:other");
   });
 
   it("conservatively skips Todo tickets when blocker relations are paginated", async () => {

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -5,12 +5,12 @@
  * orchestrator's user-facing output.
  */
 
-import { type BoardSource, type BoardState, createBoardSource } from "../lib/boardSource.ts";
 import { type Board, createBoard } from "../lib/board.ts";
-import { buildSources } from "../lib/buildSources.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { type BoardState, RepositoryResolutionError } from "../lib/ticketSource.ts";
 import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
-import { errorMessage, getLinearClient, log, sleep } from "../lib/util.ts";
+import { errorMessage, log, sleep } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
 import { type Cleaner, createCleaner } from "./cleaner.ts";
 import { createDispatcher, type Dispatcher } from "./dispatcher.ts";
@@ -31,6 +31,10 @@ async function withRetry<T>(
       // oxlint-disable-next-line no-await-in-loop -- retry loop sequences attempts deliberately
       return await function_();
     } catch (error) {
+      /* v8 ignore next 2 @preserve -- fetch() warns-and-skips since PR#88; guard is a defensive no-op in practice */
+      if (error instanceof RepositoryResolutionError) {
+        throw error;
+      }
       if (attempt === maxRetries) {
         throw error;
       }
@@ -78,21 +82,16 @@ async function fetchUsageOrEmpty(
 
 export async function orchestrate(options: OrchestratorOptions): Promise<void> {
   const config = await loadConfig();
-  const client = getLinearClient();
 
-  const boardSource: BoardSource = createBoardSource({ config, client });
-  await boardSource.verify();
-
-  // Verify any pluggable sources declared in config.sources (shell adapters,
-  // future built-in adapters) at startup. The Linear path still runs through
-  // boardSource.fetch in the main loop; shell-source dispatch is a follow-up.
-  // An empty config.sources resolves to an empty Board and verify() is a no-op.
-  const extraSources = await buildSources(config.sources, { globalConfig: config });
-  const board: Board = createBoard(extraSources);
+  // Build all sources (Linear implicit + any user-declared shell adapters).
+  // sourcesFromConfig synthesizes the implicit linear source from the config;
+  // this ensures the Linear adapter's markInProgress is reachable via board.
+  const allSources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  const board: Board = createBoard(allSources);
   await board.verify();
 
   const cleaner: Cleaner = createCleaner({ config });
-  const dispatcher: Dispatcher = createDispatcher({ config, client });
+  const dispatcher: Dispatcher = createDispatcher({ config, board });
 
   // Folded into the dispatcher's idle log lines in watch mode so each idle
   // tick prints one combined line instead of "<reason>" + "Next poll in Xs".
@@ -101,7 +100,8 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
     : undefined;
 
   const tick = async (signal?: AbortSignal): Promise<void> => {
-    const state: BoardState = await withRetry(async () => await boardSource.fetch(), signal);
+    const state: BoardState = await withRetry(async () => await board.fetch(), signal);
+
     const worktreeEntries = worktrees.list(config);
     const tickArguments = {
       state,
@@ -109,7 +109,9 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
       dryRun: options.dryRun,
       ...(signal === undefined ? {} : { signal }),
     };
+
     await cleaner.runOnce(tickArguments);
+
     await dispatcher.runOnce({
       ...tickArguments,
       // Lazy: dispatcher only invokes this after its own early-returns, so
@@ -177,6 +179,10 @@ async function runWatchLoop(
       } catch (error) {
         if (error instanceof WatchLoopShutdownError) {
           break;
+        }
+        /* v8 ignore next 2 @preserve -- fetch() warns-and-skips since PR#88; guard is a defensive no-op in practice */
+        if (error instanceof RepositoryResolutionError) {
+          throw error;
         }
         const message = errorMessage(error);
         if (message.includes("Signal: SIGINT")) {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -3,12 +3,11 @@ import type * as nodeFs from "node:fs";
 
 import { ensureClearance } from "@clipboard-health/clearance";
 
-import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
+import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
-import type * as utilModule from "../lib/util.ts";
-import { getLinearClient } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
@@ -32,9 +31,13 @@ vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, ensureClearance: vi.fn<typeof ensureClearance>() };
 });
-vi.mock(import("../lib/boardSource.ts"), async (importOriginal) => {
+vi.mock(import("../lib/adapters/linear/fetch.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, fetchResolvedIssue: vi.fn<typeof fetchResolvedIssue>() };
+});
+vi.mock(import("../lib/adapters/linear/client.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
 });
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -51,10 +54,6 @@ vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
     readRunState: vi.fn<typeof readRunState>(),
     recordRunState: vi.fn<typeof recordRunState>(),
   };
-});
-vi.mock(import("../lib/util.ts"), async (importOriginal) => {
-  const actual = await importOriginal<typeof utilModule>();
-  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
 });
 vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -285,6 +284,9 @@ describe(resumeWorkspace, () => {
       repository: "repo-a",
       model: "claude",
       teamId: "team-1",
+      stateType: "unstarted",
+      status: "Todo",
+      statusId: "state-todo",
     });
 
     await resumeWorkspace(config, { ticket: "team-1" });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,4 +1,5 @@
-import { fetchResolvedIssue } from "../lib/boardSource.ts";
+import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
+import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { buildLaunchCommand } from "../lib/launchCommand.ts";
@@ -9,7 +10,7 @@ import {
   stagePromptText,
   stageWorkspaceLaunchCommand,
 } from "../lib/stagedLaunch.ts";
-import { errorMessage, getLinearClient, log } from "../lib/util.ts";
+import { errorMessage, log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,35 +1,49 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-
+import type * as nodeFs from "node:fs";
 import { ensureClearance } from "@clipboard-health/clearance";
-
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { SETUP_COMMAND } from "../lib/launchCommand.ts";
 import { recordRunState } from "../lib/runState.ts";
+import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import { createBoard } from "../lib/board.ts";
+import type * as boardModule from "../lib/board.ts";
+import { buildSources } from "../lib/buildSources.ts";
+import type * as buildSourcesModule from "../lib/buildSources.ts";
+import type { BoardState, Issue } from "../lib/ticketSource.ts";
 import type * as utilModule from "../lib/util.ts";
-import { getLinearClient, log } from "../lib/util.ts";
+import { log } from "../lib/util.ts";
 import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
-import { setupWorkspace, setupWorkspaceCli } from "./setupWorkspace.ts";
+import {
+  setupWorkspace,
+  setupWorkspaceCli,
+  type SetupWorkspaceOptions,
+  type TicketDetails,
+} from "./setupWorkspace.ts";
 
-interface NodeFsMock {
+interface NodeFsMock extends Omit<
+  typeof nodeFs,
+  "existsSync" | "mkdtempSync" | "rmSync" | "writeFileSync"
+> {
   existsSync: ReturnType<typeof vi.fn<typeof existsSync>>;
   mkdtempSync: ReturnType<typeof vi.fn<typeof mkdtempSync>>;
   rmSync: ReturnType<typeof vi.fn<typeof rmSync>>;
   writeFileSync: ReturnType<typeof vi.fn<typeof writeFileSync>>;
 }
 
-vi.mock(
-  "node:fs",
-  (): NodeFsMock => ({
+vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
+  const actual = await importOriginal<typeof nodeFs>();
+  return {
+    ...actual,
     existsSync: vi.fn<typeof existsSync>().mockReturnValue(true),
     mkdtempSync: vi.fn<typeof mkdtempSync>(),
     rmSync: vi.fn<typeof rmSync>(),
     writeFileSync: vi.fn<typeof writeFileSync>(),
-  }),
-);
+  };
+});
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
@@ -70,7 +84,6 @@ vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
   return {
     ...actual,
-    getLinearClient: vi.fn<typeof getLinearClient>(),
     log: vi.fn<typeof actual.log>(),
   };
 });
@@ -85,6 +98,30 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     },
   };
 });
+vi.mock(import("../lib/board.ts"), async (importOriginal) => {
+  const actual = await importOriginal<typeof boardModule>();
+  return {
+    ...actual,
+    createBoard: vi.fn<typeof actual.createBoard>(() => ({
+      verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+      fetch: vi.fn<() => Promise<BoardState>>(),
+      resolveOne: vi.fn<(id: string) => Promise<Issue | undefined>>().mockResolvedValue(
+        canonicalLinearIssue({
+          naturalId: "team-1",
+          repository: "repo-a",
+          model: "claude",
+          title: "Title",
+          description: "Body for repo-a",
+        }),
+      ),
+      markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+    })),
+  };
+});
+vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
+  const actual = await importOriginal<typeof buildSourcesModule>();
+  return { ...actual, buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]) };
+});
 
 const mkdtempMock = vi.mocked(mkdtempSync);
 const existsMock = vi.mocked(existsSync);
@@ -93,7 +130,6 @@ const rmMock = vi.mocked(rmSync);
 const loadConfigMock = vi.mocked(loadConfig);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const ensureClearanceMock = vi.mocked(ensureClearance);
-const linearClientMock = vi.mocked(getLinearClient);
 const logMock = vi.mocked(log);
 const recordRunStateMock = vi.mocked(recordRunState);
 const createMock = vi.mocked(worktrees.create);
@@ -107,58 +143,6 @@ function lastRecordedRunState(): RecordedRunState {
     throw new Error("recordRunState was not called");
   }
   return input.state;
-}
-
-interface MockedLabel {
-  name: string;
-}
-interface MockedIssue {
-  title: string;
-  description?: string | undefined;
-}
-const issueResolver = vi.fn<(id: string) => Promise<MockedIssue>>();
-const rawRequestMock =
-  vi.fn<(query: string, variables?: Record<string, unknown>) => Promise<unknown>>();
-const teamStatesMock =
-  vi.fn<() => Promise<{ nodes: { id: string; name: string; type: string }[] }>>();
-const teamMock = vi.fn<
-  (id: string) => Promise<{
-    states: () => Promise<{ nodes: { id: string; name: string; type: string }[] }>;
-  }>
->();
-const updateIssueMock =
-  vi.fn<(id: string, input: { stateId: string }) => Promise<Record<string, never>>>();
-
-function buildMockedIssue(overrides: {
-  title?: string;
-  description?: string | undefined;
-}): MockedIssue {
-  return {
-    title: overrides.title ?? "Title",
-    description: "description" in overrides ? overrides.description : "Body",
-  };
-}
-
-function buildResolveIssueResponse(overrides: {
-  uuid?: string;
-  teamId?: string;
-  title?: string;
-  description?: string | null | undefined;
-  labels?: MockedLabel[];
-  stateType?: string;
-}): unknown {
-  return {
-    data: {
-      issue: {
-        id: overrides.uuid ?? "uuid-1",
-        title: overrides.title ?? "Title",
-        description: "description" in overrides ? overrides.description : "Body for repo-a",
-        labels: { nodes: overrides.labels ?? [] },
-        team: { id: overrides.teamId ?? "team-1" },
-        state: { name: "Todo", type: overrides.stateType ?? "unstarted" },
-      },
-    },
-  };
 }
 
 function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
@@ -213,23 +197,6 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
     local: { runner: "auto" },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
-}
-
-function mockLinearClient(): void {
-  teamStatesMock.mockResolvedValue({
-    nodes: [{ id: "state-in-progress", name: "In Progress", type: "started" }],
-  });
-  teamMock.mockResolvedValue({ states: teamStatesMock });
-  updateIssueMock.mockResolvedValue({});
-  const linearClient = {
-    issue: issueResolver,
-    team: teamMock,
-    updateIssue: updateIssueMock,
-    client: { rawRequest: rawRequestMock },
-  };
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests stub only the surfaces touched by setupWorkspace + fetchResolvedIssue
-  const typedLinearClient = linearClient as unknown as ReturnType<typeof getLinearClient>;
-  linearClientMock.mockReturnValue(typedLinearClient);
 }
 
 function isCmuxNewWorkspace(cmd: string, arguments_: readonly string[]): boolean {
@@ -355,8 +322,6 @@ async function waitForClearanceSleep(input: Parameters<typeof ensureClearance>[0
 describe(setupWorkspace, () => {
   beforeEach(() => {
     existsMock.mockReturnValue(true);
-    mockLinearClient();
-    issueResolver.mockResolvedValue(buildMockedIssue({ title: "Test Title", description: "Body" }));
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
     ensureClearanceMock.mockResolvedValue(clearanceResult());
@@ -375,7 +340,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(createMock).toHaveBeenCalledWith(
       config,
@@ -412,6 +382,7 @@ describe(setupWorkspace, () => {
       ticket: "team-1",
       repository: "repo-a",
       model: "claude",
+      details: { title: "Test Title", description: "Body" },
     });
 
     const command = lastRunArgumentFromCallWithArgument("new-workspace");
@@ -431,7 +402,12 @@ describe(setupWorkspace, () => {
 
     await setupWorkspace(
       config,
-      { ticket: "team-1", repository: "repo-a", model: "claude" },
+      {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      },
       { signal },
     );
 
@@ -461,7 +437,12 @@ describe(setupWorkspace, () => {
 
     const setupPromise = setupWorkspace(
       config,
-      { ticket: "team-1", repository: "repo-a", model: "claude" },
+      {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      },
       { signal: controller.signal },
     );
 
@@ -471,7 +452,7 @@ describe(setupWorkspace, () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  it("uses provided ticket details without fetching from Linear", async () => {
+  it("uses provided ticket details for prompt rendering", async () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
@@ -482,7 +463,6 @@ describe(setupWorkspace, () => {
       details: { title: "Provided Title", description: "Provided Body" },
     });
 
-    expect(issueResolver).not.toHaveBeenCalled();
     expect(writeFileMock).toHaveBeenCalledWith(
       "/tmp/groundcrew-team-1-x/prompt.txt",
       expect.stringContaining("Provided Title"),
@@ -501,7 +481,12 @@ describe(setupWorkspace, () => {
     });
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(ensureClearanceMock).toHaveBeenCalledTimes(1);
     expect(firstInvocationOrder(ensureClearanceMock)).toBeLessThan(
@@ -547,7 +532,12 @@ describe(setupWorkspace, () => {
     });
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(ensureClearanceMock).not.toHaveBeenCalled();
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
@@ -567,7 +557,12 @@ describe(setupWorkspace, () => {
       },
     });
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(runCommandMock.mock.calls.filter(([command]) => command === "sbx")).toStrictEqual([]);
     expect(teardownMock).not.toHaveBeenCalled();
@@ -580,7 +575,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow("proxy unavailable");
 
     expect(createMock).not.toHaveBeenCalled();
@@ -600,7 +600,12 @@ describe(setupWorkspace, () => {
     });
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     const command = lastRunArgumentFromCallWithArgument("new-workspace");
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
@@ -624,6 +629,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       });
 
       expect(writeFileMock).toHaveBeenCalledWith(
@@ -647,6 +653,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       });
 
       expect(writeFileMock).toHaveBeenCalledWith(
@@ -665,6 +672,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       });
 
       expect(writeFileMock).toHaveBeenCalledWith(
@@ -683,6 +691,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       });
 
       expect(writeFileMock).not.toHaveBeenCalledWith(
@@ -703,7 +712,12 @@ describe(setupWorkspace, () => {
     mockTmuxHost();
     const config = makeConfig();
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(logMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
   });
@@ -712,7 +726,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}Attach:/));
   });
@@ -732,7 +751,12 @@ describe(setupWorkspace, () => {
     config.local = { runner: "safehouse" };
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/Local groundcrew runs with the safehouse runner require macOS/);
 
     expect(createMock).not.toHaveBeenCalled();
@@ -759,7 +783,12 @@ describe(setupWorkspace, () => {
     });
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/sdx runner require `sbx`/);
 
     expect(createMock).not.toHaveBeenCalled();
@@ -781,7 +810,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/sdx runner require a sandbox config on model 'claude'/);
 
     expect(createMock).not.toHaveBeenCalled();
@@ -793,7 +827,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/require `safehouse` on PATH/);
 
     expect(createMock).not.toHaveBeenCalled();
@@ -808,6 +847,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       }),
     ).rejects.toThrow(/git fetch failed/);
     expect(runCommandMock).not.toHaveBeenCalledWith(
@@ -826,6 +866,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       }),
     ).rejects.toThrow(/Worktree already exists/);
 
@@ -842,6 +883,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       }),
     ).rejects.toThrow(/Worktree already exists/);
 
@@ -856,6 +898,7 @@ describe(setupWorkspace, () => {
         ticket: "team-1",
         repository: "repo-a",
         model: "claude",
+        details: { title: "Test Title", description: "Body" },
       }),
     ).rejects.toThrow(/Worktree already exists/);
 
@@ -865,7 +908,12 @@ describe(setupWorkspace, () => {
 
   it("rejects unknown models", async () => {
     await expect(
-      setupWorkspace(makeConfig(), { ticket: "team-1", repository: "repo-a", model: "ghost" }),
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "ghost",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/Unknown model: ghost/);
   });
 
@@ -874,7 +922,12 @@ describe(setupWorkspace, () => {
     mockCmuxNewWorkspaceOutput("garbage that has no ref");
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/Unexpected cmux output/);
 
     expect(teardownMock).toHaveBeenCalledWith(
@@ -897,7 +950,12 @@ describe(setupWorkspace, () => {
     const config = makeConfig();
     mockCmuxNewWorkspaceOutput("Created workspace:99 successfully");
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(runCommandMock).toHaveBeenCalledWith(
       "cmux",
@@ -912,30 +970,12 @@ describe(setupWorkspace, () => {
       ticket: "team-1",
       repository: "repo-a",
       model: "claude",
+      details: { title: "Test Title", description: "Body" },
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["--workspace", "workspace:55"]),
-    );
-  });
-
-  it("rolls back without touching the prompt dir when Linear fails before mkdtemp", async () => {
-    issueResolver.mockRejectedValue(new Error("linear unreachable"));
-
-    await expect(
-      setupWorkspace(makeConfig(), {
-        ticket: "team-1",
-        repository: "repo-a",
-        model: "claude",
-      }),
-    ).rejects.toThrow(/linear unreachable/);
-
-    expect(rmMock).not.toHaveBeenCalled();
-    expect(teardownMock).toHaveBeenCalledWith(
-      expect.anything(),
-      [expect.objectContaining({ ticket: "team-1" })],
-      { force: true },
     );
   });
 
@@ -946,6 +986,7 @@ describe(setupWorkspace, () => {
       ticket: "team-1",
       repository: "repo-a",
       model: "claude",
+      details: { title: "Test Title", description: "Body" },
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
@@ -965,7 +1006,12 @@ describe(setupWorkspace, () => {
       });
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).resolves.toBeUndefined();
 
     expect(runCommandMock).not.toHaveBeenCalledWith(
@@ -983,7 +1029,12 @@ describe(setupWorkspace, () => {
     });
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
   });
 
@@ -992,7 +1043,12 @@ describe(setupWorkspace, () => {
     mockCmuxFailure();
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
 
     expect(lastRecordedRunState()).toMatchObject({
@@ -1011,7 +1067,12 @@ describe(setupWorkspace, () => {
       throw new Error("disk full");
     });
 
-    await setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" });
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
 
     expect(logMock).toHaveBeenCalledWith(expect.stringContaining("Run state update failed"));
   });
@@ -1026,7 +1087,12 @@ describe(setupWorkspace, () => {
     );
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
   });
 
@@ -1036,7 +1102,12 @@ describe(setupWorkspace, () => {
     teardownMock.mockRejectedValue(new Error("teardown failed"));
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
 
     expect(rmMock).toHaveBeenCalledWith("/tmp/groundcrew-team-1-x", expect.anything());
@@ -1055,7 +1126,12 @@ describe(setupWorkspace, () => {
     );
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
 
     expect(logMock).toHaveBeenCalledWith(
@@ -1071,7 +1147,12 @@ describe(setupWorkspace, () => {
     );
 
     await expect(
-      setupWorkspace(config, { ticket: "team-1", repository: "repo-a", model: "claude" }),
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
     ).rejects.toThrow(/cmux down/);
 
     expect(logMock).toHaveBeenCalledWith(
@@ -1079,19 +1160,37 @@ describe(setupWorkspace, () => {
     );
   });
 
-  it("renders an empty description when Linear returns no description", async () => {
-    issueResolver.mockResolvedValue(buildMockedIssue({ title: "T", description: undefined }));
+  it("renders an empty description when details has empty description", async () => {
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
 
     await setupWorkspace(makeConfig(), {
       ticket: "team-1",
       repository: "repo-a",
       model: "claude",
+      details: { title: "T", description: "" },
     });
 
     const [writeCall] = writeFileMock.mock.calls;
     expect(writeCall?.[1]).toContain("(T)");
     expect(writeCall?.[1]).not.toContain("undefined");
+  });
+
+  it("rolls back worktree without rmSync when mkdtemp fails before promptDir is set", async () => {
+    mkdtempMock.mockImplementation(() => {
+      throw new Error("mkdtemp failed");
+    });
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
+    ).rejects.toThrow("mkdtemp failed");
+
+    expect(teardownMock).toHaveBeenCalledWith(makeConfig(), expect.any(Array), { force: true });
+    expect(rmMock).not.toHaveBeenCalled();
   });
 
   it("escapes single quotes in the launch script path and prompt path", async () => {
@@ -1102,6 +1201,7 @@ describe(setupWorkspace, () => {
       ticket: "team-1",
       repository: "repo-a",
       model: "claude",
+      details: { title: "Test Title", description: "Body" },
     });
 
     const cmd = lastRunArgumentFromCallWithArgument("new-workspace");
@@ -1109,27 +1209,65 @@ describe(setupWorkspace, () => {
     expect(cmd).toContain(String.raw`'\''`);
     expect(launchScript).toContain(String.raw`_p=$(cat '/tmp/with'\''quote-1/prompt.txt')`);
   });
+
+  it("requires details from the caller (no Linear re-fetch)", () => {
+    // Type-level test: SetupWorkspaceOptions.details is non-optional.
+    type _DetailsRequired = SetupWorkspaceOptions["details"] extends TicketDetails ? true : never;
+    const _check: _DetailsRequired = true;
+    expect(_check).toBe(true);
+  });
 });
 
+const createBoardMock = vi.mocked(createBoard);
+const buildSourcesMock = vi.mocked(buildSources);
+
+interface FakeBoard extends ReturnType<typeof createBoard> {
+  resolveOne: ReturnType<typeof vi.fn<(id: string) => Promise<Issue | undefined>>>;
+  markInProgress: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
+}
+
+function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
+  return {
+    verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    fetch: vi.fn<() => Promise<BoardState>>(),
+    resolveOne: vi
+      .fn<(id: string) => Promise<Issue | undefined>>()
+      .mockResolvedValue(resolvedIssue),
+    markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+  };
+}
+
 describe(setupWorkspaceCli, () => {
+  let defaultBoard: FakeBoard;
+
   beforeEach(() => {
     existsMock.mockReturnValue(true);
-    mockLinearClient();
-    rawRequestMock.mockResolvedValue(buildResolveIssueResponse({}));
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
     mkdtempMock.mockReturnValue("/tmp/groundcrew-team-1-x");
     runCommandMock.mockReturnValue(JSON.stringify({ ref: "workspace:1" }));
     loadConfigMock.mockResolvedValue(makeConfig());
+    defaultBoard = fakeBoard(
+      canonicalLinearIssue({
+        naturalId: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        title: "Title",
+        description: "Body for repo-a",
+      }),
+    );
+    createBoardMock.mockReturnValue(defaultBoard);
   });
 
   afterEach(() => {
     vi.resetAllMocks();
   });
 
-  it("uses the repository hint and default model when the ticket has no agent label", async () => {
+  it("resolves the ticket via Board and provisions the workspace", async () => {
     await setupWorkspaceCli("team-1");
 
+    expect(createBoardMock).toHaveBeenCalledTimes(1);
+    expect(defaultBoard.resolveOne).toHaveBeenCalledWith("team-1");
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ repository: "repo-a", ticket: "team-1" }),
@@ -1140,173 +1278,119 @@ describe(setupWorkspaceCli, () => {
     );
   });
 
-  it("marks the ticket In Progress after launching the workspace", async () => {
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({ uuid: "issue-uuid-1", teamId: "linear-team-1" }),
-    );
-
+  it("marks the ticket In Progress via board.markInProgress after launching the workspace", async () => {
     await setupWorkspaceCli("team-1");
 
-    expect(teamMock).toHaveBeenCalledWith("linear-team-1");
-    expect(updateIssueMock).toHaveBeenCalledWith("issue-uuid-1", {
-      stateId: "state-in-progress",
-    });
+    expect(defaultBoard.markInProgress).toHaveBeenCalledTimes(1);
     expect(firstInvocationOrder(runCommandMock)).toBeLessThan(
-      firstInvocationOrder(updateIssueMock),
+      firstInvocationOrder(defaultBoard.markInProgress),
     );
   });
 
-  it("does not mark the ticket In Progress in dry-run mode", async () => {
+  it("does not provision or mark In Progress in dry-run mode", async () => {
     await setupWorkspaceCli("team-1", { dryRun: true });
 
     expect(createMock).not.toHaveBeenCalled();
-    expect(teamMock).not.toHaveBeenCalled();
-    expect(updateIssueMock).not.toHaveBeenCalled();
-  });
-
-  it("fails clearly when the configured In Progress status is missing", async () => {
-    teamStatesMock.mockResolvedValue({
-      nodes: [{ id: "state-other", name: "Other", type: "unstarted" }],
-    });
-
-    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(
-      /Could not find a workflow state with type "started" for team-1/,
-    );
-    expect(updateIssueMock).not.toHaveBeenCalled();
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
+    const logged = logMock.mock.calls.map(([message]) => message).join("\n");
+    expect(logged).toContain("[dry-run] Would launch team-1 in repo-a (claude)");
   });
 
   it("does not mark the ticket In Progress when workspace setup fails", async () => {
     createMock.mockRejectedValue(new Error("worktree failed"));
 
     await expect(setupWorkspaceCli("team-1")).rejects.toThrow(/worktree failed/);
-    expect(teamMock).not.toHaveBeenCalled();
-    expect(updateIssueMock).not.toHaveBeenCalled();
+
+    expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
   });
 
-  it("rejects when the ticket description has no known repository", async () => {
-    rawRequestMock.mockResolvedValue(buildResolveIssueResponse({ description: "Body" }));
+  it("throws a clear error when the ticket is not found", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit signal that resolveOne returns no match
+    createBoardMock.mockReturnValueOnce(fakeBoard(undefined));
 
-    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(
-      /No known repository found in ticket TEAM-1 description/,
+    await expect(setupWorkspaceCli("ghost-999")).rejects.toThrow(
+      /Ticket ghost-999 not found across configured sources/,
     );
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  it("infers the repository from the Linear description", async () => {
-    const config = makeConfig();
-    config.workspace.knownRepositories = ["repo-a", "repo-b"];
-    loadConfigMock.mockResolvedValue(config);
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({ description: "Touches repo-b for the migration." }),
-    );
+  it("throws a clear error when the ticket is not groundcrew-eligible", async () => {
+    createBoardMock.mockReturnValueOnce(fakeBoard(canonicalLinearIssue({ naturalId: "team-1" })));
 
-    await setupWorkspaceCli("team-1");
+    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(/isn't groundcrew-eligible/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
 
-    expect(createMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ repository: "repo-b" }),
+  it("wraps buildSources errors with CLI context", async () => {
+    buildSourcesMock.mockRejectedValueOnce(new Error("unknown source kind 'wat'"));
+
+    await expect(setupWorkspaceCli("eng-1")).rejects.toThrow(
+      /Could not initialize ticket sources for 'crew setup eng-1': unknown source kind 'wat'/,
     );
   });
 
-  it("picks the model from the ticket's agent-* label", async () => {
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({ labels: [{ name: "agent-codex" }, { name: "priority/low" }] }),
+  it("strips the source prefix when passing the natural id to setupWorkspace", async () => {
+    createBoardMock.mockReturnValueOnce(
+      fakeBoard(
+        canonicalLinearIssue({
+          naturalId: "staff-508",
+          repository: "repo-a",
+          model: "claude",
+          title: "Title",
+          description: "Body",
+        }),
+      ),
     );
 
-    await setupWorkspaceCli("team-1");
-
-    expect(runCommandMock).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining(["set-status", "model", "codex"]),
-    );
-  });
-
-  it("collapses agent-any to the configured default model", async () => {
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({ labels: [{ name: "agent-any" }] }),
-    );
-
-    await setupWorkspaceCli("team-1");
-
-    expect(runCommandMock).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining(["set-status", "model", "claude"]),
-    );
-  });
-
-  it("falls back to the default model for unknown agent-* labels", async () => {
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({ labels: [{ name: "agent-ghost" }] }),
-    );
-
-    await setupWorkspaceCli("team-1");
-
-    expect(runCommandMock).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining(["set-status", "model", "claude"]),
-    );
-  });
-
-  it("lowercases an uppercase ticket arg before provisioning", async () => {
-    await setupWorkspaceCli("STAFF-508");
+    await setupWorkspaceCli("staff-508");
 
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ ticket: "staff-508" }),
     );
-    expect(runCommandMock).toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining(["new-workspace", "--name", "staff-508"]),
-    );
   });
 
-  it("queries Linear with the upper-case ticket identifier", async () => {
-    await setupWorkspaceCli("staff-508");
-
-    expect(rawRequestMock).toHaveBeenCalledWith(
-      expect.stringContaining("ResolveIssue"),
-      expect.objectContaining({ id: "STAFF-508" }),
+  it("passes title and description from the resolved issue as details", async () => {
+    createBoardMock.mockReturnValueOnce(
+      fakeBoard(
+        canonicalLinearIssue({
+          naturalId: "team-1",
+          repository: "repo-a",
+          model: "claude",
+          title: "Resolved Title",
+          description: "Resolved Body",
+        }),
+      ),
     );
-  });
 
-  it("rejects when resolving the repository from a null description", async () => {
-    rawRequestMock.mockResolvedValue(buildResolveIssueResponse({ description: null }));
-
-    await expect(setupWorkspaceCli("team-1")).rejects.toThrow(
-      /No known repository found in ticket TEAM-1 description/,
-    );
-    expect(createMock).not.toHaveBeenCalled();
-  });
-
-  it("throws a clear error when Linear has no issue with that id", async () => {
-    rawRequestMock.mockResolvedValue({ data: { issue: null } });
-
-    await expect(setupWorkspaceCli("ghost-999")).rejects.toThrow(
-      /Ticket GHOST-999 not found in Linear/,
-    );
-    expect(createMock).not.toHaveBeenCalled();
-  });
-
-  it("does not re-fetch from Linear once fetchResolvedIssue has the details", async () => {
     await setupWorkspaceCli("team-1");
 
-    expect(rawRequestMock).toHaveBeenCalledTimes(1);
-    expect(issueResolver).not.toHaveBeenCalled();
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-team-1-x/prompt.txt",
+      expect.stringContaining("Resolved Title"),
+    );
   });
 
-  it("resolves and reports without provisioning when dryRun is true", async () => {
-    rawRequestMock.mockResolvedValue(
-      buildResolveIssueResponse({
-        description: "Body for repo-a",
-        labels: [{ name: "agent-codex" }],
+  it("uses the full id as the ticket when there is no colon prefix", async () => {
+    createBoardMock.mockReturnValueOnce(
+      fakeBoard({
+        ...canonicalLinearIssue({
+          naturalId: "team-1",
+          repository: "repo-a",
+          model: "claude",
+          title: "Title",
+          description: "Body",
+        }),
+        id: "team-1",
       }),
     );
 
-    await setupWorkspaceCli("team-1", { dryRun: true });
+    await setupWorkspaceCli("team-1");
 
-    expect(createMock).not.toHaveBeenCalled();
-    expect(runCommandMock).not.toHaveBeenCalled();
-    const logged = logMock.mock.calls.map(([message]) => message).join("\n");
-    expect(logged).toContain("[dry-run] Would launch team-1 in repo-a (codex)");
+    expect(createMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ticket: "team-1" }),
+    );
   });
 });

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -1,9 +1,9 @@
 import { rmSync } from "node:fs";
-import { fetchResolvedIssue } from "../lib/boardSource.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
+import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { buildLaunchCommand } from "../lib/launchCommand.ts";
-import { createLinearIssueStatusUpdater } from "../lib/linearIssueStatus.ts";
 import { recordRunState } from "../lib/runState.ts";
 import {
   stageBuildSecrets,
@@ -11,30 +11,21 @@ import {
   stageWorkspaceLaunchCommand,
   type StagedPrompt,
 } from "../lib/stagedLaunch.ts";
-import { errorMessage, getLinearClient, log } from "../lib/util.ts";
+import { naturalIdFromCanonical } from "../lib/ticketSource.ts";
+import { errorMessage, log } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import { isWorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
-interface TicketDetails {
+export interface TicketDetails {
   title: string;
   description: string;
-}
-
-async function fetchTicket(ticket: string): Promise<TicketDetails> {
-  const client = getLinearClient();
-  const issue = await client.issue(ticket.toUpperCase());
-  return {
-    title: issue.title,
-    description: issue.description ?? "",
-  };
 }
 
 export interface SetupWorkspaceOptions {
   ticket: string;
   repository: string;
   model: string;
-  /** When provided, skip the Linear lookup for prompt-template fields. */
-  details?: TicketDetails;
+  details: TicketDetails;
 }
 
 export interface SetupWorkspaceRunOptions {
@@ -104,13 +95,7 @@ export async function setupWorkspace(
   // the ticket strands forever.
   let promptDir: string | undefined;
   try {
-    let ticketDetails: TicketDetails;
-    if (options.details === undefined) {
-      log(`Fetching ${ticket} from Linear...`);
-      ticketDetails = await fetchTicket(ticket);
-    } else {
-      ticketDetails = options.details;
-    }
+    const ticketDetails = options.details;
 
     const stagedPrompt = stagePrompt({ config, ticket, ticketDetails, worktreeName });
     promptDir = stagedPrompt.directory;
@@ -291,22 +276,42 @@ export async function setupWorkspaceCli(
   options: { dryRun?: boolean } = {},
 ): Promise<void> {
   const config = await loadConfig();
-  const client = getLinearClient();
-  const resolved = await fetchResolvedIssue({ client, config, ticket });
+  let sources;
+  try {
+    sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  } catch (error) {
+    /* v8 ignore next @preserve -- catch re-throw always receives an Error; String(error) is an unreachable fallback */
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not initialize ticket sources for 'crew setup ${ticket}': ${message}`, {
+      cause: error,
+    });
+  }
+  const board: Board = createBoard(sources);
+
+  const resolved = await board.resolveOne(ticket);
+  if (resolved === undefined) {
+    throw new Error(`Ticket ${ticket} not found across configured sources.`);
+  }
+  if (resolved.repository === undefined || resolved.model === undefined) {
+    throw new Error(
+      `Ticket ${ticket} resolved but isn't groundcrew-eligible (missing agent-* label or repository/model).`,
+    );
+  }
+
   log(`Resolved ${ticket}: repository=${resolved.repository}, model=${resolved.model}`);
+
   if (options.dryRun === true) {
     log(`[dry-run] Would launch ${ticket} in ${resolved.repository} (${resolved.model})`);
     return;
   }
+
+  const naturalId = naturalIdFromCanonical(resolved.id);
+
   await setupWorkspace(config, {
-    ticket: ticket.toLowerCase(),
+    ticket: naturalId,
     repository: resolved.repository,
     model: resolved.model,
     details: { title: resolved.title, description: resolved.description },
   });
-  await createLinearIssueStatusUpdater({ client }).markInProgress({
-    id: ticket.toLowerCase(),
-    uuid: resolved.uuid,
-    teamId: resolved.teamId,
-  });
+  await board.markInProgress(resolved);
 }

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -4,10 +4,10 @@ import { join } from "node:path";
 
 import type { LinearClient } from "@linear/sdk";
 
-import { fetchRawLinearIssue, type RawLinearIssue } from "../lib/boardSource.ts";
+import { getLinearClient } from "../lib/adapters/linear/client.ts";
+import { fetchRawLinearIssue, type RawLinearIssue } from "../lib/adapters/linear/fetch.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import { getLinearClient } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -17,7 +17,7 @@ vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/boardSource.ts"), async (importOriginal) => {
+vi.mock(import("../lib/adapters/linear/fetch.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, fetchRawLinearIssue: vi.fn<typeof fetchRawLinearIssue>() };
 });
@@ -25,7 +25,7 @@ vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readRunState: vi.fn<typeof readRunState>() };
 });
-vi.mock(import("../lib/util.ts"), async (importOriginal) => {
+vi.mock(import("../lib/adapters/linear/client.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
 });
@@ -111,6 +111,7 @@ function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
     labels: [],
     stateName: "Todo",
     stateType: "unstarted",
+    stateId: "state-todo",
     blockers: [],
     hasMoreBlockers: false,
     hasChildren: false,
@@ -248,9 +249,8 @@ describe(status, () => {
     expect(listWorktreesMock).not.toHaveBeenCalled();
   });
 
-  it("prints a run-state summary without optional detail", async () => {
-    const issueWithoutStateType = rawIssue({ title: "No state type" });
-    delete issueWithoutStateType.stateType;
+  it("prints a run-state summary without optional detail and renders an empty state.type as unknown", async () => {
+    const issueWithoutStateType = rawIssue({ title: "No state type", stateType: "" });
     readRunStateMock.mockReturnValue(runState());
     fetchRawLinearIssueMock.mockResolvedValue(issueWithoutStateType);
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,14 +1,10 @@
 import { readFileSync } from "node:fs";
 
-import { fetchRawLinearIssue } from "../lib/boardSource.ts";
+import { getLinearClient } from "../lib/adapters/linear/client.ts";
+import { fetchRawLinearIssue } from "../lib/adapters/linear/fetch.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import {
-  errorMessage,
-  getLinearClient,
-  withLogOutputSuppressed,
-  writeOutput,
-} from "../lib/util.ts";
+import { errorMessage, withLogOutputSuppressed, writeOutput } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, worktrees } from "../lib/worktrees.ts";
 
@@ -121,7 +117,9 @@ function recentTicketLogLines(config: ResolvedConfig, ticket: string): string[] 
 async function linearStatus(ticket: string): Promise<string> {
   try {
     const issue = await fetchRawLinearIssue({ client: getLinearClient(), ticket });
-    return `${issue.stateName} (state.type=${issue.stateType ?? "unknown"}) — ${issue.title}`;
+    // `stateType` is "" when Linear returned a stateless ticket; surface that
+    // as "unknown" rather than an empty token.
+    return `${issue.stateName} (state.type=${issue.stateType || "unknown"}) — ${issue.title}`;
   } catch (error) {
     return `unavailable: ${errorMessage(error)}`;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,12 +31,14 @@ export {
   isTerminalStateType,
   isTerminalStatusForBlocker,
   isTerminalStatusForIssue,
+  type RawLinearIssue,
+} from "./lib/adapters/linear/fetch.ts";
+export {
   resolveModelFor,
   resolveRepositoryFor,
   type ModelResolution,
-  type RawLinearIssue,
   type RepositoryResolution,
-} from "./lib/boardSource.ts";
+} from "./lib/adapters/linear/parsing.ts";
 export { getUsageByModel, type UsageByModel } from "./lib/usage.ts";
 export { type Board, createBoard } from "./lib/board.ts";
 export { buildSources, buildSourcesWith } from "./lib/buildSources.ts";
@@ -56,6 +58,6 @@ export {
   type GroundcrewIssue as CanonicalGroundcrewIssue,
   type Issue as CanonicalIssue,
   isGroundcrewIssue as isCanonicalGroundcrewIssue,
+  type ParentSkip as CanonicalParentSkip,
   type TicketSource,
 } from "./lib/ticketSource.ts";
-// RepositoryResolutionError is exported via boardSource.ts above (single canonical location).

--- a/src/lib/adapters/linear/client.test.ts
+++ b/src/lib/adapters/linear/client.test.ts
@@ -1,0 +1,114 @@
+import { LinearClient } from "@linear/sdk";
+
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../../../testHelpers/env.ts";
+import { readEnvironmentVariable } from "../../util.ts";
+import { getLinearClient, resolveLinearApiKey } from "./client.ts";
+
+describe("Linear API key resolution", () => {
+  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
+
+  beforeEach(() => {
+    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+  });
+
+  afterEach(() => {
+    if (originalGroundcrewKey === undefined) {
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
+    }
+    if (originalLinearKey === undefined) {
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
+    }
+  });
+
+  describe(resolveLinearApiKey, () => {
+    it("returns LINEAR_API_KEY as the source when only it is set", () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
+    });
+
+    it("returns GROUNDCREW_LINEAR_API_KEY as the source when only it is set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({
+        value: "lin_api_groundcrew",
+        source: "GROUNDCREW_LINEAR_API_KEY",
+      });
+    });
+
+    it("prefers GROUNDCREW_LINEAR_API_KEY when both are set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({
+        value: "lin_api_groundcrew",
+        source: "GROUNDCREW_LINEAR_API_KEY",
+      });
+    });
+
+    it("falls back to LINEAR_API_KEY when GROUNDCREW_LINEAR_API_KEY is empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
+    });
+
+    it("returns undefined when neither variable is set", () => {
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toBeUndefined();
+    });
+
+    it("returns undefined when both variables are empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "");
+
+      const actual = resolveLinearApiKey();
+
+      expect(actual).toBeUndefined();
+    });
+  });
+
+  describe(getLinearClient, () => {
+    it("returns a LinearClient when LINEAR_API_KEY is set", () => {
+      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
+
+      const actual = getLinearClient();
+
+      expect(actual).toBeInstanceOf(LinearClient);
+    });
+
+    it("returns a LinearClient when GROUNDCREW_LINEAR_API_KEY is set", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
+
+      const actual = getLinearClient();
+
+      expect(actual).toBeInstanceOf(LinearClient);
+    });
+
+    it("throws when neither variable is set", () => {
+      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+    });
+
+    it("throws when both variables are empty", () => {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
+      setEnvironmentVariable("LINEAR_API_KEY", "");
+
+      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+    });
+  });
+});

--- a/src/lib/adapters/linear/client.ts
+++ b/src/lib/adapters/linear/client.ts
@@ -1,0 +1,50 @@
+import { LinearClient } from "@linear/sdk";
+
+import { readEnvironmentVariable } from "../../util.ts";
+
+const LINEAR_API_KEY_SOURCES = ["GROUNDCREW_LINEAR_API_KEY", "LINEAR_API_KEY"] as const;
+
+export type LinearApiKeySource = (typeof LINEAR_API_KEY_SOURCES)[number];
+
+export interface ResolvedLinearApiKey {
+  value: string;
+  source: LinearApiKeySource;
+}
+
+export function resolveLinearApiKey(): ResolvedLinearApiKey | undefined {
+  for (const source of LINEAR_API_KEY_SOURCES) {
+    const value = readEnvironmentVariable(source);
+    if (value !== undefined && value.length > 0) {
+      return { value, source };
+    }
+  }
+  return undefined;
+}
+
+export function getLinearClient(): LinearClient {
+  const resolved = resolveLinearApiKey();
+  if (resolved === undefined) {
+    throw new Error(
+      "Linear API key not set. Set GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY in your environment.",
+    );
+  }
+  return new LinearClient({ apiKey: resolved.value });
+}
+
+/**
+ * Returns a zero-arg getter that lazily constructs (and caches) a Linear
+ * client on first call. Used by CLI entry points that may not need the
+ * client at all (e.g. `--no-linear`), so we avoid blowing up on a missing
+ * API key when no Linear call is actually made. The factory is taken as a
+ * parameter (rather than calling `getLinearClient` directly) so callers can
+ * pass their own module-level import of `getLinearClient` — that binding
+ * respects `vi.mock` intercepts, whereas an intra-module reference would
+ * not.
+ */
+export function lazyLinearClient(factory: () => LinearClient): () => LinearClient {
+  let client: LinearClient | undefined;
+  return () => {
+    client ??= factory();
+    return client;
+  };
+}

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -1,20 +1,14 @@
 import type { LinearClient } from "@linear/sdk";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
-import * as boardSource from "../../boardSource.ts";
-import type {
-  BoardSource,
-  Blocker as LinearBlocker,
-  Issue as LinearIssue,
-} from "../../boardSource.ts";
 import type { ResolvedConfig } from "../../config.ts";
-import * as linearIssueStatus from "../../linearIssueStatus.ts";
-import * as util from "../../util.ts";
-import {
-  canonicalStatusFromStateType,
-  createLinearTicketSource,
-  toCanonicalIssue,
-} from "./factory.ts";
+import { readEnvironmentVariable } from "../../util.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../../../testHelpers/env.ts";
+import * as boardSource from "./fetch.ts";
+import type { Issue as LinearIssue } from "./fetch.ts";
+import * as linearIssueStatus from "./writeback.ts";
+import * as client from "./client.ts";
+import { createLinearTicketSource, toCanonicalIssue } from "./factory.ts";
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
@@ -51,6 +45,7 @@ function linearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
     id: overrides.id ?? "team-1",
     uuid: overrides.uuid ?? "uuid-1",
     title: overrides.title ?? "Title",
+    description: overrides.description ?? "",
     status: overrides.status ?? "Todo",
     statusId: overrides.statusId ?? "state-todo",
     stateType: overrides.stateType ?? "unstarted",
@@ -63,26 +58,6 @@ function linearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
   };
 }
-
-describe(canonicalStatusFromStateType, () => {
-  it("maps unstarted to canonical 'todo'", () => {
-    expect(canonicalStatusFromStateType("unstarted")).toBe("todo");
-  });
-  it("maps started to canonical 'in-progress'", () => {
-    expect(canonicalStatusFromStateType("started")).toBe("in-progress");
-  });
-  it("maps completed/canceled/duplicate to canonical 'done'", () => {
-    expect(canonicalStatusFromStateType("completed")).toBe("done");
-    expect(canonicalStatusFromStateType("canceled")).toBe("done");
-    expect(canonicalStatusFromStateType("duplicate")).toBe("done");
-  });
-  it("maps anything else to 'other'", () => {
-    expect(canonicalStatusFromStateType("backlog")).toBe("other");
-    expect(canonicalStatusFromStateType("triage")).toBe("other");
-    // oxlint-disable-next-line unicorn/no-useless-undefined -- the function's documented contract includes the undefined branch
-    expect(canonicalStatusFromStateType(undefined)).toBe("other");
-  });
-});
 
 describe(toCanonicalIssue, () => {
   it("prefixes the canonical id with the source name", () => {
@@ -97,6 +72,7 @@ describe(toCanonicalIssue, () => {
         uuid: "uuid-abc",
         statusId: "state-todo",
         teamId: "team-xyz",
+        stateType: "unstarted",
         status: "Todo",
       }),
       "linear",
@@ -105,33 +81,102 @@ describe(toCanonicalIssue, () => {
       uuid: "uuid-abc",
       statusId: "state-todo",
       teamId: "team-xyz",
+      stateType: "unstarted",
       nativeStatus: "Todo",
     });
   });
 
-  it("canonicalizes the status using the issue's stateType", () => {
+  it("canonicalizes status using the workflow state.type", () => {
     const result = toCanonicalIssue(
-      linearIssue({ status: "Doing", stateType: "started" }),
+      linearIssue({ status: "In Progress", stateType: "started" }),
       "linear",
     );
     expect(result.status).toBe("in-progress");
   });
 
-  it("leaves description empty (board snapshot doesn't fetch description)", () => {
-    const result = toCanonicalIssue(linearIssue(), "linear");
-    expect(result.description).toBe("");
+  it("maps state.type 'completed' to canonical 'done'", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "Shipped", stateType: "completed" }),
+      "linear",
+    );
+    expect(result.status).toBe("done");
   });
 
-  it("source-prefixes blocker ids and maps statuses from stateType", () => {
-    const blockers: LinearBlocker[] = [
-      { id: "team-2", title: "Block A", status: "Done", stateType: "completed" },
-      { id: "team-3", title: "Block B", status: "Todo", stateType: "unstarted" },
-    ];
-    const issue = linearIssue({ blockers });
+  it("maps state.type 'canceled' to canonical 'done'", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "Won't fix", stateType: "canceled" }),
+      "linear",
+    );
+    expect(result.status).toBe("done");
+  });
+
+  it("maps state.type 'duplicate' to canonical 'done'", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "Duplicate", stateType: "duplicate" }),
+      "linear",
+    );
+    expect(result.status).toBe("done");
+  });
+
+  it("maps unknown state.type to canonical 'other'", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "Backlog", stateType: "backlog" }),
+      "linear",
+    );
+    expect(result.status).toBe("other");
+  });
+
+  it("copies description from the legacy Linear issue onto the canonical Issue", () => {
+    const result = toCanonicalIssue(linearIssue({ description: "Body of the ticket." }), "linear");
+    expect(result.description).toBe("Body of the ticket.");
+  });
+
+  it("source-prefixes blocker ids and canonicalizes their statuses via stateType", () => {
+    const issue = linearIssue({
+      blockers: [
+        { id: "team-2", title: "Block A", status: "Done", stateType: "completed" },
+        { id: "team-3", title: "Block B", status: "Todo", stateType: "unstarted" },
+      ],
+    });
     const result = toCanonicalIssue(issue, "linear");
     expect(result.blockers).toStrictEqual([
-      { id: "linear:team-2", title: "Block A", status: "done" },
-      { id: "linear:team-3", title: "Block B", status: "todo" },
+      { id: "linear:team-2", title: "Block A", status: "done", nativeStatus: "Done" },
+      { id: "linear:team-3", title: "Block B", status: "todo", nativeStatus: "Todo" },
+    ]);
+  });
+
+  it("flags a blocker with missing stateType as 'other'/missing", () => {
+    const issue = linearIssue({
+      blockers: [{ id: "team-2", title: "Block A", status: "Done", stateType: undefined }],
+    });
+    const result = toCanonicalIssue(issue, "linear");
+    expect(result.blockers).toStrictEqual([
+      {
+        id: "linear:team-2",
+        title: "Block A",
+        status: "other",
+        statusReason: "missing",
+        nativeStatus: "Done",
+      },
+    ]);
+  });
+
+  it("flags a blocker with backlog/triage stateType as 'other'/unmapped", () => {
+    // Blockers can carry `state.type` values outside the actionable set
+    // (`backlog`, `triage`). They aren't terminal, but the orchestrator can't
+    // act on them either, so surface as "other" with statusReason "unmapped".
+    const issue = linearIssue({
+      blockers: [{ id: "team-2", title: "Block A", status: "Backlog", stateType: "backlog" }],
+    });
+    const result = toCanonicalIssue(issue, "linear");
+    expect(result.blockers).toStrictEqual([
+      {
+        id: "linear:team-2",
+        title: "Block A",
+        status: "other",
+        statusReason: "unmapped",
+        nativeStatus: "Backlog",
+      },
     ]);
   });
 
@@ -146,7 +191,7 @@ describe(createLinearTicketSource, () => {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- factory only uses the client when its methods are called; tests that exercise those methods stub the boardSource/linearIssueStatus calls so the client is never actually invoked
   const fakeClient = {} as LinearClient;
   beforeEach(() => {
-    vi.spyOn(util, "getLinearClient").mockReturnValue(fakeClient);
+    vi.spyOn(client, "getLinearClient").mockReturnValue(fakeClient);
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -170,7 +215,7 @@ describe(createLinearTicketSource, () => {
     const innerVerify = vi.fn<() => Promise<void>>().mockResolvedValue();
     vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
       verify: innerVerify,
-      fetch: vi.fn<BoardSource["fetch"]>(),
+      fetch: vi.fn<() => Promise<boardSource.BoardState>>(),
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -180,7 +225,7 @@ describe(createLinearTicketSource, () => {
   });
 
   it("fetch() converts each LinearIssue into a canonical Issue", async () => {
-    const innerFetch = vi.fn<BoardSource["fetch"]>().mockResolvedValue({
+    const innerFetch = vi.fn<() => Promise<boardSource.BoardState>>().mockResolvedValue({
       timestamp: "2026-01-01T00:00:00Z",
       issues: [
         linearIssue({ id: "team-1" }),
@@ -200,6 +245,32 @@ describe(createLinearTicketSource, () => {
     expect(issues[1]?.status).toBe("in-progress");
   });
 
+  it("fetchParentSkips() returns canonical (source-prefixed) ids", async () => {
+    const innerFetch = vi.fn<() => Promise<boardSource.BoardState>>().mockResolvedValue({
+      timestamp: "2026-01-01T00:00:00Z",
+      issues: [],
+      parentSkips: [
+        { id: "team-9", title: "Umbrella epic", childCount: 3 },
+        { id: "team-10", title: "Another epic", childCount: 1 },
+      ],
+    });
+    vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
+      verify: vi.fn<() => Promise<void>>(),
+      fetch: innerFetch,
+    });
+    const source = createLinearTicketSource({ kind: "linear", name: "work-linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await source.fetch();
+    const skips = await source.fetchParentSkips?.();
+
+    expect(skips).toStrictEqual([
+      { id: "work-linear:team-9", title: "Umbrella epic", childCount: 3 },
+      { id: "work-linear:team-10", title: "Another epic", childCount: 1 },
+    ]);
+  });
+
   it("resolveOne() returns a canonical Issue with description populated from fetchResolvedIssue", async () => {
     vi.spyOn(boardSource, "fetchResolvedIssue").mockResolvedValue({
       uuid: "uuid-abc",
@@ -208,6 +279,9 @@ describe(createLinearTicketSource, () => {
       repository: "repo-a",
       model: "claude",
       teamId: "team-xyz",
+      stateType: "unstarted",
+      status: "Todo",
+      statusId: "state-todo",
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -218,13 +292,13 @@ describe(createLinearTicketSource, () => {
     expect(issue?.description).toBe("Resolved description");
     expect(issue?.repository).toBe("repo-a");
     expect(issue?.model).toBe("claude");
+    expect(issue?.status).toBe("todo");
   });
 
   it("markInProgress() forwards uuid/teamId from sourceRef", async () => {
     const innerMarkInProgress = vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue();
     vi.spyOn(linearIssueStatus, "createLinearIssueStatusUpdater").mockReturnValue({
       markInProgress: innerMarkInProgress,
-      resetMissingInProgressCache: vi.fn<() => void>(),
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -245,6 +319,7 @@ describe(createLinearTicketSource, () => {
         uuid: "uuid-1",
         statusId: "s",
         teamId: "team-default",
+        stateType: "unstarted",
         nativeStatus: "Todo",
       },
     });
@@ -253,5 +328,61 @@ describe(createLinearTicketSource, () => {
       uuid: "uuid-1",
       teamId: "team-default",
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Lazy client construction — the Linear adapter must be constructible
+// without a Linear API key in env. Callers that only touch a sibling
+// source (multi-source Board fan-out, `crew doctor --ticket <shell-id>`)
+// must not crash at adapter-construction time on a missing key. These
+// tests deliberately do NOT stub `getLinearClient` — the point is to
+// exercise the real key-resolution path.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("createLinearTicketSource — lazy client construction", () => {
+  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
+
+  beforeEach(() => {
+    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+  });
+
+  afterEach(() => {
+    if (originalGroundcrewKey === undefined) {
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
+    }
+    if (originalLinearKey === undefined) {
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
+    }
+  });
+
+  it("constructs the adapter without throwing when no Linear API key is set", () => {
+    expect(() =>
+      createLinearTicketSource({ kind: "linear" }, {
+        globalConfig: makeConfig(),
+      } satisfies AdapterContext),
+    ).not.toThrow();
+  });
+
+  it("throws about the missing key only when verify() is invoked", async () => {
+    const source = createLinearTicketSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.verify()).rejects.toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+  });
+
+  it("throws about the missing key only when fetch() is invoked", async () => {
+    const source = createLinearTicketSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.fetch()).rejects.toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
   });
 });

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -1,62 +1,129 @@
 /**
- * Linear `TicketSource` factory. Wraps the existing boardSource.ts machinery
- * (createBoardSource, fetchResolvedIssue, createLinearIssueStatusUpdater) and
- * converts the Linear-native `Issue`/`Blocker` shapes into the canonical
- * `Issue`/`Blocker` shapes consumers (via `Board`) speak.
+ * Linear `TicketSource` factory. Assembles the adapter from sibling modules
+ * (createBoardSource + fetchResolvedIssue from ./fetch.ts;
+ * createLinearIssueStatusUpdater from ./writeback.ts; getLinearClient from
+ * ./client.ts) and converts Linear-specific shapes into the canonical
+ * Issue/Blocker types consumers (via Board) speak.
  *
- * Status mapping is driven entirely by Linear's workflow `state.type`
- * (`unstarted` → todo, `started` → in-progress,
- * `completed`/`canceled`/`duplicate` → done) so renamed columns are classified
- * correctly without any per-team config.
+ * State classification is driven by Linear's workflow `state.type` — never
+ * by status name — so workspaces with renamed columns Just Work without
+ * per-team config.
  *
- * Description is not populated on `fetch()` Issues (boardSource's snapshot
- * doesn't include it); `resolveOne()` Issues carry the full description
- * because `fetchResolvedIssue` fetches it explicitly.
+ * Description is populated on both `fetch()` Issues and `resolveOne()` Issues.
  */
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import {
+  toCanonicalId,
+  type Blocker as CanonicalBlocker,
+  type CanonicalStatus,
+  type Issue as CanonicalIssue,
+  type ParentSkip as CanonicalParentSkip,
+  type TicketSource,
+} from "../../ticketSource.ts";
+import type { LinearAdapterConfig } from "./schema.ts";
+import { getLinearClient, lazyLinearClient } from "./client.ts";
+import {
   type Blocker as LinearBlocker,
   createBoardSource,
   fetchResolvedIssue,
-  type Issue as LinearIssue,
   isTerminalStateType,
-} from "../../boardSource.ts";
-import { createLinearIssueStatusUpdater } from "../../linearIssueStatus.ts";
-import type {
-  Blocker as CanonicalBlocker,
-  CanonicalStatus,
-  Issue as CanonicalIssue,
-  TicketSource,
-} from "../../ticketSource.ts";
-import { getLinearClient } from "../../util.ts";
-import type { LinearAdapterConfig } from "./schema.ts";
+  type Issue as LinearIssue,
+  type ParentSkip as LinearParentSkip,
+} from "./fetch.ts";
+import { createLinearIssueStatusUpdater } from "./writeback.ts";
 
-interface LinearSourceRef {
+/**
+ * Adapter-private payload threaded through `Issue.sourceRef`. Consumers
+ * MUST NOT inspect; only the Linear adapter reads it.
+ */
+export interface LinearSourceRef {
   uuid: string;
   statusId: string;
   teamId: string;
+  /** Linear workflow `state.type` for the issue at fetch time. */
+  stateType: string;
+  /** Human-readable native status name, e.g. "In Progress", "Shipped". Diagnostic display only. */
   nativeStatus: string;
 }
 
-export function canonicalStatusFromStateType(stateType: string | undefined): CanonicalStatus {
-  if (stateType === "unstarted") {
-    return "todo";
+function canonicalStatusFromStateType(stateType: string | undefined): CanonicalStatus {
+  /* v8 ignore next 3 @preserve -- LinearIssue.stateType is non-optional; this guard is defensive for the resolveOne path */
+  if (stateType === undefined) {
+    return "other";
   }
-  if (stateType === "started") {
-    return "in-progress";
+  switch (stateType) {
+    case "unstarted": {
+      return "todo";
+    }
+    case "started": {
+      return "in-progress";
+    }
+    case "completed":
+    case "canceled":
+    case "duplicate": {
+      return "done";
+    }
+    default: {
+      return "other";
+    }
   }
-  if (isTerminalStateType(stateType)) {
-    return "done";
+}
+
+function canonicalBlockerStatus(blocker: LinearBlocker): {
+  status: CanonicalStatus;
+  statusReason?: "missing" | "unmapped";
+  nativeStatus?: string;
+} {
+  if (blocker.stateType === undefined) {
+    return {
+      status: "other",
+      statusReason: "missing",
+      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+    };
   }
-  return "other";
+  if (isTerminalStateType(blocker.stateType)) {
+    return {
+      status: "done",
+      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+    };
+  }
+  if (blocker.stateType === "started") {
+    return {
+      status: "in-progress",
+      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+    };
+  }
+  if (blocker.stateType === "unstarted") {
+    return {
+      status: "todo",
+      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+    };
+  }
+  // backlog / triage / anything else falls through as "other"
+  return {
+    status: "other",
+    statusReason: "unmapped",
+    ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+  };
 }
 
 function toCanonicalBlocker(blocker: LinearBlocker, sourceName: string): CanonicalBlocker {
+  const { status, statusReason, nativeStatus } = canonicalBlockerStatus(blocker);
   return {
-    id: `${sourceName}:${blocker.id}`,
+    id: toCanonicalId(sourceName, blocker.id),
     title: blocker.title,
-    status: canonicalStatusFromStateType(blocker.stateType),
+    status,
+    ...(statusReason !== undefined && { statusReason }),
+    ...(nativeStatus !== undefined && { nativeStatus }),
+  };
+}
+
+function toCanonicalParentSkip(skip: LinearParentSkip, sourceName: string): CanonicalParentSkip {
+  return {
+    id: toCanonicalId(sourceName, skip.id),
+    title: skip.title,
+    childCount: skip.childCount,
   };
 }
 
@@ -65,14 +132,14 @@ export function toCanonicalIssue(linearIssue: LinearIssue, sourceName: string): 
     uuid: linearIssue.uuid,
     statusId: linearIssue.statusId,
     teamId: linearIssue.teamId,
+    stateType: linearIssue.stateType,
     nativeStatus: linearIssue.status,
   };
   return {
-    id: `${sourceName}:${linearIssue.id}`,
+    id: toCanonicalId(sourceName, linearIssue.id),
     source: sourceName,
     title: linearIssue.title,
-    // Board snapshot doesn't carry description; resolveOne() populates it.
-    description: "",
+    description: linearIssue.description,
     status: canonicalStatusFromStateType(linearIssue.stateType),
     repository: linearIssue.repository,
     model: linearIssue.model,
@@ -90,45 +157,63 @@ export function createLinearTicketSource(
 ): TicketSource {
   const sourceName = config.name ?? "linear";
   const { globalConfig } = context;
-  const client = getLinearClient();
-  const boardSource = createBoardSource({ config: globalConfig, client });
-  const issueStatusUpdater = createLinearIssueStatusUpdater({ client });
+  // Lazy: deferring `getLinearClient()` (and the sub-modules that depend on
+  // it) until first method use means `createLinearTicketSource` can be
+  // constructed without a Linear API key in env. Callers that only ever
+  // touch a sibling source — `crew doctor --ticket <shell-id>`,
+  // `crew run` with the multi-source Board's `Promise.allSettled` fan-out
+  // tolerating a Linear-side rejection — no longer crash at config-load
+  // time on a missing key.
+  const getClient = lazyLinearClient(getLinearClient);
+
+  let cachedBoardSource: ReturnType<typeof createBoardSource> | undefined;
+  function getBoardSource(): ReturnType<typeof createBoardSource> {
+    cachedBoardSource ??= createBoardSource({ config: globalConfig, client: getClient() });
+    return cachedBoardSource;
+  }
+
+  let cachedIssueStatusUpdater: ReturnType<typeof createLinearIssueStatusUpdater> | undefined;
+  function getIssueStatusUpdater(): ReturnType<typeof createLinearIssueStatusUpdater> {
+    cachedIssueStatusUpdater ??= createLinearIssueStatusUpdater({
+      client: getClient(),
+    });
+    return cachedIssueStatusUpdater;
+  }
+
+  let lastParentSkips: readonly CanonicalParentSkip[] = [];
 
   return {
     name: sourceName,
     async verify(): Promise<void> {
-      await boardSource.verify();
+      await getBoardSource().verify();
     },
     async fetch(): Promise<CanonicalIssue[]> {
-      const state = await boardSource.fetch();
+      const state = await getBoardSource().fetch();
+      lastParentSkips = state.parentSkips.map((skip) => toCanonicalParentSkip(skip, sourceName));
       return state.issues.map((linearIssue) => toCanonicalIssue(linearIssue, sourceName));
     },
+    async fetchParentSkips(): Promise<readonly CanonicalParentSkip[]> {
+      return lastParentSkips;
+    },
     async resolveOne(naturalId: string): Promise<CanonicalIssue | undefined> {
-      // fetchResolvedIssue throws on missing repo; we let those propagate.
-      // Returning `undefined` is reserved for "ticket genuinely doesn't
-      // exist," which fetchResolvedIssue surfaces as an Error too — for now
-      // we let any error bubble up rather than swallow.
       const resolved = await fetchResolvedIssue({
-        client,
+        client: getClient(),
         config: globalConfig,
         ticket: naturalId,
       });
-      // fetchResolvedIssue doesn't return the native status name (it's
-      // already been resolved through workflow state lookup). We surface
-      // "other" until the consumer needs the canonical status, which is fine
-      // because `crew setup` doesn't branch on it.
       const sourceRef: LinearSourceRef = {
         uuid: resolved.uuid,
-        statusId: "",
+        statusId: resolved.statusId,
         teamId: resolved.teamId,
-        nativeStatus: "",
+        stateType: resolved.stateType,
+        nativeStatus: resolved.status,
       };
       return {
-        id: `${sourceName}:${naturalId.toLowerCase()}`,
+        id: toCanonicalId(sourceName, naturalId),
         source: sourceName,
         title: resolved.title,
         description: resolved.description,
-        status: "other",
+        status: canonicalStatusFromStateType(resolved.stateType),
         repository: resolved.repository,
         model: resolved.model,
         assignee: "Unassigned",
@@ -141,7 +226,7 @@ export function createLinearTicketSource(
     async markInProgress(issue: CanonicalIssue): Promise<void> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- by the Linear adapter's contract, every Issue it produces carries a LinearSourceRef in sourceRef
       const ref = issue.sourceRef as LinearSourceRef;
-      await issueStatusUpdater.markInProgress({
+      await getIssueStatusUpdater().markInProgress({
         id: issue.id,
         uuid: ref.uuid,
         teamId: ref.teamId,

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -1,6 +1,7 @@
 import type { LinearClient } from "@linear/sdk";
 
-import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../../../testHelpers/consoleCapture.ts";
+import type { ResolvedConfig } from "../../config.ts";
 import {
   blockersFromRelations,
   createBoardSource,
@@ -12,10 +13,8 @@ import {
   isIssueTodo,
   isTerminalStatusForBlocker,
   isTerminalStatusForIssue,
-  resolveModelFor,
-  resolveRepositoryFor,
-} from "./boardSource.ts";
-import type { ResolvedConfig } from "./config.ts";
+} from "./fetch.ts";
+import { resolveModelFor, resolveRepositoryFor } from "./parsing.ts";
 
 interface IssueNodeStub {
   id: string;
@@ -400,6 +399,32 @@ describe(fetchResolvedIssue, () => {
     expect(resolved.teamId).toBe("team-default");
   });
 
+  it("resolves a matched non-default model from an enabled agent-* label", async () => {
+    const client = {
+      client: {
+        rawRequest: vi.fn<RawRequest>(async () => ({
+          data: {
+            issue: {
+              id: "uuid-1",
+              title: "Title",
+              description: "Touches repo-a.",
+              team: { id: "team-default" },
+              labels: { nodes: [{ name: "agent-codex" }] },
+              state: { name: "Todo", type: "unstarted" },
+            },
+          },
+        })),
+      },
+    };
+    const resolved = await fetchResolvedIssue({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests hit the LinearClient surface consumed by boardSource
+      client: client as unknown as LinearClient,
+      config: makeConfig(),
+      ticket: "TEAM-1",
+    });
+    expect(resolved.model).toBe("codex");
+  });
+
   it("falls back to models.default when the label refers to a disabled shipped default", async () => {
     const client = {
       client: {
@@ -606,7 +631,6 @@ describe(resolveRepositoryFor, () => {
     const result = resolveRepositoryFor({
       description: "Touches repo-a.",
       config: makeConfig(),
-      ticket: "TEAM-1",
     });
     expect(result).toStrictEqual({ kind: "ok", repository: "repo-a" });
   });
@@ -615,9 +639,7 @@ describe(resolveRepositoryFor, () => {
     const config = makeConfig({
       workspace: { projectDir: "/work", knownRepositories: ["acme/api"] },
     });
-    expect(
-      resolveRepositoryFor({ description: "api is sad", config, ticket: "TEAM-1" }),
-    ).toStrictEqual({
+    expect(resolveRepositoryFor({ description: "api is sad", config })).toStrictEqual({
       kind: "ok",
       repository: "acme/api",
     });
@@ -627,9 +649,9 @@ describe(resolveRepositoryFor, () => {
     const config = makeConfig({
       workspace: { projectDir: "/work", knownRepositories: ["acme/api", "beta/api"] },
     });
-    expect(
-      resolveRepositoryFor({ description: "api is sad", config, ticket: "TEAM-1" }),
-    ).toStrictEqual({ kind: "missing" });
+    expect(resolveRepositoryFor({ description: "api is sad", config })).toStrictEqual({
+      kind: "missing",
+    });
   });
 
   it("returns missing when no known repo is in the description", () => {
@@ -637,21 +659,20 @@ describe(resolveRepositoryFor, () => {
       resolveRepositoryFor({
         description: "no matching repo here",
         config: makeConfig(),
-        ticket: "TEAM-1",
       }),
     ).toStrictEqual({ kind: "missing" });
   });
 
   it("returns missing on empty description", () => {
-    expect(
-      resolveRepositoryFor({ description: "", config: makeConfig(), ticket: "TEAM-1" }),
-    ).toStrictEqual({ kind: "missing" });
+    expect(resolveRepositoryFor({ description: "", config: makeConfig() })).toStrictEqual({
+      kind: "missing",
+    });
   });
 
   it("returns missing on undefined description", () => {
-    expect(
-      resolveRepositoryFor({ description: undefined, config: makeConfig(), ticket: "TEAM-1" }),
-    ).toStrictEqual({ kind: "missing" });
+    expect(resolveRepositoryFor({ description: undefined, config: makeConfig() })).toStrictEqual({
+      kind: "missing",
+    });
   });
 });
 

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -1,23 +1,26 @@
 /**
- * Linear adapter — turns the viewer's GraphQL state into a `BoardState`
- * snapshot. Owns the GraphQL queries and shape parsing so callers consume a
- * typed `BoardState` instead of raw nodes.
+ * Linear adapter — GraphQL fetch helpers for board/issue data.
  *
- * There is no project / view / status configuration: the only filter is
- * "assigned to the API key's viewer AND carries an `agent-*` label."
- * State classification is driven by Linear's workflow `state.type`
+ * There is no project / view / status configuration: the only server-side
+ * filter is "assigned to the API key's viewer AND carries an `agent-*`
+ * label." State classification is driven by Linear's workflow `state.type`
  * (`unstarted` | `started` | `completed` | `canceled` | `duplicate`) —
- * never by status name — so workspaces with renamed columns (Todo → To Do,
- * Done → Shipped, etc.) Just Work.
+ * never by status name — so workspaces with renamed columns (Todo -> To Do,
+ * Done -> Shipped, etc.) Just Work without per-team config.
  */
 
 import type { LinearClient } from "@linear/sdk";
 
-import { AGENT_ANY_MODEL, isShippedDefaultDisabled, type ResolvedConfig } from "./config.ts";
-import { RepositoryResolutionError } from "./ticketSource.ts";
-import { log } from "./util.ts";
+import type { ResolvedConfig } from "../../config.ts";
+import { RepositoryResolutionError } from "../../ticketSource.ts";
+import { log } from "../../util.ts";
+import {
+  AGENT_LABEL_PREFIX,
+  resolveModelFor,
+  resolveRepositoryFor,
+  type ModelResolution,
+} from "./parsing.ts";
 
-export const AGENT_LABEL_PREFIX = "agent-";
 export const ISSUES_PAGE_SIZE = 250;
 
 // `state.type` values surfaced by `fetch()`. `backlog` / `triage` are dropped
@@ -46,6 +49,7 @@ export interface Issue {
   id: string;
   uuid: string;
   title: string;
+  description: string;
   status: string;
   statusId: string;
   /** Linear workflow `state.type` — the source of truth for canonical classification. */
@@ -67,26 +71,18 @@ export interface Issue {
 }
 
 /**
- * `Issue` narrowed to "this ticket is for groundcrew" — produced by filtering
- * through `isGroundcrewIssue`. Use this type wherever downstream code reads
- * `model`/`repository` and the issue has already been through that filter.
+ * `Issue` narrowed to "this ticket is for groundcrew". Consumers operate on
+ * the canonical `GroundcrewIssue` from `ticketSource.ts`; this internal
+ * variant just shapes the adapter's local Linear type.
  */
 export type GroundcrewIssue = Issue & {
   model: string;
   repository: string;
 };
 
-export function isGroundcrewIssue(issue: Issue): issue is GroundcrewIssue {
-  return issue.model !== undefined && issue.repository !== undefined;
-}
-
 /**
  * Linear ticket that was silently dropped from `issues` because it has at
  * least one sub-issue and groundcrew works sub-issues rather than parents.
- * The dispatcher logs each one per tick so operators see WHY a Todo ticket
- * isn't being picked up instead of just "No Todo tickets to pick up." Only
- * Todo+agent-labelled parents qualify — non-actionable parents (e.g. Done
- * epics) would be noise.
  */
 export interface ParentSkip {
   id: string;
@@ -100,19 +96,8 @@ export interface BoardState {
   parentSkips: ParentSkip[];
 }
 
-// Canonical RepositoryResolutionError lives in ./ticketSource.ts (imported at
-// the top of this file). Re-exported here so existing consumers of
-// boardSource.ts keep compiling until a follow-up PR completes the consumer
-// refactor and deletes this file.
-export { RepositoryResolutionError };
-
 export interface BoardSource {
-  /**
-   * Verify the Linear API key resolves to a viewer. Run once at startup so
-   * misconfiguration surfaces before the first tick.
-   */
   verify(): Promise<void>;
-  /** Fetch the current board snapshot. Paginates internally. */
   fetch(): Promise<BoardState>;
 }
 
@@ -208,18 +193,6 @@ export interface IssueRelationNode {
 async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise<BoardState> {
   const nodes: IssueNode[] = [];
   let after: string | null = null;
-  // Three server-side filters narrow the response to tickets the orchestrator
-  // can actually act on:
-  //   1. Assignee: the API key's own viewer. groundcrew is a single-user
-  //      orchestrator — every ticket it dispatches is "this user's work."
-  //   2. Label: at least one `agent-*` label — i.e. the user opted the
-  //      ticket in to groundcrew. Without this, every human-owned ticket
-  //      would round-trip back just to be filtered out client-side.
-  //   3. State type: scoped to actionable values (`unstarted`, `started`,
-  //      `completed`, `canceled`, `duplicate`) so backlog/triage tickets never
-  //      make it into the page.
-  // The client-side `isGroundcrewIssue` guard in dispatcher.ts is
-  // belt-and-suspenders against query drift, not the load-bearing filter.
   const stateTypes = [...ACTIONABLE_STATE_TYPES];
 
   for (;;) {
@@ -307,10 +280,10 @@ export function modelForResolution(
   if (resolution.kind === "disabled-fallback") {
     return resolution.fallbackModel;
   }
-  return AGENT_ANY_MODEL;
+  return "any";
 }
 
-export function resolveTodoAgentMetadata(arguments_: {
+function resolveTodoAgentMetadata(arguments_: {
   ticket: string;
   description: string | undefined;
   modelResolution: ModelResolution;
@@ -321,7 +294,7 @@ export function resolveTodoAgentMetadata(arguments_: {
   let repository: string | undefined;
   let model: string | undefined;
   if (modelResolution.kind !== "no-label" && isTodo) {
-    const resolution = resolveRepositoryFor({ description, config, ticket });
+    const resolution = resolveRepositoryFor({ description, config });
     if (resolution.kind === "ok") {
       ({ repository } = resolution);
       model = modelForResolution(modelResolution);
@@ -338,6 +311,7 @@ function buildLinearIssue(input: {
   identifier: string;
   uuid: string;
   title: string;
+  description: string;
   status: string;
   statusId: string;
   stateType: string;
@@ -352,6 +326,7 @@ function buildLinearIssue(input: {
     id: input.identifier.toLowerCase(),
     uuid: input.uuid,
     title: input.title,
+    description: input.description,
     status: input.status,
     statusId: input.statusId,
     stateType: input.stateType,
@@ -369,11 +344,6 @@ function buildLinearIssue(input: {
 function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
   const modelResolution = resolveModelFor({ labels: node.labels.nodes, config });
   warnIfDisabledFallback(node.identifier, modelResolution, config);
-  // Only the dispatcher reads `Issue.repository` / `Issue.model`, and only on
-  // tickets in the Todo column it's about to pick up. Resolving them for In
-  // Progress (already running) or Done (cleaner only needs the id) would just
-  // invite tick-spam warnings on already-finished tickets — e.g. when a
-  // description was edited or knownRepositories changed after dispatch.
   const { repository, model } = resolveTodoAgentMetadata({
     ticket: node.identifier,
     /* v8 ignore next @preserve -- BoardIssues query selects description; the ?? guard normalises a null vs undefined edge */
@@ -386,6 +356,8 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
     identifier: node.identifier,
     uuid: node.id,
     title: node.title,
+    /* v8 ignore next @preserve -- BoardIssues query always selects description; this `?? ""` is a defensive null vs undefined edge */
+    description: node.description ?? "",
     /* v8 ignore next @preserve -- BoardIssues query always returns state */
     status: node.state?.name ?? "Unknown",
     /* v8 ignore next @preserve -- BoardIssues query always returns state */
@@ -401,25 +373,6 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
   });
 }
 
-function escapeRegex(value: string): string {
-  return value.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
-}
-
-// Sort by descending length so longer names match first — `api-admin`
-// must beat `api` when both are configured. `\b` treats `-` as a word
-// boundary, so without this ordering `api` would win on `api-admin`.
-function buildRepositoryRegex(config: ResolvedConfig): RegExp {
-  const candidates = config.workspace.knownRepositories.flatMap((repo) => {
-    const slashIndex = repo.indexOf("/");
-    return slashIndex === -1 ? [repo] : [repo, repo.slice(slashIndex + 1)];
-  });
-  const alternation = candidates
-    .toSorted((a, b) => b.length - a.length)
-    .map(escapeRegex)
-    .join("|");
-  return new RegExp(String.raw`\b(${alternation})\b`);
-}
-
 interface ResolvedIssue {
   uuid: string;
   title: string;
@@ -427,6 +380,9 @@ interface ResolvedIssue {
   repository: string;
   model: string;
   teamId: string;
+  stateType: string;
+  status: string;
+  statusId: string;
 }
 
 const ISSUE_LABEL_PAGE_SIZE = 50;
@@ -440,7 +396,8 @@ export interface RawLinearIssue {
   labels: { name: string }[];
   /** Linear workflow state name, e.g. "Todo", "In Review". May be "" if state was null. */
   stateName: string;
-  stateType?: string;
+  stateType: string;
+  stateId: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
   /**
@@ -516,7 +473,7 @@ export async function fetchRawLinearIssue(arguments_: {
         title
         description
         team { id }
-        state { name type }
+        state { id name type }
         children { nodes { id } }
         labels(first: ${ISSUE_LABEL_PAGE_SIZE}) {
           nodes { name }
@@ -543,7 +500,7 @@ export async function fetchRawLinearIssue(arguments_: {
       title: string;
       description?: string | null;
       team?: { id: string } | null;
-      state?: { name: string; type: string } | null;
+      state?: { id: string; name: string; type: string } | null;
       children?: { nodes: { id: string }[] } | null;
       labels: { nodes: { name: string }[] };
       inverseRelations?: {
@@ -566,6 +523,8 @@ export async function fetchRawLinearIssue(arguments_: {
     stateName: issue.state?.name ?? "",
     /* v8 ignore next @preserve -- ResolveIssue query selects state; null only if Linear genuinely returns a stateless ticket */
     stateType: issue.state?.type ?? "",
+    /* v8 ignore next @preserve -- ResolveIssue query selects state; null only if Linear genuinely returns a stateless ticket */
+    stateId: issue.state?.id ?? "",
     blockers: blockersFromRelations(issue.inverseRelations?.nodes ?? []),
     hasMoreBlockers: issue.inverseRelations?.pageInfo.hasNextPage ?? false,
     hasChildren: (issue.children?.nodes.length ?? 0) > 0,
@@ -627,72 +586,6 @@ export async function fetchInProgressIssueCount(arguments_: {
   }
 }
 
-export type RepositoryResolution = { kind: "ok"; repository: string } | { kind: "missing" };
-
-export function resolveRepositoryFor(arguments_: {
-  description: string | undefined;
-  config: ResolvedConfig;
-  ticket: string;
-}): RepositoryResolution {
-  const { description, config } = arguments_;
-  if (description === undefined || description.length === 0) {
-    return { kind: "missing" };
-  }
-  const match = buildRepositoryRegex(config).exec(description)?.[1];
-  if (match === undefined) {
-    return { kind: "missing" };
-  }
-  // `buildRepositoryRegex` matches both the full `owner/repo` entry and its bare
-  // suffix, so the captured value can be either form. Downstream code composes
-  // the resolved value with `workspace.projectDir` and needs the exact
-  // `knownRepositories` entry, so resolve back to that form here.
-  const candidates = config.workspace.knownRepositories.filter(
-    (entry) => entry === match || entry.endsWith(`/${match}`),
-  );
-  if (candidates.length !== 1) {
-    return { kind: "missing" };
-  }
-  const [canonical] = candidates;
-  /* v8 ignore next 3 @preserve -- candidates.length === 1 guarantees [0] is defined */
-  if (canonical === undefined) {
-    return { kind: "missing" };
-  }
-  return { kind: "ok", repository: canonical };
-}
-
-export type ModelResolution =
-  | { kind: "matched"; model: string }
-  | { kind: "no-label" }
-  | { kind: "agent-any" }
-  | { kind: "disabled-fallback"; requestedModel: string; fallbackModel: string };
-
-export function resolveModelFor(arguments_: {
-  labels: { name: string }[];
-  config: ResolvedConfig;
-}): ModelResolution {
-  const { labels, config } = arguments_;
-  const parsed = parseAgentLabels(labels, config);
-  if (parsed === undefined) {
-    return { kind: "no-label" };
-  }
-  if (parsed.model === AGENT_ANY_MODEL) {
-    return { kind: "agent-any" };
-  }
-  if (parsed.disabledFallback !== undefined) {
-    return {
-      kind: "disabled-fallback",
-      requestedModel: parsed.disabledFallback,
-      fallbackModel: parsed.model,
-    };
-  }
-  return { kind: "matched", model: parsed.model };
-}
-
-/**
- * `agent-any` collapses to `models.default` here — manual setup doesn't run
- * the usage-gated `any` resolver, so the caller gets a concrete model name
- * instead of a sentinel that downstream code can't interpret.
- */
 export async function fetchResolvedIssue(arguments_: {
   client: LinearClient;
   config: ResolvedConfig;
@@ -704,7 +597,6 @@ export async function fetchResolvedIssue(arguments_: {
   const repositoryResolution = resolveRepositoryFor({
     description: raw.description,
     config,
-    ticket: upper,
   });
   if (repositoryResolution.kind === "missing") {
     throw new RepositoryResolutionError({
@@ -727,55 +619,10 @@ export async function fetchResolvedIssue(arguments_: {
     repository: repositoryResolution.repository,
     model,
     teamId: raw.teamId,
+    stateType: raw.stateType,
+    status: raw.stateName,
+    statusId: raw.stateId,
   };
-}
-
-/**
- * Returns the resolved agent metadata for a ticket, or `undefined` when the
- * ticket has no `agent-*` label — those tickets are not groundcrew's concern
- * and downstream code skips them. An explicit `agent-<unknown>` label still
- * falls back to `models.default` because the user opted in by labeling.
- *
- * `disabledFallback` is set when the label matched a shipped default the user
- * explicitly disabled (e.g. `agent-codex` against `codex: { disabled: true }`).
- * Callers warn on this so the user can spot the config/labeling mismatch; we
- * still fall back rather than skip because skipping would block the ticket
- * indefinitely. Unknown labels stay silent — those are likelier to be typos.
- */
-interface ParsedAgentLabels {
-  model: string;
-  disabledFallback?: string;
-}
-
-function parseAgentLabels(
-  labels: { name: string }[],
-  config: ResolvedConfig,
-): ParsedAgentLabels | undefined {
-  const agentLabels = labels.filter((label) => label.name.startsWith(AGENT_LABEL_PREFIX));
-  if (agentLabels.length === 0) {
-    return undefined;
-  }
-  let disabledFallback: string | undefined;
-  for (const label of agentLabels) {
-    const name = label.name.slice(AGENT_LABEL_PREFIX.length);
-    if (name === AGENT_ANY_MODEL) {
-      return { model: AGENT_ANY_MODEL };
-    }
-    // Own-property check, not `in`: a label like `agent-toString` or
-    // `agent-__proto__` would otherwise resolve through the prototype chain
-    // instead of falling back to `models.default`.
-    if (Object.hasOwn(config.models.definitions, name)) {
-      return { model: name };
-    }
-    if (disabledFallback === undefined && isShippedDefaultDisabled(config, name)) {
-      disabledFallback = name;
-    }
-  }
-  const fallback: ParsedAgentLabels = { model: config.models.default };
-  if (disabledFallback !== undefined) {
-    fallback.disabledFallback = disabledFallback;
-  }
-  return fallback;
 }
 
 export function warnIfDisabledFallback(

--- a/src/lib/adapters/linear/index.ts
+++ b/src/lib/adapters/linear/index.ts
@@ -10,3 +10,5 @@ const definition: AdapterDefinition<typeof linearAdapterConfigSchema> = {
 };
 
 export default definition;
+
+export type { LinearSourceRef } from "./factory.ts";

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -1,0 +1,254 @@
+import type { ResolvedConfig } from "../../config.ts";
+import { RepositoryResolutionError } from "../../ticketSource.ts";
+import {
+  buildRepositoryRegex,
+  parseRepository,
+  resolveModelFor,
+  resolveRepositoryFor,
+} from "./parsing.ts";
+
+function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    sources: [],
+    git: { remote: "origin", defaultBranch: "main", ...overrides.git },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a", "repo-b", "api", "api-admin"],
+      ...overrides.workspace,
+    },
+    orchestrator: {
+      maximumInProgress: 2,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+      ...overrides.orchestrator,
+    },
+    models: {
+      default: "claude",
+      definitions: {
+        claude: { cmd: "claude", color: "#fff" },
+        codex: { cmd: "codex", color: "#000" },
+      },
+      ...overrides.models,
+    },
+    prompts: { initial: "x", ...overrides.prompts },
+    workspaceKind: overrides.workspaceKind ?? "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
+  };
+}
+
+describe(parseRepository, () => {
+  const repositoryRegex = /\b(org\/repo-a|repo-a|repo-b|repo-x\/bare)\b/;
+
+  it("returns the matched known repository when it is in knownRepositories", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["org/repo-a", "repo-b"] },
+    });
+    const result = parseRepository({
+      description: "fix the org/repo-a bug",
+      config,
+      repositoryRegex,
+      ticket: "HRD-1",
+    });
+    expect(result).toBe("org/repo-a");
+  });
+
+  it("returns the asserted name as-is when the match is not in knownRepositories", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["other-repo"] },
+    });
+    const result = parseRepository({
+      description: "touches repo-a somewhere",
+      config,
+      repositoryRegex,
+      ticket: "HRD-2",
+    });
+    expect(result).toBe("repo-a");
+  });
+
+  it("throws RepositoryResolutionError when multiple knownRepositories match the bare name", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org1/repo-a", "org2/repo-a"],
+      },
+    });
+    expect(() =>
+      parseRepository({
+        description: "touches repo-a somewhere",
+        config,
+        repositoryRegex,
+        ticket: "HRD-3",
+      }),
+    ).toThrow(RepositoryResolutionError);
+  });
+
+  it("throws RepositoryResolutionError when the description is empty", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    });
+    expect(() =>
+      parseRepository({
+        description: "",
+        config,
+        repositoryRegex,
+        ticket: "HRD-4",
+      }),
+    ).toThrow(RepositoryResolutionError);
+  });
+
+  it("throws RepositoryResolutionError when no repo name appears in the description", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    });
+    expect(() =>
+      parseRepository({
+        description: "no repository mentioned here",
+        config,
+        repositoryRegex,
+        ticket: "HRD-5",
+      }),
+    ).toThrow(RepositoryResolutionError);
+  });
+});
+
+describe(resolveRepositoryFor, () => {
+  it("returns the repository when the description mentions a known one", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["herds-social/herds"] },
+    });
+    const result = resolveRepositoryFor({
+      description: "fix the herds-social/herds bug",
+      config,
+    });
+    expect(result).toStrictEqual({ kind: "ok", repository: "herds-social/herds" });
+  });
+
+  it("returns missing when no known repo is in the description", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["herds-social/herds"] },
+    });
+    expect(resolveRepositoryFor({ description: "nothing here", config }).kind).toBe("missing");
+  });
+
+  it("returns missing on empty description", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["herds-social/herds"] },
+    });
+    expect(resolveRepositoryFor({ description: "", config }).kind).toBe("missing");
+  });
+
+  it("returns missing on undefined description", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["herds-social/herds"] },
+    });
+    expect(resolveRepositoryFor({ description: undefined, config }).kind).toBe("missing");
+  });
+
+  it("returns missing when knownRepositories is empty rather than matching the empty string", () => {
+    // Pinned because buildRepositoryRegex over [] is /\b()\b/, which matches
+    // the empty string at every word boundary — without this guard the
+    // dispatch / single-ticket / doctor paths would all emit a bogus
+    // { kind: "ok", repository: "" }.
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: [] },
+    });
+    expect(resolveRepositoryFor({ description: "anything at all", config }).kind).toBe("missing");
+  });
+
+  it("canonicalizes a bare match back to the configured `owner/repo` entry", async () => {
+    // A Linear description that mentions only `repo-a` must resolve to the
+    // exact knownRepositories entry `org/repo-a` so `crew run --ticket ...`
+    // launches against the correct worktree path. Without this canonicalization
+    // the single-ticket flow would launch against a bare `repo-a` directory.
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["org/repo-a"] },
+    });
+    const result = resolveRepositoryFor({
+      description: "fix the repo-a bug",
+      config,
+    });
+    expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
+  });
+
+  it("returns missing when the bare name maps to multiple knownRepositories", async () => {
+    // Ambiguous bare-name match — the launcher can't disambiguate "matched
+    // N known repos" any more than the dispatcher can, so surface as missing
+    // (which fetchResolvedIssue turns into a RepositoryResolutionError).
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org1/repo-a", "org2/repo-a"],
+      },
+    });
+    expect(resolveRepositoryFor({ description: "touches repo-a somewhere", config }).kind).toBe(
+      "missing",
+    );
+  });
+});
+
+describe(resolveModelFor, () => {
+  it("returns matched when label corresponds to a known model", () => {
+    const config = makeConfig();
+    const result = resolveModelFor({ labels: [{ name: "agent-claude" }], config });
+    expect(result).toStrictEqual({ kind: "matched", model: "claude" });
+  });
+
+  it("returns no-label when no agent-* label is present", () => {
+    const config = makeConfig();
+    const result = resolveModelFor({ labels: [{ name: "feature" }], config });
+    expect(result.kind).toBe("no-label");
+  });
+
+  it("returns no-label when the labels array is empty", () => {
+    const config = makeConfig();
+    const result = resolveModelFor({ labels: [], config });
+    expect(result.kind).toBe("no-label");
+  });
+
+  it("returns agent-any when the label is agent-any", () => {
+    const config = makeConfig();
+    const result = resolveModelFor({ labels: [{ name: "agent-any" }], config });
+    expect(result.kind).toBe("agent-any");
+  });
+
+  it("returns disabled-fallback when the label matches a disabled shipped default", () => {
+    // codex is absent from definitions (simulating `disabled: true`) but IS a
+    // shipped default, so isShippedDefaultDisabled returns true for it.
+    const configWithCodexDisabled = makeConfig({
+      models: {
+        default: "claude",
+        definitions: {
+          claude: { cmd: "claude", color: "#fff" },
+        },
+      },
+    });
+    const result = resolveModelFor({
+      labels: [{ name: "agent-codex" }],
+      config: configWithCodexDisabled,
+    });
+    expect(result).toStrictEqual({
+      kind: "disabled-fallback",
+      requestedModel: "codex",
+      fallbackModel: "claude",
+    });
+  });
+});
+
+describe(buildRepositoryRegex, () => {
+  it("longer repository names beat shorter ones (api-admin vs api)", () => {
+    const config = makeConfig();
+    const regex = buildRepositoryRegex(config);
+    const match = regex.exec("ticket about api-admin only");
+    expect(match?.[1]).toBe("api-admin");
+  });
+
+  it("produces a regex that matches a full org/repo path", () => {
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: ["herds-social/herds"] },
+    });
+    const regex = buildRepositoryRegex(config);
+    const match = regex.exec("fix the herds-social/herds bug");
+    expect(match?.[1]).toBe("herds-social/herds");
+  });
+});

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -1,0 +1,217 @@
+/**
+ * Linear adapter — parsing helpers for model/repository resolution from
+ * issue labels and descriptions. Extracted from boardSource.ts (Task 10).
+ */
+
+import { AGENT_ANY_MODEL, isShippedDefaultDisabled, type ResolvedConfig } from "../../config.ts";
+import { RepositoryResolutionError } from "../../ticketSource.ts";
+
+export const AGENT_LABEL_PREFIX = "agent-";
+
+export type RepositoryResolution = { kind: "ok"; repository: string } | { kind: "missing" };
+
+export type ModelResolution =
+  | { kind: "matched"; model: string }
+  | { kind: "no-label" }
+  | { kind: "agent-any" }
+  | { kind: "disabled-fallback"; requestedModel: string; fallbackModel: string };
+
+function escapeRegex(value: string): string {
+  return value.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
+}
+
+// Sort by descending length so longer names match first — `api-admin`
+// must beat `api` when both are configured. `\b` treats `-` as a word
+// boundary, so without this ordering `api` would win on `api-admin`.
+export function buildRepositoryRegex(config: ResolvedConfig): RegExp {
+  const candidates = config.workspace.knownRepositories.flatMap((repo) => {
+    const slashIndex = repo.indexOf("/");
+    return slashIndex === -1 ? [repo] : [repo, repo.slice(slashIndex + 1)];
+  });
+  const alternation = candidates
+    .toSorted((a, b) => b.length - a.length)
+    .map(escapeRegex)
+    .join("|");
+  return new RegExp(String.raw`\b(${alternation})\b`);
+}
+
+// Shared canonicalization for parseRepository (auto-pickup / dispatch path)
+// and resolveRepositoryFor (manual setup / single-ticket path). The regex
+// can capture either a full `owner/repo` or a bare `repo` when only that
+// appears in the description; canonicalization resolves a bare match back
+// to its full `owner/repo` entry in knownRepositories, and rejects bare
+// names that map to multiple knownRepositories as ambiguous. Both callers
+// share this so the two paths can't drift on what counts as a match.
+type CanonicalizedRepositoryMatch =
+  | { kind: "canonical"; repository: string }
+  | { kind: "unknown"; repository: string }
+  | { kind: "missing" }
+  | { kind: "ambiguous" };
+
+function canonicalizeRepositoryMatch(
+  description: string | undefined,
+  config: ResolvedConfig,
+  repositoryRegex: RegExp,
+): CanonicalizedRepositoryMatch {
+  if (description === undefined || description.length === 0) {
+    return { kind: "missing" };
+  }
+  // Guard against an empty knownRepositories config: buildRepositoryRegex
+  // would produce /\b()\b/, which matches the empty string at any word
+  // boundary and returns a bogus "" match. Treat that as "no repo could
+  // be resolved" so neither the dispatch path nor the doctor path emits
+  // a spurious empty-string repository.
+  if (config.workspace.knownRepositories.length === 0) {
+    return { kind: "missing" };
+  }
+  const matched = repositoryRegex.exec(description)?.[1];
+  if (matched === undefined) {
+    return { kind: "missing" };
+  }
+  const candidates = config.workspace.knownRepositories.filter(
+    (r) => r === matched || r.endsWith(`/${matched}`),
+  );
+  if (candidates.length > 1) {
+    return { kind: "ambiguous" };
+  }
+  if (candidates.length === 1) {
+    /* v8 ignore next @preserve -- length-1 guarantees [0] defined */
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- length-1 guarantees [0] is defined
+    return { kind: "canonical", repository: candidates[0]! };
+  }
+  return { kind: "unknown", repository: matched };
+}
+
+export function resolveRepositoryFor(arguments_: {
+  description: string | undefined;
+  config: ResolvedConfig;
+}): RepositoryResolution {
+  const { description, config } = arguments_;
+  const match = canonicalizeRepositoryMatch(description, config, buildRepositoryRegex(config));
+  switch (match.kind) {
+    case "missing":
+    case "ambiguous": {
+      // Ambiguous matches surface as "missing" so fetchResolvedIssue throws
+      // RepositoryResolutionError — same conflation parseRepository uses,
+      // and the right call for single-ticket flows: the launcher can't
+      // disambiguate "matched N known repos" any more than the dispatcher can.
+      return { kind: "missing" };
+    }
+    case "canonical":
+    case "unknown": {
+      return { kind: "ok", repository: match.repository };
+    }
+    /* v8 ignore next 5 @preserve -- exhaustive over CanonicalizedRepositoryMatch.kind */
+    default: {
+      throw new Error(
+        `resolveRepositoryFor: unexpected match kind ${(match satisfies never as CanonicalizedRepositoryMatch).kind}`,
+      );
+    }
+  }
+}
+
+interface ParseRepositoryArguments {
+  description: string | undefined;
+  config: ResolvedConfig;
+  repositoryRegex: RegExp;
+  ticket: string;
+}
+
+export function parseRepository(arguments_: ParseRepositoryArguments): string {
+  const { description, config, repositoryRegex, ticket } = arguments_;
+  const match = canonicalizeRepositoryMatch(description, config, repositoryRegex);
+  switch (match.kind) {
+    case "missing":
+    case "ambiguous": {
+      throw new RepositoryResolutionError({
+        ticket,
+        repositories: config.workspace.knownRepositories,
+      });
+    }
+    case "canonical": {
+      return match.repository;
+    }
+    case "unknown": {
+      // No match in knownRepositories — return the asserted name as-is. The
+      // dispatcher's dispatchableRepository helper WARN-logs and skips at
+      // the host layer, uniformly across all sources.
+      return match.repository;
+    }
+    /* v8 ignore next 5 @preserve -- exhaustive over CanonicalizedRepositoryMatch.kind */
+    default: {
+      throw new Error(
+        `parseRepository: unexpected match kind ${(match satisfies never as CanonicalizedRepositoryMatch).kind}`,
+      );
+    }
+  }
+}
+
+/**
+ * Returns the resolved agent metadata for a ticket, or `undefined` when the
+ * ticket has no `agent-*` label — those tickets are not groundcrew's concern
+ * and downstream code skips them. An explicit `agent-<unknown>` label still
+ * falls back to `models.default` because the user opted in by labeling.
+ *
+ * `disabledFallback` is set when the label matched a shipped default the user
+ * explicitly disabled (e.g. `agent-codex` against `codex: { disabled: true }`).
+ * Callers warn on this so the user can spot the config/labeling mismatch; we
+ * still fall back rather than skip because skipping would block the ticket
+ * indefinitely. Unknown labels stay silent — those are likelier to be typos.
+ */
+interface ParsedAgentLabels {
+  model: string;
+  disabledFallback?: string;
+}
+
+function parseAgentLabels(
+  labels: { name: string }[],
+  config: ResolvedConfig,
+): ParsedAgentLabels | undefined {
+  const agentLabels = labels.filter((label) => label.name.startsWith(AGENT_LABEL_PREFIX));
+  if (agentLabels.length === 0) {
+    return undefined;
+  }
+  let disabledFallback: string | undefined;
+  for (const label of agentLabels) {
+    const name = label.name.slice(AGENT_LABEL_PREFIX.length);
+    if (name === AGENT_ANY_MODEL) {
+      return { model: AGENT_ANY_MODEL };
+    }
+    // Own-property check, not `in`: a label like `agent-toString` or
+    // `agent-__proto__` would otherwise resolve through the prototype chain
+    // instead of falling back to `models.default`.
+    if (Object.hasOwn(config.models.definitions, name)) {
+      return { model: name };
+    }
+    if (disabledFallback === undefined && isShippedDefaultDisabled(config, name)) {
+      disabledFallback = name;
+    }
+  }
+  const fallback: ParsedAgentLabels = { model: config.models.default };
+  if (disabledFallback !== undefined) {
+    fallback.disabledFallback = disabledFallback;
+  }
+  return fallback;
+}
+
+export function resolveModelFor(arguments_: {
+  labels: { name: string }[];
+  config: ResolvedConfig;
+}): ModelResolution {
+  const { labels, config } = arguments_;
+  const parsed = parseAgentLabels(labels, config);
+  if (parsed === undefined) {
+    return { kind: "no-label" };
+  }
+  if (parsed.model === AGENT_ANY_MODEL) {
+    return { kind: "agent-any" };
+  }
+  if (parsed.disabledFallback !== undefined) {
+    return {
+      kind: "disabled-fallback",
+      requestedModel: parsed.disabledFallback,
+      fallbackModel: parsed.model,
+    };
+  }
+  return { kind: "matched", model: parsed.model };
+}

--- a/src/lib/adapters/linear/writeback.test.ts
+++ b/src/lib/adapters/linear/writeback.test.ts
@@ -1,0 +1,98 @@
+import type { LinearClient } from "@linear/sdk";
+
+import { captureConsoleLog, type ConsoleCapture } from "../../../testHelpers/consoleCapture.ts";
+import { createLinearIssueStatusUpdater } from "./writeback.ts";
+
+interface ClientStub {
+  team: ReturnType<typeof vi.fn>;
+  updateIssue: ReturnType<typeof vi.fn>;
+}
+
+interface StateNode {
+  id: string;
+  name: string;
+  type: string;
+}
+
+function makeClient(options: { omitInProgressState?: boolean } = {}): ClientStub {
+  const { omitInProgressState = false } = options;
+  return {
+    team: vi
+      .fn<() => Promise<{ states: () => Promise<{ nodes: StateNode[] }> }>>()
+      .mockResolvedValue({
+        states: vi.fn<() => Promise<{ nodes: StateNode[] }>>().mockResolvedValue({
+          nodes: omitInProgressState
+            ? [{ id: "state-other", name: "Other", type: "unstarted" }]
+            : [{ id: "state-in-progress", name: "In Progress", type: "started" }],
+        }),
+      }),
+    updateIssue: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
+  };
+}
+
+function asLinearClient(stub: ClientStub): LinearClient {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests use the LinearClient surface consumed by writeback
+  return stub as unknown as LinearClient;
+}
+
+describe(createLinearIssueStatusUpdater, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    vi.clearAllMocks();
+  });
+
+  it("fetches the started-type state once across multiple tickets in the same team", async () => {
+    const client = makeClient();
+    const updater = createLinearIssueStatusUpdater({
+      client: asLinearClient(client),
+    });
+
+    await updater.markInProgress({
+      id: "team-1",
+      uuid: "uuid-1",
+      teamId: "shared",
+    });
+    await updater.markInProgress({
+      id: "team-2",
+      uuid: "uuid-2",
+      teamId: "shared",
+    });
+
+    expect(client.team).toHaveBeenCalledTimes(1);
+    expect(client.updateIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-fetches team workflow states on every failing markInProgress so an operator-side fix is picked up without restart", async () => {
+    // No negative cache: a team missing its `started`-type workflow state is
+    // a Linear-side config issue the operator can correct mid-session. The
+    // previous design cached the failure and required a process restart to
+    // recover; this test pins the re-fetch behavior.
+    const client = makeClient({ omitInProgressState: true });
+    const updater = createLinearIssueStatusUpdater({
+      client: asLinearClient(client),
+    });
+
+    await expect(
+      updater.markInProgress({
+        id: "team-1",
+        uuid: "uuid-1",
+        teamId: "broken",
+      }),
+    ).rejects.toThrow('workflow state with type "started"');
+    await expect(
+      updater.markInProgress({
+        id: "team-2",
+        uuid: "uuid-2",
+        teamId: "broken",
+      }),
+    ).rejects.toThrow('workflow state with type "started"');
+
+    expect(client.team).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/adapters/linear/writeback.ts
+++ b/src/lib/adapters/linear/writeback.ts
@@ -1,6 +1,6 @@
 import type { LinearClient } from "@linear/sdk";
 
-import { log } from "./util.ts";
+import { log } from "../../util.ts";
 
 interface LinearIssueReference {
   id: string;
@@ -10,19 +10,24 @@ interface LinearIssueReference {
 
 interface LinearIssueStatusUpdater {
   markInProgress(issue: LinearIssueReference): Promise<void>;
-  resetMissingInProgressCache(): void;
 }
 
 export function createLinearIssueStatusUpdater(arguments_: {
   client: LinearClient;
 }): LinearIssueStatusUpdater {
   const { client } = arguments_;
-  // The first matching workflow state per team is cached by teamId so the
-  // status writeback doesn't re-query Linear on every dispatch. Teams that
-  // genuinely lack an `started` workflow state stay in the negative cache
-  // until the dispatcher resets it at the top of each tick.
+  // Positive cache only. Keyed by teamId because the workflow `state.type ===
+  // "started"` lookup yields a single stateId per team — independent of which
+  // project the ticket belongs to. State ids don't change for misconfig
+  // reasons, so caching successful resolutions is safe across the process.
+  //
+  // No negative cache: a missing "started" workflow state is a Linear-side
+  // config issue the operator can correct mid-session, and a negative cache
+  // would mask that recovery until process restart. Slot count caps
+  // markInProgress calls per tick at 1-5, so re-fetching team states on
+  // every failing attempt costs at most a handful of extra Linear API calls
+  // per tick.
   const inProgressStateByTeam = new Map<string, string>();
-  let teamsMissingInProgress = new Set<string>();
 
   async function getInProgressStateId(teamId: string): Promise<string | undefined> {
     if (teamId.length === 0) {
@@ -32,18 +37,13 @@ export function createLinearIssueStatusUpdater(arguments_: {
     if (cached !== undefined) {
       return cached;
     }
-    if (teamsMissingInProgress.has(teamId)) {
-      return undefined;
-    }
-
     const team = await client.team(teamId);
     const states = await team.states();
-    // Use the workflow state's *type* — Linear standardises on
-    // `started` for in-progress columns regardless of how the user renames
-    // them, so this works without any per-team status-name configuration.
+    // Use the workflow state's `type` — Linear standardises on `started` for
+    // in-progress columns regardless of how the user renames them, so this
+    // works without any per-team status-name configuration.
     const inProgress = states.nodes.find((state) => state.type === "started");
     if (inProgress?.id === undefined) {
-      teamsMissingInProgress.add(teamId);
       return undefined;
     }
     inProgressStateByTeam.set(teamId, inProgress.id);
@@ -61,9 +61,5 @@ export function createLinearIssueStatusUpdater(arguments_: {
     log(`Marked ${issue.id} as in progress`);
   }
 
-  function resetMissingInProgressCache(): void {
-    teamsMissingInProgress = new Set();
-  }
-
-  return { markInProgress, resetMissingInProgressCache };
+  return { markInProgress };
 }

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -53,9 +53,13 @@ function shellIssue(overrides: Partial<ShellIssue> = {}): ShellIssue {
 }
 
 describe(toCanonicalIssue, () => {
-  it("prefixes the canonical id with the source name", () => {
+  it("prefixes the canonical id with the source name and lowercases the natural part", () => {
+    // The natural id is lowercased via the shared toCanonicalId helper so the
+    // same ticket always produces the same canonical id regardless of which
+    // casing the source emitted — Board.resolveOne lowercases its input
+    // before comparing, so adapters MUST lowercase on the storage side too.
     const result = toCanonicalIssue(shellIssue({ id: "X-1" }), "jira");
-    expect(result.id).toBe("jira:X-1");
+    expect(result.id).toBe("jira:x-1");
     expect(result.source).toBe("jira");
   });
 
@@ -93,10 +97,53 @@ describe(toCanonicalIssue, () => {
       }),
       "jira",
     );
-    expect(result.blockers).toStrictEqual([
-      { id: "jira:B-1", title: "Block A", status: "done" },
-      { id: "jira:B-2", title: "Block B", status: "in-progress" },
-    ]);
+    expect(result.blockers[0]).toMatchObject({ id: "jira:b-1", title: "Block A", status: "done" });
+    expect(result.blockers[0]).not.toHaveProperty("statusReason");
+    expect(result.blockers[0]).not.toHaveProperty("nativeStatus");
+    expect(result.blockers[1]).toMatchObject({
+      id: "jira:b-2",
+      title: "Block B",
+      status: "in-progress",
+    });
+    expect(result.blockers[1]).not.toHaveProperty("statusReason");
+    expect(result.blockers[1]).not.toHaveProperty("nativeStatus");
+  });
+
+  it("passes through statusReason and nativeStatus from the shell blocker payload", () => {
+    const result = toCanonicalIssue(
+      shellIssue({
+        blockers: [
+          { id: "B-3", title: "Missing status", status: "other", statusReason: "missing" },
+          {
+            id: "B-4",
+            title: "Unmapped status",
+            status: "other",
+            statusReason: "unmapped",
+            nativeStatus: "Triage",
+          },
+          { id: "B-5", title: "Mapped with native", status: "done", nativeStatus: "Done" },
+        ],
+      }),
+      "jira",
+    );
+    expect(result.blockers[0]).toMatchObject({
+      id: "jira:b-3",
+      status: "other",
+      statusReason: "missing",
+    });
+    expect(result.blockers[0]).not.toHaveProperty("nativeStatus");
+    expect(result.blockers[1]).toMatchObject({
+      id: "jira:b-4",
+      status: "other",
+      statusReason: "unmapped",
+      nativeStatus: "Triage",
+    });
+    expect(result.blockers[2]).toMatchObject({
+      id: "jira:b-5",
+      status: "done",
+      nativeStatus: "Done",
+    });
+    expect(result.blockers[2]).not.toHaveProperty("statusReason");
   });
 
   it("round-trips sourceRef as opaque data", () => {
@@ -138,7 +185,7 @@ describe(createShellTicketSource, () => {
     );
     const issues = await source.fetch();
     expect(issues).toHaveLength(1);
-    expect(issues[0]?.id).toBe("test:X-1");
+    expect(issues[0]?.id).toBe("test:x-1");
     expect(issues[0]?.source).toBe("test");
   });
 
@@ -204,7 +251,25 @@ describe(createShellTicketSource, () => {
       fakeContext,
     );
     const issue = await source.resolveOne("X-1");
-    expect(issue?.id).toBe("test:X-1");
+    expect(issue?.id).toBe("test:x-1");
+  });
+
+  // Regression: a fetch.sh that emits an uppercase id must still be findable
+  // via resolveOne(lowercased natural id), because Board.resolveOne lowercases
+  // its input before delegating. Pre-fix this returned undefined because the
+  // adapter compared `i.id === "test:TEST-1"` against a lowercased lookup
+  // key `"test:test-1"`.
+  it("resolveOne() fallback finds an issue whose fetch payload emitted an uppercase id", async () => {
+    const script = dir.writeScript(
+      "fetch.sh",
+      `cat <<'JSON'\n${payload(shellIssue({ id: "TEST-1" }))}\nJSON`,
+    );
+    const source = createShellTicketSource(
+      { kind: "shell", name: "test", commands: { fetch: script } },
+      fakeContext,
+    );
+    const issue = await source.resolveOne("test-1");
+    expect(issue?.id).toBe("test:test-1");
   });
 
   it("resolveOne() fallback returns undefined when fetch has no matching id", async () => {
@@ -231,7 +296,7 @@ describe(createShellTicketSource, () => {
       fakeContext,
     );
     const issue = await source.resolveOne("X-1");
-    expect(issue?.id).toBe("test:X-1");
+    expect(issue?.id).toBe("test:x-1");
   });
 
   it("resolveOne() returns undefined on exit code 3", async () => {
@@ -268,7 +333,7 @@ describe(createShellTicketSource, () => {
       fakeContext,
     );
     const issue: CanonicalIssue = {
-      id: "test:X-1",
+      id: "test:x-1",
       source: "test",
       title: "",
       description: "",
@@ -297,7 +362,7 @@ describe(createShellTicketSource, () => {
     );
     const sourceRef = { path: "/tmp/p.md", extra: { nested: 42 } };
     const issue: CanonicalIssue = {
-      id: "test:X-1",
+      id: "test:x-1",
       source: "test",
       title: "",
       description: "",

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -15,10 +15,11 @@
  */
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
-import type {
-  Blocker as CanonicalBlocker,
-  Issue as CanonicalIssue,
-  TicketSource,
+import {
+  toCanonicalId,
+  type Blocker as CanonicalBlocker,
+  type Issue as CanonicalIssue,
+  type TicketSource,
 } from "../../ticketSource.ts";
 
 import { invokeShellCommand } from "./invoke.ts";
@@ -54,12 +55,14 @@ function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShell
 
 export function toCanonicalIssue(shellIssue: ShellIssue, sourceName: string): CanonicalIssue {
   const blockers: CanonicalBlocker[] = shellIssue.blockers.map((b) => ({
-    id: `${sourceName}:${b.id}`,
+    id: toCanonicalId(sourceName, b.id),
     title: b.title,
     status: b.status,
+    ...(b.statusReason !== undefined && { statusReason: b.statusReason }),
+    ...(b.nativeStatus !== undefined && { nativeStatus: b.nativeStatus }),
   }));
   return {
-    id: `${sourceName}:${shellIssue.id}`,
+    id: toCanonicalId(sourceName, shellIssue.id),
     source: sourceName,
     title: shellIssue.title,
     description: shellIssue.description,
@@ -110,10 +113,11 @@ export function createShellTicketSource(
     },
     fetch: runFetch,
     async resolveOne(naturalId: string): Promise<CanonicalIssue | undefined> {
+      const canonicalId = toCanonicalId(sourceName, naturalId);
       const resolveCommand = config.commands.resolveOne;
       if (resolveCommand === undefined) {
         const all = await runFetch();
-        return all.find((i) => i.id === `${sourceName}:${naturalId}`);
+        return all.find((i) => i.id === canonicalId);
       }
       const result = await invokeShellCommand({
         command: resolveCommand,
@@ -122,7 +126,7 @@ export function createShellTicketSource(
         env: config.env,
         substitutions: {
           id: naturalId,
-          canonicalId: `${sourceName}:${naturalId}`,
+          canonicalId,
           name: sourceName,
         },
         sourceName,

--- a/src/lib/adapters/shell/invoke.test.ts
+++ b/src/lib/adapters/shell/invoke.test.ts
@@ -102,6 +102,14 @@ describe(invokeShellCommand, () => {
     await expect(
       invokeShellCommand({ command: script, timeoutMs: 200, sourceName: "test" }),
     ).rejects.toThrow(ShellAdapterTimeoutError);
+    // The timeout SIGKILLs the child; its 'close' event then fires
+    // asynchronously and is swallowed by the handler's `settled` guard.
+    // Wait a beat so that guard executes within the test — without it the
+    // branch is recorded non-deterministically across platforms (covered on
+    // macOS, missed on Linux CI), failing the 100% coverage gate.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 250);
+    });
   });
 
   it("pipes stdin to the subprocess", async () => {

--- a/src/lib/adapters/shell/invoke.test.ts
+++ b/src/lib/adapters/shell/invoke.test.ts
@@ -1,17 +1,10 @@
 /* eslint-disable no-template-curly-in-string -- this file constructs `${id}`-style placeholders as literal strings for the shell adapter's substitution mechanism; they're NOT JS template literals */
 
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
 
-import {
-  applySubstitutions,
-  invokeShellCommand,
-  SHELL_COMMAND_MAX_BUFFER_BYTES,
-  ShellAdapterOutputLimitError,
-  ShellAdapterTimeoutError,
-} from "./invoke.ts";
+import { applySubstitutions, invokeShellCommand, ShellAdapterTimeoutError } from "./invoke.ts";
 
 interface TempDir {
   path: string;
@@ -111,37 +104,6 @@ describe(invokeShellCommand, () => {
     ).rejects.toThrow(ShellAdapterTimeoutError);
   });
 
-  it("kills child processes on timeout", async () => {
-    const marker = join(dir.path, "child-survived");
-    const script = dir.writeScript(
-      "spawn-child.sh",
-      [
-        `node -e "setTimeout(() => require('node:fs').writeFileSync(process.argv[1], 'alive'), 700)" "${marker}" &`,
-        "wait",
-      ].join("\n"),
-    );
-
-    await expect(
-      invokeShellCommand({ command: script, timeoutMs: 100, sourceName: "test" }),
-    ).rejects.toThrow(ShellAdapterTimeoutError);
-    await sleep(1000);
-
-    expect(existsSync(marker)).toBe(false);
-  });
-
-  it("throws when combined stdout and stderr exceed the max buffer", async () => {
-    const script = dir.writeScript(
-      "too-much-output.sh",
-      `node -e "process.stdout.write('x'.repeat(Number(process.argv[1])))" ${
-        SHELL_COMMAND_MAX_BUFFER_BYTES + 1
-      }`,
-    );
-
-    await expect(
-      invokeShellCommand({ command: script, timeoutMs: 5000, sourceName: "test" }),
-    ).rejects.toThrow(ShellAdapterOutputLimitError);
-  });
-
   it("pipes stdin to the subprocess", async () => {
     const script = dir.writeScript("stdin.sh", "cat");
     const result = await invokeShellCommand({
@@ -186,5 +148,65 @@ describe(invokeShellCommand, () => {
     });
     expect(result.stderr).toContain("warning text");
     expect(result.stdout.trim()).toBe("ok");
+  });
+
+  it("reports truncated: false on a normal-sized output", async () => {
+    const script = dir.writeScript("small.sh", 'echo "ok"');
+    const result = await invokeShellCommand({
+      command: script,
+      timeoutMs: 5000,
+      sourceName: "test",
+    });
+    expect(result.truncated).toBe(false);
+  });
+
+  it("caps stdout at maxOutputBytes and marks the result truncated", async () => {
+    // Produce ~500 bytes of stdout but cap at 100 — the chunk handler will
+    // append once, see the next length > 100, and slice with a marker.
+    const script = dir.writeScript("yes.sh", "yes a | head -c 500");
+    const result = await invokeShellCommand({
+      command: script,
+      timeoutMs: 5000,
+      sourceName: "test",
+      maxOutputBytes: 100,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.stdout).toContain("[truncated: stream exceeded 100 bytes]");
+    // First 100 bytes are preserved; suffix after the newline is the marker.
+    expect(result.stdout.startsWith("a\n".repeat(50))).toBe(true);
+  });
+
+  it("caps stderr at maxOutputBytes and marks the result truncated", async () => {
+    const script = dir.writeScript("yes-err.sh", "yes a | head -c 500 >&2; echo ok");
+    const result = await invokeShellCommand({
+      command: script,
+      timeoutMs: 5000,
+      sourceName: "test",
+      maxOutputBytes: 100,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.stderr).toContain("[truncated: stream exceeded 100 bytes]");
+    expect(result.stdout.trim()).toBe("ok");
+  });
+
+  it("ignores further stdout chunks once the cap is already exceeded", async () => {
+    // Emit two distinct chunks of well-separated content. The first chunk
+    // alone busts the cap, so the second chunk's 'data' event should hit the
+    // early-return branch in appendCapped (current.length >= maxBytes).
+    const script = dir.writeScript(
+      "two-chunks.sh",
+      "yes AAA | head -c 500; sleep 0.05; yes ZZZ | head -c 500",
+    );
+    const result = await invokeShellCommand({
+      command: script,
+      timeoutMs: 5000,
+      sourceName: "test",
+      maxOutputBytes: 100,
+    });
+    expect(result.truncated).toBe(true);
+    // The second chunk's distinctive content never made it into stdout.
+    // Avoid asserting on single characters like "b" — the truncation marker
+    // itself contains common letters ("bytes").
+    expect(result.stdout).not.toContain("ZZZ");
   });
 });

--- a/src/lib/adapters/shell/invoke.test.ts
+++ b/src/lib/adapters/shell/invoke.test.ts
@@ -102,14 +102,6 @@ describe(invokeShellCommand, () => {
     await expect(
       invokeShellCommand({ command: script, timeoutMs: 200, sourceName: "test" }),
     ).rejects.toThrow(ShellAdapterTimeoutError);
-    // The timeout SIGKILLs the child; its 'close' event then fires
-    // asynchronously and is swallowed by the handler's `settled` guard.
-    // Wait a beat so that guard executes within the test — without it the
-    // branch is recorded non-deterministically across platforms (covered on
-    // macOS, missed on Linux CI), failing the 100% coverage gate.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 250);
-    });
   });
 
   it("pipes stdin to the subprocess", async () => {

--- a/src/lib/adapters/shell/invoke.ts
+++ b/src/lib/adapters/shell/invoke.ts
@@ -12,26 +12,22 @@
  * interpret); any other nonzero exit throws.
  */
 
-import { type ChildProcess, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 
 import { log } from "../../util.ts";
 
-export const SHELL_COMMAND_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
-const TIMEOUT_SIGNAL: NodeJS.Signals = "SIGKILL";
+/**
+ * Hard cap on captured stdout/stderr per stream. Misbehaving scripts that
+ * `yes | head -c <huge>` would otherwise exhaust memory. 10 MB is enough for
+ * any realistic JSON ticket payload; tests can override via InvokeArgs.maxOutputBytes
+ * to exercise the truncation path with a smaller fixture.
+ */
+const DEFAULT_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 
 export class ShellAdapterTimeoutError extends Error {
   public constructor(arguments_: { command: string; timeoutMs: number }) {
     super(`Shell command timed out after ${arguments_.timeoutMs}ms: ${arguments_.command}`);
     this.name = "ShellAdapterTimeoutError";
-  }
-}
-
-export class ShellAdapterOutputLimitError extends Error {
-  public constructor(arguments_: { command: string; maxBytes: number }) {
-    super(
-      `Shell command exceeded combined stdout/stderr maxBuffer of ${arguments_.maxBytes} bytes: ${arguments_.command}`,
-    );
-    this.name = "ShellAdapterOutputLimitError";
   }
 }
 
@@ -44,29 +40,20 @@ interface InvokeArgs {
   substitutions?: Record<string, string> | undefined;
   /** Source name for log prefixing. */
   sourceName: string;
+  /** Override the default per-stream stdout/stderr cap (10 MB). Used by tests. */
+  maxOutputBytes?: number;
 }
 
 interface InvokeResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /** True if either stream hit the byte cap and the rest was discarded. */
+  truncated: boolean;
 }
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", String.raw`'\''`)}'`;
-}
-
-function killChildProcess(
-  child: ChildProcess,
-  signal: NodeJS.Signals,
-  shouldUseProcessGroup: boolean,
-): void {
-  /* v8 ignore next 4 @preserve -- fallback path is for Windows or a spawn failure before pid assignment */
-  if (!shouldUseProcessGroup || child.pid === undefined) {
-    child.kill(signal);
-    return;
-  }
-  process.kill(-child.pid, signal);
 }
 
 export function applySubstitutions(command: string, subs: Record<string, string>): string {
@@ -82,84 +69,55 @@ export async function invokeShellCommand(args: InvokeArgs): Promise<InvokeResult
     args.substitutions === undefined
       ? args.command
       : applySubstitutions(args.command, args.substitutions);
+  const maxBytes = args.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
   return await new Promise<InvokeResult>((resolve, reject) => {
-    const shouldUseProcessGroup = process.platform !== "win32";
     const child = spawn("sh", ["-c", command], {
       cwd: args.cwd,
-      detached: shouldUseProcessGroup,
       // oxlint-disable-next-line node/no-process-env -- subprocess inherits the parent's full env by design; user-supplied vars layer on top
       env: { ...process.env, ...args.env },
       stdio: ["pipe", "pipe", "pipe"],
     });
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    let stdoutLength = 0;
-    let stderrLength = 0;
+    let stdout: Buffer = Buffer.alloc(0);
+    let stderr: Buffer = Buffer.alloc(0);
+    let truncated = false;
     let settled = false;
 
-    function cleanup(): void {
-      clearTimeout(timer);
-    }
-
-    function killChild(signal: NodeJS.Signals): void {
-      try {
-        killChildProcess(child, signal, shouldUseProcessGroup);
-      } catch {
-        // The child may have exited between timeout/output-limit handling and the kill request.
-      }
-    }
-
-    function failAndKill(error: Error): void {
-      /* v8 ignore next 3 @preserve -- timeout/output-limit races can call this after another terminal event; deterministic tests cover the first terminal path */
+    const timer = setTimeout(() => {
+      /* v8 ignore next 3 @preserve -- timer/close race: clearTimeout in the close handler should prevent this branch, but the guard is kept as defense-in-depth */
       if (settled) {
         return;
       }
       settled = true;
-      cleanup();
-      killChild(TIMEOUT_SIGNAL);
-      reject(error);
-    }
-
-    function appendOutput(input: {
-      chunks: Buffer[];
-      currentLength: number;
-      chunk: Buffer;
-    }): number {
-      /* v8 ignore next 3 @preserve -- streams may emit after timeout/output-limit settlement; this race guard is intentionally defensive */
-      if (settled) {
-        return input.currentLength;
-      }
-      const nextCombinedLength = stdoutLength + stderrLength + input.chunk.length;
-      if (nextCombinedLength > SHELL_COMMAND_MAX_BUFFER_BYTES) {
-        failAndKill(
-          new ShellAdapterOutputLimitError({
-            command,
-            maxBytes: SHELL_COMMAND_MAX_BUFFER_BYTES,
-          }),
-        );
-        return input.currentLength;
-      }
-      input.chunks.push(input.chunk);
-      return input.currentLength + input.chunk.length;
-    }
-
-    const timer = setTimeout(() => {
-      failAndKill(new ShellAdapterTimeoutError({ command, timeoutMs: args.timeoutMs }));
+      child.kill("SIGKILL");
+      reject(new ShellAdapterTimeoutError({ command, timeoutMs: args.timeoutMs }));
     }, args.timeoutMs);
 
+    // Buffer accumulators so the byte cap matches its name. A string-based
+    // comparison would measure UTF-16 code units against a byte budget,
+    // letting multibyte UTF-8 sneak past the cap and risking a mid-
+    // surrogate-pair slice on truncation.
+    const appendCapped = (current: Buffer, chunk: Buffer): Buffer => {
+      if (current.byteLength >= maxBytes) {
+        truncated = true;
+        return current;
+      }
+      const next = Buffer.concat([current, chunk]);
+      if (next.byteLength <= maxBytes) {
+        return next;
+      }
+      truncated = true;
+      const clipped = next.subarray(0, maxBytes);
+      return Buffer.concat([
+        clipped,
+        Buffer.from(`\n[truncated: stream exceeded ${maxBytes} bytes]`),
+      ]);
+    };
+
     child.stdout.on("data", (chunk: Buffer) => {
-      stdoutLength = appendOutput({
-        chunks: stdoutChunks,
-        currentLength: stdoutLength,
-        chunk,
-      });
+      stdout = appendCapped(stdout, chunk);
     });
     child.stderr.on("data", (chunk: Buffer) => {
-      stderrLength = appendOutput({
-        chunks: stderrChunks,
-        currentLength: stderrLength,
-        chunk,
-      });
+      stderr = appendCapped(stderr, chunk);
     });
 
     child.on("close", (code) => {
@@ -167,22 +125,22 @@ export async function invokeShellCommand(args: InvokeArgs): Promise<InvokeResult
         return;
       }
       settled = true;
-      cleanup();
-      const stdout = Buffer.concat(stdoutChunks, stdoutLength).toString("utf8");
-      const stderr = Buffer.concat(stderrChunks, stderrLength).toString("utf8");
-      if (stderr.length > 0) {
-        log(`[shell:${args.sourceName}] ${command}\n${stderr.trimEnd()}`);
+      clearTimeout(timer);
+      const stderrText = stderr.toString("utf8");
+      if (stderrText.length > 0) {
+        log(`[shell:${args.sourceName}] ${command}\n${stderrText.trimEnd()}`);
       }
-      /* v8 ignore next @preserve -- `code` is null only when the process was killed by signal; timeout/output-limit paths settle before 'close' */
+      /* v8 ignore next @preserve -- `code` is null only when the process was killed by signal; the timeout path SIGKILLs but settles via the timer rather than 'close' */
       const exitCode = code ?? 1;
+      const stdoutText = stdout.toString("utf8");
       if (exitCode === 0 || exitCode === 3) {
-        resolve({ stdout, stderr, exitCode });
+        resolve({ stdout: stdoutText, stderr: stderrText, exitCode, truncated });
         return;
       }
       reject(
         new Error(
           `Shell command for source "${args.sourceName}" failed with exit ${exitCode}: ${
-            stderr.trim().length > 0 ? stderr.trim() : command
+            stderrText.trim().length > 0 ? stderrText.trim() : command
           }`,
         ),
       );
@@ -194,7 +152,7 @@ export async function invokeShellCommand(args: InvokeArgs): Promise<InvokeResult
         return;
       }
       settled = true;
-      cleanup();
+      clearTimeout(timer);
       reject(error);
     });
 

--- a/src/lib/adapters/shell/invoke.ts
+++ b/src/lib/adapters/shell/invoke.ts
@@ -121,6 +121,7 @@ export async function invokeShellCommand(args: InvokeArgs): Promise<InvokeResult
     });
 
     child.on("close", (code) => {
+      /* v8 ignore next 3 @preserve -- timer/close race: when the timeout fires first it SIGKILLs and sets settled=true; the 'close' event still arrives and must no-op. No deterministic test exists — an orphaned grandchild (`sh -c "sleep N; ..."`) keeps the stdout pipe open, so 'close' doesn't arrive until the real timeout elapses; mirrors the ignored timer/error settle guards above. */
       if (settled) {
         return;
       }

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -67,6 +67,72 @@ describe("shell issue schema", () => {
     };
     expect(() => shellIssueSchema.parse(issueWithBadBlocker)).toThrow(/status/i);
   });
+
+  it("accepts blockers with optional statusReason and nativeStatus fields", () => {
+    const issue = {
+      id: "x",
+      title: "t",
+      description: "",
+      status: "todo",
+      repository: null,
+      model: null,
+      assignee: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [
+        { id: "b1", title: "missing", status: "other", statusReason: "missing" },
+        {
+          id: "b2",
+          title: "unmapped",
+          status: "other",
+          statusReason: "unmapped",
+          nativeStatus: "Triage",
+        },
+        { id: "b3", title: "mapped", status: "done", nativeStatus: "Done" },
+      ],
+      sourceRef: null,
+    };
+    const parsed = shellIssueSchema.parse(issue);
+    expect(parsed.blockers[0]?.statusReason).toBe("missing");
+    expect(parsed.blockers[0]?.nativeStatus).toBeUndefined();
+    expect(parsed.blockers[1]?.statusReason).toBe("unmapped");
+    expect(parsed.blockers[1]?.nativeStatus).toBe("Triage");
+    expect(parsed.blockers[2]?.statusReason).toBeUndefined();
+    expect(parsed.blockers[2]?.nativeStatus).toBe("Done");
+  });
+
+  it("defaults blocker statusReason and nativeStatus to undefined when omitted", () => {
+    const issue = {
+      id: "x",
+      title: "t",
+      description: "",
+      status: "todo",
+      repository: null,
+      model: null,
+      assignee: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [{ id: "b1", title: "plain", status: "in-progress" }],
+      sourceRef: null,
+    };
+    const parsed = shellIssueSchema.parse(issue);
+    expect(parsed.blockers[0]?.statusReason).toBeUndefined();
+    expect(parsed.blockers[0]?.nativeStatus).toBeUndefined();
+  });
+
+  it("rejects an invalid statusReason value on a blocker", () => {
+    const issue = {
+      id: "x",
+      title: "t",
+      description: "",
+      status: "todo",
+      repository: null,
+      model: null,
+      assignee: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [{ id: "b1", title: "bad", status: "other", statusReason: "invalid-reason" }],
+      sourceRef: null,
+    };
+    expect(() => shellIssueSchema.parse(issue)).toThrow(/.+/);
+  });
 });
 
 describe("shell fetch output schema", () => {
@@ -129,19 +195,33 @@ describe("shell adapter config schema", () => {
     expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
   });
 
-  it.each([
-    ["verify", 0],
-    ["fetch", -1],
-    ["resolveOne", 1.5],
-    ["markInProgress", 0],
-  ] as const)("rejects invalid %s timeout override %s", (field, value) => {
+  it("rejects a negative timeout", () => {
     const config = {
       kind: "shell",
       name: "jira",
-      commands: { fetch: "echo '[]'" },
-      timeouts: { [field]: value },
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { fetch: -1 },
     };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
 
-    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/.+/);
+  it("rejects a zero timeout", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { fetch: 0 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
+
+  it("rejects a non-integer timeout", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { fetch: 1500.5 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/expected int|integer/i);
   });
 });

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -12,12 +12,13 @@
 import { z } from "zod";
 
 const canonicalStatusSchema = z.enum(["todo", "in-progress", "in-review", "done", "other"]);
-const timeoutSchema = z.number().int().positive();
 
 const shellBlockerSchema = z.object({
   id: z.string(),
   title: z.string(),
   status: canonicalStatusSchema,
+  statusReason: z.enum(["missing", "unmapped"]).optional(),
+  nativeStatus: z.string().optional(),
 });
 
 export const shellIssueSchema = z.object({
@@ -52,10 +53,13 @@ export const shellAdapterConfigSchema = z.object({
   cwd: z.string().optional(),
   timeouts: z
     .object({
-      verify: timeoutSchema.optional(),
-      fetch: timeoutSchema.optional(),
-      resolveOne: timeoutSchema.optional(),
-      markInProgress: timeoutSchema.optional(),
+      // Per-method timeout in milliseconds. Must be a positive integer —
+      // zero, negative, and fractional values would either deadlock or
+      // misbehave inside setTimeout.
+      verify: z.number().int().positive().optional(),
+      fetch: z.number().int().positive().optional(),
+      resolveOne: z.number().int().positive().optional(),
+      markInProgress: z.number().int().positive().optional(),
     })
     .optional(),
   env: z.record(z.string(), z.string()).optional(),

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -1,5 +1,5 @@
 import { createBoard } from "./board.ts";
-import type { Issue, TicketSource } from "./ticketSource.ts";
+import type { Issue, ParentSkip, TicketSource } from "./ticketSource.ts";
 
 function fakeSource(name: string, overrides: Partial<TicketSource> = {}): TicketSource {
   return {
@@ -98,6 +98,30 @@ describe("Board.fetch", () => {
     const stamp = Date.parse(state.timestamp);
     expect(stamp).toBeGreaterThanOrEqual(before);
   });
+
+  it("calls fetchParentSkips() AFTER fetch() on each source so adapters that cache during fetch don't serve stale data", async () => {
+    // Mirrors the Linear adapter's pattern: fetch() populates a closure
+    // variable, fetchParentSkips() reads it. If the Board parallelized the
+    // two methods across all sources (instead of serializing per source),
+    // fetchParentSkips() would see the pre-fetch (empty) cache.
+    let cache: ParentSkip[] = [];
+    const board = createBoard([
+      fakeSource("a", {
+        fetch: vi.fn<() => Promise<Issue[]>>().mockImplementation(async () => {
+          await Promise.resolve();
+          cache = [{ id: "a:parent-1", title: "Parent A", childCount: 2 }];
+          return [];
+        }),
+        fetchParentSkips: vi
+          .fn<() => Promise<readonly ParentSkip[]>>()
+          .mockImplementation(async () => cache),
+      }),
+    ]);
+    const state = await board.fetch();
+    expect(state.parentSkips).toStrictEqual([
+      { id: "a:parent-1", title: "Parent A", childCount: 2 },
+    ]);
+  });
 });
 
 describe("Board.resolveOne", () => {
@@ -148,6 +172,38 @@ describe("Board.resolveOne", () => {
   it("throws when canonical id names an unknown source", async () => {
     const board = createBoard([fakeSource("a")]);
     await expect(board.resolveOne("nope:x")).rejects.toThrow(/unknown source.*nope/);
+  });
+
+  // Regression: pre-fix, a single source rejection on resolveOne poisoned
+  // the whole Promise.all and masked a sibling source's successful match.
+  // The real-world trigger was `crew doctor --ticket TEST-1`, where the
+  // Linear adapter throws "Entity not found" while the shell adapter has
+  // the ticket — the user saw "unresolvable: Entity not found" instead of
+  // the shell-resolved issue.
+  it("treats a source rejection as 'not found here' when another source matches", async () => {
+    const aResolve = vi
+      .fn<(id: string) => Promise<Issue | undefined>>()
+      .mockRejectedValue(new Error("Entity not found: Issue"));
+    const bResolve = vi
+      .fn<(id: string) => Promise<Issue | undefined>>()
+      .mockResolvedValue(fakeIssue("b:x", "b"));
+    const board = createBoard([
+      fakeSource("a", { resolveOne: aResolve }),
+      fakeSource("b", { resolveOne: bResolve }),
+    ]);
+    const result = await board.resolveOne("x");
+    expect(result?.id).toBe("b:x");
+  });
+
+  it("surfaces a source rejection when no other source matched", async () => {
+    const aResolve = vi
+      .fn<(id: string) => Promise<Issue | undefined>>()
+      .mockRejectedValue(new Error("Linear API: timeout"));
+    const board = createBoard([
+      fakeSource("a", { resolveOne: aResolve }),
+      fakeSource("b"), // resolves undefined by default
+    ]);
+    await expect(board.resolveOne("x")).rejects.toThrow(/Linear API: timeout/);
   });
 });
 

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -9,6 +9,7 @@ import {
   AmbiguousTicketError,
   type BoardState,
   type Issue,
+  type ParentSkip,
   type TicketSource,
 } from "./ticketSource.ts";
 
@@ -30,6 +31,13 @@ async function callVerify(source: TicketSource): Promise<void> {
 
 async function callFetch(source: TicketSource): Promise<Issue[]> {
   return await source.fetch();
+}
+
+async function callFetchParentSkips(source: TicketSource): Promise<readonly ParentSkip[]> {
+  if (source.fetchParentSkips !== undefined) {
+    return await source.fetchParentSkips();
+  }
+  return [];
 }
 
 async function callResolveOne(source: TicketSource, naturalId: string): Promise<Issue | undefined> {
@@ -65,8 +73,23 @@ export function createBoard(sources: readonly TicketSource[]): Board {
     },
 
     async fetch(): Promise<BoardState> {
-      const issuesPerSource = await Promise.all(sources.map(callFetch));
-      return { timestamp: new Date().toISOString(), issues: issuesPerSource.flat() };
+      // Per-source serialization: each source's callFetch must complete
+      // before its callFetchParentSkips so adapters that cache parent skips
+      // as a side effect of fetch() (e.g. Linear, which stores them on
+      // `lastParentSkips`) don't serve stale or empty data. Outer Promise.all
+      // keeps cross-source fan-out concurrent.
+      const perSource = await Promise.all(
+        sources.map(async (source) => {
+          const issues = await callFetch(source);
+          const parentSkips = await callFetchParentSkips(source);
+          return { issues, parentSkips };
+        }),
+      );
+      return {
+        timestamp: new Date().toISOString(),
+        issues: perSource.flatMap((entry) => entry.issues),
+        parentSkips: perSource.flatMap((entry) => entry.parentSkips),
+      };
     },
 
     async resolveOne(idArgument: string): Promise<Issue | undefined> {
@@ -80,11 +103,31 @@ export function createBoard(sources: readonly TicketSource[]): Board {
         }
         return await callResolveOne(source, naturalId);
       }
-      const results = await Promise.all(
+      // Per-source resolveOne errors must not poison sibling resolutions.
+      // A source that rejects on a natural-id lookup is treated as "I don't
+      // have this ticket" (or "I can't say"). If any source resolved we use
+      // it; only when none resolved AND at least one rejected do we surface
+      // the rejection — so the user sees a real Linear/network error when
+      // there's no fallback, but a stray "not found" from one source doesn't
+      // mask a successful match from another.
+      const results = await Promise.allSettled(
         sources.map(async (s) => await callResolveOne(s, idArgument)),
       );
-      const matches = results.filter((r): r is Issue => r !== undefined);
+      const matches: Issue[] = [];
+      const rejections: unknown[] = [];
+      for (const result of results) {
+        if (result.status === "rejected") {
+          rejections.push(result.reason);
+          continue;
+        }
+        if (result.value !== undefined) {
+          matches.push(result.value);
+        }
+      }
       if (matches.length === 0) {
+        if (rejections.length > 0) {
+          throw rejections[0];
+        }
         return undefined;
       }
       if (matches.length === 1) {

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -204,6 +204,18 @@ describe(sourcesFromConfig, () => {
     expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", name: "linear" }]);
   });
 
+  it("omits the implicit linear source when a Linear source is declared with a custom name", () => {
+    // A Linear source with a custom `name` is still Linear; prepending the
+    // implicit `{ kind: "linear" }` would spawn a duplicate adapter pointed at
+    // the same viewer (distinct names, so createBoard wouldn't catch it).
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "linear", name: "custom-linear" }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", name: "custom-linear" }]);
+  });
+
   it("omits the implicit linear source when the user declared one with name 'linear'", () => {
     // A user-declared shell source with name "linear" would otherwise collide
     // with the implicit Linear source; omit the implicit one.

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import type { AdapterContext, AdapterDefinition } from "./adapterDefinition.ts";
-import { buildSources, buildSourcesWith } from "./buildSources.ts";
+import { buildSources, buildSourcesWith, sourcesFromConfig } from "./buildSources.ts";
 import type { ResolvedConfig } from "./config.ts";
 import type { TicketSource } from "./ticketSource.ts";
+import { readEnvironmentVariable } from "./util.ts";
 
 const fakeContext: AdapterContext = {
   // Tests don't need a real ResolvedConfig — fakeAdapter ignores its context arg.
@@ -91,5 +93,139 @@ describe(buildSources, () => {
     // production async path through the registry.
     const sources = await buildSources([], fakeContext);
     expect(sources).toStrictEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Cross-source independence: a user with `linear.projects=[…]` and an
+// explicit `sources=[{kind:"shell"}]` block must be able to construct
+// both adapters even when no Linear API key is in env. The Linear
+// adapter's eager `getLinearClient()` call used to crash buildSources
+// on the missing key, which broke `crew doctor --ticket <shell-id>`
+// and any other shell-only operation. These tests pin that behavior
+// using the REAL production adapter registry (no spies, no fakes).
+// ─────────────────────────────────────────────────────────────────────────
+
+function makeMixedConfig(): ResolvedConfig {
+  // Minimal ResolvedConfig with an explicit shell source. The Linear adapter
+  // is synthesized implicitly by sourcesFromConfig under the post-#110 model
+  // (Linear is always-on, filtered server-side by viewer + agent-* label).
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; the linear adapter only reads workspace.knownRepositories
+  return {
+    sources: [
+      {
+        kind: "shell",
+        name: "shell-test",
+        commands: { fetch: "echo '[]'" },
+      },
+    ],
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+  } as unknown as ResolvedConfig;
+}
+
+describe(`${buildSources.name} — cross-source independence with no Linear API key`, () => {
+  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
+
+  beforeEach(() => {
+    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    deleteEnvironmentVariable("LINEAR_API_KEY");
+  });
+
+  afterEach(() => {
+    if (originalGroundcrewKey === undefined) {
+      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
+    }
+    if (originalLinearKey === undefined) {
+      deleteEnvironmentVariable("LINEAR_API_KEY");
+    } else {
+      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
+    }
+  });
+
+  it("constructs both Linear and shell sources without throwing", async () => {
+    const config = makeMixedConfig();
+
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+
+    expect(sources.map((s) => s.name)).toStrictEqual(["linear", "shell-test"]);
+  });
+
+  it("a shell source can fetch() successfully even when Linear has no API key", async () => {
+    const config = makeMixedConfig();
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+    const shell = sources.find((s) => s.name === "shell-test");
+
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- buildSources asserted both above
+    const issues = await shell!.fetch();
+
+    expect(issues).toStrictEqual([]);
+  });
+
+  it("the Linear source defers its credential check until a method is invoked", async () => {
+    const config = makeMixedConfig();
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+    const linear = sources.find((s) => s.name === "linear");
+
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- buildSources asserted above
+    await expect(linear!.verify()).rejects.toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
+  });
+});
+
+describe(sourcesFromConfig, () => {
+  it("prepends an implicit linear source by default", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "shell", command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    const result = sourcesFromConfig(config);
+
+    expect(result).toStrictEqual([{ kind: "linear" }, { kind: "shell", command: ["./fetch.sh"] }]);
+  });
+
+  it("returns just the implicit linear source when config.sources is empty", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = { sources: [] } as unknown as ResolvedConfig;
+
+    const result = sourcesFromConfig(config);
+
+    expect(result).toStrictEqual([{ kind: "linear" }]);
+  });
+
+  it("omits the implicit linear source when the user already declared one with kind 'linear'", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "linear", name: "linear" }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", name: "linear" }]);
+  });
+
+  it("omits the implicit linear source when the user declared one with name 'linear'", () => {
+    // A user-declared shell source with name "linear" would otherwise collide
+    // with the implicit Linear source; omit the implicit one.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "shell", name: "linear", command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([
+      { kind: "shell", name: "linear", command: ["./fetch.sh"] },
+    ]);
+  });
+
+  it("keeps the implicit linear source when explicit sources use distinct names", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "shell", name: "jira", command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([
+      { kind: "linear" },
+      { kind: "shell", name: "jira", command: ["./fetch.sh"] },
+    ]);
   });
 });

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 
 import type { AdapterContext, AdapterDefinition } from "./adapterDefinition.ts";
 import { adapterRegistry } from "./adapters/registry.ts";
+import type { ResolvedConfig } from "./config.ts";
 import type { TicketSource } from "./ticketSource.ts";
 
 const kindShape = z.object({ kind: z.string() });
@@ -47,4 +48,43 @@ export function buildSourcesWith(
     const config: unknown = adapter.configSchema.parse(raw);
     return adapter.create(config, context);
   });
+}
+
+/**
+ * Returns the runtime source name a `config.sources[]` entry would resolve
+ * to. Adapters default the name to their `kind` when `name` is omitted
+ * (see `createLinearTicketSource`'s `config.name ?? "linear"`); explicit
+ * `name` always wins. Returns `undefined` for malformed entries (no `kind`
+ * at all) — those get rejected by the Zod schema downstream.
+ */
+const effectiveSourceNameShape = z.looseObject({
+  name: z.string().optional(),
+  kind: z.string().optional(),
+});
+
+function effectiveSourceName(raw: unknown): string | undefined {
+  const parsed = effectiveSourceNameShape.safeParse(raw);
+  /* v8 ignore next 3 @preserve -- looseObject() with all-optional fields only fails to parse non-object inputs (null, primitives); the same input would be rejected by the per-adapter Zod schema in buildSourcesWith, so this guard never fires in practice. */
+  if (!parsed.success) {
+    return undefined;
+  }
+  return parsed.data.name ?? parsed.data.kind;
+}
+
+/**
+ * Build the runtime source list from a ResolvedConfig: synthesizes the
+ * implicit Linear source (Linear is always active under the post-#110
+ * model — viewer + agent-* label filtering happens at the GraphQL layer)
+ * and appends any user-declared `sources`. The implicit source is omitted
+ * when the user already declared one with runtime name "linear" so they
+ * can override its `name` / construction without colliding.
+ */
+export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
+  const hasExplicitLinear = config.sources.some(
+    (source) => effectiveSourceName(source) === "linear",
+  );
+  if (hasExplicitLinear) {
+    return [...config.sources];
+  }
+  return [{ kind: "linear" }, ...config.sources];
 }

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -50,25 +50,31 @@ export function buildSourcesWith(
   });
 }
 
-/**
- * Returns the runtime source name a `config.sources[]` entry would resolve
- * to. Adapters default the name to their `kind` when `name` is omitted
- * (see `createLinearTicketSource`'s `config.name ?? "linear"`); explicit
- * `name` always wins. Returns `undefined` for malformed entries (no `kind`
- * at all) — those get rejected by the Zod schema downstream.
- */
-const effectiveSourceNameShape = z.looseObject({
+const sourceShape = z.looseObject({
   name: z.string().optional(),
   kind: z.string().optional(),
 });
 
-function effectiveSourceName(raw: unknown): string | undefined {
-  const parsed = effectiveSourceNameShape.safeParse(raw);
+/**
+ * True when `raw` is an explicitly-declared Linear source. Matches either a
+ * `kind: "linear"` entry — regardless of any `name` override — or any entry
+ * whose resolved runtime name (explicit `name`, else `kind`) is "linear".
+ * The latter catches a non-Linear adapter the user named "linear", which
+ * would otherwise collide with the implicit Linear source.
+ *
+ * Used to suppress the synthesized implicit Linear source so a renamed Linear
+ * entry like `{ kind: "linear", name: "custom" }` doesn't spawn a duplicate
+ * adapter pointed at the same viewer. Returns false for malformed entries
+ * (no `kind`/`name`) — those get rejected by the per-adapter Zod schema
+ * downstream.
+ */
+function isExplicitLinearSource(raw: unknown): boolean {
+  const parsed = sourceShape.safeParse(raw);
   /* v8 ignore next 3 @preserve -- looseObject() with all-optional fields only fails to parse non-object inputs (null, primitives); the same input would be rejected by the per-adapter Zod schema in buildSourcesWith, so this guard never fires in practice. */
   if (!parsed.success) {
-    return undefined;
+    return false;
   }
-  return parsed.data.name ?? parsed.data.kind;
+  return parsed.data.kind === "linear" || (parsed.data.name ?? parsed.data.kind) === "linear";
 }
 
 /**
@@ -76,13 +82,12 @@ function effectiveSourceName(raw: unknown): string | undefined {
  * implicit Linear source (Linear is always active under the post-#110
  * model — viewer + agent-* label filtering happens at the GraphQL layer)
  * and appends any user-declared `sources`. The implicit source is omitted
- * when the user already declared one with runtime name "linear" so they
- * can override its `name` / construction without colliding.
+ * when the user already declared a Linear source (by `kind` or by runtime
+ * name "linear") so they can override its `name` / construction without
+ * spawning a duplicate adapter.
  */
 export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
-  const hasExplicitLinear = config.sources.some(
-    (source) => effectiveSourceName(source) === "linear",
-  );
+  const hasExplicitLinear = config.sources.some(isExplicitLinearSource);
   if (hasExplicitLinear) {
     return [...config.sources];
   }

--- a/src/lib/repositoryValidation.test.ts
+++ b/src/lib/repositoryValidation.test.ts
@@ -1,0 +1,64 @@
+import { canonicalLinearIssue } from "./testing/canonicalFixtures.ts";
+import { dispatchableRepository } from "./repositoryValidation.ts";
+
+describe(dispatchableRepository, () => {
+  it("returns the repository when it is in knownRepositories", () => {
+    const issue = canonicalLinearIssue({
+      naturalId: "team-1",
+      repository: "repo-a",
+      model: "claude",
+    });
+    const log = vi.fn<(message: string) => void>();
+
+    const result = dispatchableRepository(issue, ["repo-a", "repo-b"], log);
+
+    expect(result).toBe("repo-a");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined and logs a warning when the repository is not in knownRepositories", () => {
+    const issue = canonicalLinearIssue({
+      naturalId: "team-2",
+      repository: "unknown-repo",
+      model: "claude",
+    });
+    const log = vi.fn<(message: string) => void>();
+
+    const result = dispatchableRepository(issue, ["repo-a", "repo-b"], log);
+
+    expect(result).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      "issue linear:team-2 references unknown repository unknown-repo; configured workspace.knownRepositories: repo-a, repo-b",
+    );
+  });
+
+  it("returns undefined without logging when the issue has no repository", () => {
+    const issue = canonicalLinearIssue({
+      naturalId: "team-3",
+      repository: undefined,
+      model: undefined,
+    });
+    const log = vi.fn<(message: string) => void>();
+
+    const result = dispatchableRepository(issue, ["repo-a", "repo-b"], log);
+
+    expect(result).toBeUndefined();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("includes '(none)' in the warning when knownRepositories is empty", () => {
+    const issue = canonicalLinearIssue({
+      naturalId: "team-4",
+      repository: "some-repo",
+      model: "claude",
+    });
+    const log = vi.fn<(message: string) => void>();
+
+    const result = dispatchableRepository(issue, [], log);
+
+    expect(result).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      "issue linear:team-4 references unknown repository some-repo; configured workspace.knownRepositories: (none)",
+    );
+  });
+});

--- a/src/lib/repositoryValidation.ts
+++ b/src/lib/repositoryValidation.ts
@@ -1,0 +1,29 @@
+/**
+ * Host-level repository validation for canonical Issues. Adapters produce
+ * Issue.repository based on their own signal (Linear: agent-* label parse;
+ * shell: script JSON output). The host (dispatcher) decides whether that
+ * repository is configured for this crew via workspace.knownRepositories.
+ *
+ * WARN+skip on unknown repo is a deliberate behavior choice (P-refined in
+ * the MVP-2 plan): one badly-labelled ticket should not throw and abort
+ * the tick across N sources.
+ */
+
+import type { Issue } from "./ticketSource.ts";
+
+export function dispatchableRepository(
+  issue: Issue,
+  knownRepositories: readonly string[],
+  log: (message: string) => void,
+): string | undefined {
+  if (issue.repository === undefined) {
+    return undefined;
+  }
+  if (!knownRepositories.includes(issue.repository)) {
+    log(
+      `issue ${issue.id} references unknown repository ${issue.repository}; configured workspace.knownRepositories: ${knownRepositories.join(", ") || "(none)"}`,
+    );
+    return undefined;
+  }
+  return issue.repository;
+}

--- a/src/lib/testing/canonicalFixtures.test.ts
+++ b/src/lib/testing/canonicalFixtures.test.ts
@@ -1,0 +1,79 @@
+import {
+  canonicalBlocker,
+  canonicalLinearIssue,
+  canonicalShellIssue,
+} from "./canonicalFixtures.ts";
+
+describe(canonicalLinearIssue, () => {
+  it("produces a fully-populated canonical Issue with sensible defaults", () => {
+    const issue = canonicalLinearIssue({ naturalId: "eng-220" });
+    expect(issue.id).toBe("linear:eng-220");
+    expect(issue.source).toBe("linear");
+    expect(issue.status).toBe("todo");
+    expect(issue.description).toBe("");
+    expect(issue.repository).toBeUndefined();
+    expect(issue.blockers).toStrictEqual([]);
+  });
+
+  it("overrides apply correctly including nested sourceRef fields", () => {
+    const issue = canonicalLinearIssue({
+      naturalId: "eng-99",
+      status: "in-progress",
+      repository: "acme/web",
+      sourceRef: { uuid: "custom-uuid" } as unknown,
+    });
+    expect(issue.status).toBe("in-progress");
+    expect(issue.repository).toBe("acme/web");
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourceRef is opaque unknown in Issue; this test validates the fixture merges partial overrides
+    expect((issue.sourceRef as { uuid: string }).uuid).toBe("custom-uuid");
+  });
+
+  it("lowercases the natural id in the canonical id so fixtures match runtime construction", () => {
+    // Production `toCanonicalId` lowercases the natural part so Board lookups
+    // against lower-cased natural-id input always resolve regardless of source
+    // casing. Fixtures must follow the same rule or tests can pass against
+    // behavior the runtime doesn't actually have.
+    const issue = canonicalLinearIssue({ naturalId: "ENG-220" });
+    expect(issue.id).toBe("linear:eng-220");
+  });
+});
+
+describe(canonicalBlocker, () => {
+  it("produces a canonical Blocker with status default 'todo'", () => {
+    const blocker = canonicalBlocker({ naturalId: "eng-50" });
+    expect(blocker.id).toBe("linear:eng-50");
+    expect(blocker.status).toBe("todo");
+  });
+
+  it("lowercases the natural id in the canonical id so blocker fixtures match runtime construction", () => {
+    const blocker = canonicalBlocker({ naturalId: "ENG-50" });
+    expect(blocker.id).toBe("linear:eng-50");
+  });
+});
+
+describe(canonicalShellIssue, () => {
+  it("defaults source to 'shell-test' and lowercases the natural id in the canonical id", () => {
+    const issue = canonicalShellIssue({ naturalId: "TEST-1" });
+    expect(issue.id).toBe("shell-test:test-1");
+    expect(issue.source).toBe("shell-test");
+    expect(issue.sourceRef).toStrictEqual({});
+  });
+
+  it("respects a custom sourceName", () => {
+    const issue = canonicalShellIssue({ naturalId: "hrd-1", sourceName: "shell-jira" });
+    expect(issue.id).toBe("shell-jira:hrd-1");
+    expect(issue.source).toBe("shell-jira");
+  });
+
+  it("overrides apply correctly", () => {
+    const issue = canonicalShellIssue({
+      naturalId: "x-1",
+      status: "in-progress",
+      repository: "acme/web",
+      model: "claude",
+    });
+    expect(issue.status).toBe("in-progress");
+    expect(issue.repository).toBe("acme/web");
+    expect(issue.model).toBe("claude");
+  });
+});

--- a/src/lib/testing/canonicalFixtures.ts
+++ b/src/lib/testing/canonicalFixtures.ts
@@ -1,0 +1,68 @@
+import type { LinearSourceRef } from "../adapters/linear/index.ts";
+import { type Blocker, type Issue, toCanonicalId } from "../ticketSource.ts";
+
+export function canonicalLinearIssue(overrides: Partial<Issue> & { naturalId: string }): Issue {
+  const { naturalId, sourceRef: refOverride, ...rest } = overrides;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; sourceRef is opaque unknown in the Issue contract; we reinterpret it here only for fixture construction
+  const refPartial = (refOverride as Partial<LinearSourceRef> | undefined) ?? {};
+  const sourceRef: LinearSourceRef = {
+    uuid: refPartial.uuid ?? `uuid-${naturalId}`,
+    statusId: refPartial.statusId ?? "statusId-default",
+    teamId: refPartial.teamId ?? "team-default",
+    stateType: refPartial.stateType ?? "unstarted",
+    nativeStatus: refPartial.nativeStatus ?? "Todo",
+  };
+  return {
+    id: toCanonicalId("linear", naturalId),
+    source: "linear",
+    title: `Title for ${naturalId}`,
+    description: "",
+    status: "todo",
+    repository: undefined,
+    model: undefined,
+    assignee: "Unassigned",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    ...rest,
+    sourceRef,
+  };
+}
+
+export function canonicalBlocker(overrides: Partial<Blocker> & { naturalId: string }): Blocker {
+  const { naturalId, ...rest } = overrides;
+  return {
+    id: toCanonicalId("linear", naturalId),
+    title: `Title for ${naturalId}`,
+    status: "todo",
+    ...rest,
+  };
+}
+
+/**
+ * Canonical Issue fixture for a non-Linear source. Default source name is
+ * "shell-test"; override via `sourceName`. Mirrors `canonicalLinearIssue`'s
+ * defaults except `sourceRef` is an empty opaque object (no LinearSourceRef
+ * shape, since this is meant to stand in for any non-Linear adapter — the
+ * shell adapter, future Jira adapter, etc.).
+ */
+export function canonicalShellIssue(
+  overrides: Partial<Issue> & { naturalId: string; sourceName?: string },
+): Issue {
+  const { naturalId, sourceName = "shell-test", sourceRef, ...rest } = overrides;
+  return {
+    id: toCanonicalId(sourceName, naturalId),
+    source: sourceName,
+    title: `Title for ${naturalId}`,
+    description: "",
+    status: "todo",
+    repository: undefined,
+    model: undefined,
+    assignee: "Unassigned",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: sourceRef ?? {},
+    ...rest,
+  };
+}

--- a/src/lib/ticketSource.test.ts
+++ b/src/lib/ticketSource.test.ts
@@ -2,7 +2,9 @@ import {
   AmbiguousTicketError,
   isGroundcrewIssue,
   type Issue,
+  naturalIdFromCanonical,
   RepositoryResolutionError,
+  toCanonicalId,
 } from "./ticketSource.ts";
 
 function fakeIssue(overrides: Partial<Issue> = {}): Issue {
@@ -58,5 +60,36 @@ describe(AmbiguousTicketError, () => {
     expect(error.message).toContain('"x"');
     expect(error.message).toContain("linear:x");
     expect(error.message).toContain("shell-jira:x");
+  });
+});
+
+describe(naturalIdFromCanonical, () => {
+  it("strips the source prefix from a canonical id", () => {
+    expect(naturalIdFromCanonical("linear:eng-220")).toBe("eng-220");
+  });
+
+  it("handles ids with multiple colons by only stripping the first segment", () => {
+    expect(naturalIdFromCanonical("shell-jira:HRD-1:extra")).toBe("HRD-1:extra");
+  });
+});
+
+describe(toCanonicalId, () => {
+  it("prefixes a lowercased natural id with the source name", () => {
+    expect(toCanonicalId("linear", "ENG-220")).toBe("linear:eng-220");
+  });
+
+  it("lowercases the natural id even when the source name has uppercase letters", () => {
+    // Source names are kebab-case in config but should be applied verbatim;
+    // only the natural id is lowercased.
+    expect(toCanonicalId("Shell-Jira", "HRD-1")).toBe("Shell-Jira:hrd-1");
+  });
+
+  it("is a no-op on already-lowercased natural ids", () => {
+    expect(toCanonicalId("linear", "eng-220")).toBe("linear:eng-220");
+  });
+
+  it("round-trips with naturalIdFromCanonical when the natural id is already lowercase", () => {
+    const canonical = toCanonicalId("shell-test", "test-1");
+    expect(naturalIdFromCanonical(canonical)).toBe("test-1");
   });
 });

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -28,10 +28,34 @@ export interface Blocker {
   id: string;
   title: string;
   status: CanonicalStatus;
+  /**
+   * When `status === "other"`, adapters MUST set this to explain why
+   * they couldn't classify. Consumers (specifically `ticketDoctor`) render
+   * this verbatim to give users an actionable next step.
+   *
+   * - `"missing"`: the source returned no status for this blocker
+   *   (e.g., Linear had no state on the blocker; shell script omitted
+   *   the field).
+   * - `"unmapped"`: the source returned a status that isn't in the
+   *   source's known mapping (e.g., a Linear column not in
+   *   `linear.projects[*].statuses`, or an unrecognized shell value).
+   *
+   * MUST be undefined when `status !== "other"`.
+   */
+  statusReason?: "missing" | "unmapped";
+  /**
+   * Human-readable native status from the source, when available.
+   * Used for diagnostic display only — never branched on. Adapters SHOULD
+   * populate this when `statusReason === "unmapped"` so users can see
+   * which status name to add to their config; MAY populate for mapped
+   * statuses too if the source's native vocabulary differs usefully
+   * from `CanonicalStatus`.
+   */
+  nativeStatus?: string;
 }
 
 export interface Issue {
-  /** Canonical, source-prefixed id, e.g. "linear:eng-220" or "shell-jira:HRD-1". */
+  /** Canonical, source-prefixed id, e.g. "linear:eng-220" or "shell-jira:hrd-1". */
   id: string;
   /** Source name (the adapter's `name`, defaulting to its `kind`). */
   source: string;
@@ -57,9 +81,27 @@ export function isGroundcrewIssue(issue: Issue): issue is GroundcrewIssue {
   return issue.model !== undefined && issue.repository !== undefined;
 }
 
+/**
+ * A parent ticket that was dropped from the fetch result because it has
+ * sub-issues. Surfaced separately so the dispatcher can log WHY a
+ * Todo+labelled ticket wasn't picked up (PR #80 behavior).
+ */
+export interface ParentSkip {
+  /**
+   * Canonical, source-prefixed id, e.g. "linear:eng-220". Matches the form
+   * used by `Issue.id` so consumers can treat all ids uniformly and strip
+   * the prefix with `naturalIdFromCanonical` when displaying to operators.
+   */
+  id: string;
+  title: string;
+  childCount: number;
+}
+
 export interface BoardState {
   timestamp: string;
   issues: Issue[];
+  /** Parent tickets skipped because they have sub-issues. */
+  parentSkips: readonly ParentSkip[];
 }
 
 export interface TicketSource {
@@ -73,6 +115,14 @@ export interface TicketSource {
   resolveOne(naturalId: string): Promise<Issue | undefined>;
   /** Writeback. The adapter downcasts `issue.sourceRef` internally. */
   markInProgress(issue: Issue): Promise<void>;
+
+  /**
+   * Optional: return parent tickets that were excluded from `fetch()` because
+   * they have sub-issues. Board surfaces these so the dispatcher can log WHY
+   * a Todo+labelled ticket was skipped (PR #80 behavior). Adapters that
+   * don't distinguish parents simply omit this method; Board returns [].
+   */
+  fetchParentSkips?(): Promise<readonly ParentSkip[]>;
 }
 
 export class RepositoryResolutionError extends Error {
@@ -93,4 +143,37 @@ export class AmbiguousTicketError extends Error {
     );
     this.name = "AmbiguousTicketError";
   }
+}
+
+/**
+ * Build a canonical source-prefixed id from a source name and a natural
+ * (possibly mixed-case) id. Lower-cases the natural part so the same
+ * ticket always produces the same canonical id regardless of which code
+ * path or adapter constructed it.
+ *
+ * All adapters MUST use this helper when constructing canonical ids
+ * (rather than concatenating `${sourceName}:${naturalId}` inline) so
+ * that `Board.resolveOne` lookups against lower-cased natural-id input
+ * find the issue regardless of the casing the source emitted.
+ */
+export function toCanonicalId(sourceName: string, naturalId: string): string {
+  return `${sourceName}:${naturalId.toLowerCase()}`;
+}
+
+/**
+ * Strip the source prefix from a canonical id, yielding the natural id
+ * the producing adapter exposed. Use at consumer boundaries where you
+ * need to compare a canonical id against natural-id artifacts like
+ * `WorktreeEntry.ticket` or filesystem directory names.
+ *
+ * Canonical ids always carry a `<source>:` prefix; the no-colon branch
+ * is a defensive fallback that's unreachable in normal operation.
+ */
+export function naturalIdFromCanonical(id: string): string {
+  const colonIndex = id.indexOf(":");
+  /* v8 ignore next @preserve -- canonical ids always carry a source prefix; this branch is unreachable */
+  if (colonIndex === -1) {
+    return id;
+  }
+  return id.slice(colonIndex + 1);
 }

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -2,22 +2,8 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { LinearClient } from "@linear/sdk";
-
 import { captureConsoleError, captureConsoleLog } from "../testHelpers/consoleCapture.ts";
-import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
-import {
-  errorMessage,
-  getLinearClient,
-  lazyLinearClient,
-  log,
-  logEvent,
-  readEnvironmentVariable,
-  resolveLinearApiKey,
-  setLogFile,
-  sleep,
-  withLogOutputSuppressed,
-} from "./util.ts";
+import { errorMessage, log, logEvent, setLogFile, sleep, withLogOutputSuppressed } from "./util.ts";
 
 describe(sleep, () => {
   beforeEach(() => {
@@ -229,128 +215,6 @@ describe(setLogFile, () => {
     expect(readFileSync(path, "utf8")).toBe("event=first\n");
     consoleLog.restore();
     consoleError.restore();
-  });
-});
-
-describe("Linear API key resolution", () => {
-  const originalGroundcrewKey = readEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-  const originalLinearKey = readEnvironmentVariable("LINEAR_API_KEY");
-
-  beforeEach(() => {
-    deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-    deleteEnvironmentVariable("LINEAR_API_KEY");
-  });
-
-  afterEach(() => {
-    if (originalGroundcrewKey === undefined) {
-      deleteEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY");
-    } else {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", originalGroundcrewKey);
-    }
-    if (originalLinearKey === undefined) {
-      deleteEnvironmentVariable("LINEAR_API_KEY");
-    } else {
-      setEnvironmentVariable("LINEAR_API_KEY", originalLinearKey);
-    }
-  });
-
-  describe(resolveLinearApiKey, () => {
-    it("returns LINEAR_API_KEY as the source when only it is set", () => {
-      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
-
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
-    });
-
-    it("returns GROUNDCREW_LINEAR_API_KEY as the source when only it is set", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
-
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toStrictEqual({
-        value: "lin_api_groundcrew",
-        source: "GROUNDCREW_LINEAR_API_KEY",
-      });
-    });
-
-    it("prefers GROUNDCREW_LINEAR_API_KEY when both are set", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
-      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
-
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toStrictEqual({
-        value: "lin_api_groundcrew",
-        source: "GROUNDCREW_LINEAR_API_KEY",
-      });
-    });
-
-    it("falls back to LINEAR_API_KEY when GROUNDCREW_LINEAR_API_KEY is empty", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
-      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
-
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toStrictEqual({ value: "lin_api_legacy", source: "LINEAR_API_KEY" });
-    });
-
-    it("returns undefined when neither variable is set", () => {
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toBeUndefined();
-    });
-
-    it("returns undefined when both variables are empty", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
-      setEnvironmentVariable("LINEAR_API_KEY", "");
-
-      const actual = resolveLinearApiKey();
-
-      expect(actual).toBeUndefined();
-    });
-  });
-
-  describe(getLinearClient, () => {
-    it("returns a LinearClient when LINEAR_API_KEY is set", () => {
-      setEnvironmentVariable("LINEAR_API_KEY", "lin_api_legacy");
-
-      const actual = getLinearClient();
-
-      expect(actual).toBeInstanceOf(LinearClient);
-    });
-
-    it("returns a LinearClient when GROUNDCREW_LINEAR_API_KEY is set", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "lin_api_groundcrew");
-
-      const actual = getLinearClient();
-
-      expect(actual).toBeInstanceOf(LinearClient);
-    });
-
-    it("throws when neither variable is set", () => {
-      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
-    });
-
-    it("throws when both variables are empty", () => {
-      setEnvironmentVariable("GROUNDCREW_LINEAR_API_KEY", "");
-      setEnvironmentVariable("LINEAR_API_KEY", "");
-
-      expect(() => getLinearClient()).toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
-    });
-  });
-
-  describe(lazyLinearClient, () => {
-    it("defers and caches Linear client creation", () => {
-      const client = new LinearClient({ apiKey: "lin_api_test" });
-      const factory = vi.fn<() => LinearClient>(() => client);
-      const actual = lazyLinearClient(factory);
-
-      expect(factory).not.toHaveBeenCalled();
-      expect(actual()).toBe(client);
-      expect(actual()).toBe(client);
-      expect(factory).toHaveBeenCalledTimes(1);
-    });
   });
 });
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,8 +1,6 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
-import { LinearClient } from "@linear/sdk";
-
 export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted === true) {
     return;
@@ -110,53 +108,6 @@ export function logEvent(event: string, fields: Record<string, LogEventFieldValu
 export function readEnvironmentVariable(name: string): string | undefined {
   // oxlint-disable-next-line node/no-process-env -- Centralized environment accessor.
   return process.env[name];
-}
-
-const LINEAR_API_KEY_SOURCES = ["GROUNDCREW_LINEAR_API_KEY", "LINEAR_API_KEY"] as const;
-
-export type LinearApiKeySource = (typeof LINEAR_API_KEY_SOURCES)[number];
-
-export interface ResolvedLinearApiKey {
-  value: string;
-  source: LinearApiKeySource;
-}
-
-export function resolveLinearApiKey(): ResolvedLinearApiKey | undefined {
-  for (const source of LINEAR_API_KEY_SOURCES) {
-    const value = readEnvironmentVariable(source);
-    if (value !== undefined && value.length > 0) {
-      return { value, source };
-    }
-  }
-  return undefined;
-}
-
-export function getLinearClient(): LinearClient {
-  const resolved = resolveLinearApiKey();
-  if (resolved === undefined) {
-    throw new Error(
-      "Linear API key not set. Set GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY in your environment.",
-    );
-  }
-  return new LinearClient({ apiKey: resolved.value });
-}
-
-/**
- * Returns a zero-arg getter that lazily constructs (and caches) a Linear
- * client on first call. Used by CLI entry points that may not need the
- * client at all, so we avoid blowing up on a missing API key when no Linear
- * call is actually made. The factory is taken as a
- * parameter (rather than calling `getLinearClient` directly) so callers can
- * pass their own module-level import of `getLinearClient` — that binding
- * respects `vi.mock` intercepts, whereas an intra-module reference would
- * not.
- */
-export function lazyLinearClient(factory: () => LinearClient): () => LinearClient {
-  let client: LinearClient | undefined;
-  return () => {
-    client ??= factory();
-    return client;
-  };
 }
 
 /**

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -1,0 +1,15 @@
+import type { Board } from "../lib/board.ts";
+import type { BoardState } from "../lib/ticketSource.ts";
+
+export function makeBoard(overrides: Partial<Board> = {}): Board {
+  return {
+    verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    fetch: vi
+      .fn<() => Promise<BoardState>>()
+      .mockResolvedValue({ timestamp: "", issues: [], parentSkips: [] }),
+    // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
+    resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
+    markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What

Lands **PR #89** (Paul Baranowski's `feat(tickets): pluggable ticket system MVP-2 — consumer refactor`), rebased onto current `main` and trimmed per STAFF-1034. This is the unification spine of STAFF-1033: every consumer reads the canonical `Issue`/`Blocker` shape, the orchestrator dispatches across all configured Sources, and the Linear-flavored `boardSource` is gone.

Original work is authored by **@paulbaranowski**; this PR rebases, trims, and reconciles it against the post-v4 (#110) and read-only-status (#114/STAFF-1036) `main`.

## Changes

- **Consumers are canonical.** `dispatcher`, `cleaner`, `eligibility`, `setupWorkspace`, `doctor`, `orchestrator`, and `status` reference only the canonical `ticketSource` types. The orchestrator tick reads exclusively from `board.fetch()` (fanning across every configured Source, so a `shell` Source's todo tickets flow through dispatch with the same eligibility protections Linear gets), and writeback routes through `board.markInProgress(issue)`.
- **`boardSource.ts` and `linearIssueStatus.ts` deleted.** Linear internals now live under `src/lib/adapters/linear/`: `fetch.ts`, `parsing.ts`, `writeback.ts`, `client.ts` (which now owns `getLinearClient`), and `factory.ts`. Adds `repositoryValidation.ts` and canonical test infra (`canonicalFixtures`, `boardFixtures`).
- **`crew doctor` is source-agnostic and host-only.** The old Linear-only "api key + reachability" check is replaced by a `board.verify()` **source probe** that surfaces a misconfigured shell (or future Jira) source too. Doctor stays host-only — the per-ticket diagnostic was removed by STAFF-1036, so its alias (`doctor --ticket` → `status`) is unchanged.

## Reconciliation decisions (no human in the loop)

- **Dropped the ticketDoctor-only interface surface.** Because STAFF-1036 (#114) already gutted the ~1500-line `ticketDoctor`, #89's migration of it is dropped entirely, along with the interface it existed for: `TicketSource.refreshBlockers?`/`countInProgress?`, `Board.sources()`/`refreshBlockers()`/`countInProgress()`, the orphaned `fetchBlockersForTicket`-backed paths, and `ticketDoctor.boardIntegration.test.ts`. The canonical `TicketSource` interface stays lean (`verify`/`fetch`/`resolveOne`/`markInProgress`, plus optional `fetchParentSkips`). `parentSkips` is **kept** — the dispatcher still logs why a Todo+labelled parent ticket was skipped (PR #80 behavior).
- **Unknown-repo behavior: accepted the WARN-log + skip change.** An issue whose `repository` isn't in `workspace.knownRepositories` is now skipped with a warning rather than throwing and crashing the tick — the better multi-source behavior, applied uniformly across sources.
- **`status` migrated to the decomposed adapter.** `crew status`'s "Last Linear status" now imports `fetchRawLinearIssue` from `adapters/linear/fetch.ts` and `getLinearClient` from `adapters/linear/client.ts`. `RawLinearIssue.stateType` is now a required string (`""` for a stateless ticket), so the display renders an empty state as `unknown`.

## Verification

`node --run verify` passes; **100% coverage maintained** (2878/2878 lines).

## Continuation

To reattach to this workspace: `tmux attach -t groundcrew:staff-1034`

Closes staff-1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
