### PR TITLE
feat: redesign `crew status` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,28 +20,21 @@
 $ crew status HRD-446
 groundcrew status HRD-446
 ========================
-ticket: hrd-446
+ticket: hrd-446  https://linear.app/example/issue/HRD-446
+title: Add retry logic to the sync job
+run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
+workspace: live
 
-Config snapshot
----------------
-projectDir: /dev/workspaces
-repositories: owner/repo
-git: remote=origin; defaultBranch=main
-workspaceKind: auto
-
-Worktree state
---------------
+Worktrees
+---------
 - owner/repo host
   branch: rocky-hrd-446
+  dir: /dev/workspaces/owner/repo-hrd-446
   git: dirty (2 modified, 1 untracked)
 
-Workspace probe
----------------
-live: yes
-
-Last Linear status
-------------------
-In Progress (state.type=started) — Add retry logic to the sync job
+Ticket source
+-------------
+linear:hrd-446  in-progress  https://linear.app/example/issue/HRD-446
 ```
 
 ## Why
@@ -217,7 +210,7 @@ Replace `claude` with the sbx agent for the model and `<projectDir>` with `works
 
 ## Inspecting status
 
-`crew status <TICKET>` prints a read-only snapshot for one ticket: cached title/URL when present, resolved config, matching worktrees, git dirtiness, PR links for matching branches, workspace probe result, recorded run state, recent log lines for that ticket, and the latest Linear status. It does not recover, tear down, resume, or mutate any local/remote state.
+`crew status <TICKET>` prints a read-only snapshot for one ticket: cached title/URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the ticket status from the configured ticket source. It does not recover, tear down, resume, or mutate any local/remote state.
 
 `crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local worktree/session diagnostics are printed before ticket-source fetches complete; when the source fetch succeeds, status also prints slot usage plus Queue/Blocked sections for eligible Todo tickets. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
 
@@ -235,41 +228,24 @@ groundcrew status HRD-442
 =========================
 ticket: hrd-442  https://linear.app/example/issue/HRD-442
 title: Multi-event extractor: year inference can produce date_start > date_end
+run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
+workspace: live
 
-Config snapshot
----------------
-projectDir: /Users/paul/dev/groundcrew-workspaces
-repositories: herds-social/herds
-git: remote=origin; defaultBranch=main
-workspaceKind: auto
-local.runner: auto
-models: default=claude; enabled=claude, codex
-logFile: /Users/paul/.config/groundcrew/groundcrew.log
-
-Worktree state
---------------
+Worktrees
+---------
 - herds-social/herds host
-  ticket: hrd-442
   branch: paul-hrd-442
-  dir: /Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442
+  dir: /dev/workspaces/herds-social/herds-hrd-442
   git: dirty (0 modified, 1 untracked)
   pr: https://github.com/herds-social/herds/pull/224 (open)
-
-Workspace probe
----------------
-live: yes
-
-Run state
----------
-running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
 
 Recent logs
 -----------
 [10:15:30] Workspace "hrd-442" launched
 
-Last Linear status
-------------------
-In Progress (state.type=started) — Multi-event extractor: year inference can produce date_start > date_end
+Ticket source
+-------------
+linear:hrd-442  in-progress  https://linear.app/example/issue/HRD-442
 ```
 
 </details>
@@ -480,7 +456,7 @@ op run --env-file .env.1password -- crew doctor
 
 ## Troubleshooting
 
-First stop for "what exists locally right now": `crew status <ticket>` shows the ticket's worktrees, workspace presence, run state, logs, and latest Linear status. Use `crew doctor` when you need to verify host setup.
+First stop for "what exists locally right now": `crew status <ticket>` shows the ticket's worktrees, workspace presence, run state, logs, and ticket-source status. Use `crew doctor` when you need to verify host setup.
 
 <details>
 <summary>Safehouse-already-wrapped commands are not re-wrapped</summary>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 $ crew status HRD-446
 groundcrew status HRD-446
 ========================
-ticket: hrd-446  https://linear.app/example/issue/HRD-446
+ticket: hrd-446  in-progress  https://linear.app/example/issue/HRD-446
 title: Add retry logic to the sync job
 run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
 workspace: live
@@ -31,10 +31,6 @@ Worktrees
   branch: rocky-hrd-446
   dir: /dev/workspaces/owner/repo-hrd-446
   git: dirty (2 modified, 1 untracked)
-
-Ticket source
--------------
-linear:hrd-446  in-progress  https://linear.app/example/issue/HRD-446
 ```
 
 ## Why
@@ -226,7 +222,7 @@ Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKE
 ```text
 groundcrew status HRD-442
 =========================
-ticket: hrd-442  https://linear.app/example/issue/HRD-442
+ticket: hrd-442  in-progress  https://linear.app/example/issue/HRD-442
 title: Multi-event extractor: year inference can produce date_start > date_end
 run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
 workspace: live
@@ -242,10 +238,6 @@ Worktrees
 Recent logs
 -----------
 [10:15:30] Workspace "hrd-442" launched
-
-Ticket source
--------------
-linear:hrd-442  in-progress  https://linear.app/example/issue/HRD-442
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Replace `claude` with the sbx agent for the model and `<projectDir>` with `works
 
 ## Inspecting status
 
-`crew status <TICKET>` prints a read-only snapshot for one ticket: resolved config, matching worktrees, workspace probe result, recorded run state, recent log lines for that ticket, and the latest Linear status. It does not fetch, recover, tear down, resume, or mutate any local/remote state.
+`crew status <TICKET>` prints a read-only snapshot for one ticket: cached title/URL when present, resolved config, matching worktrees, git dirtiness, PR links for matching branches, workspace probe result, recorded run state, recent log lines for that ticket, and the latest Linear status. It does not recover, tear down, resume, or mutate any local/remote state.
 
-`crew status` with no ticket prints the current inventory: known worktrees with workspace/run-state presence plus live workspaces reported by the configured backend.
+`crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local worktree/session diagnostics are printed before ticket-source fetches complete; when the source fetch succeeds, status also prints slot usage plus Queue/Blocked sections for eligible Todo tickets. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
 
 Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKET>` to reopen preserved work. Status is intentionally informational only.
 
@@ -233,22 +233,39 @@ Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKE
 ```text
 groundcrew status HRD-442
 =========================
-ticket: hrd-442
+ticket: hrd-442  https://linear.app/example/issue/HRD-442
+title: Multi-event extractor: year inference can produce date_start > date_end
+
+Config snapshot
+---------------
+projectDir: /Users/paul/dev/groundcrew-workspaces
+repositories: herds-social/herds
+git: remote=origin; defaultBranch=main
+workspaceKind: auto
+local.runner: auto
+models: default=claude; enabled=claude, codex
+logFile: /Users/paul/.config/groundcrew/groundcrew.log
+
+Worktree state
+--------------
+- herds-social/herds host
+  ticket: hrd-442
+  branch: paul-hrd-442
+  dir: /Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442
+  git: dirty (0 modified, 1 untracked)
+  pr: https://github.com/herds-social/herds/pull/224 (open)
+
+Workspace probe
+---------------
+live: yes
 
 Run state
 ---------
 running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
 
-Worktree
---------
-- herds-social host
-  branch: paul-hrd-442
-  dir: /Users/paul/dev/groundcrew-workspaces/herds-social/herds-hrd-442
-  git: dirty (0 modified, 1 untracked)
-
-Workspace
----------
-live: yes
+Recent logs
+-----------
+[10:15:30] Workspace "hrd-442" launched
 
 Last Linear status
 ------------------

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -134,6 +134,21 @@ describe(createDispatcher, () => {
       );
     });
 
+    it("forwards the ticket url through setupWorkspace details when the source provides one", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue({ url: "https://linear.app/example/issue/TEAM-1" })]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      const setupCall = setupMock.mock.calls.at(-1);
+      expect(setupCall?.[1]?.details.url).toBe("https://linear.app/example/issue/TEAM-1");
+    });
+
     it("logs `At capacity` when no slots remain", async () => {
       const config = makeConfig({
         orchestrator: {

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -109,7 +109,11 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
           repository: issue.repository,
           ticket: ticketId,
           model: issue.model,
-          details: { title: issue.title, description: issue.description },
+          details: {
+            title: issue.title,
+            description: issue.description,
+            ...(issue.url === undefined ? {} : { url: issue.url }),
+          },
         };
         await (signal === undefined
           ? setupWorkspace(config, setupOptions)

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -287,6 +287,7 @@ describe(resumeWorkspace, () => {
       stateType: "unstarted",
       status: "Todo",
       statusId: "state-todo",
+      url: "https://linear.app/example/issue/TEAM-1",
     });
 
     await resumeWorkspace(config, { ticket: "team-1" });

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -371,6 +371,51 @@ describe(setupWorkspace, () => {
       branchName: "rocky-team-1",
       workspaceName: "team-1",
       state: "running",
+      title: "Test Title",
+    });
+  });
+
+  it("records the ticket url in RunState when the source provides one", async () => {
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      ticket: "team-1",
+      repository: "repo-a",
+      model: "claude",
+      details: {
+        title: "Test Title",
+        description: "Body",
+        url: "https://linear.app/example/issue/TEAM-1",
+      },
+    });
+
+    expect(lastRecordedRunState()).toMatchObject({
+      state: "running",
+      url: "https://linear.app/example/issue/TEAM-1",
+    });
+  });
+
+  it("records the ticket url even on the failed-to-launch rollback path", async () => {
+    const config = makeConfig();
+    mockCmuxFailure();
+
+    await expect(
+      setupWorkspace(config, {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        details: {
+          title: "Test Title",
+          description: "Body",
+          url: "https://linear.app/example/issue/TEAM-1",
+        },
+      }),
+    ).rejects.toThrow(/cmux down/);
+
+    expect(lastRecordedRunState()).toMatchObject({
+      state: "failed-to-launch",
+      url: "https://linear.app/example/issue/TEAM-1",
     });
   });
 
@@ -1056,6 +1101,7 @@ describe(setupWorkspace, () => {
       repository: "repo-a",
       model: "claude",
       state: "failed-to-launch",
+      title: "Test Title",
     });
     expect(lastRecordedRunState().detail).toContain("cmux down");
   });
@@ -1276,6 +1322,24 @@ describe(setupWorkspaceCli, () => {
       "cmux",
       expect.arrayContaining(["set-status", "model", "claude"]),
     );
+  });
+
+  it("forwards the resolved ticket url into RunState when the source supplied one", async () => {
+    const boardWithUrl = fakeBoard(
+      canonicalLinearIssue({
+        naturalId: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        title: "Title",
+        description: "Body for repo-a",
+        url: "https://linear.app/example/issue/TEAM-1",
+      }),
+    );
+    createBoardMock.mockReturnValue(boardWithUrl);
+
+    await setupWorkspaceCli("team-1");
+
+    expect(lastRecordedRunState().url).toBe("https://linear.app/example/issue/TEAM-1");
   });
 
   it("marks the ticket In Progress via board.markInProgress after launching the workspace", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -19,6 +19,8 @@ import { isWorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../
 export interface TicketDetails {
   title: string;
   description: string;
+  /** Direct web URL for the ticket; cached into RunState when present. */
+  url?: string;
 }
 
 export interface SetupWorkspaceOptions {
@@ -130,6 +132,8 @@ export async function setupWorkspace(
       branchName,
       workspaceName: ticket,
       state: "running",
+      title: ticketDetails.title,
+      ...(ticketDetails.url === undefined ? {} : { url: ticketDetails.url }),
     });
 
     log(`Workspace "${ticket}" launched (${model})`);
@@ -148,6 +152,8 @@ export async function setupWorkspace(
       workspaceName: ticket,
       state: "failed-to-launch",
       detail: errorMessage(error),
+      title: options.details.title,
+      ...(options.details.url === undefined ? {} : { url: options.details.url }),
     });
     throw error;
   }
