### PR TITLE
fix: remove orphaned worktree leftovers with force

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeOs from "node:os";
 import { tmpdir, userInfo } from "node:os";
 import { join, sep } from "node:path";
@@ -668,7 +668,7 @@ describe(remove, () => {
     const config = makeConfig({ projectDir });
 
     runCommandMock.mockImplementation((_command, arguments_) => {
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status fails because the dir has no .git; rev-parse reports it is not a working tree.
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status fails because the dir has no .git.
       if (hasArguments(arguments_, "worktree", "remove")) {
         throw new Error("Command failed: git worktree remove\nExit status: 128");
       }
@@ -677,8 +677,8 @@ describe(remove, () => {
         throw new Error("not a git repository");
       }
       // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
-        return "false";
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n`;
       }
       return "";
     });
@@ -696,10 +696,11 @@ describe(remove, () => {
     await expect(callRemove()).rejects.toThrow(
       /directory exists but is not a registered git worktree/,
     );
+    await expect(callRemove()).rejects.toThrow(/crew cleanup --force team-1/);
     await expect(callRemove()).rejects.toThrow(
-      new RegExp(`\`rm -rf\` ${join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`),
+      new RegExp(`remove ${join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`),
     );
-    await expect(callRemove()).rejects.toThrow(/inspect it before deleting/);
+    await expect(callRemove()).rejects.toThrow(/inspect it first/);
   });
 
   it("rethrows the original error when the registration probe itself fails", async () => {
@@ -717,8 +718,8 @@ describe(remove, () => {
         throw new Error("status probe blew up");
       }
       // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
-        throw new Error("rev-parse blew up");
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        throw new Error("worktree list blew up");
       }
       return "";
     });
@@ -740,7 +741,7 @@ describe(remove, () => {
     const config = makeConfig({ projectDir });
 
     runCommandMock.mockImplementation((_command, arguments_) => {
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- dirtiness probe is unavailable but rev-parse reports a real working tree; the orphan explanation would be wrong, so rethrow.
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- dirtiness probe is unavailable but worktree list reports a real working tree; the orphan explanation would be wrong, so rethrow.
       if (hasArguments(arguments_, "worktree", "remove")) {
         throw new Error("registered but still failed");
       }
@@ -749,8 +750,8 @@ describe(remove, () => {
         throw new Error("status probe blew up");
       }
       // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "rev-parse", "--is-inside-work-tree")) {
-        return "true";
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${join(projectDir, "repo-a-team-1")}\nHEAD def456\nbranch refs/heads/rocky-team-1\n`;
       }
       return "";
     });
@@ -790,7 +791,82 @@ describe(remove, () => {
     ).rejects.toThrow("git worktree remove failed for some other reason");
   });
 
-  it("skips both probes and rethrows when --force is already set", async () => {
+  it("force-removes an orphaned leftover directory when Git no longer has the worktree registered", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1"));
+    writeFileSync(join(projectDir, "repo-a-team-1", "leftover.log"), "leftover");
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- forced worktree remove fails after Git has already deregistered the path.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("fatal: is not a working tree");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the parent repo no longer lists the leftover path.
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n`;
+      }
+      return "";
+    });
+
+    await remove(
+      config,
+      {
+        repository: "repo-a",
+        ticket: "team-1",
+        branchName: "rocky-team-1",
+        dir: join(projectDir, "repo-a-team-1"),
+        kind: "host",
+      },
+      { force: true },
+    );
+
+    expect(existsSync(join(projectDir, "repo-a-team-1"))).toBe(false);
+    expect(runCommandMock).toHaveBeenCalledWith("git", [
+      "-C",
+      join(projectDir, "repo-a"),
+      "branch",
+      "-D",
+      "rocky-team-1",
+    ]);
+  });
+
+  it("does not force-delete an orphaned directory whose path is not the expected host worktree path", async () => {
+    mkdirSync(join(projectDir, "repo-a"));
+    mkdirSync(join(projectDir, "repo-a-team-1-unexpected"));
+    writeFileSync(join(projectDir, "repo-a-team-1-unexpected", "leftover.log"), "leftover");
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- forced worktree remove fails after Git has already deregistered the path.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("fatal: is not a working tree");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the parent repo no longer lists the leftover path.
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n`;
+      }
+      return "";
+    });
+
+    await expect(
+      remove(
+        config,
+        {
+          repository: "repo-a",
+          ticket: "team-1",
+          branchName: "rocky-team-1",
+          dir: join(projectDir, "repo-a-team-1-unexpected"),
+          kind: "host",
+        },
+        { force: true },
+      ),
+    ).rejects.toThrow(/Refusing to force-delete/);
+
+    expect(existsSync(join(projectDir, "repo-a-team-1-unexpected"))).toBe(true);
+  });
+
+  it("skips the dirtiness probe and rethrows when --force fails for a registered worktree", async () => {
     mkdirSync(join(projectDir, "repo-a"));
     mkdirSync(join(projectDir, "repo-a-team-1"));
     const config = makeConfig({ projectDir });
@@ -799,6 +875,10 @@ describe(remove, () => {
       // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator fails the worktree-remove call even with --force.
       if (hasArguments(arguments_, "worktree", "remove")) {
         throw new Error("forced remove still failed");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the failed forced remove still targets a registered worktree.
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n\nworktree ${join(projectDir, "repo-a-team-1")}\nHEAD def456\nbranch refs/heads/rocky-team-1\n`;
       }
       return "";
     });
