### PR TITLE
docs: reframe README from Linear-native to pluggable ticket sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  Dispatch your Linear backlog to AI coding agents. One git worktree per ticket, sandboxed by default.
+  Dispatch your ticket backlog to AI coding agents. One git worktree per ticket, sandboxed by default.
 </p>
 
 <p align="center">
@@ -46,9 +46,9 @@ In Progress (state.type=started) — Add retry logic to the sync job
 
 ## Why
 
-- **Linear-native.** Polls issues assigned to the API key's viewer with `agent-*` labels, honors blockers.
+- **Pluggable ticket sources.** Ships with a built-in Linear adapter (polls your API key viewer's `agent-*`-labeled issues, honors blockers); bring shell, Jira, or any source via `crew.config.ts`.
 - **One worktree per ticket.** Agents work in parallel without stepping on each other.
-- **Local-first sandboxing.** Safehouse on macOS, Docker Sandboxes on Linux, or an explicit `none` escape hatch.
+- **Local-first sandboxing.** Safehouse on macOS, Docker Sandboxes on Linux/WSL, or an explicit `none` escape hatch.
 - **Multi-agent.** Ships with `claude` and `codex`; bring your own CLI via `crew.config.ts`.
 
 ## Quickstart
@@ -225,7 +225,7 @@ Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKE
 
 ## Doctor
 
-`crew doctor` checks host prerequisites only: config validity, Linear reachability, required binaries on PATH, workspace backend availability, workspace.projectDir, local runner capability, and enabled model commands.
+`crew doctor` checks host prerequisites only: config validity, ticket-source reachability (every configured source's `verify()`, including the built-in Linear adapter), required binaries on PATH, workspace backend availability, workspace.projectDir, local runner capability, and enabled model commands.
 
 <details>
 <summary>Sample ticket status output</summary>


### PR DESCRIPTION
## Summary

For the OSS launch, the README read as a Linear-native, macOS-first tool. This reframes its *identity* to source-agnostic — pluggable ticket sources lead — while keeping Linear documented as the shipped default adapter (API-key setup, `agent-*` labels, `state.type` classification, and the literal CLI output all stay accurate).

Changes:
- Tagline: "Linear backlog" → "ticket backlog".
- "Why" lead bullet: "Linear-native" → "Pluggable ticket sources" (built-in Linear adapter named as the default; shell/Jira/any source via `crew.config.ts`).
- Doctor line: "Linear reachability" → "ticket-source reachability", matching `checkSourceProbe`'s now source-agnostic `verify()` fan-out across all configured sources (also a correctness fix).
- Minor: "Docker Sandboxes on Linux" → "Linux/WSL" to match the Runners table.

Mac-specific backends (Safehouse/clearance, cmux) were intentionally left intact — the README is already platform-balanced (sdx/tmux appear throughout, Runners table covers Linux/WSL), and there's a significant macOS user base.

Verified against the code that `crew status` and `crew resume` remain Linear-hardcoded, so the prose describing "latest Linear status" and "Linear resolution" is accurate and was kept rather than falsely generalized.

## Validation

- `node --run verify` — 908 tests passed, 100% coverage (statements/branches/functions/lines).

<!-- commit-push-pr:created v1 core@3.4.1 -->