### PR TITLE
fix: run CI on Renovate branches for branch automerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "renovate/**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary

Renovate is configured for `automergeType: branch` (minor/patch/digest and `devDependencies`), pushing a bare `renovate/*` branch with no PR, waiting for the required `main` status check to pass on that branch, then merging directly into `main`.

The `main` check never ran on those branches: CI triggered only on `push: [main]` and `pull_request`, neither of which fires for a bare `renovate/*` branch. Branch automerge could never confirm green and fell back to opening PRs that then sat blocked on required review.

This adds `renovate/**` to the push trigger so the required `main` check runs on Renovate branches. The `release` job stays gated on `github.ref == 'refs/heads/main'`, so it does not fire on Renovate branches — only the `main` check runs.

Mirrors ClipboardHealth/clipboard#153.

## Validation

- `node --run verify` passed locally (exit 0); re-run green by the pre-push hook.
- End behavior (Renovate branch automerge firing with no PR) can only be confirmed after merge, on the next Renovate run.

Agent session: `claude --resume 7076a597-7004-4a11-997b-6a2944cc54ce`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>
