### PR TITLE
feat(upgrade): show from/to version and suppress npm noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.2.4",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "@clipboard-health/clearance": "1.0.8",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -88,6 +88,7 @@ function makeFakeUpgradeOptions(): UpgradeCliOptions {
       npmBin: "/usr/local/bin/npm",
     }),
     runInstall: vi.fn<UpgradeCliOptions["runInstall"]>(),
+    readInstalledVersion: vi.fn<UpgradeCliOptions["readInstalledVersion"]>(),
   };
 }
 

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { runCommand, type RunCommandOptions } from "../lib/commandRunner.ts";
@@ -48,6 +51,7 @@ const PACKAGE_NAME = "@clipboard-health/groundcrew";
 
 type RunInstallFn = UpgradeCliOptions["runInstall"];
 type ResolveInstallFn = UpgradeCliOptions["resolveInstall"];
+type ReadInstalledVersionFn = UpgradeCliOptions["readInstalledVersion"];
 type MakeOptionsOverrides = Partial<Omit<UpgradeCliOptions, "resolveInstall">> &
   Partial<UpgradeInstallDetails> & {
     resolveInstall?: ResolveInstallFn;
@@ -65,7 +69,10 @@ function makeOptions(overrides: MakeOptionsOverrides = {}): UpgradeCliOptions {
   return {
     packageName: PACKAGE_NAME,
     resolveInstall: resolvedInstall,
-    runInstall: vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false }),
+    runInstall: vi
+      .fn<RunInstallFn>()
+      .mockResolvedValue({ exitCode: 0, sawEacces: false, outputText: "" }),
+    readInstalledVersion: vi.fn<ReadInstalledVersionFn>().mockReturnValue("4.2.4"),
     ...optionOverrides,
   };
 }
