### PR TITLE
fix(linear): move tickets to In Progress, not In Review, on launch

### DIFF
--- a/src/lib/adapters/linear/writeback.test.ts
+++ b/src/lib/adapters/linear/writeback.test.ts
@@ -12,18 +12,24 @@ interface StateNode {
   id: string;
   name: string;
   type: string;
+  position: number;
 }
 
-function makeClient(options: { omitInProgressState?: boolean } = {}): ClientStub {
-  const { omitInProgressState = false } = options;
+function makeClient(
+  options: { omitInProgressState?: boolean; states?: StateNode[] } = {},
+): ClientStub {
+  const { omitInProgressState = false, states } = options;
+  const nodes =
+    states ??
+    (omitInProgressState
+      ? [{ id: "state-other", name: "Other", type: "unstarted", position: 1 }]
+      : [{ id: "state-in-progress", name: "In Progress", type: "started", position: 1 }]);
   return {
     team: vi
       .fn<() => Promise<{ states: () => Promise<{ nodes: StateNode[] }> }>>()
       .mockResolvedValue({
         states: vi.fn<() => Promise<{ nodes: StateNode[] }>>().mockResolvedValue({
-          nodes: omitInProgressState
-            ? [{ id: "state-other", name: "Other", type: "unstarted" }]
-            : [{ id: "state-in-progress", name: "In Progress", type: "started" }],
+          nodes,
         }),
       }),
     updateIssue: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
@@ -66,6 +72,40 @@ describe(createLinearIssueStatusUpdater, () => {
 
     expect(client.team).toHaveBeenCalledTimes(1);
     expect(client.updateIssue).toHaveBeenCalledTimes(2);
+  });
+
+  it("targets the 'In Progress' state even when 'In Review' (also started) is returned first", async () => {
+    // Linear's default workflow has TWO started-type states: In Progress and
+    // In Review. team.states() orders by updatedAt, not board position, so the
+    // In Review state can come first — the old `.find(type === "started")`
+    // parked tickets in In Review on launch.
+    const client = makeClient({
+      states: [
+        { id: "state-in-review", name: "In Review", type: "started", position: 2 },
+        { id: "state-in-progress", name: "In Progress", type: "started", position: 1 },
+      ],
+    });
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await updater.markInProgress({ id: "team-1", uuid: "uuid-1", teamId: "shared" });
+
+    expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-in-progress" });
+  });
+
+  it("falls back to the lowest-position started state when no state is named 'In Progress'", async () => {
+    // Teams rename the in-progress column ("Doing", "WIP", ...). With no exact
+    // name match, the leftmost (lowest-position) started column is In Progress.
+    const client = makeClient({
+      states: [
+        { id: "state-code-review", name: "Code Review", type: "started", position: 3 },
+        { id: "state-doing", name: "Doing", type: "started", position: 1 },
+      ],
+    });
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await updater.markInProgress({ id: "team-1", uuid: "uuid-1", teamId: "shared" });
+
+    expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-doing" });
   });
 
   it("re-fetches team workflow states on every failing markInProgress so an operator-side fix is picked up without restart", async () => {

--- a/src/lib/adapters/linear/writeback.ts
+++ b/src/lib/adapters/linear/writeback.ts
@@ -16,8 +16,8 @@ export function createLinearIssueStatusUpdater(arguments_: {
   client: LinearClient;
 }): LinearIssueStatusUpdater {
   const { client } = arguments_;
-  // Positive cache only. Keyed by teamId because the workflow `state.type ===
-  // "started"` lookup yields a single stateId per team — independent of which
+  // Positive cache only. Keyed by teamId because the in-progress-state
+  // resolution yields a single stateId per team — independent of which
   // project the ticket belongs to. State ids don't change for misconfig
   // reasons, so caching successful resolutions is safe across the process.
   //
@@ -39,10 +39,17 @@ export function createLinearIssueStatusUpdater(arguments_: {
     }
     const team = await client.team(teamId);
     const states = await team.states();
-    // Use the workflow state's `type` — Linear standardises on `started` for
-    // in-progress columns regardless of how the user renames them, so this
-    // works without any per-team status-name configuration.
-    const inProgress = states.nodes.find((state) => state.type === "started");
+    // Linear's default workflow has MULTIPLE `started`-type states — both
+    // "In Progress" and "In Review" are `started`. `team.states()` orders by
+    // updatedAt (the connection has no position ordering), so array order
+    // can't disambiguate them. Prefer the state literally named "In Progress";
+    // otherwise fall back to the lowest-position (leftmost) `started` column,
+    // which by Linear convention is the in-progress one. This survives teams
+    // that rename the column ("Doing", "WIP", ...).
+    const startedStates = states.nodes.filter((state) => state.type === "started");
+    const inProgress =
+      startedStates.find((state) => state.name.trim().toLowerCase() === "in progress") ??
+      startedStates.toSorted((a, b) => a.position - b.position).at(0);
     if (inProgress?.id === undefined) {
       return undefined;
     }


### PR DESCRIPTION
## Summary

On `crew run`, tickets were being moved straight into **In Review** instead of **In Progress**.

## Root cause

`markInProgress` resolved the target workflow state with:

```ts
states.nodes.find((state) => state.type === "started")
```

Linear's default workflow has **two** `started`-type states — "In Progress" **and** "In Review" (both are "active" columns; this is why the canonical-status mapping collapses every `started` state to `in-progress`). `team.states()` orders by `updatedAt` (the connection exposes no position ordering), so `.find()` could return the **In Review** state, parking every ticket there the instant it was picked up.

There is no code path that intentionally moves a Linear ticket to "in review" — `in-review` is only ever *read*, never written — so this writeback was the sole cause.

## Fix

Resolve the in-progress column deterministically (`src/lib/adapters/linear/writeback.ts`):

1. Prefer the `started` state literally named "In Progress" (case-insensitive, trimmed).
2. Fall back to the lowest-`position` (leftmost) `started` column, so teams that renamed it ("Doing", "WIP", ...) still work.

## Validation

- Added two regression tests (`writeback.test.ts`): ticket lands in In Progress even when In Review is returned first; and the position fallback for a renamed column. Both were written test-first (red → green).
- `node --run verify` passes (exit 0): 968 tests, 100% coverage (statements/branches/functions/lines), plus format/lint/typecheck/spell/markdown/dependency checks.

## Areas of concern

- The previous test suite mock only ever returned a single `started` state, which is why this slipped through; the new tests encode the multi-`started` reality.
- No Linear ticket was supplied for this change — happy to link one if it exists.