@@ -207,7 +213,9 @@ function recordRunStateBestEffort(arguments_: {
   branchName: string;
   workspaceName: string;
   state: "running" | "failed-to-launch";
+  title: string;
   detail?: string;
+  url?: string;
 }): void {
   try {
     recordRunState({
@@ -220,7 +228,9 @@ function recordRunStateBestEffort(arguments_: {
         branchName: arguments_.branchName,
         workspaceName: arguments_.workspaceName,
         state: arguments_.state,
+        title: arguments_.title,
         ...(arguments_.detail === undefined ? {} : { detail: arguments_.detail }),
+        ...(arguments_.url === undefined ? {} : { url: arguments_.url }),
       },
     });
   } catch (error) {
@@ -311,7 +321,11 @@ export async function setupWorkspaceCli(
     ticket: naturalId,
     repository: resolved.repository,
     model: resolved.model,
-    details: { title: resolved.title, description: resolved.description },
+    details: {
+      title: resolved.title,
+      description: resolved.description,
+      ...(resolved.url === undefined ? {} : { url: resolved.url }),
+    },
   });
   await board.markInProgress(resolved);
 }

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -459,6 +459,29 @@ describe(status, () => {
     expect(output).toContain("  attach:    tmux attach -t crew:team-2");
   });
 
+  it("omits only the failed pull request row when one PR lookup rejects", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a" }),
+      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+    ]);
+    findPullRequestsMock.mockRejectedValueOnce(new Error("gh rate limited")).mockResolvedValueOnce([
+      {
+        url: "https://github.com/acme/widgets/pull/42",
+        number: 42,
+        state: "open",
+        title: "Wire up auth",
+      },
+    ]);
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-1\n  state:");
+    expect(output).toContain("team-2\n  state:");
+    expect(output).not.toContain("gh rate limited");
+    expect(output).toContain("  pr:        https://github.com/acme/widgets/pull/42 (open)");
+  });
+
   it("hides the Stray sessions section when every live session matches a worktree", async () => {
     listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -2,10 +2,6 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { LinearClient } from "@linear/sdk";
-
-import { getLinearClient } from "../lib/adapters/linear/client.ts";
-import { fetchRawLinearIssue, type RawLinearIssue } from "../lib/adapters/linear/fetch.ts";
 import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
@@ -20,17 +16,9 @@ vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
-vi.mock(import("../lib/adapters/linear/fetch.ts"), async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual, fetchRawLinearIssue: vi.fn<typeof fetchRawLinearIssue>() };
-});
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readRunState: vi.fn<typeof readRunState>() };
-});
-vi.mock(import("../lib/adapters/linear/client.ts"), async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual, getLinearClient: vi.fn<typeof getLinearClient>() };
 });
 vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -69,8 +57,6 @@ vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
   };
 });
 
-const fetchRawLinearIssueMock = vi.mocked(fetchRawLinearIssue);
-const getLinearClientMock = vi.mocked(getLinearClient);
 const loadConfigMock = vi.mocked(loadConfig);
 const readRunStateMock = vi.mocked(readRunState);
 const workspaceProbeMock = vi.mocked(workspaces.probe);
@@ -102,10 +88,6 @@ function sourceIssue(overrides: Partial<SourceIssue> = {}): SourceIssue {
 async function noop(): Promise<void> {
   await Promise.resolve();
 }
-async function noopUndefined<T>(): Promise<T | undefined> {
-  await Promise.resolve();
-  return undefined as T | undefined;
-}
 
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let index = 0; index < count; index += 1) {
@@ -119,14 +101,19 @@ function fakeSource(
   overrides: {
     name?: string;
     fetch?: TicketSource["fetch"];
+    resolveOne?: TicketSource["resolveOne"];
   } = {},
 ): TicketSource {
   const fetch: TicketSource["fetch"] = overrides.fetch ?? (async () => [...issues]);
+  const resolveOne: TicketSource["resolveOne"] =
+    overrides.resolveOne ??
+    (async (naturalId) =>
+      issues.find((issue) => issue.id === `${issue.source}:${naturalId.toLowerCase()}`));
   return {
     name: overrides.name ?? "linear",
     verify: noop,
     fetch,
-    resolveOne: noopUndefined,
+    resolveOne,
     markInProgress: noop,
   };
 }
@@ -172,24 +159,6 @@ function worktree(overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
   };
 }
 
-function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
-  return {
-    uuid: "uuid-1",
-    title: "Fix the thing",
-    description: "",
-    teamId: "team-1",
-    labels: [],
-    stateName: "Todo",
-    stateType: "unstarted",
-    stateId: "state-todo",
-    blockers: [],
-    hasMoreBlockers: false,
-    hasChildren: false,
-    url: "https://linear.app/example/issue/TEAM-1",
-    ...overrides,
-  };
-}
-
 function runState(overrides: Partial<RunState> = {}): RunState {
   return {
     ticket: "team-1",
@@ -206,11 +175,6 @@ function runState(overrides: Partial<RunState> = {}): RunState {
   };
 }
 
-function linearClient(): LinearClient {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- status tests never call the client directly; it is passed through to the mocked fetcher.
-  return { client: {} } as unknown as LinearClient;
-}
-
 describe(status, () => {
   let consoleLog: ConsoleCapture;
   let temporaryDirectory: string;
@@ -222,12 +186,11 @@ describe(status, () => {
     vi.setSystemTime(new Date("2026-05-26T02:14:30.000Z"));
     consoleLog = captureConsoleLog();
     temporaryDirectory = mkdtempSync(join(tmpdir(), "groundcrew-status-test-"));
-    getLinearClientMock.mockReturnValue(linearClient());
-    fetchRawLinearIssueMock.mockResolvedValue(rawIssue());
     readRunStateMock.mockReturnValue(runState({ reason: "manual pause" }));
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
     workspaceAccessHintMock.mockReset();
     findPullRequestsMock.mockResolvedValue([]);
+    buildSourcesMock.mockResolvedValue([]);
     findByTicketMock.mockReturnValue([worktree()]);
     listWorktreesMock.mockReturnValue([worktree()]);
     probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
@@ -266,35 +229,40 @@ describe(status, () => {
       .mockResolvedValueOnce({ kind: "clean" } satisfies WorktreeDirtiness)
       .mockResolvedValueOnce({ kind: "dirty", modified: 2, untracked: 1 })
       .mockResolvedValueOnce({ kind: "unknown" });
-    fetchRawLinearIssueMock.mockResolvedValue(
-      rawIssue({ title: "Fix status", stateName: "In Progress", stateType: "started" }),
-    );
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({
+          title: "Fix status",
+          status: "in-progress",
+          url: "https://linear.app/example/issue/TEAM-1",
+        }),
+      ]),
+    ]);
 
     await status(config, { ticket: "team-1" });
 
     const output = consoleLog.output();
     expect(output).toContain("groundcrew status TEAM-1");
-    expect(output).toContain("Config snapshot");
-    expect(output).toContain("projectDir: /work");
-    expect(output).toContain("repositories: repo-a, repo-b");
-    expect(output).toContain("models: default=claude; enabled=claude, codex");
-    expect(output).toContain("Worktree state");
+    expect(output).not.toContain("Config snapshot");
+    expect(output).toContain(
+      "run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0",
+    );
+    expect(output).toContain("manual pause");
+    expect(output).toContain("workspace: live");
+    expect(output).toContain("Worktrees");
     expect(output).toContain("repo-a host");
+    expect(output).not.toContain("  ticket: team-1");
     expect(output).toContain("git: clean");
     expect(output).toContain("git: dirty (2 modified, 1 untracked)");
     expect(output).toContain("git: unknown");
-    expect(output).toContain("Workspace probe");
-    expect(output).toContain("live: yes");
-    expect(output).toContain("Run state");
-    expect(output).toContain("running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0");
-    expect(output).toContain("manual pause");
     expect(output).toContain("Recent logs");
     expect(output).toContain("event=dispatch outcome=started ticket=team-1");
     expect(output).not.toContain("ticket=team-10");
     expect(output).toContain('Workspace "TEAM-1" launched');
     expect(output).not.toContain("unrelated ticket");
-    expect(output).toContain("Last Linear status");
-    expect(output).toContain("In Progress (state.type=started) — Fix status");
+    expect(output).toContain("Ticket source");
+    expect(output).toContain("linear:team-1  in-progress  https://linear.app/example/issue/TEAM-1");
+    expect(output).toContain("title: Fix status");
   });
 
   it("prints unavailable fields without attempting recovery", async () => {
@@ -302,20 +270,19 @@ describe(status, () => {
     findByTicketMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
     readRunStateMock.mockReset();
-    fetchRawLinearIssueMock.mockRejectedValue(new Error("Linear down"));
+    buildSourcesMock.mockRejectedValue(new Error("source down"));
 
     await status(config, { ticket: "team-404" });
 
     const output = consoleLog.output();
     expect(output).toContain("ticket: team-404");
-    expect(output).toContain("Worktree state");
+    expect(output).toContain("run: (none)");
+    expect(output).toContain("workspace: not live");
+    expect(output).toContain("Worktrees");
     expect(output).toContain("(none)");
-    expect(output).toContain("live: no");
-    expect(output).toContain("Run state");
-    expect(output).toContain("(none)");
-    expect(output).toContain("Recent logs");
-    expect(output).toContain("(none)");
-    expect(output).toContain("unavailable: Linear down");
+    expect(output).not.toContain("Recent logs");
+    expect(output).toContain("Ticket source");
+    expect(output).toContain("unavailable: source down");
   });
 
   it("rejects an empty direct-call ticket", async () => {
@@ -327,16 +294,18 @@ describe(status, () => {
     expect(listWorktreesMock).not.toHaveBeenCalled();
   });
 
-  it("prints a run-state summary without optional detail and renders an empty state.type as unknown", async () => {
-    const issueWithoutStateType = rawIssue({ title: "No state type", stateType: "" });
+  it("prints a run-state summary without optional detail and source status", async () => {
     readRunStateMock.mockReturnValue(runState());
-    fetchRawLinearIssueMock.mockResolvedValue(issueWithoutStateType);
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ title: "No state type", status: "other" })]),
+    ]);
 
     await status(makeConfig(), { ticket: "team-1" });
 
     const output = consoleLog.output();
     expect(output).toContain("running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0");
-    expect(output).toContain("Todo (state.type=unknown) — No state type");
+    expect(output).toContain("linear:team-1  other");
+    expect(output).toContain("title: No state type");
   });
 
   it("prints run-state detail when only detail is recorded", async () => {
@@ -356,13 +325,21 @@ describe(status, () => {
     await status(makeConfig(), { ticket: "team-1" });
 
     const output = consoleLog.output();
-    // Cached title (from RunState) should appear in the header, before
-    // sections like "Config snapshot". The live Linear title still appears
-    // later in "Last Linear status".
     const titleIndex = output.indexOf("title: Improve crew status command");
-    const configIndex = output.indexOf("Config snapshot");
+    const runIndex = output.indexOf("run:");
     expect(titleIndex).toBeGreaterThanOrEqual(0);
-    expect(configIndex).toBeGreaterThan(titleIndex);
+    expect(runIndex).toBeGreaterThan(titleIndex);
+  });
+
+  it("omits duplicate source title when it matches the cached title", async () => {
+    readRunStateMock.mockReturnValue(runState({ title: "Improve crew status command" }));
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ title: "Improve crew status command" })]),
+    ]);
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    expect(consoleLog.output().match(/title: Improve crew status command/g)).toHaveLength(1);
   });
 
   it("omits the cached title line when no run state has a title", async () => {
@@ -370,9 +347,8 @@ describe(status, () => {
 
     await status(makeConfig(), { ticket: "team-1" });
 
-    // No header `title:` line; only the Linear-status line at the bottom carries it.
     const output = consoleLog.output();
-    const headerSection = output.slice(0, output.indexOf("Config snapshot"));
+    const headerSection = output.slice(0, output.indexOf("run:"));
     expect(headerSection).not.toContain("title:");
   });
 
@@ -643,7 +619,7 @@ describe(status, () => {
     expect(consoleLog.output()).not.toContain("  pr:");
   });
 
-  it("renders a `pr:` line in the per-ticket Worktree state section when present", async () => {
+  it("renders a `pr:` line in the per-ticket Worktrees section when present", async () => {
     findByTicketMock.mockReturnValue([
       worktree({ ticket: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
     ]);
@@ -923,8 +899,7 @@ describe(statusCli, () => {
     workspaceAccessHintMock.mockReset();
     findPullRequestsMock.mockResolvedValue([]);
     readRunStateMock.mockReset();
-    fetchRawLinearIssueMock.mockResolvedValue(rawIssue());
-    getLinearClientMock.mockReturnValue(linearClient());
+    buildSourcesMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -935,7 +910,7 @@ describe(statusCli, () => {
   it("loads config and normalizes a ticket argument", async () => {
     await statusCli(["TEAM-1"]);
 
-    expect(findByTicketMock).toHaveBeenCalledWith(expect.any(Object), "team-1");
+    expect(findByTicketMock.mock.calls[0]?.[1]).toBe("team-1");
     expect(consoleLog.output()).toContain("groundcrew status TEAM-1");
   });
 
@@ -944,7 +919,7 @@ describe(statusCli, () => {
 
     await statusCli([]);
 
-    expect(listWorktreesMock).toHaveBeenCalledWith(expect.any(Object));
+    expect(listWorktreesMock.mock.calls.length).toBeGreaterThan(0);
     expect(consoleLog.output()).toContain("Worktrees\n---------\n(none)");
   });
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -6,8 +6,11 @@ import type { LinearClient } from "@linear/sdk";
 
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { fetchRawLinearIssue, type RawLinearIssue } from "../lib/adapters/linear/fetch.ts";
+import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
+import type { Issue as SourceIssue, TicketSource } from "../lib/ticketSource.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -36,6 +39,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
     workspaces: {
       ...actual.workspaces,
       probe: vi.fn<typeof actual.workspaces.probe>(),
+      accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
     },
   };
 });
@@ -51,19 +55,78 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     },
   };
 });
+vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]) };
+});
+vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    findPullRequestsForBranch: vi
+      .fn<typeof actual.findPullRequestsForBranch>()
+      .mockResolvedValue([]),
+  };
+});
 
 const fetchRawLinearIssueMock = vi.mocked(fetchRawLinearIssue);
 const getLinearClientMock = vi.mocked(getLinearClient);
 const loadConfigMock = vi.mocked(loadConfig);
 const readRunStateMock = vi.mocked(readRunState);
 const workspaceProbeMock = vi.mocked(workspaces.probe);
