### PR TITLE
feat: show kept tmux windows as exited

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ If a `models.definitions.<name>.cmd` already starts with `safehouse`, groundcrew
 <details>
 <summary>Dead tmux windows vanish by default</summary>
 
-When a wrapped agent command fails (e.g. `safehouse-clearance` not found, `npm install` crash), the tmux window closes immediately and the error scrolls into the void. Set `GROUNDCREW_KEEP_DEAD_WINDOWS=1` in the env you launch `crew` from to flip the per-window `remain-on-exit` to `on`; the window stays open with the error visible. Close it manually with `tmux kill-window -t groundcrew:<ticket>` after diagnosis. tmux backend only.
+When a wrapped agent command fails (e.g. `safehouse-clearance` not found, `npm install` crash), the tmux window closes immediately and the error scrolls into the void. Set `GROUNDCREW_KEEP_DEAD_WINDOWS=1` in the env you launch `crew` from to flip the per-window `remain-on-exit` to `on`; the window stays open with the error visible. `crew status` reports those kept windows as `exited` and keeps the tmux attach command visible so you can inspect scrollback before resuming or cleaning up. tmux backend only.
 
 </details>
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -286,6 +286,40 @@ describe(status, () => {
     expect(output).not.toContain("Ticket source");
   });
 
+  it("prints exited workspace status and attach command when a kept tmux window has exited", async () => {
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+    workspaceAccessHintMock.mockResolvedValue({
+      kind: "attachCommand",
+      command: "tmux attach -t groundcrew:team-1",
+    });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("workspace: exited");
+    expect(output).toContain("attach: tmux attach -t groundcrew:team-1");
+  });
+
+  it("still prints exited workspace status when the attach hint lookup fails", async () => {
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+    workspaceAccessHintMock.mockRejectedValue(new Error("tmux unavailable"));
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("workspace: exited");
+    expect(output).not.toContain("attach:");
+    expect(output).not.toContain("tmux unavailable");
+  });
+
   it("rejects an empty direct-call ticket", async () => {
     await expect(status(makeConfig(), { ticket: "   " })).rejects.toThrow(
       "ticket must be a non-empty value",
@@ -574,6 +608,47 @@ describe(status, () => {
 
     expect(consoleLog.output()).toContain(
       "  hint:      run 'crew resume team-1' to bring the session back",
+    );
+  });
+
+  it("marks running inventory rows as exited when a kept tmux window has exited", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+    workspaceAccessHintMock.mockResolvedValue({
+      kind: "attachCommand",
+      command: "tmux attach -t groundcrew:team-1",
+    });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  state:     running (session exited, 2h 14m)");
+    expect(output).toContain("  attach:    tmux attach -t groundcrew:team-1");
+    expect(output).toContain(
+      "  hint:      attach to inspect scrollback, then run 'crew resume team-1'",
+    );
+  });
+
+  it("marks idle inventory rows as stray exited sessions when a kept tmux window has exited", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReset();
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  state:     idle (stray exited session)");
+    expect(output).toContain(
+      "  hint:      run 'crew cleanup team-1' to clear this stray exited session",
     );
   });
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -89,7 +89,14 @@ function ticketWorkspaceText(probe: WorkspaceProbe, ticket: string): string {
   if (probe.kind === "unavailable") {
     return workspaceProbeUnavailableLine(probe);
   }
+  if (isWorkspaceExited(probe, ticket)) {
+    return "exited";
+  }
   return probe.names.has(ticket) ? "live" : "not live";
+}
+
+function isWorkspaceExited(probe: WorkspaceProbe, ticket: string): boolean {
+  return probe.kind === "ok" && probe.exitedNames?.has(ticket) === true;
 }
 
 function formatRunState(state: RunState | undefined): string {
@@ -152,6 +159,21 @@ function writeRecentLogs(config: ResolvedConfig, ticket: string): void {
   writeOutput(logLines.join("\n"));
 }
 
+async function exitedWorkspaceAccessHint(
+  config: ResolvedConfig,
+  probe: WorkspaceProbe,
+  ticket: string,
+): Promise<WorkspaceAccessHint | undefined> {
+  if (!isWorkspaceExited(probe, ticket)) {
+    return undefined;
+  }
+  try {
+    return await withLogOutputSuppressed(async () => await workspaces.accessHint(config, ticket));
+  } catch {
+    return undefined;
+  }
+}
+
 function formatTicketLine(
   ticket: string,
   runState: RunState | undefined,
@@ -198,10 +220,14 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
     withLogOutputSuppressed(async () => await workspaces.probe(config)),
     readTicketSourceStatus(config, ticket),
   ]);
+  const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, ticket);
   writeOutput(formatTicketLine(ticket, runState, sourceStatus));
   writeTicketTitle(runState, sourceStatus);
   writeOutput(`run: ${formatRunState(runState)}`);
   writeOutput(`workspace: ${ticketWorkspaceText(workspaceProbe, ticket)}`);
