### PR TITLE
feat: add init quickstart flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Groundcrew scans `workspace.knownRepositories` to infer which repo a ticket belo
 
 ```bash
 crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.ts
-          [--project-dir <dir>] [--repo <repo>]
+          [--project-dir <dir>] [--repo <repo>]...
           [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]
 crew doctor                                              # check setup
 crew status [<TICKET>]                                   # inspect current state or one ticket

--- a/README.md
+++ b/README.md
@@ -16,37 +16,21 @@
   <a href="./LICENSE"><img alt="license" src="https://img.shields.io/npm/l/@clipboard-health/groundcrew?style=flat-square&label=license&color=18181b&labelColor=18181b"></a>
 </p>
 
-```text
-$ crew status HRD-446
-groundcrew status HRD-446
-========================
-ticket: hrd-446  in-progress  https://linear.app/example/issue/HRD-446
-title: Add retry logic to the sync job
-run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
-workspace: live
-
-Worktrees
----------
-- owner/repo host
-  branch: rocky-hrd-446
-  dir: /dev/workspaces/owner/repo-hrd-446
-  git: dirty (2 modified, 1 untracked)
-```
+Groundcrew watches assigned tickets, creates isolated worktrees, launches agent CLIs in cmux or tmux, and leaves each ticket's work on its own branch. The longer product story is in [Tickets to pull requests while you sleep](https://www.clipboardworks.com/resources/blog/tickets-to-pull-requests-while-you-sleep).
 
 ## Why
 
-- **Pluggable ticket sources.** Ships with a built-in Linear adapter (polls your API key viewer's `agent-*`-labeled issues, honors blockers); bring shell, Jira, or any source via `crew.config.ts`.
 - **One worktree per ticket.** Agents work in parallel without stepping on each other.
-- **Local-first sandboxing.** Safehouse on macOS, Docker Sandboxes on Linux/WSL, or an explicit `none` escape hatch.
-- **Multi-agent.** Ships with `claude` and `codex`; bring your own CLI via `crew.config.ts`.
+- **Linear out of the box.** Assign yourself an `agent-*` labeled issue and Groundcrew can pick it up.
+- **Local-first isolation.** Safehouse on macOS, Docker Sandboxes on Linux/WSL, or an explicit `none` escape hatch.
+- **Multi-agent routing.** Ships with `claude` and `codex`; bring your own CLI in config.
 
 ## Quickstart
 
 ```bash
-# 1. Install Node ≥ 24, git, cmux or tmux, and the agent CLI(s) you'll use.
-#    By default, both claude and codex are enabled; use --model to keep only one.
+# 1. Install Node >= 24, git, cmux or tmux, and the agent CLI you'll use.
 
-# 2. Install groundcrew
+# 2. Install groundcrew.
 npm install -g @clipboard-health/groundcrew
 
 # 3. Scaffold a global config.
@@ -55,17 +39,25 @@ crew init --global --project-dir ~/dev --repo OWNER/REPO --runner none --model c
 
 # 4. Run the clone commands printed by `crew init`.
 
-# 5. Export your Linear API key
+# 5. If using Linear, export your API key.
 export GROUNDCREW_LINEAR_API_KEY="lin_api_..."
 
-# 6. Verify setup, then dispatch
+# 6. Verify setup, then dispatch.
 crew doctor
 crew run --watch
 ```
 
-In Linear, assign tickets to yourself and add an `agent-*` label (`agent-claude`, `agent-codex`, or `agent-any`). Groundcrew picks them up across every team and project your API key can see.
+`crew init --global` writes config to `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/`. Pass `--repo` more than once for multiple repos. Pass `--model claude` or `--model codex` to disable the missing CLI if you only have one installed.
 
-`crew init --global` writes the config into `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/` instead of the cwd. Both forms refuse to overwrite — pass `--force` to replace, `--dry-run` to preview. `--repo` can be repeated; `--model claude` disables Codex, and `--model codex` disables Claude.
+## Ticket Pickup
+
+For Linear, assign tickets to yourself and add an `agent-*` label:
+
+- `agent-claude`, `agent-codex`, or `agent-<name>` routes to that model.
+- `agent-any` routes to the enabled model with the most available capacity.
+- Tickets without an `agent-*` label are ignored by `crew run`; dispatch one manually with `crew start <TICKET>`.
+
+Groundcrew scans `workspace.knownRepositories` to infer which repo a ticket belongs to. A ticket blocked by non-terminal blockers is skipped until those blockers are done.
 
 ## Commands
 
@@ -84,474 +76,46 @@ crew cleanup <TICKET>                                    # tear down every workt
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 ```
 
-## Manual repository bootstrap
-
-Groundcrew never clones repositories for you. Clone each `workspace.knownRepositories` entry into `workspace.projectDir` using the same relative path the config uses. For an `OWNER/REPO` entry:
-
-```bash
-PROJECT_DIR="$HOME/dev/c"
-mkdir -p "$PROJECT_DIR/OWNER"
-git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"
-# HTTPS works the same: git clone https://github.com/OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"
-```
-
-Bare-name entries have no owner, so pick the remote URL yourself and clone to `$PROJECT_DIR/<name>`.
+See [command details](./docs/commands.md) for status output, doctor behavior, and the stop/resume workflow.
 
 ## Configuration
 
 Two keys are required; everything else has a default.
 