@@ -820,11 +900,11 @@ describe(remove, () => {
     const statusCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
       hasArguments(arguments_, "status", "--porcelain"),
     );
-    const revParseCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
-      hasArguments(arguments_, "rev-parse", "--is-inside-work-tree"),
+    const worktreeListCalls = runCommandMock.mock.calls.filter(([, arguments_]) =>
+      hasArguments(arguments_, "worktree", "list", "--porcelain"),
     );
     expect(statusCalls).toHaveLength(0);
-    expect(revParseCalls).toHaveLength(0);
+    expect(worktreeListCalls).toHaveLength(1);
   });
 
   it("rethrows branch deletion failures after the shutdown signal fires", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -8,9 +8,9 @@
  * git directly.
  */
 
-import { type Dirent, existsSync, readdirSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, rmSync } from "node:fs";
 import { userInfo } from "node:os";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 import { runCommandAsync, type RunCommandOptions } from "./commandRunner.ts";
 import type { ResolvedConfig } from "./config.ts";
@@ -19,6 +19,7 @@ import { errorMessage, log } from "./util.ts";
 import { type WorkspaceProbe, workspaces } from "./workspaces.ts";
 
 const LONG_RUNNING_COMMAND_OPTIONS = { stdio: "inherit", timeoutMs: 0 } as const;
+const WORKTREE_LIST_PREFIX = "worktree ";
 
 export type WorktreeKind = "host";
 
@@ -259,29 +260,48 @@ async function removeWorktree(
       // ourselves so the failure message names the condition — dirty
       // (modified/untracked files, fixable with `crew cleanup --force`) or
       // orphan (directory exists on disk but is not registered with the
-      // parent repo, requires manual inspection + `rm -rf`).
-      if (options.force || options.signal?.aborted === true) {
+      // parent repo, fixable with `crew cleanup --force` when the path still
+      // matches groundcrew's expected worktree location).
+      if (options.signal?.aborted === true) {
         throw error;
       }
-      const dirtiness = await probeWorktreeDirtiness(entry.dir, options.signal);
-      if (dirtiness.kind === "dirty") {
-        throw new Error(
-          describeDirtyWorktree({
-            ticket: entry.ticket,
-            dir: entry.dir,
-            modified: dirtiness.modified,
-            untracked: dirtiness.untracked,
-          }),
-          { cause: error },
-        );
-      }
-      if (dirtiness.kind === "unknown") {
-        const registration = await probeWorktreeRegistration(entry.dir, options.signal);
-        if (registration === "orphan") {
-          throw new Error(describeOrphanWorktree({ dir: entry.dir }), { cause: error });
+      if (options.force) {
+        const registration = await probeWorktreeRegistration({
+          repoDir,
+          worktreeDir: entry.dir,
+          ...signalProperty(options.signal),
+        });
+        if (registration !== "orphan") {
+          throw error;
         }
+        removeOrphanWorktreeDirectory(config, entry);
+      } else {
+        const dirtiness = await probeWorktreeDirtiness(entry.dir, options.signal);
+        if (dirtiness.kind === "dirty") {
+          throw new Error(
+            describeDirtyWorktree({
+              ticket: entry.ticket,
+              dir: entry.dir,
+              modified: dirtiness.modified,
+              untracked: dirtiness.untracked,
+            }),
+            { cause: error },
+          );
+        }
+        if (dirtiness.kind === "unknown") {
+          const registration = await probeWorktreeRegistration({
+            repoDir,
+            worktreeDir: entry.dir,
+            ...signalProperty(options.signal),
+          });
+          if (registration === "orphan") {
+            throw new Error(describeOrphanWorktree({ ticket: entry.ticket, dir: entry.dir }), {
+              cause: error,
+            });
+          }
+        }
+        throw error;
       }
-      throw error;
     }
   } else {
     log(`Worktree directory ${entry.dir} not found, pruning stale refs...`);
@@ -357,26 +377,62 @@ function describeDirtyWorktree(arguments_: {
 
 type WorktreeRegistration = "registered" | "orphan" | "unknown";
 
-async function probeWorktreeRegistration(
-  worktreeDir: string,
-  signal: AbortSignal | undefined,
-): Promise<WorktreeRegistration> {
+async function probeWorktreeRegistration(arguments_: {
+  repoDir: string;
+  worktreeDir: string;
+  signal?: AbortSignal;
+}): Promise<WorktreeRegistration> {
   let output: string;
   try {
     output = await runCommandAsync(
       "git",
-      ["-C", worktreeDir, "rev-parse", "--is-inside-work-tree"],
-      signalProperty(signal),
+      ["-C", arguments_.repoDir, "worktree", "list", "--porcelain"],
+      signalProperty(arguments_.signal),
     );
   } catch {
     return "unknown";
   }
-  return output === "true" ? "registered" : "orphan";
+  const resolvedWorktreeDir = resolve(arguments_.worktreeDir);
+  for (const line of output.split("\n")) {
+    if (!line.startsWith(WORKTREE_LIST_PREFIX)) {
+      continue;
+    }
+    if (resolve(line.slice(WORKTREE_LIST_PREFIX.length)) === resolvedWorktreeDir) {
+      return "registered";
+    }
+  }
+  return "orphan";
 }
 
-function describeOrphanWorktree(arguments_: { dir: string }): string {
-  const { dir } = arguments_;
-  return `directory exists but is not a registered git worktree. If ${dir} has nothing of value, \`rm -rf\` ${dir} manually; otherwise inspect it before deleting.`;
+function describeOrphanWorktree(arguments_: { ticket: string; dir: string }): string {
+  const { ticket, dir } = arguments_;
+  return `directory exists but is not a registered git worktree. Run \`crew cleanup --force ${ticket}\` to remove ${dir}, or inspect it first if it may contain valuable files.`;
+}
+
+function expectedHostWorktreeDir(config: ResolvedConfig, entry: WorktreeEntry): string {
+  return resolve(config.workspace.projectDir, `${entry.repository}-${entry.ticket}`);
+}
+
+function isInsideDirectory(parentDir: string, childDir: string): boolean {
+  const childRelativePath = relative(parentDir, childDir);
+  return (
+    childRelativePath.length > 0 &&
+    !childRelativePath.startsWith("..") &&
+    !isAbsolute(childRelativePath)
+  );
+}
+
+function removeOrphanWorktreeDirectory(config: ResolvedConfig, entry: WorktreeEntry): void {
+  const projectDir = resolve(config.workspace.projectDir);
+  const expectedDir = expectedHostWorktreeDir(config, entry);
+  const targetDir = resolve(entry.dir);
+  if (targetDir !== expectedDir || !isInsideDirectory(projectDir, targetDir)) {
+    throw new Error(
+      `Refusing to force-delete ${entry.dir}: expected groundcrew worktree path ${expectedDir}.`,
+    );
+  }
+  log(`Removing orphaned worktree directory ${entry.dir} (--force)...`);
+  rmSync(targetDir, { recursive: true, force: true });
 }
 
 function list(config: ResolvedConfig): WorktreeEntry[] {


### PR DESCRIPTION
## Summary

Fixes `crew cleanup --force` for partially removed worktrees where Git has deregistered the worktree but left files on disk. Groundcrew now confirms the path is absent from the parent repository worktree list before deleting only the expected groundcrew worktree directory.

## Validation

- `node --run verify`
- Pre-push `node --run verify`

Agent session: `codex resume 019e6f5a-5741-7542-9007-c786501c7a88`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>