+const workspaceAccessHintMock = vi.mocked(workspaces.accessHint);
 const findByTicketMock = vi.mocked(worktrees.findByTicket);
 const listWorktreesMock = vi.mocked(worktrees.list);
 const probeWorkingTreeMock = vi.mocked(worktrees.probeWorkingTree);
+const buildSourcesMock = vi.mocked(buildSources);
+const findPullRequestsMock = vi.mocked(findPullRequestsForBranch);
+
+function sourceIssue(overrides: Partial<SourceIssue> = {}): SourceIssue {
+  return {
+    id: "linear:team-1",
+    source: "linear",
+    title: "Queued ticket",
+    description: "",
+    status: "todo",
+    repository: "repo-a",
+    model: "claude",
+    assignee: "me",
+    updatedAt: "2026-05-26T00:00:00.000Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: {},
+    ...overrides,
+  };
+}
+
+async function noop(): Promise<void> {
+  await Promise.resolve();
+}
+async function noopUndefined<T>(): Promise<T | undefined> {
+  await Promise.resolve();
+  return undefined as T | undefined;
+}
+
+function fakeSource(
+  issues: readonly SourceIssue[],
+  overrides: {
+    name?: string;
+    fetch?: TicketSource["fetch"];
+  } = {},
+): TicketSource {
+  const fetch: TicketSource["fetch"] = overrides.fetch ?? (async () => [...issues]);
+  return {
+    name: overrides.name ?? "linear",
+    verify: noop,
+    fetch,
+    resolveOne: noopUndefined,
+    markInProgress: noop,
+  };
+}
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
-    sources: [],
+    sources: overrides.sources ?? [],
     git: { remote: "origin", defaultBranch: "main", ...overrides.git },
     workspace: {
       projectDir: "/work",
@@ -115,6 +178,7 @@ function rawIssue(overrides: Partial<RawLinearIssue> = {}): RawLinearIssue {
     blockers: [],
     hasMoreBlockers: false,
     hasChildren: false,
+    url: "https://linear.app/example/issue/TEAM-1",
     ...overrides,
   };
 }
@@ -145,12 +209,18 @@ describe(status, () => {
   let temporaryDirectory: string;
 
   beforeEach(() => {
+    // Pin the clock to createdAt + 2h 14m so `state: running (...)` lines
+    // include a deterministic `2h 14m` duration token.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-26T02:14:30.000Z"));
     consoleLog = captureConsoleLog();
     temporaryDirectory = mkdtempSync(join(tmpdir(), "groundcrew-status-test-"));
     getLinearClientMock.mockReturnValue(linearClient());
     fetchRawLinearIssueMock.mockResolvedValue(rawIssue());
     readRunStateMock.mockReturnValue(runState({ reason: "manual pause" }));
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    workspaceAccessHintMock.mockReset();
+    findPullRequestsMock.mockResolvedValue([]);
     findByTicketMock.mockReturnValue([worktree()]);
     listWorktreesMock.mockReturnValue([worktree()]);
     probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
@@ -160,6 +230,7 @@ describe(status, () => {
     consoleLog.restore();
     rmSync(temporaryDirectory, { recursive: true, force: true });
     vi.resetAllMocks();
+    vi.useRealTimers();
   });
 
   it("prints the read-only per-ticket status dump", async () => {
@@ -272,11 +343,47 @@ describe(status, () => {
     expect(consoleLog.output()).toContain("spawn failed");
   });
 
+  it("surfaces the cached ticket title at the top of the per-ticket view", async () => {
+    readRunStateMock.mockReturnValue(runState({ title: "Improve crew status command" }));
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    // Cached title (from RunState) should appear in the header, before
+    // sections like "Config snapshot". The live Linear title still appears
+    // later in "Last Linear status".
+    const titleIndex = output.indexOf("title: Improve crew status command");
+    const configIndex = output.indexOf("Config snapshot");
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(configIndex).toBeGreaterThan(titleIndex);
+  });
+
+  it("omits the cached title line when no run state has a title", async () => {
+    readRunStateMock.mockReturnValue(runState());
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    // No header `title:` line; only the Linear-status line at the bottom carries it.
+    const output = consoleLog.output();
+    const headerSection = output.slice(0, output.indexOf("Config snapshot"));
+    expect(headerSection).not.toContain("title:");
+  });
+
   it("prints an inventory when no ticket is provided", async () => {
     listWorktreesMock.mockReturnValue([
-      worktree({ ticket: "team-1", repository: "repo-a" }),
-      worktree({ ticket: "team-1", repository: "repo-b", branchName: "rocky-team-1-b" }),
-      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+      worktree({ ticket: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
+      worktree({
+        ticket: "team-1",
+        repository: "repo-b",
+        branchName: "rocky-team-1-b",
+        dir: "/work/repo-b-team-1",
+      }),
+      worktree({
+        ticket: "team-2",
+        repository: "repo-b",
+        branchName: "rocky-team-2",
+        dir: "/work/repo-b-team-2",
+      }),
     ]);
     const statesByTicket = new Map([["team-1", runState({ ticket: "team-1" })]]);
     readRunStateMock.mockImplementation((_config, ticket) => statesByTicket.get(ticket));
@@ -288,15 +395,433 @@ describe(status, () => {
     await status(makeConfig());
 
     const output = consoleLog.output();
-    expect(output).toContain("groundcrew status");
+    expect(output).not.toContain("groundcrew status\n");
     expect(output).toContain("Worktrees");
-    expect(output).toContain("team-1  repo-a  host  workspace=no  run=running");
-    expect(output).toContain("team-1  repo-b  host  workspace=no  run=running");
-    expect(output).toContain("team-2  repo-b  host  workspace=yes  run=none");
-    expect(output).toContain("Live workspaces");
-    expect(output).toContain("team-2");
-    expect(output).toContain("orphan-workspace");
+    // No `host` kind in the new layout; rows are labeled key-value.
+    expect(output).not.toContain("host  workspace=");
+    // team-1 has a running RunState but workspace probe says no — orphan.
+    expect(output).toContain("team-1\n  state:     running (session dead, 2h 14m)");
+    expect(output).toContain("  repo:      repo-a");
+    expect(output).toContain("  worktree:  /work/repo-a-team-1");
+    // Inventory rows intentionally omit `branch:` — derivable, low signal.
+    // The per-ticket view (`crew status TEAM-1`) still surfaces it.
+    expect(output).not.toContain("  branch:");
+    // team-2 has no RunState but the probe sees a session — stray session.
+    expect(output).toContain("team-2\n  state:     idle (stray session)");
+    expect(output).toContain("Stray sessions");
+    // team-1/team-2 sessions are tied to worktrees and should NOT appear as strays.
+    expect(output).toMatch(/Stray sessions\n-+\norphan-workspace\n/);
     expect(readRunStateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("prints the cached ticket title and attach hint in the inventory when available", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a" }),
+      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+    ]);
+    const statesByTicket = new Map([
+      ["team-1", runState({ ticket: "team-1", title: "Improve crew status command" })],
+      // team-2 has a run state but no cached title — title line must be omitted.
+      ["team-2", runState({ ticket: "team-2" })],
+    ]);
+    readRunStateMock.mockImplementation((_config, ticket) => statesByTicket.get(ticket));
+    // Worktrees iterate in sorted-ticket order: team-1 first, then team-2.
+    // First call returns a hint; second (team-2) falls through to the
+    // default `vi.fn` return of undefined.
+    workspaceAccessHintMock.mockResolvedValueOnce({
+      kind: "attachCommand",
+      command: "tmux attach -t crew:team-1",
+    });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  title:     Improve crew status command");
+    expect(output).toContain("  attach:    tmux attach -t crew:team-1");
+    // team-2 has neither a cached title nor an access hint; no extra lines.
+    expect(output).not.toMatch(/team-2[\s\S]* {2}title:/);
+    expect(output).not.toMatch(/team-2[\s\S]* {2}attach:/);
+  });
+
+  it("hides the Stray sessions section when every live session matches a worktree", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).not.toContain("Stray sessions");
+  });
+
+  it("formats durations across <1m / Nm / Nh / Nh Mm / Nd / Nd Mh ranges", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a" }),
+      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+      worktree({ ticket: "team-3", repository: "repo-b", branchName: "rocky-team-3" }),
+      worktree({ ticket: "team-4", repository: "repo-b", branchName: "rocky-team-4" }),
+      worktree({ ticket: "team-5", repository: "repo-b", branchName: "rocky-team-5" }),
+      worktree({ ticket: "team-6", repository: "repo-b", branchName: "rocky-team-6" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1", "team-2", "team-3", "team-4", "team-5", "team-6"]),
+    });
+    // beforeEach pinned now to 2026-05-26T02:14:30Z.
+    const statesByTicket = new Map<string, RunState>([
+      // ~30s old → `<1m`
+      ["team-1", runState({ ticket: "team-1", createdAt: "2026-05-26T02:14:00.000Z" })],
+      // 12m old → `12m`
+      ["team-2", runState({ ticket: "team-2", createdAt: "2026-05-26T02:02:30.000Z" })],
+      // 3d 7h old → `3d 7h`
+      ["team-3", runState({ ticket: "team-3", createdAt: "2026-05-22T19:14:30.000Z" })],
+      // Malformed createdAt → no duration token
+      ["team-4", runState({ ticket: "team-4", createdAt: "not a date" })],
+      // Exactly 5h old → `5h` (whole-hour branch)
+      ["team-5", runState({ ticket: "team-5", createdAt: "2026-05-25T21:14:30.000Z" })],
+      // Exactly 4d old → `4d` (whole-day branch)
+      ["team-6", runState({ ticket: "team-6", createdAt: "2026-05-22T02:14:30.000Z" })],
+    ]);
+    readRunStateMock.mockImplementation((_config, ticket) => statesByTicket.get(ticket));
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-1\n  state:     running (<1m)");
+    expect(output).toContain("team-2\n  state:     running (12m)");
+    expect(output).toContain("team-3\n  state:     running (3d 7h)");
+    // Malformed createdAt → no duration token.
+    expect(output).toContain("team-4\n  state:     running\n");
+    expect(output).toContain("team-5\n  state:     running (5h)");
+    expect(output).toContain("team-6\n  state:     running (4d)");
+  });
+
+  it("omits the duration from non-running states (interrupted, idle)", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a" }),
+      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    const statesByTicket = new Map<string, RunState>([
+      ["team-1", runState({ ticket: "team-1", state: "interrupted" })],
+    ]);
+    readRunStateMock.mockImplementation((_config, ticket) => statesByTicket.get(ticket));
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  state:     interrupted\n");
+    expect(output).toContain("  state:     idle\n");
+  });
+
+  it("suggests `crew cleanup` next to stray-session rows", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    // idle (no run-state) + live session => stray.
+    readRunStateMock.mockReset();
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).toContain(
+      "  hint:      run 'crew cleanup team-1' to clear this stray session",
+    );
+  });
+
+  it("suggests `crew resume` next to session-dead rows", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    // running run-state + no live session => session dead.
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).toContain(
+      "  hint:      run 'crew resume team-1' to bring the session back",
+    );
+  });
+
+  it("omits the `hint:` line on healthy rows", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).not.toContain("  hint:");
+  });
+
+  it("omits the `hint:` line when the workspace probe is unavailable", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).not.toContain("  hint:");
+  });
+
+  it("labels run state as `idle` when no RunState file exists and no session is live", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReset();
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-1\n  state:     idle\n");
+    expect(output).not.toContain("session dead");
+    expect(output).not.toContain("stray session");
+  });
+
+  it("renders a `pr:` line in inventory rows when gh finds a pull request", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    findPullRequestsMock.mockResolvedValue([
+      {
+        url: "https://github.com/acme/widgets/pull/42",
+        number: 42,
+        state: "open",
+        title: "Wire up auth",
+      },
+    ]);
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).toContain(
+      "  pr:        https://github.com/acme/widgets/pull/42 (open)",
+    );
+    expect(findPullRequestsMock).toHaveBeenCalledWith({
+      repository: "repo-a",
+      branchName: "rocky-team-1",
+    });
+  });
+
+  it("joins multiple PRs on one line in inventory rows", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    findPullRequestsMock.mockResolvedValue([
+      { url: "https://x/pull/1", number: 1, state: "open", title: "a" },
+      { url: "https://x/pull/2", number: 2, state: "merged", title: "b" },
+    ]);
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).toContain(
+      "  pr:        https://x/pull/1 (open), https://x/pull/2 (merged)",
+    );
+  });
+
+  it("omits the `pr:` line in inventory rows when gh returns nothing", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    findPullRequestsMock.mockResolvedValue([]);
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).not.toContain("  pr:");
+  });
+
+  it("renders a `pr:` line in the per-ticket Worktree state section when present", async () => {
+    findByTicketMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
+    ]);
+    findPullRequestsMock.mockResolvedValue([
+      {
+        url: "https://github.com/acme/widgets/pull/99",
+        number: 99,
+        state: "open",
+        title: "Something",
+      },
+    ]);
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    expect(consoleLog.output()).toContain("  pr: https://github.com/acme/widgets/pull/99 (open)");
+  });
+
+  it("renders the cached ticket url next to the inventory ticket id", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReturnValue(
+      runState({ ticket: "team-1", url: "https://linear.app/example/issue/TEAM-1" }),
+    );
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig());
+
+    expect(consoleLog.output()).toContain("team-1  https://linear.app/example/issue/TEAM-1\n");
+  });
+
+  it("renders the cached ticket url next to the per-ticket header", async () => {
+    readRunStateMock.mockReturnValue(runState({ url: "https://linear.app/example/issue/TEAM-1" }));
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    expect(consoleLog.output()).toContain(
+      "ticket: team-1  https://linear.app/example/issue/TEAM-1",
+    );
+  });
+
+  it("prints `slots: N/M used` reflecting in-progress source issues against the orchestrator cap", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({ id: "linear:team-901", status: "in-progress" }),
+        sourceIssue({ id: "linear:team-902", status: "in-progress" }),
+        sourceIssue({ id: "linear:team-903", status: "todo" }),
+        sourceIssue({ id: "linear:team-904", status: "done" }),
+      ]),
+    ]);
+
+    await status(
+      makeConfig({
+        sources: [{ kind: "linear", name: "linear" }],
+        orchestrator: {
+          maximumInProgress: 4,
+          pollIntervalMilliseconds: 1000,
+          sessionLimitPercentage: 85,
+        },
+      }),
+    );
+
+    expect(consoleLog.output()).toContain("slots: 2/4 used");
+  });
+
+  it("omits the slots line when the source fetch fails", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([], {
+        fetch: async () => {
+          throw new Error("linear down");
+        },
+      }),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).not.toContain("slots:");
+    // Queue section still surfaces the diagnostic.
+    expect(output).toContain("unavailable: linear down");
+  });
+
+  it("hides the Queue section entirely when the source has no eligible Todos", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    // buildSources resolves to an implicit Linear source whose fetch returns
+    // no eligible Todos — the Queue section should not appear at all.
+    buildSourcesMock.mockResolvedValue([fakeSource([])]);
+
+    await status(makeConfig({ sources: [] }));
+
+    expect(consoleLog.output()).not.toContain("Queue");
+    expect(consoleLog.output()).not.toContain("Blocked");
+  });
+
+  it("renders queue + blocked sections from the configured source", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        // Eligible Todo with url and clean blockers list.
+        sourceIssue({
+          id: "linear:team-101",
+          title: "Wire up auth",
+          url: "https://linear.app/example/issue/TEAM-101",
+          repository: "repo-a",
+          model: "claude",
+        }),
+        // Eligible Todo blocked by another in-progress ticket.
+        sourceIssue({
+          id: "linear:team-102",
+          title: "Polish UI",
+          url: "https://linear.app/example/issue/TEAM-102",
+          repository: "repo-b",
+          model: "codex",
+          blockers: [
+            {
+              id: "linear:team-50",
+              title: "Migrate db",
+              status: "in-progress",
+              nativeStatus: "In Progress",
+            },
+          ],
+        }),
+        // Ineligible (no model/repo) — excluded from Queue.
+        sourceIssue({
+          id: "linear:team-103",
+          title: "No label",
+          repository: undefined,
+          model: undefined,
+        }),
+        // Not Todo — excluded.
+        sourceIssue({ id: "linear:team-104", status: "in-progress" }),
+      ]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("Queue\n-----");
+    expect(output).toContain("team-101  https://linear.app/example/issue/TEAM-101");
+    expect(output).toContain("  title:     Wire up auth");
+    expect(output).toContain("  repo:      repo-a");
+    expect(output).toContain("  model:     claude");
+    expect(output).toContain("Blocked\n-------");
+    expect(output).toContain("team-102  https://linear.app/example/issue/TEAM-102");
+    expect(output).toContain("  blocked by:  team-50 (In Progress)");
+    // Ineligible / non-Todo issues never appear.
+    expect(output).not.toContain("team-103");
+    expect(output).not.toContain("team-104");
+  });
+
+  it("hides the Queue section when the source has only non-Todo issues", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-201", status: "in-progress" })]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    expect(consoleLog.output()).not.toContain("Queue");
+  });
+
+  it("separates multiple Queue and Blocked rows with blank lines", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    const ready1 = sourceIssue({ id: "linear:team-301", title: "First ready" });
+    const ready2 = sourceIssue({ id: "linear:team-302", title: "Second ready" });
+    const blockedA = sourceIssue({
+      id: "linear:team-401",
+      title: "First blocked",
+      blockers: [{ id: "linear:team-9", title: "x", status: "in-progress" }],
+    });
+    const blockedB = sourceIssue({
+      id: "linear:team-402",
+      title: "Second blocked",
+      blockers: [{ id: "linear:team-10", title: "y", status: "in-progress" }],
+    });
+    buildSourcesMock.mockResolvedValue([fakeSource([ready1, ready2, blockedA, blockedB])]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    // Queue rows split by a blank line.
+    expect(output).toMatch(/First ready[\s\S]*\n\nteam-302/);
+    // Blocked rows split by a blank line.
+    expect(output).toMatch(/First blocked[\s\S]*\n\nteam-402/);
+  });
+
+  it("prints `unavailable` in the Queue section when source fetch fails", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([], {
+        fetch: async () => {
+          throw new Error("linear down");
+        },
+      }),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    expect(consoleLog.output()).toContain("Queue\n-----\nunavailable: linear down");
   });
 
   it("prints inventory probe failures and empty worktrees", async () => {
@@ -324,7 +849,10 @@ describe(status, () => {
     await status(makeConfig());
 
     const output = consoleLog.output();
-    expect(output).toContain("team-1  repo-a  host  workspace=unknown  run=running");
+    // probe=unknown shouldn't be flagged as orphaned ("session dead") because
+    // we don't actually know — the probe failed. Duration still shows.
+    expect(output).toContain("team-1\n  state:     running (2h 14m)\n");
+    expect(output).not.toContain("session dead");
     expect(output).toContain("Workspace probe unavailable: cmux unavailable");
   });
 });
