### PR TITLE
fix(launch): drop -l from sandbox shell to silence profile EPERM noise

### DIFF
--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -586,9 +586,9 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain("npm clean-install");
     expect(launchScript).toContain("exec '/");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -c",
     );
-    // The agent runs inside the wrap (after setup), so the prompt is the sh -lc arg.
+    // The agent runs inside the wrap (after setup), so the prompt is the sh -c arg.
     expect(launchScript).toContain('exec claude --permission-mode auto "$@"');
     expect(launchScript).toContain('sh "$_p"');
     // setup-status guard so a failed install still launches the agent
@@ -629,7 +629,7 @@ describe(setupWorkspace, () => {
     expect(ensureClearanceMock).not.toHaveBeenCalled();
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(launchScript).toMatch(
-      /exec sbx exec -it (?:-e [A-Z_]+ )*-w '\/work\/repo-a-team-1' 'groundcrew-claude' sh -lc/,
+      /exec sbx exec -it (?:-e [A-Z_]+ )*-w '\/work\/repo-a-team-1' 'groundcrew-claude' sh -c/,
     );
     expect(launchScript).toContain("exec claude --permission-mode auto");
     expect(launchScript).not.toContain("safehouse-clearance");

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -79,7 +79,7 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
     expect(out).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -lc",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -c",
     );
     // Setup now runs inside the wrap (fs-isolated + clearance egress), not on the host.
     expect(out).toContain(SETUP_COMMAND);
@@ -108,7 +108,7 @@ describe(buildLaunchCommand, () => {
       }),
     );
 
-    // The agent command is single-quoted for the wrap's `sh -lc`, so embedded
+    // The agent command is single-quoted for the wrap's `sh -c`, so embedded
     // worktree quotes are escaped via the `'\''` close-escape-reopen dance.
     expect(out).toContain(String.raw`--worktree '\''/work/repo-a-team-1'\''`);
     // `{{sandbox}}` is a legacy placeholder; local runs no longer have one.
@@ -171,7 +171,7 @@ describe(buildLaunchCommand, () => {
     it("does not unset secrets on the host (the wrap needs them to forward)", () => {
       const out = buildLaunchCommand(arguments_({ secretsFile: "/tmp/prompt-team-1/secrets.env" }));
 
-      // The only unset is inside the wrapped `sh -lc`, after the wrapper token.
+      // The only unset is inside the wrapped `sh -c`, after the wrapper token.
       const hostSegment = out.slice(0, out.indexOf("safehouse-clearance"));
       expect(hostSegment).not.toContain("unset NPM_TOKEN");
       expect(out).toMatch(/sh "\$_p"$/);
@@ -219,12 +219,10 @@ describe(buildLaunchCommand, () => {
       });
     }
 
-    it("wraps the agent in `sbx exec -it -w <worktree> <sandbox> sh -lc <setup; exec agent>`", () => {
+    it("wraps the agent in `sbx exec -it -w <worktree> <sandbox> sh -c <setup; exec agent>`", () => {
       const out = buildLaunchCommand(sdxArguments());
 
-      expect(out).toContain(
-        "exec sbx exec -it -w '/work/repo-a-team-1' 'groundcrew-claude' sh -lc",
-      );
+      expect(out).toContain("exec sbx exec -it -w '/work/repo-a-team-1' 'groundcrew-claude' sh -c");
       expect(out).toContain("exec claude");
       expect(out).toMatch(/sh "\$_p"$/);
     });
@@ -262,7 +260,7 @@ describe(buildLaunchCommand, () => {
         }),
       );
 
-      // The inner agent command is single-quoted for `sh -lc`, so embedded
+      // The inner agent command is single-quoted for `sh -c`, so embedded
       // sandbox / worktree quotes are escaped via the `'\''` close-escape-reopen
       // dance — `groundcrew-claude` still lands as `--sandbox`'s value.
       expect(out).toContain(String.raw`--sandbox '\''groundcrew-claude'\''`);

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -195,7 +195,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
+    `exec ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)} ${envPassFlag}sh -c ${shellSingleQuote(innerCommand)} sh "$_p"`,
   );
   return lines.join(" && ");
 }
@@ -235,7 +235,7 @@ function buildSdxLaunchCommand(arguments_: LaunchCommandArguments): string {
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec sbx exec -it ${sbxEnvironmentFlags}-w ${shellSingleQuote(arguments_.worktreeDir)} ${shellSingleQuote(arguments_.sandboxName)} sh -lc ${shellSingleQuote(innerCommand)} sh "$_p"`,
+    `exec sbx exec -it ${sbxEnvironmentFlags}-w ${shellSingleQuote(arguments_.worktreeDir)} ${shellSingleQuote(arguments_.sandboxName)} sh -c ${shellSingleQuote(innerCommand)} sh "$_p"`,
   );
   return lines.join(" && ");
 }


### PR DESCRIPTION
## Why

Every sandboxed agent launch (observed via emdash in a herds worktree) printed two warnings during setup:

```
sh: /etc/profile: Operation not permitted
sh: /Users/paul/.profile: Operation not permitted
```

They're harmless — setup completes, exit 0 — but they're noise on every launch.

**Root cause:** both the safehouse and sdx launch paths ran the inner `setup + agent` command through a **login** shell (`sh -lc`). On macOS a login `sh` sources `/etc/profile` then `~/.profile` at startup. Inside the safehouse/sbx sandbox those paths are read-blocked, so login-shell sourcing + blocked reads produce the two EPERM lines.

## What

Drop `-l` (`sh -lc` → `sh -c`) in both launch builders in `src/lib/launchCommand.ts`:

- `buildSafehouseLaunchCommand`
- `buildSdxLaunchCommand`

## Why it's safe

The only thing the host profiles do is set `PATH` (`~/.profile` prepends `~/.local/bin`; `/etc/profile` runs `path_helper`). Inside the sandbox those profiles are blocked **today**, so that `PATH` setup never runs — yet launches work because the sandbox inherits a usable `PATH` from the parent and per-repo `setup.sh` hooks export their own. So `-l` provides nothing in the sandbox except the error lines; `sh -c` yields an identical environment, minus the noise.

## Validation

- `node --run verify` passes end-to-end: format, lint, knip, markdown, syncpack, and **966 tests at 100% coverage**.
- TDD: flipped the command-string assertions to `sh -c` first (red), then changed the builders (green).
- Updated the corresponding assertions/comments in `launchCommand.test.ts` and `setupWorkspace.test.ts`.

## Notes / areas of concern

- `clearance-only.sb` is **not** the right lever — it only governs network egress. Relaxing safehouse's base profile to allow profile reads would also silence the warning but weakens FS isolation and lives in a separate package; dropping `-l` is the targeted fix.
- No Linear ticket — this came from a local plan.