### PR TITLE
feat(launch): run setup inside the Safehouse wrap, not on the host

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -69,8 +69,6 @@ www.npmjs.com
 
 # Google APIs
 developers.google.com
-drive.googleapis.com
-forms.googleapis.com
 www.googleapis.com
 
 # Developer tooling

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -501,9 +501,11 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain("npm clean-install");
     expect(launchScript).toContain("exec '/");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' claude",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
     );
-    expect(launchScript).toContain('claude --permission-mode auto "$_p"');
+    // The agent runs inside the wrap (after setup), so the prompt is the sh -lc arg.
+    expect(launchScript).toContain('exec claude --permission-mode auto "$@"');
+    expect(launchScript).toContain('sh "$_p"');
     // setup-status guard so a failed install still launches the agent
     expect(launchScript).toContain('"$setup_status" -ne 0');
   });

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -72,17 +72,19 @@ describe(buildLaunchCommand, () => {
     });
   });
 
-  it("cd's into the worktree, runs setup, then execs the Safehouse-wrapped agent with the prompt", () => {
+  it("cd's into the worktree on the host, then runs setup and the agent inside the Safehouse wrap", () => {
     const out = buildLaunchCommand(arguments_());
 
     expect(out).toContain("cd '/work/repo-a-team-1'");
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
-    expect(out).toContain("exec '/");
     expect(out).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' claude",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
     );
-    expect(out).toMatch(/claude "\$_p"$/);
+    // Setup now runs inside the wrap (fs-isolated + clearance egress), not on the host.
+    expect(out).toContain(SETUP_COMMAND);
+    expect(out).toContain(`exec claude "$@"`);
+    expect(out).toMatch(/sh "\$_p"$/);
   });
 
   it("does not double-wrap when cmd already starts with safehouse", () => {
@@ -106,9 +108,11 @@ describe(buildLaunchCommand, () => {
       }),
     );
 
-    expect(out).toContain("--worktree '/work/repo-a-team-1'");
+    // The agent command is single-quoted for the wrap's `sh -lc`, so embedded
+    // worktree quotes are escaped via the `'\''` close-escape-reopen dance.
+    expect(out).toContain(String.raw`--worktree '\''/work/repo-a-team-1'\''`);
     // `{{sandbox}}` is a legacy placeholder; local runs no longer have one.
-    expect(out).toContain("--sandbox ''");
+    expect(out).toContain(String.raw`--sandbox '\'''\''`);
     expect(out).not.toContain("{{worktree}}");
     expect(out).not.toContain("{{sandbox}}");
   });
