### PR TITLE
fix: select Safehouse agent profiles through launch shim

### DIFF
--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -584,10 +584,11 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain(SETUP_COMMAND);
     expect(launchScript).not.toContain(".claude/setup.sh");
     expect(launchScript).not.toContain("npm clean-install");
-    expect(launchScript).toContain("exec '/");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --enable=all-agents sh -lc",
+      '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -lc',
     );
+    expect(launchScript).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(launchScript).not.toContain("--enable=all-agents");
     // The agent runs inside the wrap (after setup), so the prompt is the sh -lc arg.
     expect(launchScript).toContain('exec claude --permission-mode auto "$@"');
     expect(launchScript).toContain('sh "$_p"');

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -585,6 +585,9 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain(".claude/setup.sh");
     expect(launchScript).not.toContain("npm clean-install");
     expect(launchScript).toContain(
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
+    );
+    expect(launchScript).toContain(
       '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -lc',
     );
     expect(launchScript).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -586,7 +586,7 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain("npm clean-install");
     expect(launchScript).toContain("exec '/");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --enable=all-agents sh -lc",
     );
     // The agent runs inside the wrap (after setup), so the prompt is the sh -lc arg.
     expect(launchScript).toContain('exec claude --permission-mode auto "$@"');

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -79,27 +79,120 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
     expect(out).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --enable=all-agents sh -lc",
+      '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -lc',
     );
+    expect(out).not.toContain("--enable=all-agents");
     // Setup now runs inside the wrap (fs-isolated + clearance egress), not on the host.
     expect(out).toContain(SETUP_COMMAND);
     expect(out).toContain(`exec claude "$@"`);
-    expect(out).toMatch(/sh "\$_p"$/);
+    expect(out).toContain('sh "$_p"; _safehouse_status=$?');
   });
 