-| Key                           | What                                                                   |
-| ----------------------------- | ---------------------------------------------------------------------- |
-| `workspace.projectDir`        | Parent dir for cloned repos and sibling ticket worktrees.              |
-| `workspace.knownRepositories` | Repos searched for in ticket descriptions to infer where work belongs. |
+```ts
+import type { Config } from "@clipboard-health/groundcrew";
 
-The branch prefix (`<prefix>-<TICKET>`) is derived from `os.userInfo().username` and isn't configurable. There is no `linear` config block — groundcrew picks up every issue assigned to your API key's viewer that carries an `agent-*` label across every visible team and project, governed by a single `orchestrator.maximumInProgress` budget.
-
-<details>
-<summary>Agent label routing</summary>
-
-- `agent-claude`, `agent-codex`, `agent-<name>` → that model.
-- `agent-any` → the model with the most available session capacity.
-- Unknown `agent-<name>` → falls back to `models.default` with a warning.
-- No `agent-*` label → ignored by `crew run`. Dispatch on demand with `crew start <TICKET>` (also falls back to `models.default`).
-- Todo tickets blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
-
-Status classification uses Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so renamed status columns work without configuration. Parent issues with children are ignored — sub-issues are the work items.
-
-</details>
-
-<details>
-<summary>Config discovery</summary>
-
-Resolution order: `GROUNDCREW_CONFIG` → cosmiconfig project-walk from cwd (any of `crew.config.{ts,mjs,js,json}`, `.crewrc{,.json,.ts}`, `.config/crew.config.{ts,json}`, `.config/crewrc{,.json}`) → `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts`. The "Loaded config from …" line at startup tells you which won.
-
-</details>
-
-<details>
-<summary>Full configuration reference</summary>
-
-| Key                                      | Default             | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ---------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sources`                                | `[]`                | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `git.remote`                             | `"origin"`          | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `git.defaultBranch`                      | `"main"`            | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `workspace.projectDir`                   | **required**        | Parent dir for cloned repos and sibling ticket worktrees.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `workspace.knownRepositories`            | **required**        | Repos searched for in ticket descriptions to infer where work belongs. A ticket labeled for groundcrew (`agent-*`) fails fast when no known repo appears; unlabeled tickets are ignored.                                                                                                                                                                                                                                                                                                                                                                       |
-| `orchestrator.maximumInProgress`         | `4`                 | Cap on in-progress tickets at once for this `crew` instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `orchestrator.pollIntervalMilliseconds`  | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `orchestrator.sessionLimitPercentage`    | `85`                | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `models.default`                         | `"claude"`          | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew start <TICKET>` for unlabeled tickets. `crew run` ignores unlabeled tickets and does not apply this default. Must exist in `models.definitions`.                                                                                                                                                                                                                                                                                                |
-| `models.definitions`                     | `{ claude, codex }` | Agent definitions. Additive merge with shipped defaults.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `models.definitions.<name>.cmd`          | —                   | Shell command launched for the model. Runs in the worktree through the resolved `local.runner`. `{{worktree}}` is replaced before launch; `{{sandbox}}` expands to the sbx sandbox name under the sdx runner and an empty string otherwise.                                                                                                                                                                                                                                                                                                                    |
-| `models.definitions.<name>.color`        | —                   | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `models.definitions.<name>.usage`        | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Falls back to default when unset, with gating enabled for known models. When `usage.codexbar.source` is omitted, groundcrew uses `oauth` for Codex/Claude on macOS, `auto` for other macOS providers, and `cli` elsewhere. Set to `{ disabled: true }` to disable usage gating.                                                                                                                                                                                        |
-| `models.definitions.<name>.sandbox`      | optional            | Docker Sandboxes binding for the model. Required at launch when `local.runner` resolves to `sdx`. Fields: `agent` (required sbx agent name) and `setupCommand` (override for the inside-sandbox setup script). Groundcrew assumes the `groundcrew-<agent>` sandbox already exists.                                                                                                                                                                                                                                                                             |
-| `models.definitions.<name>.preLaunch`    | optional            | Host-only shell snippet run **before** the agent exec and **outside** Safehouse/sdx. Exports survive into the launch shell; under the default `safehouse` runner they're only forwarded to the agent when listed via `preLaunchEnv` (recommended) or when `cmd` includes its own `safehouse --env-pass=NAMES`. `{{worktree}}` is substituted. A non-zero exit aborts launch. Not supported when `local.runner` resolves to `sdx` (v1).                                                                                                                         |
-| `models.definitions.<name>.preLaunchEnv` | optional            | Companion to `preLaunch`: list of env var names to append to groundcrew's `safehouse-clearance` `--env-pass=` flag, so `preLaunch` exports reach the agent **without** overriding `cmd` and losing the project's egress allowlist. Each entry must match `[A-Za-z_][A-Za-z0-9_]*`. Under `runner: "none"` exports already inherit and `preLaunchEnv` is a no-op. An empty array is a uniform no-op in every runner; a **non-empty** list is rejected when `cmd` already starts with `safehouse` (user owns env forwarding) or when `runner` resolves to `sdx`. |
-| `models.definitions.<name>.disabled`     | optional            | When set to exactly `true`, drops the named shipped default (`claude` or `codex`). Doctor skips probing it; `agent-<name>` labels fall back to `models.default` with a warning.                                                                                                                                                                                                                                                                                                                                                                                |
-| `prompts.initial`                        | unattended template | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override this from `crew.config.ts` for team-specific statuses, tools, plugins, or review loops.                                                                                                                                                                                                                                                                                                                                                  |
-| `workspaceKind`                          | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `local.runner`                           | `"auto"`            | Local isolation backend. `"auto"` → `safehouse` on macOS, `sdx` on Linux/WSL. Explicit: `"safehouse"`, `"sdx"`, `"none"`. `"none"` is never picked implicitly.                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `logging.file`                           | XDG state path      | Append-mode log file. `log()` / `logEvent()` tee here in addition to stdout. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                                                                                                                                                                                                                                                                                                                                                                                                    |
-
-</details>
-
-### Per-session credentials (`preLaunch` + `preLaunchEnv`)
-
-Build secrets shuttle build-time values _into_ setup. `preLaunch` does the opposite for the _agent_ phase: it runs a host-shell snippet **outside** Safehouse/sdx so the minting snippet never sees `NPM_TOKEN` / `BUF_TOKEN`, and its exports still land in the launch shell. Use this when the agent needs a short-lived credential that has to be minted from something the sandbox can't reach (e.g. an engineer CLI session in Keychain), and you don't want any of that source material — build-time or otherwise — in the minting snippet's environment or in the agent's process.
-
-The "preLaunch never sees build secrets" contract is enforced differently per runner — same outcome, different mechanism:
-
-- **`runner: "safehouse"` (default):** `preLaunch` runs immediately after `cd`, **before** `secrets.env` is sourced into the launch shell. `.groundcrew/setup.sh` then runs inside its own profile-neutral `safehouse-clearance` wrap with `--env-pass=NPM_TOKEN,BUF_TOKEN`; build secrets are `unset` on the host before the agent's Safehouse wrap is exec'd.
-- **`runner: "none"`:** `secrets.env` is sourced first, `.groundcrew/setup.sh` runs on the host, build-secret names are `unset`, **then** `preLaunch` runs against a clean env, then the agent is exec'd.
-
-Same security invariant, enforced via source-after-mint ordering under `safehouse` and post-cleanup ordering under `none`. If your snippet depends on a tool installed by `setup.sh`, prefer `runner: "none"` (preLaunch runs after setup) or inline the dependency; under `safehouse`, preLaunch runs before setup.
-
-Under the default `safehouse` runner, the agent runs under a sanitized env allowlist — exports from `preLaunch` land in the launch shell but are stripped before reaching the agent unless they're forwarded. `preLaunchEnv` is the supported way to forward them: groundcrew passes the names via `--env-pass=` on the **agent** Safehouse wrap, so you keep the project's egress host allowlist (`clearance-allow-hosts`) without touching `cmd`. The names are scoped to the agent wrap only — the setup wrap and `.groundcrew/setup.sh` never see them, by design (setup runs profile-neutral and never carries the agent's grants).
-
-```typescript
-models: {
-  definitions: {
-    claude: {
-      preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
-      preLaunchEnv: ["SESSION_TOKEN"],
-    },
+export default {
+  workspace: {
+    projectDir: "~/dev",
+    knownRepositories: ["OWNER/REPO"],
   },
-},
-```
-
-`&&` ensures `export` only runs when the mint succeeded; a failed mint propagates non-zero out of `preLaunch` and aborts launch before the agent starts. `{{worktree}}` is substituted the same way as in `cmd`. Under `runner: "none"`, exports flow through unchanged and `preLaunchEnv` is a no-op. A **non-empty** `preLaunchEnv` is not supported when `local.runner` resolves to `sdx` in v1 (sdx does not forward arbitrary host env into the sandbox); validated early in `setupWorkspace`. An empty `preLaunchEnv: []` is a uniform no-op in every runner — it forwards zero names, so the unsupported-runner guards do not fire.
-
-<details>
-<summary>Manual fallback when <code>cmd</code> brings its own <code>safehouse</code> wrap</summary>
-
-If your `cmd` already starts with `safehouse` (because you need wrap flags groundcrew doesn't provide), groundcrew won't auto-compose `--env-pass=` for you and a **non-empty** `preLaunchEnv` is rejected at launch (an empty `[]` is accepted as a no-op). Add the names to your own `cmd` instead — note that this opts the model out of groundcrew's default `safehouse-clearance` wrap (egress allowlist), so re-supply `--append-profile` / `--env` yourself if you need it:
-
-```typescript
-claude: {
-  preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
-  cmd: 'safehouse --env-pass=SESSION_TOKEN your-agent-cli',
-},
-```
-
-</details>
-
-## Runners
-
-`local.runner` picks the local isolation backend. `auto` resolves per platform.
-
-| Runner      | Default on  | Backend                                                                                                  |
-| ----------- | ----------- | -------------------------------------------------------------------------------------------------------- |
-| `safehouse` | macOS       | [Safehouse](https://agent-safehouse.dev/) — fastest local; cannot safely give the agent Docker.          |
-| `sdx`       | Linux / WSL | [Docker Sandboxes](https://docs.docker.com/sandboxes/) (`sbx`) — required when the agent needs `docker`. |
-| `none`      | —           | Unsandboxed escape hatch. Never picked implicitly; doctor warns when configured.                         |
-
-<details>
-<summary>Safehouse clearance allowlist</summary>
-
-Only applies when `local.runner` resolves to `safehouse`. Groundcrew starts `clearance` on `http://127.0.0.1:19999` and runs the agent through the bundled `safehouse-clearance` wrapper. Clearance refuses to start without an allowlist — see [its README](https://github.com/ClipboardHealth/core-utils/tree/main/packages/clearance) for proxy env vars, log paths, and DNS rules. Shortest path:
-
-```bash
-CLEARANCE_ALLOW_HOSTS="api.openai.com,auth.openai.com,api.anthropic.com,mcp.linear.app,api.linear.app" \
-crew run --watch
-```
-
-Groundcrew ships a starter file covering model APIs, Linear, Notion, Slack, Datadog, GitHub, npm, and common dev tooling at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`. Point clearance at it (and optionally a personal file) via `CLEARANCE_ALLOW_HOSTS_FILES`:
-
-```bash
-CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts" \
-crew run --watch
-```
-
-Watch `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log` for `DENY` lines and add only the domains your agents actually need.
-
-`@clipboard-health/clearance` is pulled in transitively when you install groundcrew and provides the `clearance` / `clearance-ensure` bins used by Safehouse runs.
-
-</details>
-
-<details>
-<summary>Docker Sandboxes (sdx) setup</summary>
-
-Each model that runs under `sdx` needs a `sandbox: { agent: "<sbx-agent>" }` block in `crew.config.ts`. Groundcrew addresses the sandbox as `groundcrew-<agent>` (e.g. `groundcrew-claude`) and reuses one existing sandbox per agent across repos and tickets.
-
-First-time setup is manual:
-
-```bash
-sbx create --name groundcrew-claude claude <projectDir>
-sbx exec -it groundcrew-claude claude auth login
-sbx exec -it groundcrew-claude gh auth login
-```
-
-Replace `claude` with the sbx agent for the model and `<projectDir>` with `workspace.projectDir` from `crew.config.ts`. Manage lifecycle and auth with `sbx` directly (`sbx ls`, `sbx exec`, `sbx rm`). Groundcrew does not create, authenticate, regenerate, list, or remove sandboxes.
-
-</details>
-
-## Inspecting status
-
-`crew status <TICKET>` prints a read-only snapshot for one ticket: cached title/URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the ticket status from the configured ticket source. It does not recover, tear down, resume, or mutate any local/remote state.
-
-`crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local worktree/session diagnostics are printed before ticket-source fetches complete; when the source fetch succeeds, status also prints slot usage plus Queue/Blocked sections for eligible Todo tickets. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
-
-Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKET>` to reopen preserved work. Status is intentionally informational only.
-
-## Doctor
-
-`crew doctor` checks host prerequisites only: config validity, ticket-source reachability (every configured source's `verify()`, including the built-in Linear adapter), required binaries on PATH, workspace backend availability, workspace.projectDir, local runner capability, and enabled model commands.
-
-<details>
-<summary>Sample ticket status output</summary>
-
-```text
-groundcrew status HRD-442
-=========================
-ticket: hrd-442  in-progress  https://linear.app/example/issue/HRD-442
-title: Multi-event extractor: year inference can produce date_start > date_end
-run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
-workspace: live
-
-Worktrees
----------
-- herds-social/herds host
-  branch: paul-hrd-442
-  dir: /dev/workspaces/herds-social/herds-hrd-442
-  git: dirty (0 modified, 1 untracked)
-  pr: https://github.com/herds-social/herds/pull/224 (open)
-
-Recent logs
------------
-[10:15:30] Workspace "hrd-442" launched
-```
-
-</details>
-
-### `crew start <TICKET>`
-
-Launches one ticket immediately, bypassing orchestrator eligibility. Use it to dispatch a specific ticket on demand — including unlabeled tickets that `crew run` ignores.
-
-```bash
-crew start HRD-442
-crew start HRD-442 --dry-run
-```
-
-### `crew stop <TICKET>`
-
-Stops a live workspace pane while preserving the ticket worktree and branch. The manual pause button for cases where you need terminal capacity back, want to stop an agent that's going in the wrong direction, or need to inspect the diff before letting another agent continue.
-
-```bash
-crew stop HRD-442 --reason "wrong implementation direction"
-crew status HRD-442
-crew resume HRD-442
-```
-
-The command closes the cmux/tmux workspace if present, records local run state, and never tears down the worktree. If the workspace was already gone but the worktree is still present, stop records that fact so status can show the preserved branch.
-
-### `crew resume <TICKET>`
-
-Reopens an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew start <ticket>`.
-
-The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and ticket context.
-
-## Secrets
-
-Groundcrew forwards a small allowlist of build-time secrets from your shell into the setup phase (so `npm install` can authenticate against private registries) and strips them before the agent runs. The agent process never inherits these values.
-
-Recognized names, defined in [`BUILD_SECRET_NAMES`](./src/lib/buildSecrets.ts):
-
-- `NPM_TOKEN`
-- `BUF_TOKEN`
-
-Set them in the shell you run `crew` from. Anything not in this list is ignored.
-
-<details>
-<summary>How the secret shuttle works</summary>
-
-For each ticket:
-
-1. If any recognized var is set and non-empty, groundcrew writes `secrets.env` (mode `0600`) into the ticket's temp prompt dir as `KEY='value'` lines — see `stageBuildSecrets` in [`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts).
-2. The launch script sources `secrets.env` with `set -a` so the values are exported into the setup phase only (and under `sdx`, forwarded into the sandbox via `-e KEY` flags).
-3. After setup completes, the script `unset`s every name in `BUILD_SECRET_NAMES` and then `rm -rf`s the entire prompt dir (including `secrets.env`) before `exec`'ing the agent. See `sourceSecretsLine` / `unsetSecretsLine` and the `rm -rf` / `exec` lines in [`src/lib/launchCommand.ts`](./src/lib/launchCommand.ts). The rollback path on setup failure ([`src/commands/setupWorkspace.ts`](./src/commands/setupWorkspace.ts)) wipes the prompt dir too.
-
-Net effect: by the time the agent process exists, the values are gone from the environment and the file is gone from disk.
-
-</details>
-
-## Per-repo setup hook
-
-If `.groundcrew/setup.sh` exists in the repo root, groundcrew runs `bash .groundcrew/setup.sh --deps-only` before each agent launch; otherwise nothing runs. Same convention applies inside the sdx sandbox (overridable per-model via `models.definitions.<name>.sandbox.setupCommand`). No implicit `npm install`, `uv sync`, or anything else — groundcrew is language-agnostic, so opt in by adding the script.
-
-The `--deps-only` flag tells the script "you're being called by an automated system before an agent launches — skip anything interactive or one-time-only." The same script handles both modes; branch on `$1`:
-
-- **With `--deps-only`**: do the cheap recurring work this worktree needs (lockfile install, generate types, etc.). No prompts, no global installs, no `nvm` / `pyenv` bootstrap.
-- **Without the flag**: full interactive bootstrap. Use this when an engineer runs the script by hand for first-time onboarding, or when wiring it into another tool's SessionStart hook.
-
-Setup failures are advisory — groundcrew logs the non-zero exit and still launches the agent so a flaky network or stale lockfile doesn't block the session.
-
-<details>
-<summary>Examples</summary>
-
-**Python (uv):**
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-if [ "${1:-}" = "--deps-only" ]; then
-  uv sync --dev
-else
-  uv sync --dev
-  # ... extra one-time bootstrap (e.g., pre-commit install, db seed) ...
-fi
-```
-
-**Node (npm):**
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-if [ "${1:-}" = "--deps-only" ]; then
-  npm clean-install
-else
-  npm clean-install
-  # ... extra one-time bootstrap (e.g., husky install, codegen, link local packages) ...
-fi
-```
-
-**Docs-only or polyglot repo with no install step:** omit the script. With nothing at `.groundcrew/setup.sh`, groundcrew skips the hook silently.
-
-For a comprehensive real-world example (nvm bootstrap, hash-based skip-on-no-changes caching, portable SHA-256 detection), see [this repo's own `.groundcrew/setup.sh`](./.groundcrew/setup.sh). It's also symlinked at `.claude/setup.sh` so the same script doubles as a Claude Code SessionStart hook for this repo — that symlink is local convenience, not part of groundcrew's contract.
-
-To scaffold `.groundcrew/setup.sh` with a coding agent (Claude Code, Cursor, etc.), see [docs/setup-hook-agent-prompt.md](./docs/setup-hook-agent-prompt.md) — it encodes the contract above as a copy-pasteable prompt.
-
-</details>
-
-## Pluggable ticket sources
-
-`sources` declares extra ticket-system adapters. They're verified at `crew run` startup and dispatched alongside the built-in Linear adapter, so a shell, Jira, or local-plan integration feeds the same orchestration loop as Linear.
-
-The built-in `shell` adapter runs command templates and reads JSON from stdout:
-
-```ts
-export default {
-  // ...
-  sources: [
-    {
-      kind: "shell",
-      name: "jira",
-      commands: {
-        verify: "jira me",
-        fetch: "~/.config/groundcrew/jira-fetch.sh",
-        resolveOne: "~/.config/groundcrew/jira-resolve.sh ${id}",
-        markInProgress: "jira issue move ${id} 'In Progress'",
-      },
-      timeouts: { fetch: 60_000 },
-    },
-  ],
-};
-```
-
-`commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when set, must print one issue, print nothing for "not found", or exit `3` for "not found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as JSON on stdin. `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
-
-```json
-[
-  {
-    "id": "JIRA-123",
-    "title": "Add retry logic",
-    "description": "Ticket body",
-    "status": "todo",
-    "repository": "your-org/your-repo",
-    "model": "claude",
-    "assignee": "Alice",
-    "updatedAt": "2026-05-22T15:00:00Z",
-    "blockers": [{ "id": "JIRA-122", "title": "Schema migration", "status": "done" }],
-    "hasMoreBlockers": false,
-    "sourceRef": { "nativeId": "10042" }
-  }
-]
-```
-
-Allowed `status` values are `todo`, `in-progress`, `in-review`, `done`, and `other`. Use `null` for `repository` or `model` when a ticket should not be groundcrew-eligible. `hasMoreBlockers` is optional and defaults to `false`; `sourceRef` is opaque data that groundcrew passes back to your writeback command.
-
-## Prompt customization
-
-Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.
-
-For a personal workflow, keep the prompt next to your local config and load it with `readFileSync`:
-
-```ts
-import { readFileSync } from "node:fs";
-
-export default {
-  // ...
-  prompts: {
-    initial: readFileSync(new URL("./initial-prompt.md", import.meta.url), "utf8"),
+  local: {
+    runner: "none",
   },
-};
-```
-
-This keeps package defaults portable while letting your private config reference team-specific statuses, tools, plugins, or review loops.
-
-## Disabling a shipped default model
-
-Groundcrew ships `claude` and `codex` as default model definitions, additively merged into every resolved config. To stop probing one:
-
-```ts
-// crew.config.ts
-export default {
-  // …
   models: {
     default: "claude",
     definitions: {
       codex: { disabled: true },
     },
   },
-};
+} satisfies Config;
 ```
 
-Effects:
+There is no `linear` config block. Groundcrew reads `GROUNDCREW_LINEAR_API_KEY` first, then falls back to `LINEAR_API_KEY`.
 
-- `crew doctor` does not probe the disabled model's CLI. `crew doctor || exit 1` becomes viable as a CI gate when you only have one agent installed.
-- `agent-any` only resolves to enabled models.
-- An `agent-<disabled>` label on a ticket falls back to `models.default` with a warning in the log.
+## Reference
 
-Rules:
-
-- `disabled` only accepts shipped-default keys (`claude`, `codex`). A typo fails loudly at config load.
-- `disabled` must be exactly the boolean `true`.
-- It cannot be combined with `cmd`, `color`, or `usage` in the same entry.
-- `models.default` must point at an enabled model.
-
-## Using 1Password for the API key
-
-`crew` reads `GROUNDCREW_LINEAR_API_KEY` first, then falls back to `LINEAR_API_KEY`. To resolve from 1Password:
-
-```bash
-echo "GROUNDCREW_LINEAR_API_KEY='op://<vault>/LINEAR_API_KEY/credential'" > .env.1password
-op run --env-file .env.1password -- crew doctor
-```
-
-## Troubleshooting
-
-First stop for "what exists locally right now": `crew status <ticket>` shows the ticket's worktrees, workspace presence, run state, logs, and ticket-source status. Use `crew doctor` when you need to verify host setup.
-
-<details>
-<summary>Safehouse-already-wrapped commands are not re-wrapped</summary>
-
-If a `models.definitions.<name>.cmd` already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the `safehouse-clearance` wrapper a second time. Changing the proxy's allowlist after it's running requires killing the PID in `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid` so the next launch picks up the new env.
-
-</details>
-
-<details>
-<summary>Dead tmux windows vanish by default</summary>
-
-When a wrapped agent command fails (e.g. `safehouse-clearance` not found, `npm install` crash), the tmux window closes immediately and the error scrolls into the void. Set `GROUNDCREW_KEEP_DEAD_WINDOWS=1` in the env you launch `crew` from to flip the per-window `remain-on-exit` to `on`; the window stays open with the error visible. Close it manually with `tmux kill-window -t groundcrew:<ticket>` after diagnosis. tmux backend only.
-
-</details>
-
-<details>
-<summary>Tickets stay in-progress until something else moves them</summary>
-
-Groundcrew sets a ticket to `Started` (the first workflow state with `type === "started"` on that team) when it provisions a workspace and never advances it. The next transition (typically "In Review" when a PR opens) is left to your Linear automation rules.
-
-</details>
-
-<details>
-<summary>Claude launches in auto mode by default</summary>
-
-Groundcrew creates isolated per-ticket worktrees for unattended runs, so the shipped `claude` command is `claude --permission-mode auto` to let Claude proceed without stopping for clarifying questions while keeping its built-in safety prompts intact. Override `models.definitions.claude.cmd` for `bypassPermissions` if you need to suppress tool-permission prompts entirely, or for a stricter mode.
-
-</details>
-
-<details>
-<summary>Doctor's command introspection is shallow</summary>
-
-Doctor reports the resolved local runner (safehouse / sdx / none) and whether its prerequisites are met, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed — verify those manually. When `local.runner` is `"none"`, doctor surfaces a single WARNING line.
-
-</details>
-
-<details>
-<summary>Doctor checks every enabled model</summary>
-
-`models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and don't have `codex` installed, set `models.definitions.codex: { disabled: true }`. Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
-
-</details>
-
-<details>
-<summary>Switch to tmux if cmux is misbehaving</summary>
-
-Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky (symptoms: `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick). tmux is more reliable — just a unix socket, no GUI app — at the cost of losing cmux's status pills, notifications, and sidebar.
-
-</details>
-
-<details>
-<summary>Agent CLI must accept a positional prompt</summary>
-
-The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.
-
-</details>
+- [Configuration](./docs/configuration.md): discovery order, repo layout, full config table, prompt customization.
+- [Runners](./docs/runners.md): Safehouse, Docker Sandboxes, and the `none` escape hatch.
+- [Credentials](./docs/credentials.md): Linear API keys, 1Password, build secrets, and `preLaunch`.
+- [Setup hooks](./docs/setup-hooks.md): `.groundcrew/setup.sh --deps-only` for per-repo dependency setup.
+- [Ticket sources](./docs/ticket-sources.md): custom shell/Jira/local-plan adapters.
+- [Troubleshooting](./docs/troubleshooting.md): common operational pitfalls and fixes.
 
 ## Development
 
-Clone the repo and the `crew` / `crew:op` scripts execute straight from TypeScript source — no build step needed.
+Clone the repo and run the CLI from TypeScript source:
 
 ```bash
 cd ~/dev/c/groundcrew
@@ -561,11 +125,7 @@ node --run crew -- doctor
 node --run crew:op -- run --watch
 ```
 
-Both forms discover config via cosmiconfig — project-walk from cwd for `crew.config.ts` and friends, then `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts`. Set `GROUNDCREW_CONFIG` to point elsewhere. The `crew:op` wrapper additionally reads `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/op.env` (1Password env-file with `op://` references resolved at launch).
-
-Logs land in `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log` by default (override via `logging.file`).
-
-Source edits in `src/**` are picked up on the next invocation. Requires Node ≥ 24 (native `.ts` type stripping).
+Both forms discover config through cosmiconfig. Source edits in `src/**` are picked up on the next invocation. Requires Node >= 24.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,18 +43,17 @@ Worktrees
 ## Quickstart
 
 ```bash
-# 1. Install Node ≥ 24, git, cmux or tmux, and the agent CLIs you'll use (claude, codex, ...).
+# 1. Install Node ≥ 24, git, cmux or tmux, and the agent CLI(s) you'll use.
+#    By default, both claude and codex are enabled; use --model to keep only one.
 
 # 2. Install groundcrew
 npm install -g @clipboard-health/groundcrew
 
-# 3. Scaffold a config and edit workspace.projectDir + workspace.knownRepositories
-crew init && $EDITOR crew.config.ts
+# 3. Scaffold a global config.
+#    runner=none is the quickest path, but it runs agents unsandboxed on the host.
+crew init --global --project-dir ~/dev --repo OWNER/REPO --runner none --model claude
 
-# 4. Clone the repos referenced in your config
-PROJECT_DIR="$HOME/dev/c"
-mkdir -p "$PROJECT_DIR/OWNER"
-git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"
+# 4. Run the clone commands printed by `crew init`.
 
 # 5. Export your Linear API key
 export GROUNDCREW_LINEAR_API_KEY="lin_api_..."
@@ -66,12 +65,14 @@ crew run --watch
 
 In Linear, assign tickets to yourself and add an `agent-*` label (`agent-claude`, `agent-codex`, or `agent-any`). Groundcrew picks them up across every team and project your API key can see.
 
-`crew init --global` writes the config into `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/` instead of the cwd. Both forms refuse to overwrite — pass `--force` to replace, `--dry-run` to preview.
+`crew init --global` writes the config into `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/` instead of the cwd. Both forms refuse to overwrite — pass `--force` to replace, `--dry-run` to preview. `--repo` can be repeated; `--model claude` disables Codex, and `--model codex` disables Claude.
 
 ## Commands
 
 ```bash
 crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.ts
+          [--project-dir <dir>] [--repo <repo>]
+          [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]
 crew doctor                                              # check setup
 crew status [<TICKET>]                                   # inspect current state or one ticket
 crew run                                                 # one-shot orchestration

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,68 @@
+# Commands
+
+## Status
+
+`crew status <TICKET>` prints a read-only snapshot for one ticket: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the ticket status from the configured ticket source.
+
+`crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local diagnostics are printed before ticket-source fetches complete. When the source fetch succeeds, status also prints slot usage plus Queue/Blocked sections for eligible Todo tickets. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
+
+Status is informational only. Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKET>` to reopen preserved work.
+
+<details>
+<summary>Sample ticket status output</summary>
+
+```text
+groundcrew status HRD-442
+=========================
+ticket: hrd-442  in-progress  https://linear.app/example/issue/HRD-442
+title: Multi-event extractor: year inference can produce date_start > date_end
+run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
+workspace: live
+
+Worktrees
+---------
+- herds-social/herds host
+  branch: paul-hrd-442
+  dir: /dev/workspaces/herds-social/herds-hrd-442
+  git: dirty (0 modified, 1 untracked)
+  pr: https://github.com/herds-social/herds/pull/224 (open)
+
+Recent logs
+-----------
+[10:15:30] Workspace "hrd-442" launched
+```
+
+</details>
+
+## Doctor
+
+`crew doctor` checks host prerequisites only: config validity, ticket-source reachability, required binaries on PATH, workspace backend availability, `workspace.projectDir`, local runner capability, and enabled model commands.
+
+Doctor's command introspection is intentionally shallow. It reports the resolved local runner and tokenizes each model `cmd`, then checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments, shell pipelines, and subshells are not parsed.
+
+## Start
+
+`crew start <TICKET>` launches one ticket immediately, bypassing orchestrator eligibility. Use it to dispatch a specific ticket on demand, including unlabeled tickets that `crew run` ignores.
+
+```bash
+crew start HRD-442
+crew start HRD-442 --dry-run
+```
+
+## Stop
+
+`crew stop <TICKET>` stops a live workspace pane while preserving the ticket worktree and branch. Use it when you need terminal capacity back, want to stop an agent going in the wrong direction, or need to inspect the diff before letting another agent continue.
+
+```bash
+crew stop HRD-442 --reason "wrong implementation direction"
+crew status HRD-442
+crew resume HRD-442
+```
+
+The command closes the cmux/tmux workspace if present, records local run state, and never tears down the worktree. If the workspace was already gone but the worktree is still present, stop records that fact so status can show the preserved branch.
+
+## Resume
+
+`crew resume <TICKET>` reopens an existing ticket worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew start <ticket>`.
+
+The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and ticket context.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,8 +12,8 @@ Status is informational only. Use `crew cleanup <TICKET>` to tear down stale wor
 <summary>Sample ticket status output</summary>
 
 ```text
-groundcrew status HRD-442
-=========================
+crew status HRD-442
+===================
 ticket: hrd-442  in-progress  https://linear.app/example/issue/HRD-442
 title: Multi-event extractor: year inference can produce date_start > date_end
 run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,121 @@
+# Configuration
+
+Two keys are required; everything else has a default.
+
+| Key                           | What                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `workspace.projectDir`        | Parent dir for cloned repos and sibling ticket worktrees.              |
+| `workspace.knownRepositories` | Repos searched for in ticket descriptions to infer where work belongs. |
+
+The branch prefix (`<prefix>-<TICKET>`) is derived from `os.userInfo().username` and is not configurable. There is no `linear` config block. Groundcrew picks up every issue assigned to your API key's viewer that carries an `agent-*` label across every visible team and project, governed by a single `orchestrator.maximumInProgress` budget.
+
+## Repository Layout
+
+Groundcrew never clones repositories for you. `crew init --repo OWNER/REPO` prints the clone command to run. If you are cloning manually, clone each `workspace.knownRepositories` entry into `workspace.projectDir` using the same relative path the config uses.
+
+```bash
+PROJECT_DIR="$HOME/dev"
+mkdir -p "$PROJECT_DIR/OWNER"
+git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"
+```
+
+Bare-name entries have no owner, so pick the remote URL yourself and clone to `$PROJECT_DIR/<name>`.
+
+## Config Discovery
+
+Resolution order:
+
+1. `GROUNDCREW_CONFIG`
+2. cosmiconfig project-walk from cwd
+3. `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/crew.config.ts`
+
+The project walk checks:
+
+- `crew.config.{ts,mjs,js,json}`
+- `.crewrc{,.json,.ts}`
+- `.config/crew.config.{ts,json}`
+- `.config/crewrc{,.json}`
+
+The "Loaded config from ..." line at startup tells you which config won.
+
+## Agent Label Routing
+
+- `agent-claude`, `agent-codex`, `agent-<name>` routes to that model.
+- `agent-any` routes to the model with the most available session capacity.
+- Unknown `agent-<name>` falls back to `models.default` with a warning.
+- No `agent-*` label is ignored by `crew run`. Dispatch on demand with `crew start <TICKET>`, which falls back to `models.default`.
+- Todo tickets blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
+
+Status classification uses Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so renamed status columns work without configuration. Parent issues with children are ignored; sub-issues are the work items.
+
+## Disabling A Shipped Default Model
+
+Groundcrew ships `claude` and `codex` as default model definitions, additively merged into every resolved config. To stop probing one:
+
+```ts
+export default {
+  models: {
+    default: "claude",
+    definitions: {
+      codex: { disabled: true },
+    },
+  },
+};
+```
+
+Effects:
+
+- `crew doctor` does not probe the disabled model's CLI.
+- `agent-any` only resolves to enabled models.
+- An `agent-<disabled>` label on a ticket falls back to `models.default` with a warning in the log.
+
+Rules:
+
+- `disabled` only accepts shipped-default keys (`claude`, `codex`). A typo fails loudly at config load.
+- `disabled` must be exactly the boolean `true`.
+- It cannot be combined with `cmd`, `color`, or `usage` in the same entry.
+- `models.default` must point at an enabled model.
+
+## Prompt Customization
+
+Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.
+
+For a personal workflow, keep the prompt next to your local config and load it with `readFileSync`:
+
+```ts
+import { readFileSync } from "node:fs";
+
+export default {
+  prompts: {
+    initial: readFileSync(new URL("./initial-prompt.md", import.meta.url), "utf8"),
+  },
+};
+```
+
+This keeps package defaults portable while letting your private config reference team-specific statuses, tools, plugins, or review loops.
+
+## Full Reference
+
+| Key                                      | Default             | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sources`                                | `[]`                | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`.                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `git.remote`                             | `"origin"`          | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `git.defaultBranch`                      | `"main"`            | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `workspace.projectDir`                   | **required**        | Parent dir for cloned repos and sibling ticket worktrees.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `workspace.knownRepositories`            | **required**        | Repos searched for in ticket descriptions to infer where work belongs. A ticket labeled for groundcrew (`agent-*`) fails fast when no known repo appears; unlabeled tickets are ignored.                                                                                                                                                                                                                                                                                                                                    |
+| `orchestrator.maximumInProgress`         | `4`                 | Cap on in-progress tickets at once for this `crew` instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `orchestrator.pollIntervalMilliseconds`  | `120_000`           | Poll interval in `--watch` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `orchestrator.sessionLimitPercentage`    | `85`                | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `models.default`                         | `"claude"`          | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew start <TICKET>` for unlabeled tickets. `crew run` ignores unlabeled tickets and does not apply this default. Must exist in `models.definitions`.                                                                                                                                                                                                                                                             |
+| `models.definitions`                     | `{ claude, codex }` | Agent definitions. Additive merge with shipped defaults.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `models.definitions.<name>.cmd`          | —                   | Shell command launched for the model. Runs in the worktree through the resolved `local.runner`. `{{worktree}}` is replaced before launch; `{{sandbox}}` expands to the sbx sandbox name under the sdx runner and an empty string otherwise.                                                                                                                                                                                                                                                                                 |
+| `models.definitions.<name>.color`        | —                   | Color for the workspace status pill (cmux only; tmux silently drops it).                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `models.definitions.<name>.usage`        | optional            | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage`. Falls back to default when unset, with gating enabled for known models. When `usage.codexbar.source` is omitted, groundcrew uses `oauth` for Codex/Claude on macOS, `auto` for other macOS providers, and `cli` elsewhere. Set to `{ disabled: true }` to disable usage gating.                                                                                                                                                     |
+| `models.definitions.<name>.sandbox`      | optional            | Docker Sandboxes binding for the model. Required at launch when `local.runner` resolves to `sdx`. Fields: `agent` (required sbx agent name) and `setupCommand` (override for the inside-sandbox setup script). Groundcrew assumes the `groundcrew-<agent>` sandbox already exists.                                                                                                                                                                                                                                          |
+| `models.definitions.<name>.preLaunch`    | optional            | Host-only shell snippet run before the agent exec and outside Safehouse/sdx. Exports survive into the launch shell; under the default `safehouse` runner they are only forwarded to the agent when listed via `preLaunchEnv` or when `cmd` includes its own `safehouse --env-pass=NAMES`. `{{worktree}}` is substituted. A non-zero exit aborts launch. Not supported when `local.runner` resolves to `sdx` in v1.                                                                                                          |
+| `models.definitions.<name>.preLaunchEnv` | optional            | Companion to `preLaunch`: list of env var names to append to groundcrew's `safehouse-clearance` `--env-pass=` flag, so `preLaunch` exports reach the agent without overriding `cmd` and losing the project's egress allowlist. Each entry must match `[A-Za-z_][A-Za-z0-9_]*`. Under `runner: "none"` exports already inherit and `preLaunchEnv` is a no-op. An empty array is a uniform no-op in every runner; a non-empty list is rejected when `cmd` already starts with `safehouse` or when `runner` resolves to `sdx`. |
+| `models.definitions.<name>.disabled`     | optional            | When set to exactly `true`, drops the named shipped default (`claude` or `codex`). Doctor skips probing it; `agent-<name>` labels fall back to `models.default` with a warning.                                                                                                                                                                                                                                                                                                                                             |
+| `prompts.initial`                        | unattended template | First message sent to the agent. Placeholders: `{{ticket}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override this from `crew.config.ts` for team-specific statuses, tools, plugins, or review loops.                                                                                                                                                                                                                                                                                                               |
+| `workspaceKind`                          | `"auto"`            | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"` or `"tmux"` to fail loudly when the chosen backend is missing.                                                                                                                                                                                                                                                                                                                                                                   |
+| `local.runner`                           | `"auto"`            | Local isolation backend. `"auto"` uses `safehouse` on macOS and `sdx` on Linux/WSL. Explicit: `"safehouse"`, `"sdx"`, `"none"`. `"none"` is never picked implicitly.                                                                                                                                                                                                                                                                                                                                                        |
+| `logging.file`                           | XDG state path      | Append-mode log file. `log()` / `logEvent()` tee here in addition to stdout. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                                                                                                                                                                                                                                                                                                                                                                 |

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,81 @@
+# Credentials
+
+## Linear API Key
+
+`crew` reads `GROUNDCREW_LINEAR_API_KEY` first, then falls back to `LINEAR_API_KEY`.
+
+```bash
+export GROUNDCREW_LINEAR_API_KEY="lin_api_..."
+crew doctor
+```
+
+To resolve the key from 1Password:
+
+```bash
+echo "GROUNDCREW_LINEAR_API_KEY='op://<vault>/LINEAR_API_KEY/credential'" > .env.1password
+op run --env-file .env.1password -- crew doctor
+```
+
+## Build-Time Secrets
+
+Groundcrew forwards a small allowlist of build-time secrets from your shell into the setup phase so package installs can authenticate against private registries. The agent process never inherits these values.
+
+Recognized names, defined in [`BUILD_SECRET_NAMES`](../src/lib/buildSecrets.ts):
+
+- `NPM_TOKEN`
+- `BUF_TOKEN`
+
+Set them in the shell you run `crew` from. Anything not in this list is ignored.
+
+<details>
+<summary>How the secret shuttle works</summary>
+
+For each ticket:
+
+1. If any recognized var is set and non-empty, groundcrew writes `secrets.env` with mode `0600` into the ticket's temp prompt dir as `KEY='value'` lines.
+2. The launch script sources `secrets.env` with `set -a` so the values are exported into the setup phase only. Under `sdx`, they are forwarded into the sandbox via `-e KEY` flags.
+3. After setup completes, the script removes every name in `BUILD_SECRET_NAMES` from the environment and removes the entire prompt dir before executing the agent.
+
+Net effect: by the time the agent process exists, the values are gone from the environment and the file is gone from disk.
+
+</details>
+
+## Per-Session Credentials
+
+`preLaunch` runs a host-shell snippet outside Safehouse/sdx before the agent starts. Use it when the agent needs a short-lived credential that must be minted from something the sandbox cannot reach, such as an engineer CLI session in Keychain.
+
+The "preLaunch never sees build secrets" contract is enforced differently per runner:
+
+- `runner: "safehouse"`: `preLaunch` runs immediately after `cd`, before `secrets.env` is sourced into the launch shell. `.groundcrew/setup.sh` then runs inside its own profile-neutral `safehouse-clearance` wrap with `--env-pass=NPM_TOKEN,BUF_TOKEN`; build secrets are unset on the host before the agent's Safehouse wrap is executed.
+- `runner: "none"`: `secrets.env` is sourced first, `.groundcrew/setup.sh` runs on the host, build-secret names are unset, then `preLaunch` runs against a clean env, then the agent is executed.
+
+Under the default `safehouse` runner, the agent runs under a sanitized env allowlist. Exports from `preLaunch` land in the launch shell but are stripped before reaching the agent unless they are forwarded. `preLaunchEnv` is the supported way to forward them:
+
+```ts
+models: {
+  definitions: {
+    claude: {
+      preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
+      preLaunchEnv: ["SESSION_TOKEN"],
+    },
+  },
+},
+```
+
+`&&` ensures `export` only runs when the mint succeeds. A failed mint propagates non-zero out of `preLaunch` and aborts launch before the agent starts. `{{worktree}}` is substituted the same way as in `cmd`.
+
+Under `runner: "none"`, exports flow through unchanged and `preLaunchEnv` is a no-op. A non-empty `preLaunchEnv` is not supported when `local.runner` resolves to `sdx` in v1. An empty `preLaunchEnv: []` is a uniform no-op in every runner.
+
+<details>
+<summary>Manual fallback when <code>cmd</code> brings its own <code>safehouse</code> wrap</summary>
+
+If your `cmd` already starts with `safehouse`, groundcrew will not auto-compose `--env-pass=` for you and a non-empty `preLaunchEnv` is rejected at launch. Add the names to your own `cmd` instead. This opts the model out of groundcrew's default `safehouse-clearance` wrap, so re-supply `--append-profile` / `--env` yourself if you need it:
+
+```ts
+claude: {
+  preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
+  cmd: "safehouse --env-pass=SESSION_TOKEN your-agent-cli",
+},
+```
+
+</details>

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -1,0 +1,45 @@
+# Runners
+
+`local.runner` picks the local isolation backend. `auto` resolves per platform.
+
+| Runner      | Default on  | Backend                                                                                                  |
+| ----------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `safehouse` | macOS       | [Safehouse](https://agent-safehouse.dev/) — fastest local; cannot safely give the agent Docker.          |
+| `sdx`       | Linux / WSL | [Docker Sandboxes](https://docs.docker.com/sandboxes/) (`sbx`) — required when the agent needs `docker`. |
+| `none`      | —           | Unsandboxed escape hatch. Never picked implicitly; doctor warns when configured.                         |
+
+## Safehouse Clearance Allowlist
+
+Only applies when `local.runner` resolves to `safehouse`. Groundcrew starts `clearance` on `http://127.0.0.1:19999` and runs the agent through the bundled `safehouse-clearance` wrapper. Clearance refuses to start without an allowlist.
+
+Shortest path:
+
+```bash
+CLEARANCE_ALLOW_HOSTS="api.openai.com,auth.openai.com,api.anthropic.com,mcp.linear.app,api.linear.app" \
+crew run --watch
+```
+
+Groundcrew ships a starter file covering model APIs, Linear, Notion, Slack, Datadog, GitHub, npm, and common dev tooling at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`. Point clearance at it, optionally with a personal file:
+
+```bash
+CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts" \
+crew run --watch
+```
+
+Watch `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.log` for `DENY` lines and add only the domains your agents actually need.
+
+`@clipboard-health/clearance` is pulled in transitively when you install groundcrew and provides the `clearance` / `clearance-ensure` bins used by Safehouse runs. See the [clearance README](https://github.com/ClipboardHealth/core-utils/tree/main/packages/clearance) for proxy env vars, log paths, and DNS rules.
+
+## Docker Sandboxes Setup
+
+Each model that runs under `sdx` needs a `sandbox: { agent: "<sbx-agent>" }` block in `crew.config.ts`. Groundcrew addresses the sandbox as `groundcrew-<agent>` and reuses one existing sandbox per agent across repos and tickets.
+
+First-time setup is manual:
+
+```bash
+sbx create --name groundcrew-claude claude <projectDir>
+sbx exec -it groundcrew-claude claude auth login
+sbx exec -it groundcrew-claude gh auth login
+```
+
+Replace `claude` with the sbx agent for the model and `<projectDir>` with `workspace.projectDir` from `crew.config.ts`. Manage lifecycle and auth with `sbx` directly (`sbx ls`, `sbx exec`, `sbx rm`). Groundcrew does not create, authenticate, regenerate, list, or remove sandboxes.

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -1,0 +1,46 @@
+# Setup Hooks
+
+If `.groundcrew/setup.sh` exists in the repo root, groundcrew runs `bash .groundcrew/setup.sh --deps-only` before each agent launch. Otherwise nothing runs. Same convention applies inside the sdx sandbox, overridable per model via `models.definitions.<name>.sandbox.setupCommand`.
+
+There is no implicit `npm install`, `uv sync`, or anything else. Groundcrew is language-agnostic, so opt in by adding the script.
+
+The `--deps-only` flag tells the script it is being called by an automated system before an agent launches. Skip anything interactive or one-time-only. The same script handles both modes; branch on `$1`:
+
+- With `--deps-only`: do the cheap recurring work this worktree needs, such as lockfile installs or type generation. No prompts, no global installs, no `nvm` / `pyenv` bootstrap.
+- Without the flag: full interactive bootstrap for first-time onboarding or another tool's SessionStart hook.
+
+Setup failures are advisory. Groundcrew logs the non-zero exit and still launches the agent so a flaky network or stale lockfile does not block the session.
+
+## Examples
+
+Python with uv:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--deps-only" ]; then
+  uv sync --dev
+else
+  uv sync --dev
+  # Extra one-time bootstrap, such as pre-commit install or db seed.
+fi
+```
+
+Node with npm:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--deps-only" ]; then
+  npm clean-install
+else
+  npm clean-install
+  # Extra one-time bootstrap, such as husky install or codegen.
+fi
+```
+
+Docs-only or polyglot repos can omit the script. With nothing at `.groundcrew/setup.sh`, groundcrew skips the hook silently.
+
+For a comprehensive real-world example with nvm bootstrap, hash-based skip-on-no-changes caching, and portable SHA-256 detection, see [this repo's own `.groundcrew/setup.sh`](../.groundcrew/setup.sh). It is also symlinked at `.claude/setup.sh` so the same script doubles as a Claude Code SessionStart hook for this repo; that symlink is local convenience, not part of groundcrew's contract.
+
+To scaffold `.groundcrew/setup.sh` with a coding agent, see [setup-hook-agent-prompt.md](./setup-hook-agent-prompt.md).

--- a/docs/ticket-sources.md
+++ b/docs/ticket-sources.md
@@ -1,0 +1,45 @@
+# Ticket Sources
+
+`sources` declares extra ticket-system adapters. They are verified at `crew run` startup and dispatched alongside the built-in Linear adapter, so a shell, Jira, or local-plan integration feeds the same orchestration loop as Linear.
+
+The built-in `shell` adapter runs command templates and reads JSON from stdout:
+
+```ts
+export default {
+  sources: [
+    {
+      kind: "shell",
+      name: "jira",
+      commands: {
+        verify: "jira me",
+        fetch: "~/.config/groundcrew/jira-fetch.sh",
+        resolveOne: "~/.config/groundcrew/jira-resolve.sh ${id}",
+        markInProgress: "jira issue move ${id} 'In Progress'",
+      },
+      timeouts: { fetch: 60_000 },
+    },
+  ],
+};
+```
+
+`commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when set, must print one issue, print nothing for "not found", or exit `3` for "not found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as JSON on stdin. `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
+
+```json
+[
+  {
+    "id": "JIRA-123",
+    "title": "Add retry logic",
+    "description": "Ticket body",
+    "status": "todo",
+    "repository": "your-org/your-repo",
+    "model": "claude",
+    "assignee": "Alice",
+    "updatedAt": "2026-05-22T15:00:00Z",
+    "blockers": [{ "id": "JIRA-122", "title": "Schema migration", "status": "done" }],
+    "hasMoreBlockers": false,
+    "sourceRef": { "nativeId": "10042" }
+  }
+]
+```
+
+Allowed `status` values are `todo`, `in-progress`, `in-review`, `done`, and `other`. Use `null` for `repository` or `model` when a ticket should not be groundcrew-eligible. `hasMoreBlockers` is optional and defaults to `false`; `sourceRef` is opaque data that groundcrew passes back to your writeback command.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+First stop for "what exists locally right now": `crew status <ticket>` shows the ticket's worktrees, workspace presence, run state, logs, and ticket-source status. Use `crew doctor` when you need to verify host setup.
+
+## Missing Model CLI
+
+`models.definitions` includes both shipped defaults (`claude`, `codex`) by default via additive merge. If you only intend to label tickets `agent-claude` and do not have `codex` installed, initialize with `crew init --model claude` or set:
+
+```ts
+models: {
+  default: "claude",
+  definitions: {
+    codex: { disabled: true },
+  },
+},
+```
+
+Without that, doctor exits non-zero on a missing `codex` binary even though `crew run` would never route to it.
+
+## Safehouse-Wrapped Commands Are Not Re-Wrapped
+
+If a `models.definitions.<name>.cmd` already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the `safehouse-clearance` wrapper a second time. Changing the proxy's allowlist after it is running requires killing the PID in `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid` so the next launch picks up the new env.
+
+## Dead Tmux Windows Vanish By Default
+
+When a wrapped agent command fails, the tmux window closes immediately and the error scrolls away. Set `GROUNDCREW_KEEP_DEAD_WINDOWS=1` in the env you launch `crew` from to flip the per-window `remain-on-exit` to `on`; the window stays open with the error visible. Close it manually with `tmux kill-window -t groundcrew:<ticket>` after diagnosis.
+
+This applies to the tmux backend only.
+
+## Tickets Stay In-Progress
+
+Groundcrew sets a ticket to `Started`, the first workflow state with `type === "started"` on that team, when it provisions a workspace and never advances it. The next transition, typically "In Review" when a PR opens, is left to your Linear automation rules.
+
+## Claude Launches In Auto Mode By Default
+
+Groundcrew creates isolated per-ticket worktrees for unattended runs, so the shipped `claude` command is `claude --permission-mode auto` to let Claude proceed without stopping for clarifying questions while keeping its built-in safety prompts intact. Override `models.definitions.claude.cmd` for `bypassPermissions` if you need to suppress tool-permission prompts entirely, or for a stricter mode.
+
+## Doctor's Command Introspection Is Shallow
+
+Doctor reports the resolved local runner and whether its prerequisites are met, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed. When `local.runner` is `"none"`, doctor surfaces a single WARNING line.
+
+## Switch To Tmux If Cmux Is Misbehaving
+
+Set `workspaceKind: "tmux"` to force the tmux backend when cmux's CLI/socket bridge is flaky, such as `cmux --json list-workspaces` returning `Failed to write to socket (Broken pipe)` or `Socket not found at ...cmux.sock` on every tick. Tmux is more reliable because it uses a unix socket, at the cost of losing cmux's status pills, notifications, and sidebar.
+
+## Agent CLI Must Accept A Positional Prompt
+
+The handoff is `<your cmd> "<prompt>"`. `claude`, `codex`, and `cursor-agent` all support this.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clearance-allow-hosts",
     "crew.config.example.ts",
     "dist",
+    "docs",
     "static"
   ],
   "type": "module",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -136,7 +136,9 @@ describe(run, () => {
     expect(helpOutput).toContain("-v, --version");
     expect(helpOutput).toContain("run");
     expect(helpOutput).toContain("--project-dir <dir>");
+    expect(helpOutput).toContain("--repo <repo>");
     expect(helpOutput).toContain("--runner <runner>");
+    expect(helpOutput).toContain("--model <model>");
     expect(helpOutput).not.toContain("sandbox");
     expect(helpOutput).not.toContain("crew ticket");
     expect(process.exitCode).toBe(1);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -136,7 +136,7 @@ describe(run, () => {
     expect(helpOutput).toContain("-v, --version");
     expect(helpOutput).toContain("run");
     expect(helpOutput).toContain("--project-dir <dir>");
-    expect(helpOutput).toContain("--repo <repo>");
+    expect(helpOutput).toContain("[--repo <repo>]...");
     expect(helpOutput).toContain("--runner <runner>");
     expect(helpOutput).toContain("--model <model>");
     expect(helpOutput).not.toContain("sandbox");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -135,6 +135,8 @@ describe(run, () => {
     expect(helpOutput).toContain("Usage: crew <command>");
     expect(helpOutput).toContain("-v, --version");
     expect(helpOutput).toContain("run");
+    expect(helpOutput).toContain("--project-dir <dir>");
+    expect(helpOutput).toContain("--runner <runner>");
     expect(helpOutput).not.toContain("sandbox");
     expect(helpOutput).not.toContain("crew ticket");
     expect(process.exitCode).toBe(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,7 +154,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   init: {
     summary: "Create a crew.config.ts in the cwd (or --global into the XDG config dir)",
     usage:
-      "[--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <repo>] [--runner <runner>] [--model <model>]",
+      "[--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <repo>]... [--runner <runner>] [--model <model>]",
     invoke: initConfigCli,
   },
   run: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,7 +153,8 @@ async function doctorCli(argv: string[]): Promise<void> {
 const SUBCOMMANDS: Record<string, Subcommand> = {
   init: {
     summary: "Create a crew.config.ts in the cwd (or --global into the XDG config dir)",
-    usage: "[--global | --local] [--force] [--dry-run]",
+    usage:
+      "[--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <repo>] [--runner <runner>] [--model <model>]",
     invoke: initConfigCli,
   },
   run: {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -246,6 +246,26 @@ describe(doctor, () => {
     expect(consoleLog.output()).toContain("[--] git");
   });
 
+  it("explains how to disable a missing shipped default model CLI", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "claude",
+        definitions: {
+          claude: { cmd: "claude", color: "#fff" },
+          codex: { cmd: "codex --dangerously-bypass-approvals-and-sandbox", color: "#3267e3" },
+        },
+      }),
+    );
+    mockWhichFailure("codex", "not installed");
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain(
+      "[--] codex  — install codex or disable it in crew.config.ts: `models.definitions.codex = { disabled: true }`",
+    );
+  });
+
   it("treats an empty `which` result as missing", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
     mockWhichEmpty("cmux");
@@ -492,6 +512,41 @@ describe(doctor, () => {
     await doctor();
 
     expect(consoleLog.output()).toMatch(/\[--] bare-cli\s*$/m);
+  });
+
+  it("does not use shipped-default disable guidance for custom model names", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "cursor",
+        definitions: {
+          cursor: { cmd: "cursor", color: "#fff" },
+        },
+      }),
+    );
+    mockWhichFailure("cursor", "missing");
+
+    await doctor();
+
+    expect(consoleLog.output()).toMatch(/\[--] cursor\s*$/m);
+  });
+
+  it("keeps the first useful hint when multiple models share a command token", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "claude",
+        definitions: {
+          claude: { cmd: "claude", color: "#fff" },
+          alias: { cmd: "claude", color: "#fff" },
+        },
+      }),
+    );
+    mockWhichFailure("claude", "missing");
+
+    await doctor();
+
+    expect(consoleLog.output()).toContain(
+      "[--] claude  — install claude or disable it in crew.config.ts: `models.definitions.claude = { disabled: true }`",
+    );
   });
 
   it("treats the token after a leading flag as the flag's value and stops after MAX tokens", async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -22,6 +22,7 @@ import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspace
 // Tokenization stops after this many non-flag tokens. Two is enough to
 // catch wrapper + wrapped CLI commands like `safehouse claude --foo`.
 const MAX_TOKENS_PER_CMD = 2;
+const SHIPPED_DEFAULT_MODEL_NAMES = ["claude", "codex"] as const;
 
 interface Check {
   name: string;
@@ -121,14 +122,38 @@ function commandTokensToCheck(cmd: string): string[] {
   return result;
 }
 
-function gatherToolTokens(config: ResolvedConfig): string[] {
-  const all = new Set<string>();
-  for (const definition of Object.values(config.models.definitions)) {
+interface ToolCheckTarget {
+  token: string;
+  hint?: string;
+}
+
+function gatherToolTargets(config: ResolvedConfig): ToolCheckTarget[] {
+  const all = new Map<string, string | undefined>();
+  for (const [modelName, definition] of Object.entries(config.models.definitions)) {
     for (const token of commandTokensToCheck(definition.cmd)) {
-      all.add(token);
+      const hint = modelCliHint(modelName, token);
+      if (!all.has(token) || all.get(token) === undefined) {
+        all.set(token, hint);
+      }
     }
   }
-  return [...all];
+  return [...all].map(([token, hint]) => (hint === undefined ? { token } : { token, hint }));
+}
+
+function modelCliHint(modelName: string, token: string): string | undefined {
+  if (token !== modelName) {
+    return undefined;
+  }
+  if (!isShippedDefaultModelName(modelName)) {
+    return undefined;
+  }
+  return `install ${token} or disable it in crew.config.ts: \`models.definitions.${modelName} = { disabled: true }\``;
+}
+
+function isShippedDefaultModelName(
+  value: string,
+): value is (typeof SHIPPED_DEFAULT_MODEL_NAMES)[number] {
+  return value === "claude" || value === "codex";
 }
 
 function format(check: Check): string {
@@ -184,11 +209,11 @@ export async function doctor(): Promise<boolean> {
     localCapability,
   ];
 
-  const toolTokens = gatherToolTokens(config);
-  for (const token of toolTokens) {
+  const toolTargets = gatherToolTargets(config);
+  for (const { token, hint } of toolTargets) {
     const required = localCapability.ok;
     // oxlint-disable-next-line no-await-in-loop -- doctor reports tools in deterministic order
-    const check = await checkCmd(token, required, required ? undefined : "required for local runs");
+    const check = await checkCmd(token, required, required ? hint : "required for local runs");
     checks.push(check);
   }
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -304,6 +304,10 @@ describe("crew init", () => {
       );
     });
 
+    it("rejects --model without a value", async () => {
+      await expect(initConfigCli(["--model"])).rejects.toThrow(/crew init --model/);
+    });
+
     it("rejects unsupported model values", async () => {
       await expect(initConfigCli(["--model", "cursor"])).rejects.toThrow(
         /--model must be one of claude, codex/,

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -157,6 +157,19 @@ describe("crew init", () => {
       expect(actual).toContain('default: "claude"');
       expect(actual).toContain("codex: { disabled: true }");
     });
+
+    it("fails loudly when a quickstart template anchor is missing", () => {
+      const template = join(cwd, "crew.config.example.ts");
+      writeFileSync(
+        template,
+        exampleContents.replace('projectDir: "~/dev/groundcrew"', 'projectDir: "~/elsewhere"'),
+      );
+
+      expect(() => initConfig({ cwd, projectDir: "~/dev", examplePath: template })).toThrow(
+        /crew init --project-dir: template anchor not found/,
+      );
+      expect(existsSync(join(cwd, "crew.config.ts"))).toBe(false);
+    });
   });
 
   describe(initConfigCli, () => {

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -138,6 +138,25 @@ describe("crew init", () => {
       expect(result.outcome).toBe("dry-run-would-write");
       expect(readFileSync(destination, "utf8")).toBe("existing content");
     });
+
+    it("writes a customized config when quickstart fields are supplied", () => {
+      const result = initConfig({
+        cwd,
+        projectDir: "~/dev",
+        repositories: ["OWNER/REPO"],
+        runner: "none",
+        model: "claude",
+      });
+
+      const destination = join(cwd, "crew.config.ts");
+      const actual = readFileSync(destination, "utf8");
+      expect(result.outcome).toBe("wrote");
+      expect(actual).toContain('projectDir: "~/dev"');
+      expect(actual).toContain('knownRepositories: ["OWNER/REPO"]');
+      expect(actual).toContain('local: { runner: "none" }');
+      expect(actual).toContain('default: "claude"');
+      expect(actual).toContain("codex: { disabled: true }");
+    });
   });
 
   describe(initConfigCli, () => {
@@ -169,6 +188,74 @@ describe("crew init", () => {
       expect(existsSync(join(xdgHome, "groundcrew", "crew.config.ts"))).toBe(true);
     });
 
+    it("accepts quickstart flags and prints clone plus Linear guidance", async () => {
+      await initConfigCli([
+        "--global",
+        "--project-dir",
+        "~/dev",
+        "--repo",
+        "OWNER/REPO",
+        "--runner",
+        "none",
+        "--model",
+        "claude",
+      ]);
+
+      const destination = join(xdgHome, "groundcrew", "crew.config.ts");
+      const actual = readFileSync(destination, "utf8");
+      const output = consoleLog.output();
+      expect(actual).toContain('projectDir: "~/dev"');
+      expect(actual).toContain('knownRepositories: ["OWNER/REPO"]');
+      expect(actual).toContain('local: { runner: "none" }');
+      expect(actual).toContain("codex: { disabled: true }");
+      expect(output).toContain('PROJECT_DIR="$HOME/dev"');
+      expect(output).toContain('mkdir -p "$PROJECT_DIR/OWNER"');
+      expect(output).toContain('git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"');
+      expect(output).toContain('export GROUNDCREW_LINEAR_API_KEY="lin_api_..."');
+      expect(output).toContain("crew doctor");
+      expect(output).toContain("crew run --watch");
+    });
+
+    it("supports Codex-only quickstart config and shell-escapes a ~/ project dir", async () => {
+      await initConfigCli([
+        "--global",
+        "--project-dir",
+        "~/Dev $Box",
+        "--repo",
+        "OWNER/REPO",
+        "--model",
+        "codex",
+      ]);
+
+      const destination = join(xdgHome, "groundcrew", "crew.config.ts");
+      const actual = readFileSync(destination, "utf8");
+      const output = consoleLog.output();
+      expect(actual).toContain('default: "codex"');
+      expect(actual).toContain("claude: { disabled: true }");
+      expect(output).toContain(String.raw`PROJECT_DIR="$HOME/Dev \$Box"`);
+    });
+
+    it("prints clone guidance for a bare repo and shell-quotes an absolute project dir", async () => {
+      await initConfigCli(["--global", "--project-dir", "/tmp/ground crew's", "--repo", "repo-a"]);
+
+      const output = consoleLog.output();
+      expect(output).toContain(String.raw`PROJECT_DIR='/tmp/ground crew'\''s'`);
+      expect(output).toContain('mkdir -p "$PROJECT_DIR"');
+      expect(output).toContain('git clone <REMOTE_URL_FOR_repo-a> "$PROJECT_DIR/repo-a"');
+    });
+
+    it("uses the example project dir in clone guidance when only repos are supplied", async () => {
+      await initConfigCli(["--global", "--repo", "OWNER/REPO"]);
+
+      expect(consoleLog.output()).toContain('PROJECT_DIR="$HOME/dev/groundcrew"');
+    });
+
+    it("prints a HOME-only assignment when project dir is ~", async () => {
+      await initConfigCli(["--global", "--project-dir", "~", "--repo", "OWNER/REPO"]);
+
+      expect(consoleLog.output()).toContain('PROJECT_DIR="$HOME"');
+    });
+
     it("accepts an explicit --local flag (cwd default)", async () => {
       await withCwd(cwd, async () => {
         await initConfigCli(["--local"]);
@@ -191,6 +278,22 @@ describe("crew init", () => {
     it("rejects an unknown flag with a helpful usage line", async () => {
       await expect(initConfigCli(["--what"])).rejects.toThrow(
         /Unknown option: --what[\s\S]*Usage: crew init/,
+      );
+    });
+
+    it("rejects --runner without a value", async () => {
+      await expect(initConfigCli(["--runner"])).rejects.toThrow(/crew init --runner/);
+    });
+
+    it("rejects unsupported runner values", async () => {
+      await expect(initConfigCli(["--runner", "unsafe"])).rejects.toThrow(
+        /--runner must be one of/,
+      );
+    });
+
+    it("rejects unsupported model values", async () => {
+      await expect(initConfigCli(["--model", "cursor"])).rejects.toThrow(
+        /--model must be one of claude, codex/,
       );
     });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,7 +17,7 @@ const CONFIG_FILE_NAME = "crew.config.ts";
 const EXAMPLE_FILE_NAME = "crew.config.example.ts";
 const DEFAULT_EXAMPLE_PROJECT_DIR = "~/dev/groundcrew";
 const INIT_USAGE =
-  "Usage: crew init [--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <owner/repo>] [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]";
+  "Usage: crew init [--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <owner/repo>]... [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]";
 const INIT_MODELS = ["claude", "codex"] as const;
 
 type InitConfigScope = "global" | "local";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,16 +5,23 @@
  * `cp` dance documented in the README.
  */
 
-import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
+import { LOCAL_RUNNER_SETTINGS, type LocalRunnerSetting } from "../lib/config.ts";
+import { shellSingleQuote } from "../lib/shell.ts";
 import { log, writeOutput } from "../lib/util.ts";
 import { xdgConfigPath } from "../lib/xdg.ts";
 
 const CONFIG_FILE_NAME = "crew.config.ts";
 const EXAMPLE_FILE_NAME = "crew.config.example.ts";
+const DEFAULT_EXAMPLE_PROJECT_DIR = "~/dev/groundcrew";
+const INIT_USAGE =
+  "Usage: crew init [--global | --local] [--force] [--dry-run] [--project-dir <dir>] [--repo <owner/repo>] [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]";
+const INIT_MODELS = ["claude", "codex"] as const;
 
 type InitConfigScope = "global" | "local";
+type InitModel = (typeof INIT_MODELS)[number];
 
 interface InitConfigOptions {
   /** Where to write the config. Defaults to "local" (cwd). */
@@ -25,6 +32,14 @@ interface InitConfigOptions {
   dryRun?: boolean;
   /** Override for the working directory; defaults to `process.cwd()`. */
   cwd?: string;
+  /** Pre-fill workspace.projectDir in the generated config. */
+  projectDir?: string;
+  /** Pre-fill workspace.knownRepositories in the generated config. */
+  repositories?: string[];
+  /** Pre-fill local.runner in the generated config. */
+  runner?: LocalRunnerSetting;
+  /** Keep one shipped default model enabled and disable the other. */
+  model?: InitModel;
 }
 
 type InitConfigOutcome = "dry-run-would-write" | "exists" | "wrote";
@@ -51,7 +66,7 @@ export function initConfig(options: InitConfigOptions = {}): InitConfigResult {
   }
 
   mkdirSync(dirname(destination), { recursive: true });
-  copyFileSync(source, destination);
+  writeFileSync(destination, renderConfig(source, options));
   log(`[wrote] ${destination}`);
   return { destination, outcome: "wrote" };
 }
@@ -65,13 +80,7 @@ export async function initConfigCli(argv: string[]): Promise<void> {
     return;
   }
   if (result.outcome === "wrote") {
-    writeOutput("");
-    writeOutput("Next steps:");
-    writeOutput(`  - Edit ${result.destination}`);
-    writeOutput("  - Set workspace.projectDir, workspace.knownRepositories");
-    writeOutput("  - Export GROUNDCREW_LINEAR_API_KEY (or LINEAR_API_KEY)");
-    writeOutput("  - Assign Linear tickets to yourself and add an agent-* label to opt them in");
-    writeOutput("  - Verify with `crew doctor`");
+    writeInitGuidance(result.destination, options);
   }
 }
 
@@ -79,14 +88,21 @@ function parseArguments(argv: string[]): InitConfigOptions {
   let scope: InitConfigScope | undefined;
   let force = false;
   let dryRun = false;
+  let projectDir: string | undefined;
+  const repositories: string[] = [];
+  let runner: LocalRunnerSetting | undefined;
+  let model: InitModel | undefined;
 
-  for (const argument of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    /* v8 ignore next 3 @preserve -- loop bounds keep argv[index] defined */
+    if (argument === undefined) {
+      continue;
+    }
     if (argument === "--global" || argument === "--local") {
       const next: InitConfigScope = argument === "--global" ? "global" : "local";
       if (scope !== undefined && scope !== next) {
-        throw new Error(
-          "crew init: --global and --local are mutually exclusive.\nUsage: crew init [--global | --local] [--force] [--dry-run]",
-        );
+        throw new Error(`crew init: --global and --local are mutually exclusive.\n${INIT_USAGE}`);
       }
       scope = next;
       continue;
@@ -99,12 +115,45 @@ function parseArguments(argv: string[]): InitConfigOptions {
       dryRun = true;
       continue;
     }
-    throw new Error(
-      `Unknown option: ${argument}\nUsage: crew init [--global | --local] [--force] [--dry-run]`,
-    );
+    if (argument === "--project-dir") {
+      projectDir = readOptionValue(argv, index, argument);
+      index += 1;
+      continue;
+    }
+    if (argument === "--repo") {
+      repositories.push(readOptionValue(argv, index, argument));
+      index += 1;
+      continue;
+    }
+    if (argument === "--runner") {
+      runner = parseRunner(readOptionValue(argv, index, argument));
+      index += 1;
+      continue;
+    }
+    if (argument === "--model") {
+      model = parseModel(readOptionValue(argv, index, argument));
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${argument}\n${INIT_USAGE}`);
   }
 
-  return { scope: scope ?? "local", force, dryRun };
+  const parsed: InitConfigOptions = {
+    scope: scope ?? "local",
+    force,
+    dryRun,
+    repositories,
+  };
+  if (projectDir !== undefined) {
+    parsed.projectDir = projectDir;
+  }
+  if (runner !== undefined) {
+    parsed.runner = runner;
+  }
+  if (model !== undefined) {
+    parsed.model = model;
+  }
+  return parsed;
 }
 
 function destinationFor(args: { scope: InitConfigScope; cwd: string }): string {
@@ -118,4 +167,146 @@ function resolveExamplePath(): string {
   // `init.ts` lives at src/commands/init.ts in source and dist/commands/init.js
   // after build; the example ships at the package root in both cases.
   return resolve(import.meta.dirname, "..", "..", EXAMPLE_FILE_NAME);
+}
+
+function readOptionValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.length === 0 || value.startsWith("-")) {
+    throw new Error(`crew init ${flag}: value is required\n${INIT_USAGE}`);
+  }
+  return value;
+}
+
+function parseRunner(value: string): LocalRunnerSetting {
+  if (isLocalRunnerSetting(value)) {
+    return value;
+  }
+  throw new Error(`crew init --runner must be one of ${LOCAL_RUNNER_SETTINGS.join(", ")}`);
+}
+
+function parseModel(value: string): InitModel {
+  if (isInitModel(value)) {
+    return value;
+  }
+  throw new Error(`crew init --model must be one of ${INIT_MODELS.join(", ")}`);
+}
+
+function isLocalRunnerSetting(value: string): value is LocalRunnerSetting {
+  return value === "auto" || value === "safehouse" || value === "sdx" || value === "none";
+}
+
+function isInitModel(value: string): value is InitModel {
+  return value === "claude" || value === "codex";
+}
+
+function tsString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderConfig(source: string, options: InitConfigOptions): string {
+  let contents = readFileSync(source, "utf8");
+  if (options.projectDir !== undefined) {
+    contents = contents.replace(
+      `projectDir: ${tsString(DEFAULT_EXAMPLE_PROJECT_DIR)}`,
+      `projectDir: ${tsString(options.projectDir)}`,
+    );
+  }
+  if (options.repositories !== undefined && options.repositories.length > 0) {
+    contents = contents.replace(
+      'knownRepositories: ["your-org/your-repo"]',
+      `knownRepositories: [${options.repositories.map(tsString).join(", ")}]`,
+    );
+  }
+  if (options.runner !== undefined) {
+    contents = contents.replace(
+      `  // local: { runner: "auto" },`,
+      `  local: { runner: ${tsString(options.runner)} },`,
+    );
+  }
+  if (options.model !== undefined) {
+    contents = contents.replace("  // prompts: {", `${modelBlock(options.model)}\n  // prompts: {`);
+  }
+  return contents;
+}
+
+function modelBlock(model: InitModel): string {
+  const disabled = model === "claude" ? "codex" : "claude";
+  return [
+    "  models: {",
+    `    default: ${tsString(model)},`,
+    "    definitions: {",
+    `      ${disabled}: { disabled: true },`,
+    "    },",
+    "  },",
+    "",
+  ].join("\n");
+}
+
+function writeInitGuidance(destination: string, options: InitConfigOptions): void {
+  writeOutput("");
+  writeOutput("Next steps:");
+  writeOutput(`  - Review ${destination}`);
+  if (
+    options.projectDir === undefined ||
+    options.repositories === undefined ||
+    options.repositories.length === 0
+  ) {
+    writeOutput("  - Set workspace.projectDir and workspace.knownRepositories");
+  }
+  writeCloneGuidance(options);
+  writeOutput("  - If using Linear, export your API key:");
+  writeOutput('      export GROUNDCREW_LINEAR_API_KEY="lin_api_..."');
+  writeOutput("  - In Linear, assign tickets to yourself and add an agent-* label to opt them in");
+  writeOutput("  - Validate and start:");
+  writeOutput("      crew doctor");
+  writeOutput("      crew run --watch");
+}
+
+function writeCloneGuidance(options: InitConfigOptions): void {
+  if (options.repositories === undefined || options.repositories.length === 0) {
+    return;
+  }
+  writeOutput("  - Clone configured repositories:");
+  writeOutput(`      ${projectDirAssignment(options.projectDir ?? DEFAULT_EXAMPLE_PROJECT_DIR)}`);
+  for (const repository of options.repositories) {
+    for (const command of cloneCommands(repository)) {
+      writeOutput(`      ${command}`);
+    }
+  }
+}
+
+function projectDirAssignment(projectDir: string): string {
+  if (projectDir === "~") {
+    return 'PROJECT_DIR="$HOME"';
+  }
+  if (projectDir.startsWith("~/")) {
+    return `PROJECT_DIR="$HOME/${escapeDoubleQuotedShellValue(projectDir.slice(2))}"`;
+  }
+  return `PROJECT_DIR=${shellSingleQuote(projectDir)}`;
+}
+
+function cloneCommands(repository: string): string[] {
+  const parts = repository.split("/");
+  const [owner, name, extra] = parts;
+  if (owner !== undefined && name !== undefined && extra === undefined) {
+    return [
+      `mkdir -p "$PROJECT_DIR/${owner}"`,
+      `git clone git@github.com:${owner}/${name}.git "$PROJECT_DIR/${owner}/${name}"`,
+    ];
+  }
+  return [
+    'mkdir -p "$PROJECT_DIR"',
+    `git clone <REMOTE_URL_FOR_${repository}> "$PROJECT_DIR/${repository}"`,
+  ];
+}
+
+function escapeDoubleQuotedShellValue(value: string): string {
+  let escaped = "";
+  for (const character of value) {
+    escaped +=
+      character === '"' || character === "\\" || character === "$" || character === "`"
+        ? `\\${character}`
+        : character;
+  }
+  return escaped;
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -40,6 +40,8 @@ interface InitConfigOptions {
   runner?: LocalRunnerSetting;
   /** Keep one shipped default model enabled and disable the other. */
   model?: InitModel;
+  /** Override the source template path. */
+  examplePath?: string;
 }
 
 type InitConfigOutcome = "dry-run-would-write" | "exists" | "wrote";
@@ -52,7 +54,7 @@ interface InitConfigResult {
 export function initConfig(options: InitConfigOptions = {}): InitConfigResult {
   const scope = options.scope ?? "local";
   const cwd = options.cwd ?? process.cwd();
-  const source = resolveExamplePath();
+  const source = options.examplePath ?? resolveExamplePath();
   const destination = destinationFor({ scope, cwd });
 
   if (existsSync(destination) && options.force !== true) {
@@ -206,27 +208,50 @@ function tsString(value: string): string {
 function renderConfig(source: string, options: InitConfigOptions): string {
   let contents = readFileSync(source, "utf8");
   if (options.projectDir !== undefined) {
-    contents = contents.replace(
+    contents = replaceRequired(
+      contents,
       `projectDir: ${tsString(DEFAULT_EXAMPLE_PROJECT_DIR)}`,
       `projectDir: ${tsString(options.projectDir)}`,
+      "--project-dir",
     );
   }
   if (options.repositories !== undefined && options.repositories.length > 0) {
-    contents = contents.replace(
+    contents = replaceRequired(
+      contents,
       'knownRepositories: ["your-org/your-repo"]',
       `knownRepositories: [${options.repositories.map(tsString).join(", ")}]`,
+      "--repo",
     );
   }
   if (options.runner !== undefined) {
-    contents = contents.replace(
+    contents = replaceRequired(
+      contents,
       `  // local: { runner: "auto" },`,
       `  local: { runner: ${tsString(options.runner)} },`,
+      "--runner",
     );
   }
   if (options.model !== undefined) {
-    contents = contents.replace("  // prompts: {", `${modelBlock(options.model)}\n  // prompts: {`);
+    contents = replaceRequired(
+      contents,
+      "  // prompts: {",
+      `${modelBlock(options.model)}\n  // prompts: {`,
+      "--model",
+    );
   }
   return contents;
+}
+
+function replaceRequired(
+  contents: string,
+  search: string,
+  replacement: string,
+  flag: string,
+): string {
+  if (!contents.includes(search)) {
+    throw new Error(`crew init ${flag}: template anchor not found in ${EXAMPLE_FILE_NAME}`);
+  }
+  return contents.replace(search, replacement);
 }
 
 function modelBlock(model: InitModel): string {


### PR DESCRIPTION
## Summary

Add quickstart-oriented `crew init` flags that prefill workspace, runner, repo, and single-model config, then print clone/API/doctor/run guidance so README setup can point users at one init command. Update `crew doctor` to explain how to disable a missing shipped default model CLI.

Simplify the README into a shorter onboarding path, move reference-heavy material into focused docs pages, include those docs in the npm package, and link to the longer Clipboard Works write-up for readers who want the product narrative.

## Validation

- `node --run verify`

## Notes

The workflow graphic was not added because the provided file path under `Downloads` was not readable from this process. The README is structured so a screenshot or graphic can be added near the top later.

Agent session: `codex resume 019e7419-7e1a-7a40-aa7d-f6c18cb1ee46`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