@@ -139,7 +146,9 @@ describe(upgradeCli, () => {
   });
 
   it("installs latest when no version is provided", async () => {
-    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    const runInstall = vi
+      .fn<RunInstallFn>()
+      .mockResolvedValue({ exitCode: 0, sawEacces: false, outputText: "" });
 
     await upgradeCli([], makeOptions({ runInstall }));
 
@@ -152,7 +161,9 @@ describe(upgradeCli, () => {
   });
 
   it("installs a supplied npm version or tag", async () => {
-    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 0, sawEacces: false });
+    const runInstall = vi
+      .fn<RunInstallFn>()
+      .mockResolvedValue({ exitCode: 0, sawEacces: false, outputText: "" });
 
     await upgradeCli(["next"], makeOptions({ runInstall }));
 
@@ -165,7 +176,9 @@ describe(upgradeCli, () => {
   });
 
   it("forwards a non-zero install exit code", async () => {
-    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 7, sawEacces: false });
+    const runInstall = vi
+      .fn<RunInstallFn>()
+      .mockResolvedValue({ exitCode: 7, sawEacces: false, outputText: "" });
 
     await upgradeCli([], makeOptions({ runInstall }));
 
@@ -173,13 +186,90 @@ describe(upgradeCli, () => {
   });
 
   it("appends an EACCES hint when install fails with EACCES", async () => {
-    const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({ exitCode: 243, sawEacces: true });
+    const runInstall = vi
+      .fn<RunInstallFn>()
+      .mockResolvedValue({ exitCode: 243, sawEacces: true, outputText: "npm ERR! EACCES" });
 
     await upgradeCli([], makeOptions({ runInstall }));
 
     expect(consoleErr.output()).toMatch(/EACCES/i);
     expect(consoleErr.output()).toMatch(/permission/i);
     expect(process.exitCode).toBe(243);
+  });
+
+  it("reports the from/to versions on a successful upgrade", async () => {
+    const readInstalledVersion = vi
+      .fn<ReadInstalledVersionFn>()
+      .mockReturnValueOnce("4.2.4")
+      .mockReturnValueOnce("4.3.0");
+
+    await upgradeCli([], makeOptions({ readInstalledVersion }));
+
+    expect(consoleLog.output()).toContain("Upgrading crew…");
+    expect(consoleLog.output()).toContain("Upgraded crew from 4.2.4 to 4.3.0");
+  });
+
+  it("reports already-on-version when the install left the version unchanged", async () => {
+    const readInstalledVersion = vi.fn<ReadInstalledVersionFn>().mockReturnValue("4.3.0");
+
+    await upgradeCli([], makeOptions({ readInstalledVersion }));
+
+    expect(consoleLog.output()).toContain("crew is already on version 4.3.0");
+  });
+
+  it("falls back to a generic success when the version reads fail", async () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- exercises the fallback path
+    const readInstalledVersion = vi.fn<ReadInstalledVersionFn>().mockReturnValue(undefined);
+
+    await upgradeCli([], makeOptions({ readInstalledVersion }));
+
+    expect(consoleLog.output()).toContain("crew upgrade complete");
+    expect(consoleLog.output()).not.toMatch(/version/i);
+  });
+
+  it("reports the new version when only the post-install read succeeds", async () => {
+    const readInstalledVersion = vi
+      .fn<ReadInstalledVersionFn>()
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- first read fails, second succeeds
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce("4.3.0");
+
+    await upgradeCli([], makeOptions({ readInstalledVersion }));
+
+    expect(consoleLog.output()).toContain("crew is now on version 4.3.0");
+  });
+
+  it("replays captured npm output on stderr when the install fails", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const runInstall = vi.fn<RunInstallFn>().mockResolvedValue({
+        exitCode: 1,
+        sawEacces: false,
+        outputText: "npm ERR! something went wrong\n",
+      });
+
+      await upgradeCli([], makeOptions({ runInstall }));
+
+      expect(stderrSpy).toHaveBeenCalledWith("npm ERR! something went wrong\n");
+      expect(process.exitCode).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("skips the stderr replay when the install produced no output", async () => {
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const runInstall = vi
+        .fn<RunInstallFn>()
+        .mockResolvedValue({ exitCode: 1, sawEacces: false, outputText: "" });
+
+      await upgradeCli([], makeOptions({ runInstall }));
+
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it("rejects an unknown flag", async () => {
@@ -247,7 +337,7 @@ describe(createDefaultUpgradeCliOptions, () => {
     runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
     const fakeSpawner = vi.fn<NpmSpawner>();
     createDefaultNpmSpawnerMock.mockReturnValue(fakeSpawner);
-    runNpmInstallGlobalMock.mockResolvedValue({ exitCode: 0, sawEacces: false });
+    runNpmInstallGlobalMock.mockResolvedValue({ exitCode: 0, sawEacces: false, outputText: "" });
 
     const options = await createDefaultUpgradeCliOptions({
       packageName: PACKAGE_NAME,
@@ -259,13 +349,87 @@ describe(createDefaultUpgradeCliOptions, () => {
       npmBin: "/usr/local/bin/npm",
     });
 
-    expect(createDefaultNpmSpawnerMock).toHaveBeenCalledWith(process.stderr);
+    expect(createDefaultNpmSpawnerMock).toHaveBeenCalledWith();
     expect(runNpmInstallGlobalMock).toHaveBeenCalledWith({
       packageName: PACKAGE_NAME,
       version: "latest",
       npmBin: "/usr/local/bin/npm",
       spawner: fakeSpawner,
     });
-    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false });
+    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false, outputText: "" });
+  });
+
+  it("wires readInstalledVersion to read the version from package.json on disk", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+
+    const tmp = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-"));
+    try {
+      writeFileSync(join(tmp, "package.json"), JSON.stringify({ version: "4.3.0" }));
+
+      const options = await createDefaultUpgradeCliOptions({
+        packageName: PACKAGE_NAME,
+        cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+      });
+
+      expect(options.readInstalledVersion(tmp)).toBe("4.3.0");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined from readInstalledVersion when package.json is missing", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+
+    const tmp = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-"));
+    try {
+      const options = await createDefaultUpgradeCliOptions({
+        packageName: PACKAGE_NAME,
+        cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+      });
+
+      expect(options.readInstalledVersion(tmp)).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined from readInstalledVersion when package.json is malformed JSON", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+
+    const tmp = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-"));
+    try {
+      writeFileSync(join(tmp, "package.json"), "{ this is not valid json");
+
+      const options = await createDefaultUpgradeCliOptions({
+        packageName: PACKAGE_NAME,
+        cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+      });
+
+      expect(options.readInstalledVersion(tmp)).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined from readInstalledVersion when package.json lacks a string version", async () => {
+    whichMock.mockResolvedValue("/usr/local/bin/npm");
+    runCommandMock.mockReturnValue("/usr/local/lib/node_modules");
+
+    const tmp = mkdtempSync(join(tmpdir(), "groundcrew-upgrade-"));
+    try {
+      writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "no-version" }));
+
+      const options = await createDefaultUpgradeCliOptions({
+        packageName: PACKAGE_NAME,
+        cliMetaUrl: pathToFileURL("/opt/pkg/dist/cli.js").toString(),
+      });
+
+      expect(options.readInstalledVersion(tmp)).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -186,15 +186,22 @@ describe(upgradeCli, () => {
   });
 
   it("appends an EACCES hint when install fails with EACCES", async () => {
-    const runInstall = vi
-      .fn<RunInstallFn>()
-      .mockResolvedValue({ exitCode: 243, sawEacces: true, outputText: "npm ERR! EACCES" });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    try {
+      const runInstall = vi
+        .fn<RunInstallFn>()
+        .mockResolvedValue({ exitCode: 243, sawEacces: true, outputText: "npm ERR! EACCES" });
 
-    await upgradeCli([], makeOptions({ runInstall }));
+      await upgradeCli([], makeOptions({ runInstall }));
 
-    expect(consoleErr.output()).toMatch(/EACCES/i);
-    expect(consoleErr.output()).toMatch(/permission/i);
-    expect(process.exitCode).toBe(243);
+      expect(stderrSpy).toHaveBeenCalledWith("npm ERR! EACCES");
+      expect(stderrSpy).toHaveBeenCalledWith("\n");
+      expect(consoleErr.output()).toMatch(/EACCES/i);
+      expect(consoleErr.output()).toMatch(/permission/i);
+      expect(process.exitCode).toBe(243);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   it("reports the from/to versions on a successful upgrade", async () => {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { runCommand } from "../lib/commandRunner.ts";
 import { which } from "../lib/host.ts";
 import {
@@ -22,12 +25,18 @@ export interface UpgradeCliOptions {
     version: string;
     npmBin: string;
   }) => Promise<NpmRunResult>;
+  readInstalledVersion: (installPath: string) => string | undefined;
 }
 
 export interface UpgradeInstallDetails {
   installKind: InstallKind;
   installPath: string;
   npmBin: string | undefined;
+}
+
+interface GlobalInstall {
+  installPath: string;
+  npmBin: string;
 }
 
 type ParsedArgs =
@@ -100,14 +109,16 @@ export async function upgradeCli(
   }
 
   const options = await resolveOptions(optionsInput);
-  const npmBin = await resolveGlobalNpmBin(options);
-  if (npmBin === undefined) {
+  const install = await resolveGlobalInstall(options);
+  if (install === undefined) {
     return;
   }
-  await runInstallAndReport(options, npmBin, parsed.version);
+  await runInstallAndReport(options, install, parsed.version);
 }
 
-async function resolveGlobalNpmBin(options: UpgradeCliOptions): Promise<string | undefined> {
+async function resolveGlobalInstall(
+  options: UpgradeCliOptions,
+): Promise<GlobalInstall | undefined> {
   const install = await options.resolveInstall();
   if (install.installKind !== "global") {
     writeError(refusalMessage(install.installKind, install.installPath, options.packageName));
@@ -119,21 +130,28 @@ async function resolveGlobalNpmBin(options: UpgradeCliOptions): Promise<string |
     process.exitCode = 1;
     return undefined;
   }
-  return install.npmBin;
+  return { installPath: install.installPath, npmBin: install.npmBin };
 }
 
 async function runInstallAndReport(
   options: UpgradeCliOptions,
-  npmBin: string,
+  install: GlobalInstall,
   version: string,
 ): Promise<void> {
+  const fromVersion = options.readInstalledVersion(install.installPath);
+  writeOutput("Upgrading crew…");
   const result = await options.runInstall({
     packageName: options.packageName,
     version,
-    npmBin,
+    npmBin: install.npmBin,
   });
   if (result.exitCode === 0) {
+    const toVersion = options.readInstalledVersion(install.installPath);
+    writeOutput(formatUpgradeSuccess({ fromVersion, toVersion }));
     return;
+  }
+  if (result.outputText.length > 0) {
+    process.stderr.write(result.outputText);
   }
   if (result.sawEacces) {
     writeError(
@@ -141,6 +159,23 @@ async function runInstallAndReport(
     );
   }
   process.exitCode = result.exitCode;
+}
+
+function formatUpgradeSuccess(versions: {
+  fromVersion: string | undefined;
+  toVersion: string | undefined;
+}): string {
+  const { fromVersion, toVersion } = versions;
+  if (toVersion === undefined) {
+    return "crew upgrade complete";
+  }
+  if (fromVersion === undefined) {
+    return `crew is now on version ${toVersion}`;
+  }
+  if (fromVersion === toVersion) {
+    return `crew is already on version ${toVersion}`;
+  }
+  return `Upgraded crew from ${fromVersion} to ${toVersion}`;
 }
 
 export interface CreateUpgradeOptionsArgs {
@@ -168,7 +203,32 @@ export async function createDefaultUpgradeCliOptions(
     runInstall: async (options) =>
       await runNpmInstallGlobal({
         ...options,
-        spawner: createDefaultNpmSpawner(process.stderr),
+        spawner: createDefaultNpmSpawner(),
       }),
+    readInstalledVersion: readInstalledVersionFromDisk,
   };
+}
+
+function readInstalledVersionFromDisk(installPath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(join(installPath, "package.json"), "utf8");
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "version" in parsed &&
+    typeof parsed.version === "string"
+  ) {
+    return parsed.version;
+  }
+  return undefined;
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -152,6 +152,9 @@ async function runInstallAndReport(
   }
   if (result.outputText.length > 0) {
     process.stderr.write(result.outputText);
+    if (!result.outputText.endsWith("\n")) {
+      process.stderr.write("\n");
+    }
   }
   if (result.sawEacces) {
     writeError(

--- a/src/lib/npmGlobal.test.ts
+++ b/src/lib/npmGlobal.test.ts
@@ -1,7 +1,6 @@
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
-import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -76,7 +75,7 @@ describe(classifyInstall, () => {
 
 describe(runNpmInstallGlobal, () => {
   it("invokes npm install -g <package>@<version> and forwards the exit code", async () => {
-    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 0, stderrText: "" });
+    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 0, outputText: "" });
     const result = await runNpmInstallGlobal({
       packageName: "@scope/pkg",
       version: "3.2.0",
@@ -88,67 +87,65 @@ describe(runNpmInstallGlobal, () => {
       "-g",
       "@scope/pkg@3.2.0",
     ]);
-    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false });
+    expect(result).toStrictEqual({ exitCode: 0, sawEacces: false, outputText: "" });
   });
 
   it("forwards a non-zero exit code", async () => {
-    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 1, stderrText: "boom" });
+    const spawner = vi.fn<NpmSpawner>().mockResolvedValueOnce({ exitCode: 1, outputText: "boom" });
     const result = await runNpmInstallGlobal({
       packageName: "@scope/pkg",
       version: "3.2.0",
       npmBin: "npm",
       spawner,
     });
-    expect(result).toStrictEqual({ exitCode: 1, sawEacces: false });
+    expect(result).toStrictEqual({ exitCode: 1, sawEacces: false, outputText: "boom" });
   });
 
-  it("flags sawEacces when stderr contains EACCES", async () => {
+  it("flags sawEacces when captured output contains EACCES", async () => {
     const spawner = vi
       .fn<NpmSpawner>()
-      .mockResolvedValueOnce({ exitCode: 243, stderrText: "npm ERR! EACCES: permission denied" });
+      .mockResolvedValueOnce({ exitCode: 243, outputText: "npm ERR! EACCES: permission denied" });
     const result = await runNpmInstallGlobal({
       packageName: "@scope/pkg",
       version: "3.2.0",
       npmBin: "npm",
       spawner,
     });
-    expect(result).toStrictEqual({ exitCode: 243, sawEacces: true });
+    expect(result).toStrictEqual({
+      exitCode: 243,
+      sawEacces: true,
+      outputText: "npm ERR! EACCES: permission denied",
+    });
   });
 });
 
 describe(createDefaultNpmSpawner, () => {
-  it("captures stderr text and exit code from a real subprocess", async () => {
-    const passthrough = new PassThrough();
-    const chunks: Buffer[] = [];
-    passthrough.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-
-    const spawner = createDefaultNpmSpawner(passthrough);
+  it("captures both stdout and stderr from a real subprocess", async () => {
+    const spawner = createDefaultNpmSpawner();
     const result = await spawner(process.execPath, [
       "--eval",
-      String.raw`process.stderr.write('EACCES: permission denied\n'); process.exit(2);`,
+      String.raw`process.stdout.write('changed 24 packages\n'); process.stderr.write('EACCES: permission denied\n'); process.exit(2);`,
     ]);
 
     expect(result.exitCode).toBe(2);
-    expect(result.stderrText).toContain("EACCES");
-    expect(Buffer.concat(chunks).toString("utf8")).toContain("EACCES");
+    expect(result.outputText).toContain("EACCES");
+    expect(result.outputText).toContain("changed 24 packages");
   });
 
   it("rejects when the subprocess cannot be spawned", async () => {
-    const spawner = createDefaultNpmSpawner(new PassThrough());
+    const spawner = createDefaultNpmSpawner();
     await expect(spawner("/definitely/missing/npm", [])).rejects.toThrow(/ENOENT/);
   });
 
   it("reports exit code 0 for a successful subprocess", async () => {
-    const spawner = createDefaultNpmSpawner(new PassThrough());
+    const spawner = createDefaultNpmSpawner();
     const result = await spawner(process.execPath, ["--eval", "process.exit(0)"]);
     expect(result.exitCode).toBe(0);
-    expect(result.stderrText).toBe("");
+    expect(result.outputText).toBe("");
   });
 
   it("reports exit code 1 when the subprocess is terminated by a signal", async () => {
-    const spawner = createDefaultNpmSpawner(new PassThrough());
+    const spawner = createDefaultNpmSpawner();
     const result = await spawner(process.execPath, [
       "--eval",
       "process.kill(process.pid, 'SIGTERM')",

--- a/src/lib/npmGlobal.ts
+++ b/src/lib/npmGlobal.ts
@@ -27,7 +27,7 @@ export function classifyInstall(options: ClassifyInstallOptions): InstallKind {
 
 export interface NpmSpawnerResult {
   exitCode: number;
-  stderrText: string;
+  outputText: string;
 }
 
 export type NpmSpawner = (command: string, args: readonly string[]) => Promise<NpmSpawnerResult>;
@@ -35,6 +35,7 @@ export type NpmSpawner = (command: string, args: readonly string[]) => Promise<N
 export interface NpmRunResult {
   exitCode: number;
   sawEacces: boolean;
+  outputText: string;
 }
 
 export interface RunNpmInstallOptions {
@@ -49,7 +50,8 @@ export async function runNpmInstallGlobal(options: RunNpmInstallOptions): Promis
   const result = await options.spawner(options.npmBin, args);
   return {
     exitCode: result.exitCode,
-    sawEacces: result.stderrText.includes("EACCES"),
+    sawEacces: result.outputText.includes("EACCES"),
+    outputText: result.outputText,
   };
 }
 
@@ -75,22 +77,22 @@ export function detectIsSymlink(path: string): boolean {
   }
 }
 
-export function createDefaultNpmSpawner(passthroughStderr: NodeJS.WritableStream): NpmSpawner {
+export function createDefaultNpmSpawner(): NpmSpawner {
   return async (command, args) =>
     await new Promise<NpmSpawnerResult>((resolve, reject) => {
-      const child = spawn(command, [...args], { stdio: ["inherit", "inherit", "pipe"] });
-      const { stderr } = child;
+      const child = spawn(command, [...args], { stdio: ["inherit", "pipe", "pipe"] });
       const chunks: Buffer[] = [];
 
-      stderr.on("data", (chunk: Buffer) => {
+      const collect = (chunk: Buffer): void => {
         chunks.push(chunk);
-        passthroughStderr.write(chunk);
-      });
+      };
+      child.stdout.on("data", collect);
+      child.stderr.on("data", collect);
       child.on("error", reject);
       child.on("close", (code) => {
         resolve({
           exitCode: code ?? 1,
-          stderrText: Buffer.concat(chunks).toString("utf8"),
+          outputText: Buffer.concat(chunks).toString("utf8"),
         });
       });
     });


### PR DESCRIPTION
## Summary
- `crew upgrade` now prints a clean `Upgraded crew from <from> to <to>` line on success, with fallback variants for partial information.
- npm's noisy output (`EBADENGINE`, `changed N packages`, `looking for funding`) is captured silently on the happy path. On install failure we replay the captured output to stderr so the user can still diagnose.
- Versions come from a fresh read of `<installPath>/package.json` on either side of the install — the running process's cached `package.json` would always show the pre-install version.

## Before
```
> crew upgrade
npm warn EBADENGINE Unsupported engine {
  package: '@clipboard-health/groundcrew@4.3.0',
  required: { node: '24.14.1', npm: '~11.11.0' },
  current: { node: 'v25.9.0', npm: '11.11.1' }
}
changed 24 packages in 3s
4 packages are looking for funding
  run \`npm fund\` for details
```

## After
```
> crew upgrade
Upgrading crew…
Upgraded crew from 4.2.4 to 4.3.0
```

Other success messages:
- `crew is already on version 4.3.0` (no change)
- `crew is now on version 4.3.0` (pre-install version unreadable, but post-install read succeeded)
- `crew upgrade complete` (neither read succeeded)

## Implementation notes
- `createDefaultNpmSpawner()` switched from `stdio: ["inherit", "inherit", "pipe"]` + stderr passthrough to `stdio: ["inherit", "pipe", "pipe"]` with both streams collected into one ordered buffer. `NpmSpawnerResult.stderrText` → `outputText`; `NpmRunResult` now carries `outputText` too so the upgrade command can replay on failure.
- New `readInstalledVersion` seam on `UpgradeCliOptions`, mirrored by `readInstalledVersionFromDisk` in `createDefaultUpgradeCliOptions`. Type-guarded JSON parse, returns `undefined` on any failure.
- Picks up a `package-lock.json` self-version bump that the 4.3.0 release commit missed.

## Test plan
- [x] `node --run verify` — all 10 steps green, 976 tests, 100% statements/branches/functions/lines coverage.
- [x] Unit tests cover: from/to upgrade, already-on-version, partial-version-read fallback (`now on version`), full-fallback (`upgrade complete`), failure-replay-to-stderr, no-output-on-failure-skips-replay, malformed-JSON `package.json`, missing `package.json`, version-less `package.json`.
- [x] Spawner test asserts both stdout and stderr land in the captured buffer.
- [x] `node --run crew -- upgrade --help` smoke test — help text unchanged.
- [ ] Manual verification with a real `npm install -g` (requires merging or local-link install — happy to test in dev if useful).