-  it("force-enables agent sandbox profiles so Safehouse applies claude-code's grants through the sh wrapper", () => {
+  it("uses an agent-named shell shim so Safehouse applies only the matching agent profile", () => {
     const out = buildLaunchCommand(arguments_());
 
-    // Safehouse auto-selects an agent profile from the wrapped command's
-    // basename. groundcrew wraps the agent in `sh -lc`, so the basename it
-    // sees is `sh`; without this flag claude-code.sb (and its transitive
-    // keychain/state grants + PATH injection) is never applied and the agent
-    // hangs at startup.
-    expect(out).toContain("safehouse-clearance' --enable=all-agents ");
-    const enableIndex = out.indexOf("--enable=all-agents");
-    const shIndex = out.indexOf(" sh -lc ");
-    expect(enableIndex).toBeGreaterThan(-1);
-    expect(shIndex).toBeGreaterThan(enableIndex);
+    expect(out).toContain('_safehouse_shim_dir=$(mktemp -d "');
+    expect(out).toContain('/groundcrew-safehouse-XXXXXX")');
+    expect(out).toContain("trap 'rm -rf \"$_safehouse_shim_dir\"' EXIT");
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain('ln -s /bin/sh "$_safehouse_shim"');
+    expect(out).toContain('"$_safehouse_shim" -lc');
+    expect(out).not.toContain("--enable=all-agents");
+  });
+
+  it("infers the Safehouse profile command from an absolute agent path", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: { cmd: "/Users/dev/.local/bin/claude --permission-mode auto", color: "#fff" },
+      }),
+    );
+
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain('exec /Users/dev/.local/bin/claude --permission-mode auto "$@"');
+  });
+
+  it("skips `env` environment assignments when inferring the Safehouse profile command", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "env ANTHROPIC_MODEL=sonnet claude --permission-mode auto",
+          color: "#fff",
+        },
+      }),
+    );
+
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain('exec env ANTHROPIC_MODEL=sonnet claude --permission-mode auto "$@"');
+  });
+
+  it("skips an `env --` delimiter when inferring the Safehouse profile command", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "env -- claude --permission-mode auto",
+          color: "#fff",
+        },
+      }),
+    );
+
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain('exec env -- claude --permission-mode auto "$@"');
+  });
+
+  it("skips leading environment assignments when inferring the Safehouse profile command", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "ANTHROPIC_MODEL=sonnet claude --permission-mode auto",
+          color: "#fff",
+        },
+      }),
+    );
+
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain('exec ANTHROPIC_MODEL=sonnet claude --permission-mode auto "$@"');
+  });
+
+  it("skips `env` and quoted environment assignments when inferring the Safehouse profile command", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: String.raw`env ANTHROPIC_MODEL='claude 3' claude  --permission-mode auto`,
+          color: "#fff",
+        },
+      }),
+    );
+
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+    expect(out).toContain(String.raw`ANTHROPIC_MODEL='\''claude 3'\'' claude`);
+  });
+
+  it("fails loudly when the Safehouse profile command cannot be inferred", () => {
+    expect(() =>
+      buildLaunchCommand(
+        arguments_({
+          definition: { cmd: "env ANTHROPIC_MODEL=sonnet", color: "#fff" },
+        }),
+      ),
+    ).toThrow(/Cannot infer Safehouse agent profile command/);
+
+    expect(() =>
+      buildLaunchCommand(
+        arguments_({
+          definition: { cmd: "   ", color: "#fff" },
+        }),
+      ),
+    ).toThrow(/Cannot infer Safehouse agent profile command/);
+  });
+
+  it("rejects unsafe inferred Safehouse profile command names", () => {
+    expect(() =>
+      buildLaunchCommand(
+        arguments_({
+          definition: { cmd: String.raw`claude\ code --permission-mode auto`, color: "#fff" },
+        }),
+      ),
+    ).toThrow(/Cannot use "claude code" as a Safehouse agent profile command name/);
   });
 
   it("does not double-wrap when cmd already starts with safehouse", () => {
@@ -192,7 +285,7 @@ describe(buildLaunchCommand, () => {
       // The only unset is inside the wrapped `sh -lc`, after the wrapper token.
       const hostSegment = out.slice(0, out.indexOf("safehouse-clearance"));
       expect(hostSegment).not.toContain("unset NPM_TOKEN");
-      expect(out).toMatch(/sh "\$_p"$/);
+      expect(out).toContain('sh "$_p"; _safehouse_status=$?');
     });
   });
 

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -72,8 +72,14 @@ describe(buildLaunchCommand, () => {
     });
   });
 
