### PR TITLE
[hrd-456] crew setup repos <new-repo> — add a repo to config and clone it

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ crew start <TICKET>                                      # provision + launch on
 crew stop <TICKET> [--reason <text>]                     # stop workspace, keep worktree
 crew resume <TICKET>                                     # reopen a paused ticket
 crew cleanup <TICKET>                                    # tear down every worktree for a ticket
-crew setup repos <OWNER/REPO>                            # add a repo to the config and clone it
+crew setup repos <OWNER/REPO | REPO>                     # add a repo to the config (clones when OWNER/ is given)
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,24 @@ crew start <TICKET>                                      # provision + launch on
 crew stop <TICKET> [--reason <text>]                     # stop workspace, keep worktree
 crew resume <TICKET>                                     # reopen a paused ticket
 crew cleanup <TICKET>                                    # tear down every worktree for a ticket
+crew setup repos <OWNER/REPO>                            # add a repo to the config and clone it
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 ```
 
+## Adding a repository
+
+`crew setup repos <OWNER/REPO>` adds the entry to `workspace.knownRepositories` in your crew config and clones the repo into `workspace.projectDir/<OWNER>/<REPO>` via `gh repo clone`. It is idempotent: re-running with an entry that is already in the config and already cloned reports no work.
+
+```bash
+crew setup repos ClipboardHealth/web
+crew setup repos ClipboardHealth/web --dry-run   # preview the config edit and clone
+```
+
+Bare-name entries (no `OWNER/`) are added to the config but not cloned, because the canonical remote URL is not derivable — clone those manually as below.
+
 ## Manual repository bootstrap
 
-Groundcrew never clones repositories for you. Clone each `workspace.knownRepositories` entry into `workspace.projectDir` using the same relative path the config uses. For an `OWNER/REPO` entry:
+`crew setup repos` is the one-shot path; the manual flow below still works when `gh` is unavailable or when you want a bare-name entry. Clone each `workspace.knownRepositories` entry into `workspace.projectDir` using the same relative path the config uses. For an `OWNER/REPO` entry:
 
 ```bash
 PROJECT_DIR="$HOME/dev/c"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,6 +9,7 @@ import { doctor } from "./commands/doctor.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { statusCli } from "./commands/status.ts";
 import {
@@ -38,6 +39,9 @@ vi.mock(import("./commands/orchestrator.ts"), () => ({
 vi.mock(import("./commands/resumeWorkspace.ts"), () => ({
   resumeWorkspaceCli: vi.fn<typeof resumeWorkspaceCli>(),
 }));
+vi.mock(import("./commands/setupRepos.ts"), () => ({
+  setupReposCli: vi.fn<typeof setupReposCli>(),
+}));
 vi.mock(import("./commands/setupWorkspace.ts"), () => ({
   setupWorkspaceCli: vi.fn<typeof setupWorkspaceCli>(),
 }));
@@ -54,6 +58,7 @@ const doctorMock = vi.mocked(doctor);
 const interruptMock = vi.mocked(interruptWorkspaceCli);
 const resumeMock = vi.mocked(resumeWorkspaceCli);
 const setupMock = vi.mocked(setupWorkspaceCli);
+const setupReposMock = vi.mocked(setupReposCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const statusMock = vi.mocked(statusCli);
 const upgradeCliMock = vi.mocked(upgradeCli);
@@ -113,6 +118,7 @@ describe(run, () => {
     interruptMock.mockResolvedValue();
     resumeMock.mockResolvedValue();
     setupMock.mockResolvedValue();
+    setupReposMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
     statusMock.mockResolvedValue();
     upgradeCliMock.mockResolvedValue();
@@ -424,37 +430,35 @@ describe(run, () => {
     expect(resumeMock).toHaveBeenCalledWith(["TEAM-1"]);
   });
 
-  it("hard-fails removed `setup repos` with a README-backed manual clone pointer", async () => {
+  it("dispatches `setup repos <new-repo>` to setupReposCli with the remaining argv", async () => {
+    await run(["setup", "repos", "owner/repo"]);
+
+    expect(setupReposMock).toHaveBeenCalledWith(["owner/repo"]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("forwards --dry-run to setupReposCli", async () => {
     await run(["setup", "repos", "--dry-run", "owner/repo"]);
 
-    expect(consoleError.output()).toContain("crew setup repos was removed");
-    expect(consoleError.output()).toContain("git clone");
-    expect(consoleError.output()).toContain("README.md#manual-repository-bootstrap");
-    expect(process.exitCode).toBe(1);
+    expect(setupReposMock).toHaveBeenCalledWith(["--dry-run", "owner/repo"]);
   });
 
-  it("hard-fails bare `setup repos` with the same replacement workflow", async () => {
-    await run(["setup", "repos"]);
-
-    expect(consoleError.output()).toContain("crew setup repos was removed");
-    expect(consoleError.output()).toContain("README.md#manual-repository-bootstrap");
-    expect(process.exitCode).toBe(1);
-  });
-
-  it("reports an unknown `setup` verb with the removed command usage", async () => {
+  it("reports an unknown `setup` verb with the setup usage", async () => {
     await run(["setup", "bogus"]);
 
     expect(consoleError.output()).toContain("Usage: crew setup repos");
-    expect(consoleError.output()).toContain("README.md#manual-repository-bootstrap");
+    expect(consoleError.output()).toContain("<new-repo>");
     expect(process.exitCode).toBe(1);
+    expect(setupReposMock).not.toHaveBeenCalled();
   });
 
   it("prints the setup usage when no verb is given", async () => {
     await run(["setup"]);
 
     expect(consoleError.output()).toContain("Usage: crew setup repos");
-    expect(consoleError.output()).toContain("README.md#manual-repository-bootstrap");
+    expect(consoleError.output()).toContain("<new-repo>");
     expect(process.exitCode).toBe(1);
+    expect(setupReposMock).not.toHaveBeenCalled();
   });
 
   it("prints the error message and sets exit code 1 when a subcommand throws", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { initConfigCli } from "./commands/init.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
+import { setupReposCli } from "./commands/setupRepos.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { statusCli } from "./commands/status.ts";
 import { createDefaultUpgradeCliOptions, upgradeCli } from "./commands/upgrade.ts";
@@ -39,11 +40,7 @@ interface Subcommand {
 
 const requireFromCli = createRequire(import.meta.url);
 
-const SETUP_REPOS_REMOVED_MESSAGE = [
-  "crew setup repos was removed.",
-  "Clone repositories manually with git clone into workspace.projectDir.",
-  "See README.md#manual-repository-bootstrap for the replacement workflow.",
-].join(" ");
+const SETUP_USAGE = "crew setup repos [--dry-run] <new-repo>";
 
 /**
  * Prints a deprecation warning to stderr naming the canonical command and that
@@ -55,16 +52,13 @@ function warnDeprecated(forms: { oldForm: string; newForm: string }): void {
   );
 }
 
-function setupUsage(): string {
-  return `Usage: crew setup repos\n\n${SETUP_REPOS_REMOVED_MESSAGE}`;
-}
-
 async function setupCli(argv: string[]): Promise<void> {
-  const [verb] = argv;
+  const [verb, ...rest] = argv;
   if (verb === "repos") {
-    throw new Error(SETUP_REPOS_REMOVED_MESSAGE);
+    await setupReposCli(rest);
+    return;
   }
-  throw new Error(setupUsage());
+  throw new Error(`Usage: ${SETUP_USAGE}`);
 }
 
 async function runCli(argv: string[]): Promise<void> {
@@ -201,9 +195,8 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: resumeWorkspaceCli,
   },
   setup: {
-    summary: "Removed repository bootstrap command",
-    usage: "repos",
-    hidden: true,
+    summary: "Add a repository to workspace.knownRepositories and clone it",
+    usage: "repos [--dry-run] <new-repo>",
     invoke: setupCli,
   },
   upgrade: {

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -212,6 +212,24 @@ knownRepositories: ["a/b"]
     expect(actual.text).toBe(`knownRepositories: [\r\n  "a/b",\r\n  "c/d",\r\n  "e/f",\r\n]`);
   });
 
+  it("keeps positions aligned when a nearby comment contains an astral character (emoji)", () => {
+    // Astral characters (4-byte UTF-8 / surrogate-pair UTF-16) inside a
+    // masked region must not shrink the masked string's code-unit length —
+    // otherwise the `match.indices` returned by the regex would slice the
+    // wrong bytes from the original text. The fishing-pole emoji ('🎣') is a
+    // surrogate-pair character (two UTF-16 code units).
+    const input = `// 🎣 known repos live here
+knownRepositories: ["a/b"]
+`;
+
+    const actual = addRepositoryToConfigText(input, "new/repo");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toBe(
+      `// 🎣 known repos live here\nknownRepositories: ["a/b", "new/repo"]\n`,
+    );
+  });
+
   it("does not misinterpret backslash-escape sequences in surrounding strings", () => {
     // The Windows-style path contains backslash-escape sequences (`\\U`, `\\m`)
     // that the masker must consume without exiting the string state — otherwise

--- a/src/commands/setupRepos.test.ts
+++ b/src/commands/setupRepos.test.ts
@@ -1,0 +1,523 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type { RunCommandOptions } from "../lib/commandRunner.ts";
+import { findConfigFilepath, loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { addRepositoryToConfigText, setupRepos, setupReposCli } from "./setupRepos.ts";
+
+type RunCommandMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => string;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandMock>());
+
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test mock intentionally shares one recorder across sync and async command APIs.
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+vi.mock(import("../lib/host.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, which: vi.fn<typeof actual.which>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    loadConfig: vi.fn<typeof loadConfig>(),
+    findConfigFilepath: vi.fn<typeof findConfigFilepath>(),
+  };
+});
+
+const whichMock = vi.mocked(which);
+const loadConfigMock = vi.mocked(loadConfig);
+const findConfigFilepathMock = vi.mocked(findConfigFilepath);
+
+function makeConfig(overrides: {
+  projectDir: string;
+  knownRepositories: string[];
+}): ResolvedConfig {
+  return {
+    sources: [],
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: overrides.projectDir,
+      knownRepositories: overrides.knownRepositories,
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+describe(addRepositoryToConfigText, () => {
+  it("appends a new entry to a single-line array", () => {
+    const input = `export default {
+  workspace: {
+    projectDir: "~/dev",
+    knownRepositories: ["a/b"],
+  },
+};
+`;
+    const actual = addRepositoryToConfigText(input, "c/d");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`knownRepositories: ["a/b", "c/d"]`);
+  });
+
+  it("returns alreadyPresent: true when the entry exists (single-line)", () => {
+    const input = `knownRepositories: ["a/b", "c/d"]`;
+
+    const actual = addRepositoryToConfigText(input, "c/d");
+
+    expect(actual.alreadyPresent).toBe(true);
+    expect(actual.text).toBe(input);
+  });
+
+  it("appends to a multi-line array preserving indentation", () => {
+    const input = `export default {
+  workspace: {
+    projectDir: "~/dev",
+    knownRepositories: [
+      "a/b",
+      "c/d",
+    ],
+  },
+};
+`;
+    const actual = addRepositoryToConfigText(input, "e/f");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`      "a/b",\n      "c/d",\n      "e/f",\n    ],`);
+  });
+
+  it("adds a trailing comma when the multi-line array lacked one", () => {
+    const input = `knownRepositories: [
+  "a/b",
+  "c/d"
+]`;
+    const actual = addRepositoryToConfigText(input, "e/f");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`"c/d",\n  "e/f",\n]`);
+  });
+
+  it("treats the array as empty when written as []", () => {
+    const input = `knownRepositories: []`;
+
+    const actual = addRepositoryToConfigText(input, "new/repo");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toBe(`knownRepositories: ["new/repo"]`);
+  });
+
+  it("handles single-quoted entries (detects existing values)", () => {
+    const input = `knownRepositories: ['a/b']`;
+
+    const actual = addRepositoryToConfigText(input, "a/b");
+
+    expect(actual.alreadyPresent).toBe(true);
+  });
+
+  it("throws when the knownRepositories key cannot be located", () => {
+    const input = `export default { workspace: { projectDir: "~/dev" } };`;
+
+    expect(() => addRepositoryToConfigText(input, "new/repo")).toThrow(
+      /Could not locate.*knownRepositories/,
+    );
+  });
+
+  it("ignores a JSDoc occurrence and edits the real declaration", () => {
+    const input = `/**
+ * Example: workspace: { knownRepositories: ["foo/bar"] }
+ */
+export default {
+  workspace: {
+    knownRepositories: ["a/b"],
+  },
+};
+`;
+    const actual = addRepositoryToConfigText(input, "new/repo");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`knownRepositories: ["foo/bar"]`); // comment untouched
+    expect(actual.text).toContain(`knownRepositories: ["a/b", "new/repo"]`); // real edit
+  });
+
+  it("ignores a line-comment occurrence and edits the real declaration", () => {
+    const input = `// Old config: knownRepositories: ["x/y"]
+knownRepositories: ["a/b"]
+`;
+    const actual = addRepositoryToConfigText(input, "new/repo");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toBe(
+      `// Old config: knownRepositories: ["x/y"]\nknownRepositories: ["a/b", "new/repo"]\n`,
+    );
+  });
+
+  it("treats a commented-out entry inside the array as absent (does not double-add)", () => {
+    const input = `knownRepositories: [
+  "a/b",
+  // "c/d", disabled for now
+]`;
+    const actual = addRepositoryToConfigText(input, "c/d");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`"a/b",\n  // "c/d", disabled for now\n  "c/d",\n]`);
+  });
+
+  it("preserves an entry whose string content contains a literal ]", () => {
+    const input = `knownRepositories: ["weird]name", "a/b"]`;
+
+    const actual = addRepositoryToConfigText(input, "new/repo");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toBe(`knownRepositories: ["weird]name", "a/b", "new/repo"]`);
+  });
+
+  it("throws when an entry is written as a template literal (cannot safely rewrite)", () => {
+    const input = "knownRepositories: [`a/b`]";
+
+    expect(() => addRepositoryToConfigText(input, "new/repo")).toThrow(
+      /template-literal.*Add.*by hand/i,
+    );
+  });
+
+  it("handles CRLF line endings in a multi-line array and preserves CRLF on the inserted line", () => {
+    const input = `knownRepositories: [\r\n  "a/b",\r\n  "c/d",\r\n]`;
+
+    const actual = addRepositoryToConfigText(input, "e/f");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toBe(`knownRepositories: [\r\n  "a/b",\r\n  "c/d",\r\n  "e/f",\r\n]`);
+  });
+
+  it("does not misinterpret backslash-escape sequences in surrounding strings", () => {
+    // The Windows-style path contains backslash-escape sequences (`\\U`, `\\m`)
+    // that the masker must consume without exiting the string state — otherwise
+    // a stray `"` inside the masked output could shift the `knownRepositories`
+    // match.
+    const input = `export default {
+  workspace: {
+    projectDir: "C:\\\\Users\\\\me\\\\dev",
+    knownRepositories: ["a/b"],
+  },
+};`;
+
+    const actual = addRepositoryToConfigText(input, "c/d");
+
+    expect(actual.alreadyPresent).toBe(false);
+    expect(actual.text).toContain(`knownRepositories: ["a/b", "c/d"]`);
+    expect(actual.text).toContain(`projectDir: "C:\\\\Users\\\\me\\\\dev"`);
+  });
+});
+
+describe(setupRepos, () => {
+  let projectDir: string;
+  let configFilepath: string;
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-"));
+    configFilepath = join(projectDir, "crew.config.ts");
+    writeFileSync(
+      configFilepath,
+      `export default {
+  workspace: {
+    projectDir: "${projectDir}",
+    knownRepositories: ["existing/repo"],
+  },
+};
+`,
+    );
+    consoleLog = captureConsoleLog();
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("adds the repository to config and clones via gh repo clone", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new/repo" });
+
+    expect(actual.configChange).toBe("added");
+    expect(actual.cloneChange).toBe("cloned");
+    expect(readFileSync(configFilepath, "utf8")).toContain(
+      `knownRepositories: ["existing/repo", "new/repo"]`,
+    );
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "new/repo", join(projectDir, "new/repo")],
+      expect.objectContaining({ stdio: "inherit", timeoutMs: 0 }),
+    );
+  });
+
+  it("creates the owner parent directory before cloning", async () => {
+    runCommandMock.mockImplementationOnce((_command, arguments_) => {
+      const { 3: target = "" } = arguments_;
+      expect(existsSync(dirname(target))).toBe(true);
+      return "";
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    await setupRepos(config, configFilepath, { repository: "owner/repo" });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips config edit when the repo is already in knownRepositories", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+    const originalText = readFileSync(configFilepath, "utf8");
+
+    const actual = await setupRepos(config, configFilepath, { repository: "existing/repo" });
+
+    expect(actual.configChange).toBe("already-present");
+    expect(readFileSync(configFilepath, "utf8")).toBe(originalText);
+  });
+
+  it("skips clone when the target already exists as a directory (already cloned)", async () => {
+    mkdirSync(join(projectDir, "new/repo", ".git"), { recursive: true });
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new/repo" });
+
+    expect(actual.cloneChange).toBe("already-cloned");
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("skips clone for bare-name entries (no owner/) but still updates config", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "bare" });
+
+    expect(actual.configChange).toBe("added");
+    expect(actual.cloneChange).toBe("skipped-bare-name");
+    expect(readFileSync(configFilepath, "utf8")).toContain(`"bare"`);
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toMatch(/bare name.*owner.*prefix/i);
+  });
+
+  it("reports gh-missing when the gh CLI is not on PATH", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the gh-missing branch
+    whichMock.mockResolvedValue(undefined);
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new/repo" });
+
+    expect(actual.configChange).toBe("added");
+    expect(actual.cloneChange).toBe("gh-missing");
+    expect(runCommandMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toMatch(/gh CLI not found/);
+  });
+
+  it("reports a failed clone without throwing", async () => {
+    runCommandMock.mockImplementationOnce(() => {
+      throw new Error("clone failed");
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new/repo" });
+
+    expect(actual.cloneChange).toBe("failed");
+    expect(actual.cloneError?.message).toBe("clone failed");
+  });
+
+  it("wraps a non-Error thrown value from the clone subprocess", async () => {
+    runCommandMock.mockImplementationOnce(() => {
+      // oxlint-disable-next-line no-throw-literal,typescript/only-throw-error -- exercising the non-Error throw branch
+      throw "raw string failure";
+    });
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new/repo" });
+
+    expect(actual.cloneChange).toBe("failed");
+    expect(actual.cloneError?.message).toBe("raw string failure");
+  });
+
+  it("rejects an empty repository identifier", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    await expect(setupRepos(config, configFilepath, { repository: "" })).rejects.toThrow(
+      /non-empty/i,
+    );
+  });
+
+  it("rejects a repository with empty segments (e.g. owner/)", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    await expect(setupRepos(config, configFilepath, { repository: "owner/" })).rejects.toThrow(
+      /Invalid repository/,
+    );
+  });
+
+  it("rejects a repository with too many slash segments", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    await expect(setupRepos(config, configFilepath, { repository: "a/b/c" })).rejects.toThrow(
+      /Invalid repository/,
+    );
+  });
+
+  it("rejects a repository whose target resolves outside projectDir", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    await expect(setupRepos(config, configFilepath, { repository: "../escape" })).rejects.toThrow(
+      /outside workspace.projectDir/,
+    );
+  });
+
+  it("does not edit the config or clone under --dry-run", async () => {
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+    const originalText = readFileSync(configFilepath, "utf8");
+
+    const actual = await setupRepos(config, configFilepath, {
+      repository: "new/repo",
+      dryRun: true,
+    });
+
+    expect(actual.configChange).toBe("would-add");
+    expect(actual.cloneChange).toBe("would-clone");
+    expect(readFileSync(configFilepath, "utf8")).toBe(originalText);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("reports already-present + would-clone under --dry-run after a crashed first run", async () => {
+    // Simulates the recovery state: config edit was already written by a
+    // prior invocation, but the clone never ran (target dir missing).
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, {
+      repository: "existing/repo",
+      dryRun: true,
+    });
+
+    expect(actual.configChange).toBe("already-present");
+    expect(actual.cloneChange).toBe("would-clone");
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("reports skipped-target-not-directory when the target is a file", async () => {
+    writeFileSync(join(projectDir, "new"), "not a directory");
+    const config = makeConfig({ projectDir, knownRepositories: ["existing/repo"] });
+
+    const actual = await setupRepos(config, configFilepath, { repository: "new" });
+
+    expect(actual.cloneChange).toBe("skipped-target-not-directory");
+  });
+});
+
+describe(setupReposCli, () => {
+  let projectDir: string;
+  let configFilepath: string;
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "groundcrew-setup-repos-cli-"));
+    configFilepath = join(projectDir, "crew.config.ts");
+    writeFileSync(
+      configFilepath,
+      `export default {
+  workspace: {
+    projectDir: "${projectDir}",
+    knownRepositories: ["existing/repo"],
+  },
+};
+`,
+    );
+    consoleLog = captureConsoleLog();
+    process.exitCode = undefined;
+    whichMock.mockResolvedValue("/usr/local/bin/gh");
+    runCommandMock.mockReturnValue("");
+    loadConfigMock.mockResolvedValue(
+      makeConfig({ projectDir, knownRepositories: ["existing/repo"] }),
+    );
+    findConfigFilepathMock.mockResolvedValue(configFilepath);
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    process.exitCode = undefined;
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("rejects when no <new-repo> positional is given", async () => {
+    await expect(setupReposCli([])).rejects.toThrow(/Usage: crew setup repos/);
+  });
+
+  it("rejects when more than one positional is given", async () => {
+    await expect(setupReposCli(["a/b", "c/d"])).rejects.toThrow(/Usage: crew setup repos/);
+  });
+
+  it("clones a single repo through the full pipeline", async () => {
+    await setupReposCli(["new/repo"]);
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(findConfigFilepathMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "clone", "new/repo", join(projectDir, "new/repo")],
+      expect.objectContaining({ stdio: "inherit", timeoutMs: 0 }),
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("sets exit code 1 when gh is missing", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the gh-missing branch
+    whichMock.mockResolvedValue(undefined);
+
+    await setupReposCli(["new/repo"]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets exit code 1 when the entry is bare (manual clone required)", async () => {
+    await setupReposCli(["bare"]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not set exit code 1 when the repo is already in config and cloned", async () => {
+    mkdirSync(join(projectDir, "existing/repo", ".git"), { recursive: true });
+
+    await setupReposCli(["existing/repo"]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("forwards --dry-run through to setupRepos", async () => {
+    const originalText = readFileSync(configFilepath, "utf8");
+
+    await setupReposCli(["--dry-run", "new/repo"]);
+
+    expect(readFileSync(configFilepath, "utf8")).toBe(originalText);
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -1,0 +1,432 @@
+/**
+ * `crew setup repos <new-repo>` — add a single repository to the user's
+ * `workspace.knownRepositories` array and initialize it by cloning into
+ * `workspace.projectDir`. Idempotent: re-running with an already-known and
+ * already-cloned repo reports no work. Bare-name entries are added to the
+ * config but not cloned, because the canonical remote URL is unknowable
+ * without involving the user's `gh` login.
+ */
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+
+import { runCommandAsync } from "../lib/commandRunner.ts";
+import { findConfigFilepath, loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { which } from "../lib/host.ts";
+import { errorMessage, log, parseDryRunPositionals, writeOutput } from "../lib/util.ts";
+
+export interface SetupReposOptions {
+  /** Repository identifier. Either `<owner>/<repo>` or bare `<name>`. */
+  repository: string;
+  /** Print the plan without touching the config file or running clone. */
+  dryRun?: boolean;
+}
+
+export type SetupReposConfigChange = "added" | "already-present" | "would-add";
+
+export type SetupReposCloneChange =
+  | "cloned"
+  | "would-clone"
+  | "already-cloned"
+  | "skipped-bare-name"
+  | "skipped-target-not-directory"
+  | "gh-missing"
+  | "failed";
+
+export interface SetupReposResult {
+  repository: string;
+  /** Absolute path the repo should live at under `projectDir`. */
+  target: string;
+  configChange: SetupReposConfigChange;
+  cloneChange: SetupReposCloneChange;
+  /** Set only when `cloneChange === "failed"`. */
+  cloneError?: Error;
+}
+
+const KNOWN_REPOSITORIES_RE =
+  /(?:["']knownRepositories["']|knownRepositories)\s*:\s*\[([\s\S]*?)\]/d;
+const QUOTED_STRING_RE = /(['"])([\s\S]*?)\1/dg;
+const ENTRY_INDENT_RE = /^([ \t]+)["']/;
+
+interface ParsedEntry {
+  value: string;
+}
+
+/**
+ * Replaces string contents and comment contents in `text` with placeholder
+ * characters of the same length, preserving structural characters (brackets,
+ * commas, the boundary quote/comment markers themselves). This lets a
+ * structure-only regex on the masked text find the real `knownRepositories`
+ * array without being misled by:
+ *
+ * - JSDoc or `//` comments that mention `knownRepositories: [...]` as an
+ *   example (otherwise the regex picks the first textual match, not the
+ *   real declaration);
+ * - string entries that contain a literal `]` (otherwise the non-greedy
+ *   body match terminates inside the string).
+ *
+ * The masked text has identical length and identical newline placement, so
+ * positions returned by the regex map 1:1 back to the original text.
+ */
+type ScanState = "code" | "line-comment" | "block-comment" | "str-sq" | "str-dq" | "str-bt";
+
+const STRING_CLOSE_CHARS: Record<"str-sq" | "str-dq" | "str-bt", string> = {
+  "str-sq": "'",
+  "str-dq": '"',
+  "str-bt": "`",
+};
+
+function maskNonCode(text: string): string {
+  // Spread iterates by code point, which would re-encode surrogate pairs;
+  // for our purpose we only inspect ASCII syntax characters and `.join("")`
+  // re-emits the original code units, so any non-ASCII content round-trips
+  // unchanged through the array.
+  // oxlint-disable-next-line typescript/no-misused-spread -- structural-only scan; we don't care about non-ASCII grapheme integrity
+  const chars = [...text];
+  let state: ScanState = "code";
+  let index = 0;
+  while (index < chars.length) {
+    const ch = chars[index];
+    const next = chars[index + 1];
+    if (state === "code") {
+      if (ch === "/" && next === "/") {
+        chars[index] = " ";
+        chars[index + 1] = " ";
+        state = "line-comment";
+        index += 2;
+        continue;
+      }
+      if (ch === "/" && next === "*") {
+        chars[index] = " ";
+        chars[index + 1] = " ";
+        state = "block-comment";
+        index += 2;
+        continue;
+      }
+      if (ch === "'") {
+        state = "str-sq";
+      } else if (ch === '"') {
+        state = "str-dq";
+      } else if (ch === "`") {
+        state = "str-bt";
+      }
+      index += 1;
+      continue;
+    }
+    if (state === "line-comment") {
+      if (ch === "\n") {
+        state = "code";
+      } else {
+        chars[index] = " ";
+      }
+      index += 1;
+      continue;
+    }
+    if (state === "block-comment") {
+      if (ch === "*" && next === "/") {
+        chars[index] = " ";
+        chars[index + 1] = " ";
+        state = "code";
+        index += 2;
+        continue;
+      }
+      if (ch !== "\n") {
+        chars[index] = " ";
+      }
+      index += 1;
+      continue;
+    }
+    // String states: str-sq | str-dq | str-bt
+    if (ch === "\\") {
+      chars[index] = "_";
+      /* v8 ignore next 3 @preserve -- guards against `\` as the final code unit of the input, which a well-formed config file cannot produce */
+      if (index + 1 < chars.length) {
+        chars[index + 1] = "_";
+      }
+      index += 2;
+      continue;
+    }
+    const closeChar = STRING_CLOSE_CHARS[state];
+    if (ch === closeChar) {
+      state = "code";
+    } else {
+      chars[index] = "_";
+    }
+    index += 1;
+  }
+  return chars.join("");
+}
+
+function detectEntryIndent(body: string): string {
+  const lines = body.split("\n");
+  let indent = "  ";
+  for (const line of lines) {
+    const indentMatch = ENTRY_INDENT_RE.exec(line);
+    const captured = indentMatch?.[1];
+    if (captured !== undefined) {
+      indent = captured;
+    }
+  }
+  return indent;
+}
+
+function buildSingleLineBody(existing: ParsedEntry[], repository: string): string {
+  const allValues = [...existing.map((entry) => entry.value), repository];
+  return allValues.map((value) => `"${value}"`).join(", ");
+}
+
+function buildMultiLineBody(body: string, bodyMasked: string, repository: string): string {
+  const indent = detectEntryIndent(body);
+  // Match the existing line ending so a CRLF-formatted file stays CRLF, and
+  // split on the WHOLE terminator so the insertion lands between the last
+  // entry line and the closing bracket without orphaning a `\r`.
+  const lineEnding = body.includes("\r\n") ? "\r\n" : "\n";
+  const lastLineEndingIndex = body.lastIndexOf(lineEnding);
+  const beforeClosing = body.slice(0, lastLineEndingIndex);
+  const afterLastNewline = body.slice(lastLineEndingIndex);
+  // Decide whether the last code-level character before the closing bracket
+  // already terminates an entry with `,`. Inspect the masked text (comments
+  // and string interiors blanked out) so a trailing `,` inside a comment
+  // doesn't fool the check, and the new entry isn't appended after a
+  // commented-out line as if it were inside the comment.
+  const trimmedBeforeMasked = bodyMasked.slice(0, lastLineEndingIndex).trim();
+  const needsLeadingComma = trimmedBeforeMasked.length > 0 && !trimmedBeforeMasked.endsWith(",");
+  const leadingComma = needsLeadingComma ? "," : "";
+  return `${beforeClosing}${leadingComma}${lineEnding}${indent}"${repository}",${afterLastNewline}`;
+}
+
+/**
+ * Scans `bodyMasked` for quoted-string boundaries (every `'`/`"` in the
+ * masked text is necessarily a real string delimiter, never a character
+ * inside another string or comment) and returns the corresponding raw
+ * entries from `bodyOriginal` by slicing at the matched positions.
+ */
+function parseExistingEntries(bodyMasked: string, bodyOriginal: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  for (const match of bodyMasked.matchAll(QUOTED_STRING_RE)) {
+    const indices = match.indices?.[2];
+    /* v8 ignore next 3 @preserve -- QUOTED_STRING_RE has the `/d` flag and always exposes capture-group 2 indices on a successful match */
+    if (indices === undefined) {
+      continue;
+    }
+    entries.push({ value: bodyOriginal.slice(indices[0], indices[1]) });
+  }
+  return entries;
+}
+
+/**
+ * Inserts `repository` into the `workspace.knownRepositories: [...]` array
+ * literal of a TypeScript or JavaScript config file. Returns the new text and
+ * whether the entry was already present (in which case `text` is unchanged).
+ * Preserves single-line vs multi-line shape and existing indentation; new
+ * entries are emitted with double quotes (matching the shipped example).
+ *
+ * Locates the array via a comment-/string-aware mask of the original text so
+ * a JSDoc example like `// knownRepositories: ["foo/bar"]` cannot trick the
+ * editor into corrupting a comment, and so a literal `]` inside an existing
+ * entry cannot truncate the matched body.
+ *
+ * Throws when:
+ * - the `knownRepositories` key cannot be located in code (only-in-comment
+ *   occurrences do not count);
+ * - any entry is written as a template literal (backticks), which the
+ *   double-quoted entry writer cannot safely round-trip.
+ */
+export function addRepositoryToConfigText(
+  text: string,
+  repository: string,
+): { text: string; alreadyPresent: boolean } {
+  const masked = maskNonCode(text);
+  const match = KNOWN_REPOSITORIES_RE.exec(masked);
+  if (match === null) {
+    throw new Error(
+      `Could not locate \`workspace.knownRepositories\` array in config file. Add "${repository}" to the array by hand.`,
+    );
+  }
+  const bodyIndices = match.indices?.[1];
+  /* v8 ignore next 5 @preserve -- KNOWN_REPOSITORIES_RE has the `/d` flag and always exposes capture-group 1 indices on a successful match */
+  if (bodyIndices === undefined) {
+    throw new Error(
+      `Could not parse workspace.knownRepositories array (match succeeded but capture indices were missing).`,
+    );
+  }
+  const [bodyStart, bodyEnd] = bodyIndices;
+  const body = text.slice(bodyStart, bodyEnd);
+  const bodyMasked = masked.slice(bodyStart, bodyEnd);
+  if (bodyMasked.includes("`")) {
+    throw new Error(
+      `\`workspace.knownRepositories\` contains a template-literal entry, which the editor cannot safely rewrite. Add "${repository}" to the array by hand.`,
+    );
+  }
+  const entries = parseExistingEntries(bodyMasked, body);
+  if (entries.some((entry) => entry.value === repository)) {
+    return { text, alreadyPresent: true };
+  }
+  const newBody = body.includes("\n")
+    ? buildMultiLineBody(body, bodyMasked, repository)
+    : buildSingleLineBody(entries, repository);
+  return {
+    text: `${text.slice(0, bodyStart)}${newBody}${text.slice(bodyEnd)}`,
+    alreadyPresent: false,
+  };
+}
+
+function validateRepositoryFormat(repository: string): void {
+  if (repository.length === 0) {
+    throw new Error("crew setup repos: <new-repo> must be a non-empty repository identifier");
+  }
+  const parts = repository.split("/");
+  if (parts.length > 2 || parts.some((part) => part.length === 0)) {
+    throw new Error(`Invalid repository "${repository}": use either "owner/repo" or "repo".`);
+  }
+}
+
+function isInsideProjectDir(projectDir: string, target: string): boolean {
+  const rel = relative(projectDir, target);
+  return rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+type TargetState = "missing" | "directory" | "not-directory";
+
+function targetState(target: string): TargetState {
+  const stats = statSync(target, { throwIfNoEntry: false });
+  if (stats === undefined) {
+    return "missing";
+  }
+  if (!stats.isDirectory()) {
+    return "not-directory";
+  }
+  return "directory";
+}
+
+function applyConfigChange(args: {
+  configFilepath: string;
+  repository: string;
+  dryRun: boolean;
+}): SetupReposConfigChange {
+  const existingText = readFileSync(args.configFilepath, "utf8");
+  const { text: newText, alreadyPresent } = addRepositoryToConfigText(
+    existingText,
+    args.repository,
+  );
+  if (alreadyPresent) {
+    log(`[exists] ${args.repository} already in workspace.knownRepositories`);
+    return "already-present";
+  }
+  if (args.dryRun) {
+    log(
+      `[dry-run] would add ${args.repository} to workspace.knownRepositories in ${args.configFilepath}`,
+    );
+    return "would-add";
+  }
+  writeFileSync(args.configFilepath, newText);
+  log(`[added] ${args.repository} → workspace.knownRepositories in ${args.configFilepath}`);
+  return "added";
+}
+
+async function cloneRepository(args: {
+  repository: string;
+  target: string;
+}): Promise<{ change: SetupReposCloneChange; error?: Error }> {
+  const ghPath = await which("gh");
+  if (ghPath === undefined) {
+    writeOutput(
+      "gh CLI not found - install GitHub CLI from https://cli.github.com/ (or clone the repo manually).",
+    );
+    return { change: "gh-missing" };
+  }
+  log(`[clone] ${args.repository} → ${args.target}`);
+  try {
+    mkdirSync(dirname(args.target), { recursive: true });
+    await runCommandAsync("gh", ["repo", "clone", args.repository, args.target], {
+      stdio: "inherit",
+      timeoutMs: 0,
+    });
+    return { change: "cloned" };
+  } catch (error) {
+    const wrapped = error instanceof Error ? error : new Error(errorMessage(error));
+    log(`[fail] ${args.repository}: ${wrapped.message}`);
+    return { change: "failed", error: wrapped };
+  }
+}
+
+export async function setupRepos(
+  config: ResolvedConfig,
+  configFilepath: string,
+  options: SetupReposOptions,
+): Promise<SetupReposResult> {
+  const { repository, dryRun = false } = options;
+  validateRepositoryFormat(repository);
+  const projectDir = resolve(config.workspace.projectDir);
+  const target = resolve(projectDir, repository);
+  if (!isInsideProjectDir(projectDir, target)) {
+    throw new Error(
+      `Repository "${repository}" resolves outside workspace.projectDir (${projectDir}): ${target}`,
+    );
+  }
+
+  const configChange = applyConfigChange({ configFilepath, repository, dryRun });
+
+  const state = targetState(target);
+  if (state === "not-directory") {
+    log(`[skip] ${repository} — target exists but is not a directory: ${target}`);
+    return { repository, target, configChange, cloneChange: "skipped-target-not-directory" };
+  }
+  if (state === "directory") {
+    log(`[exists] ${target}`);
+    return { repository, target, configChange, cloneChange: "already-cloned" };
+  }
+
+  const isBareName = !repository.includes("/");
+  if (isBareName) {
+    log(
+      `[skip] ${repository} — bare name needs owner/ prefix to auto-clone; clone manually into ${target}`,
+    );
+    return { repository, target, configChange, cloneChange: "skipped-bare-name" };
+  }
+
+  if (dryRun) {
+    log(`[dry-run] would clone ${repository} → ${target}`);
+    return { repository, target, configChange, cloneChange: "would-clone" };
+  }
+
+  const cloneResult = await cloneRepository({ repository, target });
+  const result: SetupReposResult = {
+    repository,
+    target,
+    configChange,
+    cloneChange: cloneResult.change,
+  };
+  if (cloneResult.error !== undefined) {
+    result.cloneError = cloneResult.error;
+  }
+  return result;
+}
+
+function parseArguments(argv: string[]): SetupReposOptions {
+  const { dryRun, positionals } = parseDryRunPositionals(
+    argv,
+    "crew setup repos [--dry-run] <new-repo>",
+  );
+  const [repository] = positionals;
+  if (positionals.length !== 1 || repository === undefined) {
+    throw new Error("Usage: crew setup repos [--dry-run] <new-repo>");
+  }
+  return { repository, dryRun };
+}
+
+const EXIT_CODE_CLONE_CHANGES: ReadonlySet<SetupReposCloneChange> = new Set([
+  "failed",
+  "gh-missing",
+  "skipped-bare-name",
+  "skipped-target-not-directory",
+]);
+
+export async function setupReposCli(argv: string[]): Promise<void> {
+  const options = parseArguments(argv);
+  const [config, configFilepath] = await Promise.all([loadConfig(), findConfigFilepath()]);
+  const result = await setupRepos(config, configFilepath, options);
+  if (EXIT_CODE_CLONE_CHANGES.has(result.cloneChange)) {
+    process.exitCode = 1;
+  }
+}

--- a/src/commands/setupRepos.ts
+++ b/src/commands/setupRepos.ts
@@ -77,12 +77,15 @@ const STRING_CLOSE_CHARS: Record<"str-sq" | "str-dq" | "str-bt", string> = {
 };
 
 function maskNonCode(text: string): string {
-  // Spread iterates by code point, which would re-encode surrogate pairs;
-  // for our purpose we only inspect ASCII syntax characters and `.join("")`
-  // re-emits the original code units, so any non-ASCII content round-trips
-  // unchanged through the array.
-  // oxlint-disable-next-line typescript/no-misused-spread -- structural-only scan; we don't care about non-ASCII grapheme integrity
-  const chars = [...text];
+  // Split by UTF-16 code unit, NOT by code point. Spread iteration collapses
+  // surrogate pairs into single array elements; replacing one of those with
+  // a single ASCII placeholder would shrink the masked string by one code
+  // unit and break alignment with the RegExp `match.indices` we later slice
+  // from the original text. An astral character (emoji, CJK supplemental, …)
+  // inside a nearby comment is enough to trip this, so we work at the
+  // code-unit level instead.
+  // oxlint-disable-next-line unicorn/prefer-spread -- code-unit alignment with `match.indices` is the whole point of using `.split("")` here
+  const chars = text.split("");
   let state: ScanState = "code";
   let index = 0;
   while (index < chars.length) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -861,24 +861,30 @@ function findXdgConfigFile(): string | undefined {
   );
 }
 
-async function discoverUserConfig(): Promise<DiscoveredConfig> {
+/**
+ * Discover the path to the user's crew config file using the same precedence
+ * as `loadConfig`: `GROUNDCREW_CONFIG` env var → cosmiconfig project search →
+ * XDG fallback. Commands that mutate the config (e.g. `crew setup repos`)
+ * resolve the same file `loadConfig` reads via this helper.
+ */
+export async function findConfigFilepath(): Promise<string> {
   const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
   if (override !== undefined && override.length > 0) {
     const overridePath = resolve(override);
     if (!existsSync(overridePath)) {
       fail(`GROUNDCREW_CONFIG=${overridePath} not found`);
     }
-    return await loadAt(overridePath);
+    return overridePath;
   }
 
   const project = await explorer.search(process.cwd());
   if (project !== null && project.isEmpty !== true) {
-    return project;
+    return project.filepath;
   }
 
   const xdgPath = findXdgConfigFile();
   if (xdgPath !== undefined) {
-    return await loadAt(xdgPath);
+    return xdgPath;
   }
 
   // Throw directly so oxlint's `consistent-return` rule sees a
@@ -889,6 +895,11 @@ async function discoverUserConfig(): Promise<DiscoveredConfig> {
       "crew.config.ts",
     )}, or set GROUNDCREW_CONFIG.`,
   );
+}
+
+async function discoverUserConfig(): Promise<DiscoveredConfig> {
+  const filepath = await findConfigFilepath();
+  return await loadAt(filepath);
 }
 
 let cached: Readonly<ResolvedConfig> | undefined;


### PR DESCRIPTION
## Summary

- Adds `crew setup repos <new-repo>`: append the entry to `workspace.knownRepositories` in the user's crew config and clone the repo (via `gh repo clone`) into `workspace.projectDir`. Idempotent.
- The config-file editor masks comments and string interiors before running the structural regex, so it cannot be tricked by a JSDoc example like `// knownRepositories: ["foo/bar"]` or by an existing entry containing `]`.
- Template-literal entries (backticks) trigger an explicit "add by hand" error rather than silent corruption.
- CRLF line endings are preserved.
- README updated: new "Adding a repository" section and a `crew setup repos <OWNER/REPO>` row in the command catalog.
- The previous tombstone in `src/cli.ts` (left by #117) is replaced with real dispatch to `setupReposCli`.

## Decisions

The ticket said "Create a \`crew setup repos <new-repo>\` command to add a repo to the config and initialize it." Specific choices I made, with the alternatives I considered:

- **Single positional arg, not bulk.** The old removed command (#117) took a list of entries from the config and tried to clone every missing one. I read "add a repo" literally and made it accept exactly one `<new-repo>`. If the intent was actually a bulk-add path, that should be a separate command (`crew setup repos --all` or similar).
- **Config edit is text-based, not AST.** Used a comment-/string-aware character scan (`maskNonCode`) before applying a structural regex. The codebase relies on Node 24 native TS stripping for runtime; pulling in `typescript` or `ts-morph` for AST edits felt heavier than warranted. The masker handles the realistic edge cases (comments, `]` in strings, CRLF, backslash escapes); template literals trigger a clean refusal rather than risky rewrite.
- **Edit-first, then clone.** If clone fails, the config still reflects the user's intent; re-running picks up where it left off (`configChange: already-present`, retries the clone).
- **Bare names are added to the config but not auto-cloned.** Mirrors the bare-name handling in the old removed code — no canonical remote URL to derive. Exit code 1 in this case so CI / scripted callers notice manual work is needed; the message names the target path.
- **\`crew setup\` is now a visible subcommand again.** The previous tombstone hid it; with a real action restored, the help catalog should advertise it.

Alternative I rejected: making the command silently skip config edits and only clone (treat `knownRepositories` as immutable). Rejected because the title literally says "add a repo to the config."

## Test plan

- [x] \`node --run verify\` — all 10 checks pass (architecture, build, cpd, format, knip, lint, markdown, spell, syncpack, test with 100% coverage thresholds).
- [x] End-to-end: \`crew setup repos --dry-run owner/repo\` against a synthetic config — prints planned edit and clone, leaves file untouched.
- [x] End-to-end: \`crew setup repos bare-name\` against a synthetic config — appends \`"bare-name"\` to the array, skips clone with a message, exits 1.
- [x] End-to-end: \`crew setup repos owner/repo\` against a synthetic config — edits the array and runs \`gh repo clone\` (no actual network call in the sandbox; verified via mocks in unit tests).
- [x] End-to-end: JSDoc decoy — a config with `/** knownRepositories: ["foo/bar"] */` above the real declaration is correctly identified as a decoy; the real `knownRepositories: ["a/b"]` gets the new entry.
- [x] Independent sub-agent review run after each substantive change set; final review's blocking findings all resolved.

## To continue work on this

\`tmux attach -t groundcrew:hrd-456\`