@@ -338,6 +866,8 @@ describe(statusCli, () => {
     listWorktreesMock.mockReturnValue([]);
     findByTicketMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+    workspaceAccessHintMock.mockReset();
+    findPullRequestsMock.mockResolvedValue([]);
     readRunStateMock.mockReset();
     fetchRawLinearIssueMock.mockResolvedValue(rawIssue());
     getLinearClientMock.mockReturnValue(linearClient());
@@ -361,8 +891,7 @@ describe(statusCli, () => {
     await statusCli([]);
 
     expect(listWorktreesMock).toHaveBeenCalledWith(expect.any(Object));
-    expect(consoleLog.output()).toContain("groundcrew status");
-    expect(consoleLog.output()).toContain("(none)");
+    expect(consoleLog.output()).toContain("Worktrees\n---------\n(none)");
   });
 
   it("rejects an empty ticket argument", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -260,8 +260,10 @@ describe(status, () => {
     expect(output).not.toContain("ticket=team-10");
     expect(output).toContain('Workspace "TEAM-1" launched');
     expect(output).not.toContain("unrelated ticket");
-    expect(output).toContain("Ticket source");
-    expect(output).toContain("linear:team-1  in-progress  https://linear.app/example/issue/TEAM-1");
+    expect(output).not.toContain("Ticket source");
+    expect(output).toContain(
+      "ticket: team-1  in-progress  https://linear.app/example/issue/TEAM-1",
+    );
     expect(output).toContain("title: Fix status");
   });
 
@@ -275,14 +277,13 @@ describe(status, () => {
     await status(config, { ticket: "team-404" });
 
     const output = consoleLog.output();
-    expect(output).toContain("ticket: team-404");
+    expect(output).toContain("ticket: team-404  source unavailable: source down");
     expect(output).toContain("run: (none)");
     expect(output).toContain("workspace: not live");
     expect(output).toContain("Worktrees");
     expect(output).toContain("(none)");
     expect(output).not.toContain("Recent logs");
-    expect(output).toContain("Ticket source");
-    expect(output).toContain("unavailable: source down");
+    expect(output).not.toContain("Ticket source");
   });
 
   it("rejects an empty direct-call ticket", async () => {
@@ -304,7 +305,7 @@ describe(status, () => {
 
     const output = consoleLog.output();
     expect(output).toContain("running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0");
-    expect(output).toContain("linear:team-1  other");
+    expect(output).toContain("ticket: team-1  other");
     expect(output).toContain("title: No state type");
   });
 
@@ -340,6 +341,17 @@ describe(status, () => {
     await status(makeConfig(), { ticket: "team-1" });
 
     expect(consoleLog.output().match(/title: Improve crew status command/g)).toHaveLength(1);
+  });
+
+  it("prints a changed source title separately from the cached title", async () => {
+    readRunStateMock.mockReturnValue(runState({ title: "Cached title" }));
+    buildSourcesMock.mockResolvedValue([fakeSource([sourceIssue({ title: "Current title" })])]);
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("title: Cached title");
+    expect(output).toContain("source title: Current title");
   });
 
   it("omits the cached title line when no run state has a title", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -107,6 +107,13 @@ async function noopUndefined<T>(): Promise<T | undefined> {
   return undefined as T | undefined;
 }
 
+async function flushMicrotasks(count = 10): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    // oxlint-disable-next-line no-await-in-loop -- test helper intentionally drains queued promise work.
+    await Promise.resolve();
+  }
+}
+
 function fakeSource(
   issues: readonly SourceIssue[],
   overrides: {
@@ -443,6 +450,27 @@ describe(status, () => {
     expect(output).not.toMatch(/team-2[\s\S]* {2}attach:/);
   });
 
+  it("omits only the failed attach hint when one workspace access hint lookup rejects", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a" }),
+      worktree({ ticket: "team-2", repository: "repo-b", branchName: "rocky-team-2" }),
+    ]);
+    workspaceAccessHintMock
+      .mockRejectedValueOnce(new Error("tmux unavailable"))
+      .mockResolvedValueOnce({
+        kind: "attachCommand",
+        command: "tmux attach -t crew:team-2",
+      });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-1\n  state:");
+    expect(output).toContain("team-2\n  state:");
+    expect(output).not.toContain("tmux unavailable");
+    expect(output).toContain("  attach:    tmux attach -t crew:team-2");
+  });
+
   it("hides the Stray sessions section when every live session matches a worktree", async () => {
     listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
@@ -698,6 +726,32 @@ describe(status, () => {
     expect(output).not.toContain("slots:");
     // Queue section still surfaces the diagnostic.
     expect(output).toContain("unavailable: linear down");
+  });
+
+  it("prints local inventory before source fetch completes", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    let resolveFetch: ((issues: SourceIssue[]) => void) | undefined;
+    const pendingFetch = new Promise<SourceIssue[]>((resolve) => {
+      resolveFetch = resolve;
+    });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([], {
+        fetch: async () => await pendingFetch,
+      }),
+    ]);
+
+    const statusPromise = status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+    await flushMicrotasks();
+
+    const output = consoleLog.output();
+    expect(output).toContain("Worktrees");
+    expect(output).toContain("team-1\n  state:");
+    expect(output).not.toContain("Queue");
+    const completeFetch = resolveFetch;
+    expect(completeFetch).toBeTypeOf("function");
+    completeFetch?.([]);
+    await statusPromise;
   });
 
   it("hides the Queue section entirely when the source has no eligible Todos", async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -123,29 +123,23 @@ async function resolveTicketSource(
   return await withLogOutputSuppressed(async () => await board.resolveOne(ticket));
 }
 
-function formatTicketSourceIssue(issue: SourceIssue): string {
-  const base = `${issue.id}  ${issue.status}`;
-  return issue.url === undefined ? base : `${base}  ${issue.url}`;
-}
+type TicketSourceStatus =
+  | { kind: "found"; issue: SourceIssue }
+  | { kind: "not-found" }
+  | { kind: "unavailable"; reason: string };
 
-async function writeTicketSourceStatus(
+async function readTicketSourceStatus(
   config: ResolvedConfig,
   ticket: string,
-  cachedTitle: string | undefined,
-): Promise<void> {
-  writeSection("Ticket source");
+): Promise<TicketSourceStatus> {
   try {
     const issue = await resolveTicketSource(config, ticket);
     if (issue === undefined) {
-      writeOutput("(not found)");
-      return;
+      return { kind: "not-found" };
     }
-    writeOutput(formatTicketSourceIssue(issue));
-    if (issue.title !== cachedTitle) {
-      writeOutput(`title: ${issue.title}`);
-    }
+    return { kind: "found", issue };
   } catch (error) {
-    writeOutput(`unavailable: ${errorMessage(error)}`);
+    return { kind: "unavailable", reason: errorMessage(error) };
   }
 }
 
@@ -158,6 +152,41 @@ function writeRecentLogs(config: ResolvedConfig, ticket: string): void {
   writeOutput(logLines.join("\n"));
 }
 
+function formatTicketLine(
+  ticket: string,
+  runState: RunState | undefined,
+  sourceStatus: TicketSourceStatus,
+): string {
+  const parts = [`ticket: ${ticket}`];
+  if (sourceStatus.kind === "found") {
+    parts.push(sourceStatus.issue.status);
+  }
+  const url =
+    sourceStatus.kind === "found" ? (sourceStatus.issue.url ?? runState?.url) : runState?.url;
+  if (url !== undefined) {
+    parts.push(url);
+  }
+  if (sourceStatus.kind === "not-found") {
+    parts.push("source not found");
+  }
+  if (sourceStatus.kind === "unavailable") {
+    parts.push(`source unavailable: ${sourceStatus.reason}`);
+  }
+  return parts.join("  ");
+}
+
+function writeTicketTitle(runState: RunState | undefined, sourceStatus: TicketSourceStatus): void {
+  const cachedTitle = runState?.title;
+  const sourceTitle = sourceStatus.kind === "found" ? sourceStatus.issue.title : undefined;
+  const title = cachedTitle ?? sourceTitle;
+  if (title !== undefined) {
+    writeOutput(`title: ${title}`);
+  }
+  if (cachedTitle !== undefined && sourceTitle !== undefined && cachedTitle !== sourceTitle) {
+    writeOutput(`source title: ${sourceTitle}`);
+  }
+}
+
 async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Promise<void> {
   const ticket = rawTicket.toLowerCase();
   const displayTicket = ticket.toUpperCase();
@@ -165,19 +194,17 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   writeOutput("=".repeat(`groundcrew status ${displayTicket}`.length));
 
   const runState = readRunState(config, ticket);
-  const workspaceProbe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-  writeOutput(
-    runState?.url === undefined ? `ticket: ${ticket}` : `ticket: ${ticket}  ${runState.url}`,
-  );
-  if (runState?.title !== undefined) {
-    writeOutput(`title: ${runState.title}`);
-  }
+  const [workspaceProbe, sourceStatus] = await Promise.all([
+    withLogOutputSuppressed(async () => await workspaces.probe(config)),
+    readTicketSourceStatus(config, ticket),
+  ]);
+  writeOutput(formatTicketLine(ticket, runState, sourceStatus));
+  writeTicketTitle(runState, sourceStatus);
   writeOutput(`run: ${formatRunState(runState)}`);
   writeOutput(`workspace: ${ticketWorkspaceText(workspaceProbe, ticket)}`);
 
   await writeTicketWorktrees(config, ticket);
   writeRecentLogs(config, ticket);
-  await writeTicketSourceStatus(config, ticket, runState?.title);
 }
 
 /**

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -354,13 +354,15 @@ async function collectAccessHints(
   entries: readonly { ticket: string }[],
 ): Promise<Map<string, WorkspaceAccessHint | undefined>> {
   const uniqueTickets = [...new Set(entries.map((entry) => entry.ticket))];
-  const results = await Promise.all(
-    uniqueTickets.map(async (ticket) => {
-      const hint = await workspaces.accessHint(config, ticket);
-      return [ticket, hint] as const;
+  const results = await Promise.allSettled(
+    uniqueTickets.map(async (ticket) => await workspaces.accessHint(config, ticket)),
+  );
+  return new Map(
+    uniqueTickets.map((ticket, index) => {
+      const result = results[index];
+      return [ticket, result?.status === "fulfilled" ? result.value : undefined] as const;
     }),
   );
-  return new Map(results);
 }
 
 async function collectPullRequests(
@@ -493,15 +495,18 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
   // Banner ("groundcrew status\n=================") dropped: the command
   // you just ran already tells you what report you're looking at, and the
   // section headers (`Worktrees`, `Queue`, etc.) carry the visual anchors.
-  const boardResult = await fetchBoardForStatus(config);
-  if (boardResult.kind === "ok") {
-    const used = inProgressCount(boardResult.issues);
-    writeOutput(`slots: ${used}/${config.orchestrator.maximumInProgress} used`);
-  }
+  const boardResultPromise = fetchBoardForStatus(config);
   const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
   await writeInventoryWorktrees(config, probe);
   const worktreeTickets = new Set(worktrees.list(config).map((entry) => entry.ticket));
   writeStraySessions(probe, worktreeTickets);
+
+  const boardResult = await boardResultPromise;
+  if (boardResult.kind === "ok") {
+    const used = inProgressCount(boardResult.issues);
+    writeOutput();
+    writeOutput(`slots: ${used}/${config.orchestrator.maximumInProgress} used`);
+  }
   writeQueueSections(boardResult);
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,10 +2,19 @@ import { readFileSync } from "node:fs";
 
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { fetchRawLinearIssue } from "../lib/adapters/linear/fetch.ts";
+import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
+import {
+  type GroundcrewIssue,
+  isGroundcrewIssue,
+  type Issue as SourceIssue,
+  naturalIdFromCanonical,
+} from "../lib/ticketSource.ts";
 import { errorMessage, withLogOutputSuppressed, writeOutput } from "../lib/util.ts";
-import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
+import { type WorkspaceAccessHint, type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, worktrees } from "../lib/worktrees.ts";
 
 export interface StatusOptions {
@@ -65,12 +74,22 @@ async function writeTicketWorktrees(config: ResolvedConfig, ticket: string): Pro
   }
   for (const entry of entries) {
     // oxlint-disable-next-line no-await-in-loop -- status output is easier to read in worktree order.
-    const dirtiness = await worktrees.probeWorkingTree({ worktreeDir: entry.dir });
+    const dirtiness = await worktrees.probeWorkingTree({
+      worktreeDir: entry.dir,
+    });
+    // oxlint-disable-next-line no-await-in-loop -- one gh lookup per worktree is acceptable; multi-worktree-per-ticket is rare.
+    const prs = await findPullRequestsForBranch({
+      repository: entry.repository,
+      branchName: entry.branchName,
+    });
     writeOutput(`- ${entry.repository} ${entry.kind}`);
     writeOutput(`  ticket: ${entry.ticket}`);
     writeOutput(`  branch: ${entry.branchName}`);
     writeOutput(`  dir: ${entry.dir}`);
     writeOutput(`  git: ${formatDirtiness(dirtiness)}`);
+    if (prs.length > 0) {
+      writeOutput(`  pr: ${formatPullRequests(prs)}`);
+    }
   }
 }
 
@@ -116,7 +135,10 @@ function recentTicketLogLines(config: ResolvedConfig, ticket: string): string[] 
 
 async function linearStatus(ticket: string): Promise<string> {
   try {
-    const issue = await fetchRawLinearIssue({ client: getLinearClient(), ticket });
+    const issue = await fetchRawLinearIssue({
+      client: getLinearClient(),
+      ticket,
+    });
     // `stateType` is "" when Linear returned a stateless ticket; surface that
     // as "unknown" rather than an empty token.
     return `${issue.stateName} (state.type=${issue.stateType || "unknown"}) — ${issue.title}`;
@@ -130,7 +152,17 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   const displayTicket = ticket.toUpperCase();
   writeOutput(`groundcrew status ${displayTicket}`);
   writeOutput("=".repeat(`groundcrew status ${displayTicket}`.length));
-  writeOutput(`ticket: ${ticket}`);
+
+  // Cached title and url are local; surface them before the
+  // network-dependent Linear section so the header is informative even
+  // when offline.
+  const runState = readRunState(config, ticket);
+  writeOutput(
+    runState?.url === undefined ? `ticket: ${ticket}` : `ticket: ${ticket}  ${runState.url}`,
+  );
+  if (runState?.title !== undefined) {
+    writeOutput(`title: ${runState.title}`);
+  }
 
   writeConfigSnapshot(config);
   await writeTicketWorktrees(config, ticket);
@@ -138,7 +170,7 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   writeTicketWorkspace(workspaceProbe, ticket);
 
   writeSection("Run state");
-  writeOutput(formatRunState(readRunState(config, ticket)));
+  writeOutput(formatRunState(runState));
 
   writeSection("Recent logs");
   const logLines = recentTicketLogLines(config, ticket);
@@ -148,14 +180,126 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   writeOutput(await linearStatus(ticket));
 }
 
-function workspacePresence(probe: WorkspaceProbe, ticket: string): string {
-  if (probe.kind === "unavailable") {
-    return "unknown";
+/**
+ * Wall-clock elapsed time since the run was first recorded (RunState.createdAt
+ * is preserved across resume/interrupt). Returns undefined when the row isn't
+ * actively running, when no run state exists, or when the timestamp cannot
+ * be parsed.
+ */
+function runStateDurationMs(runState: RunState | undefined, now: Date): number | undefined {
+  if (runState === undefined) {
+    return undefined;
   }
-  return probe.names.has(ticket) ? "yes" : "no";
+  if (runState.state !== "running" && runState.state !== "resumed") {
+    return undefined;
+  }
+  const created = Date.parse(runState.createdAt);
+  if (Number.isNaN(created)) {
+    return undefined;
+  }
+  return now.getTime() - created;
 }
 
-function writeInventoryWorktrees(config: ResolvedConfig, probe: WorkspaceProbe): void {
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+function formatDuration(ms: number): string {
+  if (ms < MS_PER_MINUTE) {
+    return "<1m";
+  }
+  if (ms < MS_PER_HOUR) {
+    return `${Math.floor(ms / MS_PER_MINUTE)}m`;
+  }
+  if (ms < MS_PER_DAY) {
+    const hours = Math.floor(ms / MS_PER_HOUR);
+    const minutes = Math.floor((ms - hours * MS_PER_HOUR) / MS_PER_MINUTE);
+    return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+  }
+  const days = Math.floor(ms / MS_PER_DAY);
+  const hours = Math.floor((ms - days * MS_PER_DAY) / MS_PER_HOUR);
+  return hours === 0 ? `${days}d` : `${days}d ${hours}h`;
+}
+
+/**
+ * Combined human-readable state for the inventory row. Surfaces RunState
+ * lifecycle and flags the two interesting disagreements with the workspace
+ * probe — `(session dead)` when we recorded a running dispatch but no
+ * session is alive, and `(stray session)` when a session is alive without
+ * any recorded dispatch. `probe.kind === "unavailable"` is treated as
+ * "we don't know" and never produces a suffix. When the row is actively
+ * running, appends the elapsed wall-clock time since dispatch.
+ */
+function inventoryStateText(
+  runState: RunState | undefined,
+  probe: WorkspaceProbe,
+  ticket: string,
+  now: Date,
+): string {
+  const lifecycle = runState?.state ?? "idle";
+  const duration = runStateDurationMs(runState, now);
+  const flags: string[] = [];
+  if (probe.kind === "ok") {
+    const sessionLive = probe.names.has(ticket);
+    if (lifecycle === "idle" && sessionLive) {
+      flags.push("stray session");
+    }
+    if ((lifecycle === "running" || lifecycle === "resumed") && !sessionLive) {
+      flags.push("session dead");
+    }
+  }
+  if (duration !== undefined) {
+    flags.push(formatDuration(duration));
+  }
+  return flags.length === 0 ? lifecycle : `${lifecycle} (${flags.join(", ")})`;
+}
+
+/**
+ * Hint command for inventory rows where the run-state and the workspace
+ * probe disagree. Returned commands are safe defaults; the user is free to
+ * ignore them and use `attach:` + `pr:` to investigate first.
+ *
+ * - Stray session (live session, no run-state record) → `crew cleanup` to
+ *   tear down the orphaned worktree + close the session.
+ * - Session dead (run-state says running/resumed, no live session) →
+ *   `crew resume` to bring the agent back; the worktree is preserved.
+ *
+ * No hint when the probe is unavailable (we genuinely don't know whether
+ * there's a disagreement) or when the row is healthy.
+ */
+function inventoryHint(
+  runState: RunState | undefined,
+  probe: WorkspaceProbe,
+  ticket: string,
+): string | undefined {
+  if (probe.kind === "unavailable") {
+    return undefined;
+  }
+  const lifecycle = runState?.state ?? "idle";
+  const sessionLive = probe.names.has(ticket);
+  if (lifecycle === "idle" && sessionLive) {
+    return `run 'crew cleanup ${ticket}' to clear this stray session`;
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionLive) {
+    return `run 'crew resume ${ticket}' to bring the session back`;
+  }
+  return undefined;
+}
+
+const INVENTORY_LABEL_WIDTH = "worktree:".length;
+
+function inventoryField(label: string, value: string): string {
+  return `  ${`${label}:`.padEnd(INVENTORY_LABEL_WIDTH)}  ${value}`;
+}
+
+function formatPullRequests(prs: readonly PullRequestSummary[]): string {
+  return prs.map((pr) => `${pr.url} (${pr.state})`).join(", ");
+}
+
+async function writeInventoryWorktrees(
+  config: ResolvedConfig,
+  probe: WorkspaceProbe,
+): Promise<void> {
   writeSection("Worktrees");
   const entries = worktrees
     .list(config)
@@ -164,35 +308,201 @@ function writeInventoryWorktrees(config: ResolvedConfig, probe: WorkspaceProbe):
     writeOutput("(none)");
     return;
   }
+  const accessHints = await collectAccessHints(config, entries);
+  const pullRequests = await collectPullRequests(entries);
   const runStates = new Map<string, RunState | undefined>();
-  for (const entry of entries) {
+  const now = new Date();
+  for (const [index, entry] of entries.entries()) {
     if (!runStates.has(entry.ticket)) {
       runStates.set(entry.ticket, readRunState(config, entry.ticket));
     }
     const runState = runStates.get(entry.ticket);
-    writeOutput(
-      `${entry.ticket}  ${entry.repository}  ${entry.kind}  workspace=${workspacePresence(probe, entry.ticket)}  run=${runState?.state ?? "none"}`,
-    );
-    writeOutput(`  ${entry.branchName}  ${entry.dir}`);
+    const accessHint = accessHints.get(entry.ticket);
+    // `collectPullRequests` guarantees an entry for every (repo, branch)
+    // pair seen in `entries`; the lookup always returns the array.
+    /* v8 ignore next @preserve -- defensive fallback for a Map key that collectPullRequests always populates */
+    const prs = pullRequests.get(pullRequestKey(entry.repository, entry.branchName)) ?? [];
+    if (index > 0) {
+      writeOutput();
+    }
+    writeOutput(runState?.url === undefined ? entry.ticket : `${entry.ticket}  ${runState.url}`);
+    if (runState?.title !== undefined) {
+      writeOutput(inventoryField("title", runState.title));
+    }
+    writeOutput(inventoryField("state", inventoryStateText(runState, probe, entry.ticket, now)));
+    writeOutput(inventoryField("repo", entry.repository));
+    writeOutput(inventoryField("worktree", entry.dir));
+    if (accessHint !== undefined) {
+      writeOutput(inventoryField("attach", accessHint.command));
+    }
+    if (prs.length > 0) {
+      writeOutput(inventoryField("pr", formatPullRequests(prs)));
+    }
+    const hint = inventoryHint(runState, probe, entry.ticket);
+    if (hint !== undefined) {
+      writeOutput(inventoryField("hint", hint));
+    }
   }
 }
 
-function writeInventoryWorkspaces(probe: WorkspaceProbe): void {
-  writeSection("Live workspaces");
+function pullRequestKey(repository: string, branchName: string): string {
+  return `${repository} ${branchName}`;
+}
+
+async function collectAccessHints(
+  config: ResolvedConfig,
+  entries: readonly { ticket: string }[],
+): Promise<Map<string, WorkspaceAccessHint | undefined>> {
+  const uniqueTickets = [...new Set(entries.map((entry) => entry.ticket))];
+  const results = await Promise.all(
+    uniqueTickets.map(async (ticket) => {
+      const hint = await workspaces.accessHint(config, ticket);
+      return [ticket, hint] as const;
+    }),
+  );
+  return new Map(results);
+}
+
+async function collectPullRequests(
+  entries: readonly { repository: string; branchName: string }[],
+): Promise<Map<string, readonly PullRequestSummary[]>> {
+  // Same-(repo, branch) entries collapse to one lookup; later inserts
+  // overwrite earlier ones with the same identifier, which is fine because
+  // gh would return the same PR list for both.
+  const uniqueKeys = new Map<string, { repository: string; branchName: string }>();
+  for (const entry of entries) {
+    uniqueKeys.set(pullRequestKey(entry.repository, entry.branchName), {
+      repository: entry.repository,
+      branchName: entry.branchName,
+    });
+  }
+  const results = await Promise.all(
+    [...uniqueKeys.entries()].map(async ([key, { repository, branchName }]) => {
+      const prs = await findPullRequestsForBranch({ repository, branchName });
+      return [key, prs] as const;
+    }),
+  );
+  return new Map(results);
+}
+
+function writeStraySessions(probe: WorkspaceProbe, worktreeTickets: ReadonlySet<string>): void {
   if (probe.kind === "unavailable") {
+    // Surface probe failures so the user knows we couldn't classify strays
+    // (silently dropping the section would hide that diagnostic).
+    writeSection("Stray sessions");
     writeOutput(workspaceProbeUnavailableLine(probe));
     return;
   }
-  const names = [...probe.names].toSorted();
-  writeOutput(names.length === 0 ? "(none)" : names.join("\n"));
+  const strays = [...probe.names].filter((name) => !worktreeTickets.has(name)).toSorted();
+  if (strays.length === 0) {
+    return;
+  }
+  writeSection("Stray sessions");
+  writeOutput(strays.join("\n"));
+}
+
+function isTodoSourceIssue(issue: SourceIssue): boolean {
+  return issue.status === "todo";
+}
+
+function hasOpenBlocker(issue: SourceIssue): boolean {
+  return issue.blockers.some((b) => b.status !== "done");
+}
+
+function describeOpenBlockers(issue: SourceIssue): string {
+  return issue.blockers
+    .filter((b) => b.status !== "done")
+    .map((b) => `${naturalIdFromCanonical(b.id)} (${b.nativeStatus ?? b.status})`)
+    .join(", ");
+}
+
+function writeQueueIssue(issue: GroundcrewIssue): void {
+  const naturalId = naturalIdFromCanonical(issue.id);
+  writeOutput(issue.url === undefined ? naturalId : `${naturalId}  ${issue.url}`);
+  writeOutput(inventoryField("title", issue.title));
+  writeOutput(inventoryField("repo", issue.repository));
+  writeOutput(inventoryField("model", issue.model));
+}
+
+async function buildBoardForStatus(config: ResolvedConfig): Promise<Board> {
+  const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  return createBoard(sources);
+}
+
+type BoardFetchResult =
+  | { kind: "ok"; issues: readonly SourceIssue[] }
+  | { kind: "error"; error: unknown };
+
+/**
+ * Single board fetch used by both the slot count header and the
+ * Queue/Blocked sections. `sourcesFromConfig` prepends an implicit Linear
+ * source when none are configured, so we always attempt; failures
+ * (e.g., missing API key) are captured and rendered later as
+ * `unavailable: ...` in the Queue section.
+ */
+async function fetchBoardForStatus(config: ResolvedConfig): Promise<BoardFetchResult> {
+  try {
+    const board = await buildBoardForStatus(config);
+    const { issues } = await withLogOutputSuppressed(async () => await board.fetch());
+    return { kind: "ok", issues };
+  } catch (error) {
+    return { kind: "error", error };
+  }
+}
+
+function writeQueueSections(boardResult: BoardFetchResult): void {
+  if (boardResult.kind === "error") {
+    writeSection("Queue");
+    writeOutput(`unavailable: ${errorMessage(boardResult.error)}`);
+    return;
+  }
+  // Only groundcrew-eligible Todos are dispatchable; non-eligible ones lack
+  // a repo or model, so `crew run` would skip them.
+  const todos = boardResult.issues.filter(isTodoSourceIssue).filter(isGroundcrewIssue);
+  const ready = todos.filter((i) => !hasOpenBlocker(i));
+  const blocked = todos.filter(hasOpenBlocker);
+
+  // Hide the section entirely when nothing's queued and nothing's blocked.
+  if (ready.length > 0) {
+    writeSection("Queue");
+    for (const [index, issue] of ready.entries()) {
+      if (index > 0) {
+        writeOutput();
+      }
+      writeQueueIssue(issue);
+    }
+  }
+
+  if (blocked.length > 0) {
+    writeSection("Blocked");
+    for (const [index, issue] of blocked.entries()) {
+      if (index > 0) {
+        writeOutput();
+      }
+      writeQueueIssue(issue);
+      writeOutput(inventoryField("blocked by", describeOpenBlockers(issue)));
+    }
+  }
+}
+
+function inProgressCount(issues: readonly SourceIssue[]): number {
+  return issues.filter((issue) => issue.status === "in-progress").length;
 }
 
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  writeOutput("groundcrew status");
-  writeOutput("=================");
+  // Banner ("groundcrew status\n=================") dropped: the command
+  // you just ran already tells you what report you're looking at, and the
+  // section headers (`Worktrees`, `Queue`, etc.) carry the visual anchors.
+  const boardResult = await fetchBoardForStatus(config);
+  if (boardResult.kind === "ok") {
+    const used = inProgressCount(boardResult.issues);
+    writeOutput(`slots: ${used}/${config.orchestrator.maximumInProgress} used`);
+  }
   const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-  writeInventoryWorktrees(config, probe);
-  writeInventoryWorkspaces(probe);
+  await writeInventoryWorktrees(config, probe);
+  const worktreeTickets = new Set(worktrees.list(config).map((entry) => entry.ticket));
+  writeStraySessions(probe, worktreeTickets);
+  writeQueueSections(boardResult);
 }
 
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,7 +1,5 @@
 import { readFileSync } from "node:fs";
 
-import { getLinearClient } from "../lib/adapters/linear/client.ts";
-import { fetchRawLinearIssue } from "../lib/adapters/linear/fetch.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -45,19 +43,6 @@ function writeSection(title: string): void {
   writeOutput("-".repeat(title.length));
 }
 
-function writeConfigSnapshot(config: ResolvedConfig): void {
-  writeSection("Config snapshot");
-  writeOutput(`projectDir: ${config.workspace.projectDir}`);
-  writeOutput(`repositories: ${config.workspace.knownRepositories.join(", ")}`);
-  writeOutput(`git: remote=${config.git.remote}; defaultBranch=${config.git.defaultBranch}`);
-  writeOutput(`workspaceKind: ${config.workspaceKind}`);
-  writeOutput(`local.runner: ${config.local.runner}`);
-  writeOutput(
-    `models: default=${config.models.default}; enabled=${Object.keys(config.models.definitions).join(", ")}`,
-  );
-  writeOutput(`logFile: ${config.logging.file}`);
-}
-
 function formatDirtiness(dirtiness: WorktreeDirtiness): string {
   if (dirtiness.kind === "dirty") {
     return `dirty (${dirtiness.modified} modified, ${dirtiness.untracked} untracked)`;
@@ -66,7 +51,7 @@ function formatDirtiness(dirtiness: WorktreeDirtiness): string {
 }
 
 async function writeTicketWorktrees(config: ResolvedConfig, ticket: string): Promise<void> {
-  writeSection("Worktree state");
+  writeSection("Worktrees");
   const entries = worktrees.findByTicket(config, ticket);
   if (entries.length === 0) {
     writeOutput("(none)");
@@ -83,7 +68,6 @@ async function writeTicketWorktrees(config: ResolvedConfig, ticket: string): Pro
       branchName: entry.branchName,
     });
     writeOutput(`- ${entry.repository} ${entry.kind}`);
-    writeOutput(`  ticket: ${entry.ticket}`);
     writeOutput(`  branch: ${entry.branchName}`);
     writeOutput(`  dir: ${entry.dir}`);
     writeOutput(`  git: ${formatDirtiness(dirtiness)}`);
@@ -101,13 +85,11 @@ function workspaceProbeUnavailableLine(
     : `Workspace probe unavailable: ${errorMessage(probe.error)}`;
 }
 
-function writeTicketWorkspace(probe: WorkspaceProbe, ticket: string): void {
-  writeSection("Workspace probe");
+function ticketWorkspaceText(probe: WorkspaceProbe, ticket: string): string {
   if (probe.kind === "unavailable") {
-    writeOutput(workspaceProbeUnavailableLine(probe));
-    return;
+    return workspaceProbeUnavailableLine(probe);
   }
-  writeOutput(`live: ${probe.names.has(ticket) ? "yes" : "no"}`);
+  return probe.names.has(ticket) ? "live" : "not live";
 }
 
 function formatRunState(state: RunState | undefined): string {
@@ -133,18 +115,47 @@ function recentTicketLogLines(config: ResolvedConfig, ticket: string): string[] 
     .slice(-RECENT_LOG_LINE_COUNT);
 }
 
-async function linearStatus(ticket: string): Promise<string> {
+async function resolveTicketSource(
+  config: ResolvedConfig,
+  ticket: string,
+): Promise<SourceIssue | undefined> {
+  const board = await buildBoardForStatus(config);
+  return await withLogOutputSuppressed(async () => await board.resolveOne(ticket));
+}
+
+function formatTicketSourceIssue(issue: SourceIssue): string {
+  const base = `${issue.id}  ${issue.status}`;
+  return issue.url === undefined ? base : `${base}  ${issue.url}`;
+}
+
+async function writeTicketSourceStatus(
+  config: ResolvedConfig,
+  ticket: string,
+  cachedTitle: string | undefined,
+): Promise<void> {
+  writeSection("Ticket source");
   try {
-    const issue = await fetchRawLinearIssue({
-      client: getLinearClient(),
-      ticket,
-    });
-    // `stateType` is "" when Linear returned a stateless ticket; surface that
-    // as "unknown" rather than an empty token.
-    return `${issue.stateName} (state.type=${issue.stateType || "unknown"}) — ${issue.title}`;
+    const issue = await resolveTicketSource(config, ticket);
+    if (issue === undefined) {
+      writeOutput("(not found)");
+      return;
+    }
+    writeOutput(formatTicketSourceIssue(issue));
+    if (issue.title !== cachedTitle) {
+      writeOutput(`title: ${issue.title}`);
+    }
   } catch (error) {
-    return `unavailable: ${errorMessage(error)}`;
+    writeOutput(`unavailable: ${errorMessage(error)}`);
   }
+}
+
+function writeRecentLogs(config: ResolvedConfig, ticket: string): void {
+  const logLines = recentTicketLogLines(config, ticket);
+  if (logLines.length === 0) {
+    return;
+  }
+  writeSection("Recent logs");
+  writeOutput(logLines.join("\n"));
 }
 
 async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Promise<void> {
@@ -153,31 +164,20 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   writeOutput(`groundcrew status ${displayTicket}`);
   writeOutput("=".repeat(`groundcrew status ${displayTicket}`.length));
 
-  // Cached title and url are local; surface them before the
-  // network-dependent Linear section so the header is informative even
-  // when offline.
   const runState = readRunState(config, ticket);
+  const workspaceProbe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
   writeOutput(
     runState?.url === undefined ? `ticket: ${ticket}` : `ticket: ${ticket}  ${runState.url}`,
   );
   if (runState?.title !== undefined) {
     writeOutput(`title: ${runState.title}`);
   }
+  writeOutput(`run: ${formatRunState(runState)}`);
+  writeOutput(`workspace: ${ticketWorkspaceText(workspaceProbe, ticket)}`);
 
-  writeConfigSnapshot(config);
   await writeTicketWorktrees(config, ticket);
-  const workspaceProbe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-  writeTicketWorkspace(workspaceProbe, ticket);
-
-  writeSection("Run state");
-  writeOutput(formatRunState(runState));
-
-  writeSection("Recent logs");
-  const logLines = recentTicketLogLines(config, ticket);
-  writeOutput(logLines.length === 0 ? "(none)" : logLines.join("\n"));
-
-  writeSection("Last Linear status");
-  writeOutput(await linearStatus(ticket));
+  writeRecentLogs(config, ticket);
+  await writeTicketSourceStatus(config, ticket, runState?.title);
 }
 
 /**

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -405,13 +405,18 @@ async function collectPullRequests(
       branchName: entry.branchName,
     });
   }
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     [...uniqueKeys.entries()].map(async ([key, { repository, branchName }]) => {
       const prs = await findPullRequestsForBranch({ repository, branchName });
       return [key, prs] as const;
     }),
   );
-  return new Map(results);
+  return new Map(
+    [...uniqueKeys.keys()].map((key, index) => {
+      const result = results[index];
+      return [key, result?.status === "fulfilled" ? result.value[1] : []] as const;
+    }),
+  );
 }
 
 function writeStraySessions(probe: WorkspaceProbe, worktreeTickets: ReadonlySet<string>): void {

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -56,6 +56,7 @@ function linearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
     teamId: overrides.teamId ?? "team-default",
     blockers: overrides.blockers ?? [],
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
+    url: overrides.url ?? "https://linear.app/example/issue/TEAM-1",
   };
 }
 
@@ -282,6 +283,7 @@ describe(createLinearTicketSource, () => {
       stateType: "unstarted",
       status: "Todo",
       statusId: "state-todo",
+      url: "https://linear.app/example/issue/TEAM-1",
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -147,6 +147,7 @@ export function toCanonicalIssue(linearIssue: LinearIssue, sourceName: string): 
     updatedAt: linearIssue.updatedAt,
     blockers: linearIssue.blockers.map((b) => toCanonicalBlocker(b, sourceName)),
     hasMoreBlockers: linearIssue.hasMoreBlockers,
+    url: linearIssue.url,
     sourceRef,
   };
 }
@@ -220,6 +221,7 @@ export function createLinearTicketSource(
         updatedAt: new Date().toISOString(),
         blockers: [],
         hasMoreBlockers: false,
+        url: resolved.url,
         sourceRef,
       };
     },

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -68,6 +68,8 @@ export interface Issue {
   teamId: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
+  /** Linear `Issue.url` — direct web link to the ticket. */
+  url: string;
 }
 
 /**
@@ -165,6 +167,7 @@ interface IssueNode {
   title: string;
   description?: string;
   updatedAt: string;
+  url: string;
   state?: { id: string; name: string; type: string };
   team?: { id: string; key: string };
   assignee?: { name: string } | null;
@@ -215,6 +218,7 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
             title
             description
             updatedAt
+            url
             state { id name type }
             team { id key }
             assignee { name }
@@ -320,6 +324,7 @@ function buildLinearIssue(input: {
   repository: string | undefined;
   model: string | undefined;
   teamId: string;
+  url: string;
   inverseRelations: { nodes: IssueRelationNode[]; pageInfo: { hasNextPage: boolean } } | undefined;
 }): Issue {
   return {
@@ -336,6 +341,7 @@ function buildLinearIssue(input: {
     repository: input.repository,
     model: input.model,
     teamId: input.teamId,
+    url: input.url,
     blockers: blockersFromRelations(input.inverseRelations?.nodes ?? []),
     hasMoreBlockers: input.inverseRelations?.pageInfo.hasNextPage ?? false,
   };
@@ -369,6 +375,7 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
     repository,
     model,
     teamId: node.team?.id ?? "",
+    url: node.url,
     inverseRelations: node.inverseRelations,
   });
 }
@@ -383,6 +390,7 @@ interface ResolvedIssue {
   stateType: string;
   status: string;
   statusId: string;
+  url: string;
 }
 
 const ISSUE_LABEL_PAGE_SIZE = 50;
@@ -407,6 +415,8 @@ export interface RawLinearIssue {
    * reporting "would dispatch."
    */
   hasChildren: boolean;
+  /** Linear `Issue.url` — direct web link to the ticket. */
+  url: string;
 }
 
 export async function fetchBlockersForTicket(arguments_: {
@@ -472,6 +482,7 @@ export async function fetchRawLinearIssue(arguments_: {
         id
         title
         description
+        url
         team { id }
         state { id name type }
         children { nodes { id } }
@@ -499,6 +510,7 @@ export async function fetchRawLinearIssue(arguments_: {
       id: string;
       title: string;
       description?: string | null;
+      url: string;
       team?: { id: string } | null;
       state?: { id: string; name: string; type: string } | null;
       children?: { nodes: { id: string }[] } | null;
@@ -528,6 +540,7 @@ export async function fetchRawLinearIssue(arguments_: {
     blockers: blockersFromRelations(issue.inverseRelations?.nodes ?? []),
     hasMoreBlockers: issue.inverseRelations?.pageInfo.hasNextPage ?? false,
     hasChildren: (issue.children?.nodes.length ?? 0) > 0,
+    url: issue.url,
   };
 }
 
@@ -622,6 +635,7 @@ export async function fetchResolvedIssue(arguments_: {
     stateType: raw.stateType,
     status: raw.stateName,
     statusId: raw.stateId,
+    url: raw.url,
   };
 }
 

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -49,6 +49,7 @@ function shellIssue(overrides: Partial<ShellIssue> = {}): ShellIssue {
     blockers: overrides.blockers ?? [],
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
     sourceRef: "sourceRef" in overrides ? overrides.sourceRef : { path: "/tmp/p.md" },
+    ...("url" in overrides ? { url: overrides.url } : {}),
   };
 }
 
@@ -85,6 +86,19 @@ describe(toCanonicalIssue, () => {
     );
     expect(result.repository).toBe("org/repo");
     expect(result.model).toBe("claude");
+  });
+
+  it("passes a url through to the canonical Issue when the script provides one", () => {
+    const result = toCanonicalIssue(
+      shellIssue({ url: "https://jira.example.com/browse/X-1" }),
+      "jira",
+    );
+    expect(result.url).toBe("https://jira.example.com/browse/X-1");
+  });
+
+  it("omits the canonical url when the script's payload has none", () => {
+    const result = toCanonicalIssue(shellIssue(), "jira");
+    expect(result).not.toHaveProperty("url");
   });
 
   it("source-prefixes blocker ids", () => {

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -73,6 +73,7 @@ export function toCanonicalIssue(shellIssue: ShellIssue, sourceName: string): Ca
     updatedAt: shellIssue.updatedAt,
     blockers,
     hasMoreBlockers: shellIssue.hasMoreBlockers,
+    ...(shellIssue.url === undefined ? {} : { url: shellIssue.url }),
     sourceRef: shellIssue.sourceRef,
   };
 }

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -32,6 +32,11 @@ export const shellIssueSchema = z.object({
   updatedAt: z.string(),
   blockers: z.array(shellBlockerSchema),
   hasMoreBlockers: z.boolean().optional().default(false),
+  /**
+   * Direct web URL for the ticket. Optional so scripts can omit it without
+   * breaking; `crew status` falls back to displaying just the id.
+   */
+  url: z.url().optional(),
   sourceRef: z.unknown(),
 });
 

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -1,0 +1,149 @@
+import type { RunCommandOptions } from "./commandRunner.ts";
+import { findPullRequestsForBranch } from "./pullRequests.ts";
+
+type RunCommandAsyncMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => Promise<string>;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandAsyncMock>());
+
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- single recorder for the captured-stdio overload of runCommandAsync
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+
+describe(findPullRequestsForBranch, () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses gh's JSON output into typed PR summaries", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      JSON.stringify([
+        {
+          url: "https://github.com/acme/widgets/pull/42",
+          number: 42,
+          state: "OPEN",
+          title: "Wire up auth",
+        },
+      ]),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "feature/auth",
+    });
+
+    expect(prs).toStrictEqual([
+      {
+        url: "https://github.com/acme/widgets/pull/42",
+        number: 42,
+        state: "open",
+        title: "Wire up auth",
+      },
+    ]);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["pr", "list", "--repo", "acme/widgets", "--head", "feature/auth"]),
+      {},
+    );
+  });
+
+  it("normalises MERGED and CLOSED states to lowercase", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { url: "https://x/pull/1", number: 1, state: "MERGED", title: "a" },
+        { url: "https://x/pull/2", number: 2, state: "CLOSED", title: "b" },
+      ]),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.state)).toStrictEqual(["merged", "closed"]);
+  });
+
+  it("returns empty when gh fails (not installed / not authenticated / network)", async () => {
+    runCommandMock.mockRejectedValueOnce(new Error("gh: command not found"));
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs).toStrictEqual([]);
+  });
+
+  it("returns empty when gh emits non-JSON output", async () => {
+    runCommandMock.mockResolvedValueOnce("not json at all");
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs).toStrictEqual([]);
+  });
+
+  it("returns empty when gh emits a non-array JSON value", async () => {
+    runCommandMock.mockResolvedValueOnce("null");
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs).toStrictEqual([]);
+  });
+
+  it("skips entries that don't match the expected PR shape", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      JSON.stringify([
+        { url: "https://x/pull/1", number: 1, state: "OPEN", title: "valid" },
+        { url: 42, number: "not a number" }, // malformed; dropped silently
+        null, // also dropped
+      ]),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([1]);
+  });
+
+  it("forwards the AbortSignal to runCommandAsync when provided", async () => {
+    runCommandMock.mockResolvedValueOnce("[]");
+    const { signal } = new AbortController();
+
+    await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+      signal,
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith("gh", expect.any(Array), { signal });
+  });
+
+  it("forwards a lowercased unknown state value verbatim", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      JSON.stringify([{ url: "https://x/pull/1", number: 1, state: "DRAFT", title: "wip" }]),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      repository: "acme/widgets",
+      branchName: "x",
+    });
+
+    expect(prs[0]?.state).toBe("draft");
+  });
+});

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -1,0 +1,108 @@
+/**
+ * Best-effort lookup of GitHub pull requests for a worktree branch via the
+ * `gh` CLI. `crew status` uses this to surface PR links inline; failures
+ * (gh not on PATH, not authenticated, non-GitHub remote) are silent — the
+ * caller falls back to omitting the row.
+ */
+
+import { runCommandAsync } from "./commandRunner.ts";
+
+export interface PullRequestSummary {
+  url: string;
+  number: number;
+  /** Lowercased lifecycle: "open" | "merged" | "closed". */
+  state: string;
+  title: string;
+}
+
+const GH_PR_LIST_LIMIT = 5;
+const STATE_MAP: Record<string, string> = {
+  OPEN: "open",
+  MERGED: "merged",
+  CLOSED: "closed",
+};
+
+interface LookupArgs {
+  /** GitHub `owner/repo` slug. */
+  repository: string;
+  /** Branch name to filter PRs by. */
+  branchName: string;
+  signal?: AbortSignal;
+}
+
+interface RawPullRequest {
+  url: string;
+  number: number;
+  state: string;
+  title: string;
+}
+
+function parsePullRequests(output: string): PullRequestSummary[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  const summaries: PullRequestSummary[] = [];
+  for (const entry of parsed) {
+    if (!isRawPullRequest(entry)) {
+      continue;
+    }
+    summaries.push({
+      url: entry.url,
+      number: entry.number,
+      state: STATE_MAP[entry.state] ?? entry.state.toLowerCase(),
+      title: entry.title,
+    });
+  }
+  return summaries;
+}
+
+function isRawPullRequest(value: unknown): value is RawPullRequest {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowing untyped JSON.parse output to a record so we can probe its keys
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record["url"] === "string" &&
+    typeof record["number"] === "number" &&
+    typeof record["state"] === "string" &&
+    typeof record["title"] === "string"
+  );
+}
+
+export async function findPullRequestsForBranch(
+  arguments_: LookupArgs,
+): Promise<readonly PullRequestSummary[]> {
+  const { repository, branchName, signal } = arguments_;
+  try {
+    const output = await runCommandAsync(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--repo",
+        repository,
+        "--head",
+        branchName,
+        "--state",
+        "all",
+        "--limit",
+        String(GH_PR_LIST_LIMIT),
+        "--json",
+        "url,number,state,title",
+      ],
+      signal === undefined ? {} : { signal },
+    );
+    return parsePullRequests(output);
+  } catch {
+    // gh not installed / not authenticated / non-GitHub remote / network
+    // error / etc. All resolve to "no PR info available" for display.
+    return [];
+  }
+}

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -105,6 +105,134 @@ describe("run state store", () => {
     });
   });
 