-  it("cd's into the worktree on the host, then runs setup and the agent inside the Safehouse wrap", () => {
+  it("runs setup under plain Safehouse, then runs only the agent through the profile shim", () => {
     const out = buildLaunchCommand(arguments_());
+
+    const setupWrapIndex = out.indexOf("safehouse-clearance' sh -lc");
+    const setupIndex = out.indexOf(SETUP_COMMAND);
+    const shimIndex = out.indexOf("_safehouse_shim_dir=$(mktemp");
+    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -lc');
+    const agentIndex = out.indexOf(`exec claude "$@"`);
 
     expect(out).toContain("cd '/work/repo-a-team-1'");
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
@@ -82,10 +88,15 @@ describe(buildLaunchCommand, () => {
       '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -lc',
     );
     expect(out).not.toContain("--enable=all-agents");
-    // Setup now runs inside the wrap (fs-isolated + clearance egress), not on the host.
     expect(out).toContain(SETUP_COMMAND);
     expect(out).toContain(`exec claude "$@"`);
     expect(out).toContain('sh "$_p"; _safehouse_status=$?');
+    expect(setupWrapIndex).toBeGreaterThan(-1);
+    expect(setupIndex).toBeGreaterThan(setupWrapIndex);
+    expect(shimIndex).toBeGreaterThan(setupIndex);
+    expect(agentWrapIndex).toBeGreaterThan(shimIndex);
+    expect(agentIndex).toBeGreaterThan(agentWrapIndex);
+    expect(out.slice(agentWrapIndex)).not.toContain(SETUP_COMMAND);
   });
 
   it("uses an agent-named shell shim so Safehouse applies only the matching agent profile", () => {
@@ -257,34 +268,41 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("--env-pass");
     });
 
-    it("sources secrets on the host, forwards them via --env-pass, and clears them inside the wrap before the agent", () => {
+    it("sources secrets on the host, forwards them only to setup, and clears them before the agent", () => {
       const out = buildLaunchCommand(arguments_({ secretsFile: "/tmp/prompt-team-1/secrets.env" }));
 
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
-      const wrapIndex = out.indexOf("safehouse-clearance");
+      const setupWrapIndex = out.indexOf(
+        "safehouse-clearance' --env-pass=NPM_TOKEN,BUF_TOKEN sh -lc",
+      );
       const setupIndex = out.indexOf("setup_status=$?");
       const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
+      const agentWrapIndex = out.indexOf('"$_safehouse_shim" -lc');
       const agentIndex = out.indexOf(`exec claude "$@"`);
 
       // Secrets are sourced into the host shell before the wrap so Safehouse can
-      // forward them in; setup runs inside the wrap; the agent never inherits them.
+      // forward them into setup; the agent Safehouse process never gets them.
       expect(sourceIndex).toBeGreaterThan(-1);
-      expect(wrapIndex).toBeGreaterThan(sourceIndex);
+      expect(setupWrapIndex).toBeGreaterThan(sourceIndex);
       expect(out).toContain("--env-pass=NPM_TOKEN,BUF_TOKEN");
-      expect(setupIndex).toBeGreaterThan(wrapIndex);
+      expect(setupIndex).toBeGreaterThan(setupWrapIndex);
       expect(unsetIndex).toBeGreaterThan(setupIndex);
-      expect(agentIndex).toBeGreaterThan(unsetIndex);
+      expect(agentWrapIndex).toBeGreaterThan(unsetIndex);
+      expect(agentIndex).toBeGreaterThan(agentWrapIndex);
+      expect(out.slice(agentWrapIndex)).not.toContain("--env-pass");
+      expect(out.slice(agentWrapIndex)).not.toContain("unset NPM_TOKEN");
       expect(out).toContain(
         "if [ -f '/tmp/prompt-team-1/secrets.env' ]; then set -a && . '/tmp/prompt-team-1/secrets.env' && set +a; fi",
       );
     });
 
-    it("does not unset secrets on the host (the wrap needs them to forward)", () => {
+    it("clears secrets on the host before the agent Safehouse invocation", () => {
       const out = buildLaunchCommand(arguments_({ secretsFile: "/tmp/prompt-team-1/secrets.env" }));
 
-      // The only unset is inside the wrapped `sh -lc`, after the wrapper token.
-      const hostSegment = out.slice(0, out.indexOf("safehouse-clearance"));
-      expect(hostSegment).not.toContain("unset NPM_TOKEN");
+      const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
+      const agentWrapIndex = out.indexOf('"$_safehouse_shim" -lc');
+      expect(unsetIndex).toBeGreaterThan(-1);
+      expect(agentWrapIndex).toBeGreaterThan(unsetIndex);
       expect(out).toContain('sh "$_p"; _safehouse_status=$?');
     });
   });

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -79,12 +79,27 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
     expect(out).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --enable=all-agents sh -lc",
     );
     // Setup now runs inside the wrap (fs-isolated + clearance egress), not on the host.
     expect(out).toContain(SETUP_COMMAND);
     expect(out).toContain(`exec claude "$@"`);
     expect(out).toMatch(/sh "\$_p"$/);
+  });
+
+  it("force-enables agent sandbox profiles so Safehouse applies claude-code's grants through the sh wrapper", () => {
+    const out = buildLaunchCommand(arguments_());
+
+    // Safehouse auto-selects an agent profile from the wrapped command's
+    // basename. groundcrew wraps the agent in `sh -lc`, so the basename it
+    // sees is `sh`; without this flag claude-code.sb (and its transitive
+    // keychain/state grants + PATH injection) is never applied and the agent
+    // hangs at startup.
+    expect(out).toContain("safehouse-clearance' --enable=all-agents ");
+    const enableIndex = out.indexOf("--enable=all-agents");
+    const shIndex = out.indexOf(" sh -lc ");
+    expect(enableIndex).toBeGreaterThan(-1);
+    expect(shIndex).toBeGreaterThan(enableIndex);
   });
 
   it("does not double-wrap when cmd already starts with safehouse", () => {
@@ -96,6 +111,9 @@ describe(buildLaunchCommand, () => {
 
     expect(out).toMatch(/exec safehouse claude "\$_p"$/);
     expect(out).not.toContain("safehouse safehouse");
+    // A bring-your-own-safehouse cmd owns its sandbox flags; groundcrew must
+    // not splice its own --enable into a command it does not control.
+    expect(out).not.toContain("--enable=all-agents");
   });
 
   it("substitutes {{worktree}} and {{sandbox}} in the agent command", () => {
@@ -183,6 +201,7 @@ describe(buildLaunchCommand, () => {
       const out = buildLaunchCommand(arguments_({ runner: "none" }));
 
       expect(out).not.toContain("safehouse-clearance");
+      expect(out).not.toContain("--enable=all-agents");
       expect(out).toMatch(/exec claude "\$_p"$/);
     });
 
@@ -227,6 +246,9 @@ describe(buildLaunchCommand, () => {
       );
       expect(out).toContain("exec claude");
       expect(out).toMatch(/sh "\$_p"$/);
+      // sdx routes through `sbx exec`, not Safehouse, so the Safehouse-only
+      // profile-selection flag must not leak onto this path.
+      expect(out).not.toContain("--enable=all-agents");
     });
 
     it("uses the per-model sandbox setupCommand override when configured", () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { dirname, resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 
 import { BUILD_SECRET_NAMES, type LocalRunner, type ModelDefinition } from "./config.ts";
 import { shellSingleQuote } from "./shell.ts";
@@ -70,6 +70,86 @@ function sourceSecretsLine(secretsFile: string): string {
 
 function unsetSecretsLine(): string {
   return `unset ${BUILD_SECRET_NAMES.join(" ")}`;
+}
+
+function tokenizeShellPrefix(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let isEscaped = false;
+  for (const character of command.trim()) {
+    if (isEscaped) {
+      current += character;
+      isEscaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      isEscaped = true;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += character;
+  }
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+function isEnvironmentAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+function safehouseProfileCommandName(agentCmd: string): string {
+  const tokens = tokenizeShellPrefix(agentCmd);
+  let tokenIndex = tokens[0] === "env" ? 1 : 0;
+  if (tokens[0] === "env" && tokens[tokenIndex] === "--") {
+    tokenIndex += 1;
+  }
+  let commandToken: string | undefined;
+  for (const token of tokens.slice(tokenIndex)) {
+    if (isEnvironmentAssignment(token)) {
+      continue;
+    }
+    commandToken = token;
+    break;
+  }
+  if (commandToken === undefined) {
+    throw new Error(
+      `Cannot infer Safehouse agent profile command from model cmd ${JSON.stringify(agentCmd)}.`,
+    );
+  }
+
+  const commandName = basename(commandToken);
+  if (
+    commandName === "." ||
+    commandName === ".." ||
+    commandName.startsWith("-") ||
+    !/^[A-Za-z0-9._-]+$/.test(commandName)
+  ) {
+    throw new Error(
+      `Cannot use ${JSON.stringify(commandName)} as a Safehouse agent profile command name inferred from model cmd ${JSON.stringify(agentCmd)}.`,
+    );
+  }
+  return commandName;
 }
 
 interface LaunchCommandArguments {
@@ -167,10 +247,13 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
  * Build secrets are sourced into the host launch shell so Safehouse can forward
  * them into the sandbox via `--env-pass` (Safehouse's `--env=FILE` mode otherwise
  * strips them); they're `unset` inside the wrap after setup so the agent process
- * never inherits them. The host keeps only `cd`, the prompt read, and the wrap exec.
+ * never inherits them. The host keeps `cd`, the prompt read, and a temporary
+ * command-named shim so Safehouse can select the intended agent profile while
+ * the actual wrapped command remains `sh -lc`.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = dirname(arguments_.promptFile);
+  const safehouseCommandName = safehouseProfileCommandName(arguments_.definition.cmd);
   const agentCmd = renderAgentCommand({
     agentCmd: arguments_.definition.cmd,
     worktreeDir: arguments_.worktreeDir,
@@ -184,7 +267,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   innerParts.push(`exec ${agentCmd} "$@"`);
   const innerCommand = innerParts.join("; ");
 
-  // Trailing space keeps the flag and `sh` separated; empty when no secrets.
+  // Trailing space keeps the flag and shim command separated; empty when no secrets.
   const envPassFlag =
     arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
 
@@ -195,16 +278,15 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    // `--enable=all-agents`: Safehouse picks the agent sandbox profile
-    // (e.g. claude-code.sb, which grants ~/.claude, ~/.claude.json, keychain,
-    // electron, and puts the agent's install dir on PATH) by matching the
-    // *wrapped command's basename* against each profile's command alias. We
-    // wrap the agent in `sh -lc`, so the basename Safehouse sees is `sh` — the
-    // agent profile never matches, the agent is silently denied its grants
-    // (and its binary is left off PATH), and an interactive agent hangs at
-    // startup. Forcing all agent profiles on restores them regardless of the
-    // command token. (Safehouse has no per-agent --enable token today.)
-    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} --enable=all-agents ${envPassFlag}sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
+    `_safehouse_shim_dir=$(mktemp -d "\${TMPDIR:-/tmp}/groundcrew-safehouse-XXXXXX")`,
+    `trap 'rm -rf "$_safehouse_shim_dir"' EXIT`,
+    `_safehouse_shim="$_safehouse_shim_dir/${safehouseCommandName}"`,
+    `ln -s /bin/sh "$_safehouse_shim"`,
+    // Safehouse selects an agent profile from the wrapped command's basename.
+    // Running the real launch chain as `sh -lc` would make it see `sh`, so use
+    // an agent-named symlink to /bin/sh. This preserves per-agent profile
+    // selection without enabling every agent profile.
+    `${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}"$_safehouse_shim" -lc ${shellSingleQuote(innerCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"`,
   );
   return lines.join(" && ");
 }

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -240,16 +240,18 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 }
 
 /**
- * Safehouse launch. Setup runs *inside* the `safehouse-clearance` wrap (mirroring
- * the sdx runner) so the repo's `.groundcrew/setup.sh` and its `npm install` are
- * filesystem-isolated and egress-restricted, rather than running on the bare host.
+ * Safehouse launch. Setup runs *inside* a plain `safehouse-clearance` wrap
+ * (mirroring the sdx runner) so the repo's `.groundcrew/setup.sh` and its
+ * `npm install` are filesystem-isolated and egress-restricted without inheriting
+ * agent credentials/state grants. The agent then runs in a second Safehouse wrap
+ * through an agent-named shim so Safehouse can select only the agent profile.
  *
  * Build secrets are sourced into the host launch shell so Safehouse can forward
  * them into the sandbox via `--env-pass` (Safehouse's `--env=FILE` mode otherwise
- * strips them); they're `unset` inside the wrap after setup so the agent process
- * never inherits them. The host keeps `cd`, the prompt read, and a temporary
+ * strips them); they're `unset` on the host after setup and not passed to the
+ * agent wrap. The host keeps `cd`, the prompt read, and a temporary
  * command-named shim so Safehouse can select the intended agent profile while
- * the actual wrapped command remains `sh -lc`.
+ * the actual agent command remains `sh -lc`.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = dirname(arguments_.promptFile);
@@ -260,16 +262,13 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     sandboxName: "",
   });
 
-  const innerParts = [setupWithStatusReporting(SETUP_COMMAND)];
-  if (arguments_.secretsFile !== undefined) {
-    innerParts.push(unsetSecretsLine());
-  }
-  innerParts.push(`exec ${agentCmd} "$@"`);
-  const innerCommand = innerParts.join("; ");
+  const setupCommand = setupWithStatusReporting(SETUP_COMMAND);
+  const agentCommand = `exec ${agentCmd} "$@"`;
 
-  // Trailing space keeps the flag and shim command separated; empty when no secrets.
+  // Trailing space keeps the flag and setup command separated; empty when no secrets.
   const envPassFlag =
     arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
+  const safehouseWrapper = shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH);
 
   const lines: string[] = [`cd ${shellSingleQuote(arguments_.worktreeDir)}`];
   if (arguments_.secretsFile !== undefined) {
@@ -278,6 +277,12 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
+    `${safehouseWrapper} ${envPassFlag}sh -lc ${shellSingleQuote(setupCommand)}`,
+  );
+  if (arguments_.secretsFile !== undefined) {
+    lines.push(unsetSecretsLine());
+  }
+  lines.push(
     `_safehouse_shim_dir=$(mktemp -d "\${TMPDIR:-/tmp}/groundcrew-safehouse-XXXXXX")`,
     `trap 'rm -rf "$_safehouse_shim_dir"' EXIT`,
     `_safehouse_shim="$_safehouse_shim_dir/${safehouseCommandName}"`,
@@ -286,7 +291,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     // Running the real launch chain as `sh -lc` would make it see `sh`, so use
     // an agent-named symlink to /bin/sh. This preserves per-agent profile
     // selection without enabling every agent profile.
-    `${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}"$_safehouse_shim" -lc ${shellSingleQuote(innerCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"`,
+    `${safehouseWrapper} "$_safehouse_shim" -lc ${shellSingleQuote(agentCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"`,
   );
   return lines.join(" && ");
 }

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -195,7 +195,16 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
+    // `--enable=all-agents`: Safehouse picks the agent sandbox profile
+    // (e.g. claude-code.sb, which grants ~/.claude, ~/.claude.json, keychain,
+    // electron, and puts the agent's install dir on PATH) by matching the
+    // *wrapped command's basename* against each profile's command alias. We
+    // wrap the agent in `sh -lc`, so the basename Safehouse sees is `sh` — the
+    // agent profile never matches, the agent is silently denied its grants
+    // (and its binary is left off PATH), and an interactive agent hangs at
+    // startup. Forcing all agent profiles on restores them regardless of the
+    // command token. (Safehouse has no per-agent --enable token today.)
+    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} --enable=all-agents ${envPassFlag}sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
   );
   return lines.join(" && ");
 }


### PR DESCRIPTION
## Summary

Groundcrew still launches Safehouse agent sessions through `sh -lc`, but now creates a temporary symlink named after the configured agent command and asks `safehouse-clearance` to execute only the final agent command through that shim. Safehouse can therefore select the matching agent profile, such as `claude-code.sb`, without enabling every agent profile.

The setup hook is intentionally split into its own plain Safehouse invocation before the agent starts. `.groundcrew/setup.sh --deps-only` and dependency lifecycle scripts keep the base sandbox plus optional build-secret env pass, but do not inherit the selected agent profile's credential/state grants. Build secrets are unset on the host before the agent Safehouse invocation.

The launch command infers the agent command from the model `cmd`, including absolute paths and common `env`/environment-assignment prefixes, and rejects unsafe or uninferrable shim names before launching.

## Validation

- `node --run verify`
- Pre-push hook reran `node --run verify`
- Manual Safehouse check: a temporary `claude` symlink to `/bin/sh` selected `claude-code.sb` under `safehouse --explain --stdout "$tmpdir/claude" -lc true`.

## Notes

The Safehouse-only path changed. Bring-your-own `safehouse ...` commands, `local.runner: "none"`, and the sdx runner continue to avoid this wrapper.

Agent session: `codex resume 019e6ebc-96c6-7f32-ab5f-54e6ea7022db`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>