+  if (accessHint !== undefined) {
+    writeOutput(`attach: ${accessHint.command}`);
+  }
 
   await writeTicketWorktrees(config, ticket);
   writeRecentLogs(config, ticket);
@@ -251,11 +277,11 @@ function formatDuration(ms: number): string {
 /**
  * Combined human-readable state for the inventory row. Surfaces RunState
  * lifecycle and flags the two interesting disagreements with the workspace
- * probe — `(session dead)` when we recorded a running dispatch but no
- * session is alive, and `(stray session)` when a session is alive without
- * any recorded dispatch. `probe.kind === "unavailable"` is treated as
- * "we don't know" and never produces a suffix. When the row is actively
- * running, appends the elapsed wall-clock time since dispatch.
+ * probe. A recorded running dispatch can have a missing or exited session;
+ * an idle row can have a stray live or exited session. `probe.kind ===
+ * "unavailable"` is treated as "we don't know" and never produces a suffix.
+ * When the row is actively running, appends the elapsed wall-clock time since
+ * dispatch.
  */
 function inventoryStateText(
   runState: RunState | undefined,
@@ -267,11 +293,14 @@ function inventoryStateText(
   const duration = runStateDurationMs(runState, now);
   const flags: string[] = [];
   if (probe.kind === "ok") {
-    const sessionLive = probe.names.has(ticket);
-    if (lifecycle === "idle" && sessionLive) {
-      flags.push("stray session");
+    const sessionPresent = probe.names.has(ticket);
+    const sessionExited = isWorkspaceExited(probe, ticket);
+    if (lifecycle === "idle" && sessionPresent) {
+      flags.push(sessionExited ? "stray exited session" : "stray session");
     }
-    if ((lifecycle === "running" || lifecycle === "resumed") && !sessionLive) {
+    if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
+      flags.push("session exited");
+    } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
       flags.push("session dead");
     }
   }
@@ -286,9 +315,11 @@ function inventoryStateText(
  * probe disagree. Returned commands are safe defaults; the user is free to
  * ignore them and use `attach:` + `pr:` to investigate first.
  *
- * - Stray session (live session, no run-state record) → `crew cleanup` to
- *   tear down the orphaned worktree + close the session.
- * - Session dead (run-state says running/resumed, no live session) →
+ * - Stray session (session present, no run-state record) -> `crew cleanup`
+ *   to tear down the orphaned worktree and close the session.
+ * - Session exited (run-state says running/resumed, kept dead tmux window)
+ *   -> attach first so the failed command remains available for inspection.
+ * - Session dead (run-state says running/resumed, no session present) ->
  *   `crew resume` to bring the agent back; the worktree is preserved.
  *
  * No hint when the probe is unavailable (we genuinely don't know whether
@@ -303,11 +334,17 @@ function inventoryHint(
     return undefined;
   }
   const lifecycle = runState?.state ?? "idle";
-  const sessionLive = probe.names.has(ticket);
-  if (lifecycle === "idle" && sessionLive) {
-    return `run 'crew cleanup ${ticket}' to clear this stray session`;
+  const sessionPresent = probe.names.has(ticket);
+  const sessionExited = isWorkspaceExited(probe, ticket);
+  if (lifecycle === "idle" && sessionPresent) {
+    return sessionExited
+      ? `run 'crew cleanup ${ticket}' to clear this stray exited session`
+      : `run 'crew cleanup ${ticket}' to clear this stray session`;
   }
-  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionLive) {
+  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
+    return `attach to inspect scrollback, then run 'crew resume ${ticket}'`;
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
     return `run 'crew resume ${ticket}' to bring the session back`;
   }
   return undefined;

--- a/src/lib/tmuxAdapter.ts
+++ b/src/lib/tmuxAdapter.ts
@@ -26,8 +26,7 @@ export const tmuxAdapter: Adapter = {
   async open(spec, signal) {
     await ensureTmuxSession(signal);
     const target = tmuxTarget(spec.name);
-    const keepDeadWindowsEnv = readEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
-    const keepDeadWindows = keepDeadWindowsEnv !== undefined && keepDeadWindowsEnv.length > 0;
+    const keepDeadWindows = shouldKeepDeadWindows();
     await runWorkspaceCommand(
       "tmux",
       [
@@ -67,7 +66,7 @@ export const tmuxAdapter: Adapter = {
       // oxlint-disable-next-line unicorn/no-useless-undefined -- undefined marks the workspace backend as unavailable.
       return undefined;
     }
-    return parseTmuxWindows(probe.output);
+    return parseTmuxWindows(probe.output, { includeExited: shouldKeepDeadWindows() });
   },
   async close(name, signal) {
     try {
@@ -90,6 +89,11 @@ export const tmuxAdapter: Adapter = {
 
 function tmuxTarget(name: string): string {
   return `${TMUX_SESSION}:${name}`;
+}
+
+function shouldKeepDeadWindows(): boolean {
+  const keepDeadWindowsEnv = readEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
+  return keepDeadWindowsEnv !== undefined && keepDeadWindowsEnv.length > 0;
 }
 
 function isTmuxNotFoundError(error: unknown): boolean {
@@ -158,7 +162,7 @@ async function ensureTmuxSession(signal?: AbortSignal): Promise<void> {
   }
 }
 
-function parseTmuxWindows(output: string): Workspace[] {
+function parseTmuxWindows(output: string, options: { includeExited?: boolean } = {}): Workspace[] {
   const items: Workspace[] = [];
   for (const line of output.split("\n")) {
     if (line.length === 0) {
@@ -175,10 +179,11 @@ function parseTmuxWindows(output: string): Workspace[] {
     // pane_dead != 0 means the command exited and the window is a zombie
     // (only happens when remain-on-exit is on; defense in depth in case a
     // user-globally-set value beats our per-window override).
-    if (deadFlag !== undefined && deadFlag !== "0") {
+    const isExited = deadFlag !== undefined && deadFlag !== "0";
+    if (isExited && options.includeExited !== true) {
       continue;
     }
-    items.push({ name });
+    items.push(isExited ? { name, state: "exited" } : { name });
   }
   return items;
 }

--- a/src/lib/tmuxAdapter.ts
+++ b/src/lib/tmuxAdapter.ts
@@ -93,7 +93,7 @@ function tmuxTarget(name: string): string {
 
 function shouldKeepDeadWindows(): boolean {
   const keepDeadWindowsEnv = readEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
-  return keepDeadWindowsEnv !== undefined && keepDeadWindowsEnv.length > 0;
+  return keepDeadWindowsEnv === "1";
 }
 
 function isTmuxNotFoundError(error: unknown): boolean {

--- a/src/lib/workspaceAdapter.ts
+++ b/src/lib/workspaceAdapter.ts
@@ -14,6 +14,8 @@ export type WorkspaceKind = "cmux" | "tmux";
 export interface Workspace {
   /** Ticket id; the join key callers use. */
   name: string;
+  /** Omitted means live, for backends that do not expose an exited state. */
+  state?: "exited";
 }
 
 export interface WorkspaceStatus {
@@ -43,7 +45,7 @@ export interface OpenSpec {
  * would close every live workspace by deduction.
  */
 export type WorkspaceProbe =
-  | { kind: "ok"; names: Set<string> }
+  | { kind: "ok"; names: Set<string>; exitedNames?: Set<string> }
   | { kind: "unavailable"; error?: unknown };
 
 export type WorkspaceInterruptResult =
@@ -59,7 +61,7 @@ export type WorkspaceCloseResult =
 export interface Adapter {
   open(spec: OpenSpec, signal?: AbortSignal): Promise<void>;
   /**
-   * Live workspaces only. Returns:
+   * Known workspaces. Returns:
    * - `Workspace[]` when the adapter probe succeeded (may be empty).
    * - `undefined` when the adapter binary failed in a way that doesn't
    *   distinguish "no live workspaces" from "couldn't ask".

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -95,6 +95,7 @@ function commonBeforeEach(): void {
 }
 
 function commonAfterEach(): void {
+  deleteEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
   vi.resetAllMocks();
 }
 
@@ -669,6 +670,17 @@ describe("workspaces.probe (tmux)", () => {
       "-F",
       "#{window_name}\t#{pane_dead}",
     ]);
+  });
+
+  it("includes exited tmux windows when GROUNDCREW_KEEP_DEAD_WINDOWS is set", async () => {
+    setEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS", "1");
+    runMock.mockReturnValue("_groundcrew_idle\t0\nTEAM-1\t0\nTEAM-2\t1\nTEAM-3\t0\n");
+
+    await expect(workspaces.probe(makeConfig("tmux"))).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1", "TEAM-2", "TEAM-3"]),
+      exitedNames: new Set(["TEAM-2"]),
+    });
   });
 
   it("returns kind=ok with empty names when the groundcrew session does not exist", async () => {

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -546,6 +546,40 @@ describe("workspaces.open (tmux)", () => {
     ]);
   });
 
+  it("sets remain-on-exit off when GROUNDCREW_KEEP_DEAD_WINDOWS is not 1", async () => {
+    setEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS", "0");
+
+    await workspaces.open(makeConfig("tmux"), {
+      name: "TEAM-1",
+      cwd: "/work/repo-a-TEAM-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("tmux", [
+      "new-window",
+      "-d",
+      "-t",
+      "groundcrew",
+      "-n",
+      "TEAM-1",
+      "-c",
+      "/work/repo-a-TEAM-1",
+      "exec claude",
+      ";",
+      "set-window-option",
+      "-t",
+      "groundcrew:TEAM-1",
+      "remain-on-exit",
+      "off",
+      ";",
+      "set-window-option",
+      "-t",
+      "groundcrew:TEAM-1",
+      "allow-rename",
+      "off",
+    ]);
+  });
+
   it("creates the groundcrew session with a named idle window when has-session fails", async () => {
     runMock
       .mockImplementationOnce(() => {
@@ -680,6 +714,16 @@ describe("workspaces.probe (tmux)", () => {
       kind: "ok",
       names: new Set(["TEAM-1", "TEAM-2", "TEAM-3"]),
       exitedNames: new Set(["TEAM-2"]),
+    });
+  });
+
+  it("filters exited tmux windows when GROUNDCREW_KEEP_DEAD_WINDOWS is not 1", async () => {
+    setEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS", "0");
+    runMock.mockReturnValue("_groundcrew_idle\t0\nTEAM-1\t0\nTEAM-2\t1\nTEAM-3\t0\n");
+
+    await expect(workspaces.probe(makeConfig("tmux"))).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1", "TEAM-3"]),
     });
   });
 

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -126,7 +126,9 @@ async function probeWorkspaces(
   if (raw === undefined) {
     return { kind: "unavailable" };
   }
-  return { kind: "ok", names: new Set(raw.map((ws) => ws.name)) };
+  const names = new Set(raw.map((ws) => ws.name));
+  const exitedNames = new Set(raw.filter((ws) => ws.state === "exited").map((ws) => ws.name));
+  return exitedNames.size === 0 ? { kind: "ok", names } : { kind: "ok", names, exitedNames };
 }
 
 async function accessHintForWorkspace(


### PR DESCRIPTION
## Summary

Keeps the existing `GROUNDCREW_KEEP_DEAD_WINDOWS=1` tmux behavior as the opt-in path for preserving failed agent panes, and teaches `crew status` to report those retained tmux windows as `exited` with attach/resume/cleanup guidance.

This is a smaller alternative to PR #30's persistent agent-log capture.

## Validation

- `npx vitest run src/lib/workspaces.test.ts src/commands/status.test.ts`
- `node --run verify` (fails only on existing `knip` configuration/dependency/binary hints; build, lint, spellcheck, format, markdown, architecture, syncpack, and the full test suite pass)

Session: codex 019e7063-f8ce-7b03-97a9-b5d2411e972b

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