+  it("round-trips an optional ticket title", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        title: "Improve crew status command output",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      title: "Improve crew status command output",
+    });
+  });
+
+  it("preserves a previously-recorded title when a later recordRunState omits it", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        title: "Improve crew status command output",
+      },
+    });
+
+    // resume/interrupt callers don't carry the title; the title should
+    // survive on disk so `crew status` can still surface it.
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "interrupted",
+        reason: "manual pause",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      state: "interrupted",
+      title: "Improve crew status command output",
+    });
+  });
+
+  it("round-trips an optional ticket url and preserves it across transitions", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        url: "https://linear.app/example/issue/TEAM-1",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      url: "https://linear.app/example/issue/TEAM-1",
+    });
+
+    // Subsequent transition omits url — must be preserved.
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "interrupted",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      state: "interrupted",
+      url: "https://linear.app/example/issue/TEAM-1",
+    });
+  });
+
+  it("prefers a freshly provided title over the previously-recorded one", () => {
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        title: "Old title",
+      },
+    });
+
+    recordRunState({
+      config,
+      state: {
+        ticket: "team-1",
+        repository: "repo-a",
+        model: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "rocky-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        title: "New title",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({ title: "New title" });
+  });
+
   it("round-trips every lifecycle state", () => {
     const states: RunLifecycleState[] = ["running", "interrupted", "resumed", "failed-to-launch"];
 

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -18,6 +18,19 @@ export interface RunState {
   resumeCount: number;
   reason?: string;
   detail?: string;
+  /**
+   * Ticket title at dispatch time. Cached so `crew status` can render it
+   * without re-hitting the ticket source; lifecycle transitions
+   * (resume/interrupt) that omit the field preserve the on-disk value.
+   */
+  title?: string;
+  /**
+   * Direct ticket URL at dispatch time. Same caching rationale as `title`;
+   * the source adapter populates it when it can (e.g., Linear), otherwise
+   * the field stays undefined and `crew status` falls back to displaying
+   * just the ticket id.
+   */
+  url?: string;
 }
 
 export interface RunStateDraft {
@@ -31,6 +44,8 @@ export interface RunStateDraft {
   reason?: string;
   detail?: string;
   resumeCount?: number;
+  title?: string;
+  url?: string;
 }
 
 export interface RecordRunStateInput {
@@ -102,6 +117,8 @@ function parseRunState(value: unknown): RunState | undefined {
   const updatedAt = stringField(value, "updatedAt");
   const reason = stringField(value, "reason");
   const detail = stringField(value, "detail");
+  const title = stringField(value, "title");
+  const url = stringField(value, "url");
   if (
     ticket === undefined ||
     repository === undefined ||
@@ -131,6 +148,8 @@ function parseRunState(value: unknown): RunState | undefined {
     resumeCount,
     ...(reason === undefined ? {} : { reason }),
     ...(detail === undefined ? {} : { detail }),
+    ...(title === undefined ? {} : { title }),
+    ...(url === undefined ? {} : { url }),
   };
 }
 
@@ -159,6 +178,11 @@ export function readRunState(config: ResolvedConfig, ticket: string): RunState |
 export function recordRunState(input: RecordRunStateInput): RunState {
   const existing = readRunState(input.config, input.state.ticket);
   const timestamp = nowIso();
+  // Resume/interrupt callers don't know the title or url, so they omit
+  // them. Fall back to the on-disk value so cached display fields survive
+  // transitions.
+  const title = input.state.title ?? existing?.title;
+  const url = input.state.url ?? existing?.url;
   const state: RunState = {
     ticket: ticketKey(input.state.ticket),
     repository: input.state.repository,
@@ -172,6 +196,8 @@ export function recordRunState(input: RecordRunStateInput): RunState {
     resumeCount: input.state.resumeCount ?? existing?.resumeCount ?? 0,
     ...(input.state.reason === undefined ? {} : { reason: input.state.reason }),
     ...(input.state.detail === undefined ? {} : { detail: input.state.detail }),
+    ...(title === undefined ? {} : { title }),
+    ...(url === undefined ? {} : { url }),
   };
   writeState(input.config, state);
   return state;

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -70,6 +70,13 @@ export interface Issue {
   updatedAt: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
+  /**
+   * Direct web URL for the ticket on the source system, when the adapter
+   * knows one. `undefined` when the source can't produce a public URL (e.g.,
+   * a shell script that omits the `url` field). Display-only — never
+   * branched on.
+   */
+  url?: string;
   /** Adapter-private. Consumers MUST NOT inspect; only the producing adapter reads it. */
   sourceRef: unknown;
 }

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -129,6 +129,15 @@ async function probeWorkspaces(
   return { kind: "ok", names: new Set(raw.map((ws) => ws.name)) };
 }
 
+async function accessHintForWorkspace(
+  config: ResolvedConfig,
+  name: string,
+  signal?: AbortSignal,
+): Promise<WorkspaceAccessHint | undefined> {
+  const adapter = await adapterFor(config, signal);
+  return adapter.accessHint(name);
+}
+
 async function interruptWorkspace(
   config: ResolvedConfig,
   name: string,
@@ -165,12 +174,5 @@ export const workspaces = {
     return await adapter.close(name, signal);
   },
   interrupt: interruptWorkspace,
-  async accessHint(
-    config: ResolvedConfig,
-    name: string,
-    signal?: AbortSignal,
-  ): Promise<WorkspaceAccessHint | undefined> {
-    const adapter = await adapterFor(config, signal);
-    return adapter.accessHint(name);
-  },
+  accessHint: accessHintForWorkspace,
 };


### PR DESCRIPTION
## Summary
Redesigns `crew status` into labeled, operational output with cached ticket titles + URLs, PR state, run duration, dispatcher slot count, Queue/Blocked visibility, and contextual hints for orphaned state.

The follow-up pass trims `crew status <ticket>` so the detail view is less noisy: it drops the config snapshot, redundant per-worktree ticket line, separate workspace/run sections, empty log sections, duplicate source titles, and the separate `Ticket source` section. Configured source status now folds into the top `ticket:` line, using the source URL/title when cached run state does not have them.

## Validation

- `mise exec -- node --run verify`
- Pre-push hook: `node --run verify`
- Not run: live `crew status` smoke test against real workspaces.

Agent session: `codex resume 019e6af7-ef85-7200-8d73-b8c2c43cd21e`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