@@ -133,36 +137,44 @@ describe(buildLaunchCommand, () => {
   });
 
   describe("secretsFile (build-time secret shuttling)", () => {
-    it("omits source/unset lines when secretsFile is undefined", () => {
+    it("omits source/unset/env-pass when secretsFile is undefined", () => {
       const out = buildLaunchCommand(arguments_());
 
       expect(out).not.toContain("secrets.env");
       expect(out).not.toContain("unset NPM_TOKEN");
       expect(out).not.toContain("unset BUF_TOKEN");
+      expect(out).not.toContain("--env-pass");
     });
 
-    it("sources secretsFile before setup and clears the names before exec", () => {
+    it("sources secrets on the host, forwards them via --env-pass, and clears them inside the wrap before the agent", () => {
       const out = buildLaunchCommand(arguments_({ secretsFile: "/tmp/prompt-team-1/secrets.env" }));
 
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
+      const wrapIndex = out.indexOf("safehouse-clearance");
       const setupIndex = out.indexOf("setup_status=$?");
       const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
-      const execIndex = out.indexOf("safehouse-clearance");
+      const agentIndex = out.indexOf(`exec claude "$@"`);
+
+      // Secrets are sourced into the host shell before the wrap so Safehouse can
+      // forward them in; setup runs inside the wrap; the agent never inherits them.
       expect(sourceIndex).toBeGreaterThan(-1);
-      expect(setupIndex).toBeGreaterThan(sourceIndex);
+      expect(wrapIndex).toBeGreaterThan(sourceIndex);
+      expect(out).toContain("--env-pass=NPM_TOKEN,BUF_TOKEN");
+      expect(setupIndex).toBeGreaterThan(wrapIndex);
       expect(unsetIndex).toBeGreaterThan(setupIndex);
-      expect(execIndex).toBeGreaterThan(unsetIndex);
+      expect(agentIndex).toBeGreaterThan(unsetIndex);
       expect(out).toContain(
         "if [ -f '/tmp/prompt-team-1/secrets.env' ]; then set -a && . '/tmp/prompt-team-1/secrets.env' && set +a; fi",
       );
     });
 
-    it("also sources and clears secrets before the Safehouse-wrapped command", () => {
+    it("does not unset secrets on the host (the wrap needs them to forward)", () => {
       const out = buildLaunchCommand(arguments_({ secretsFile: "/tmp/prompt-team-1/secrets.env" }));
 
-      expect(out).toContain(". '/tmp/prompt-team-1/secrets.env'");
-      expect(out).toContain("unset NPM_TOKEN BUF_TOKEN");
-      expect(out).toMatch(/safehouse-clearance' claude "\$_p"$/);
+      // The only unset is inside the wrapped `sh -lc`, after the wrapper token.
+      const hostSegment = out.slice(0, out.indexOf("safehouse-clearance"));
+      expect(hostSegment).not.toContain("unset NPM_TOKEN");
+      expect(out).toMatch(/sh "\$_p"$/);
     });
   });
 
@@ -172,6 +184,22 @@ describe(buildLaunchCommand, () => {
 
       expect(out).not.toContain("safehouse-clearance");
       expect(out).toMatch(/exec claude "\$_p"$/);
+    });
+
+    it("sources and clears build secrets on the host (no sandbox to forward into)", () => {
+      const out = buildLaunchCommand(
+        arguments_({ runner: "none", secretsFile: "/tmp/prompt-team-1/secrets.env" }),
+      );
+
+      const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
+      const setupIndex = out.indexOf("setup_status=$?");
+      const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
+      const execIndex = out.indexOf(`exec claude "$_p"`);
+      expect(sourceIndex).toBeGreaterThan(-1);
+      expect(setupIndex).toBeGreaterThan(sourceIndex);
+      expect(unsetIndex).toBeGreaterThan(setupIndex);
+      expect(execIndex).toBeGreaterThan(unsetIndex);
+      expect(out).not.toContain("--env-pass");
     });
   });
 

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -111,21 +111,36 @@ export function buildLaunchCommand(arguments_: LaunchCommandArguments): string {
   if (arguments_.runner === "sdx") {
     return buildSdxLaunchCommand(arguments_);
   }
-  return buildHostLaunchCommand(arguments_);
+  if (shouldWrapWithSafehouse(arguments_)) {
+    return buildSafehouseLaunchCommand(arguments_);
+  }
+  return buildUnwrappedHostLaunchCommand(arguments_);
 }
 
-function buildHostLaunchCommand(arguments_: LaunchCommandArguments): string {
+/**
+ * The Safehouse wrap applies only when `runner === "safehouse"` and `cmd` does
+ * not already invoke `safehouse` itself. A `safehouse …` cmd owns its own
+ * sandbox flags, and we can't splice setup into a command we don't control, so
+ * those (and the `none` runner) fall through to the unwrapped host path.
+ */
+function shouldWrapWithSafehouse(arguments_: LaunchCommandArguments): boolean {
+  if (arguments_.runner !== "safehouse") {
+    return false;
+  }
+  return !/^safehouse(\s|$)/.test(arguments_.definition.cmd);
+}
+
+/**
+ * Unsandboxed host launch (`runner === "none"`, or a `safehouse …` cmd that
+ * brings its own wrap). Setup, secret sourcing, and the agent all run on the
+ * host shell because there is no groundcrew-managed sandbox to run them inside.
+ */
+function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = dirname(arguments_.promptFile);
   const agentCmd = renderAgentCommand({
     agentCmd: arguments_.definition.cmd,
     worktreeDir: arguments_.worktreeDir,
     sandboxName: "",
-  });
-
-  const wrapped = wrapAgentForHostRunner({
-    runner: arguments_.runner,
-    rawCmd: arguments_.definition.cmd,
-    agentCmd,
   });
 
   const lines: string[] = [`cd ${shellSingleQuote(arguments_.worktreeDir)}`];
@@ -139,36 +154,50 @@ function buildHostLaunchCommand(arguments_: LaunchCommandArguments): string {
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec ${wrapped} "$_p"`,
+    `exec ${agentCmd} "$_p"`,
   );
   return lines.join(" && ");
 }
 
-interface WrapForHostRunnerArguments {
-  runner: LocalRunner;
-  rawCmd: string;
-  agentCmd: string;
-}
+/**
+ * Safehouse launch. Setup runs *inside* the `safehouse-clearance` wrap (mirroring
+ * the sdx runner) so the repo's `.groundcrew/setup.sh` and its `npm install` are
+ * filesystem-isolated and egress-restricted, rather than running on the bare host.
+ *
+ * Build secrets are sourced into the host launch shell so Safehouse can forward
+ * them into the sandbox via `--env-pass` (Safehouse's `--env=FILE` mode otherwise
+ * strips them); they're `unset` inside the wrap after setup so the agent process
+ * never inherits them. The host keeps only `cd`, the prompt read, and the wrap exec.
+ */
+function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
+  const promptDir = dirname(arguments_.promptFile);
+  const agentCmd = renderAgentCommand({
+    agentCmd: arguments_.definition.cmd,
+    worktreeDir: arguments_.worktreeDir,
+    sandboxName: "",
+  });
 
-function wrapAgentForHostRunner(arguments_: WrapForHostRunnerArguments): string {
-  if (arguments_.runner === "none") {
-    return arguments_.agentCmd;
+  const innerParts = [setupWithStatusReporting(SETUP_COMMAND)];
+  if (arguments_.secretsFile !== undefined) {
+    innerParts.push(unsetSecretsLine());
   }
-  // buildLaunchCommand routes `sdx` through buildSdxLaunchCommand, so the
-  // only remaining shape here is `safehouse`. Treat the explicit branch as
-  // the safehouse wrap to keep this function readable; the `sdx` arm exists
-  // only to satisfy TS's exhaustiveness checker.
-  /* v8 ignore next 3 @preserve -- buildLaunchCommand short-circuits sdx before calling this helper */
-  if (arguments_.runner === "sdx") {
-    return arguments_.agentCmd;
+  innerParts.push(`exec ${agentCmd} "$@"`);
+  const innerCommand = innerParts.join("; ");
+
+  // Trailing space keeps the flag and `sh` separated; empty when no secrets.
+  const envPassFlag =
+    arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
+
+  const lines: string[] = [`cd ${shellSingleQuote(arguments_.worktreeDir)}`];
+  if (arguments_.secretsFile !== undefined) {
+    lines.push(sourceSecretsLine(arguments_.secretsFile));
   }
-  // safehouse: skip the wrap if `cmd` already starts with `safehouse` so
-  // legacy configs don't double-wrap.
-  const cmdStartsWithSafehouse = /^safehouse(\s|$)/.test(arguments_.rawCmd);
-  if (cmdStartsWithSafehouse) {
-    return arguments_.agentCmd;
-  }
-  return [shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH), arguments_.agentCmd].join(" ");
+  lines.push(
+    `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
+    `rm -rf ${shellSingleQuote(promptDir)}`,
+    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
+  );
+  return lines.join(" && ");
 }
 
 function buildSdxLaunchCommand(arguments_: LaunchCommandArguments): string {


### PR DESCRIPTION
## Summary

Closes a containment gap surfaced while reviewing groundcrew against Anthropic's "How we contain Claude": under the **safehouse** runner, only the agent exec was wrapped — `cd`, build-secret sourcing, and `.groundcrew/setup.sh` (including its `npm install` and every dependency postinstall script) ran on the **bare host**, outside filesystem isolation and the clearance egress allowlist, with build secrets in env.

This makes the safehouse path mirror what the **sdx** runner already does: setup runs *inside* the `safehouse-clearance` wrap. Build secrets are sourced on the host so Safehouse can forward them into the sandbox via `--env-pass` (its `--env=FILE` mode otherwise strips them), then `unset` inside the wrap after setup so the agent process never inherits them. The `none` runner and bring-your-own `safehouse …` cmds keep the unwrapped host path, since there's no groundcrew-managed sandbox to run inside.

Also removes `drive.googleapis.com` and `forms.googleapis.com` from the starter `clearance-allow-hosts` — write-capable exfil channels not needed by default.

Independent of #87 (the `preLaunch` host hook); this touches `buildHostLaunchCommand`/its tests, so expect to rebase whichever merges second.

## Validation

- `node --run verify` — green (917 tests, 100% coverage thresholds met, lint/build/architecture/cpd/format/knip/markdown/spell/syncpack all pass).
- Verified against `safehouse 0.10.1`: `--env-pass=NPM_TOKEN` forwards a value through the wrapper alongside `--env=FILE`; default sanitized mode strips it (exit 1).

## Notes

- Runtime/migration item (not in this diff): the agent now runs under `sh -lc` inside the wrap and `setup.sh` runs behind the egress allowlist. If the Seatbelt profile denies profile/`shell-init` reads, an nvm-provided node could drop off PATH, and any host `setup.sh` reaches beyond `registry.npmjs.org` will surface as a clearance `DENY`. Watch `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log` on first run and extend `clearance-allow-hosts` / enable `shell-init` as needed.

Agent session: claude --resume 0cb126c3-9db3-4e1a-bd76-9b55a697822a
<!-- commit-push-pr:created v1 core@3.4.1 -->