### PR TITLE
chore: allow generic tooling hosts

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -64,8 +64,9 @@ raw.githubusercontent.com
 release-assets.githubusercontent.com
 results-receiver.actions.githubusercontent.com
 
-# npm registry + package website
+# npm/Conda registries + package websites
 api.npmjs.org
+conda.anaconda.org
 registry.npmjs.org
 www.npmjs.com
 
@@ -79,10 +80,14 @@ buf.build
 cdn.playwright.dev
 cloud.nx.app
 fastdl.mongodb.org
+ffmpeg.org
 formulae.brew.sh
 hub.docker.com
 index.docker.io
 json.schemastore.org
+mise-versions.jdx.dev
 nx.dev
+playwright.azureedge.net
+registry.terraform.io
 sourcegraph.com
 vitest.dev

--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -80,7 +80,6 @@ buf.build
 cdn.playwright.dev
 cloud.nx.app
 fastdl.mongodb.org
-ffmpeg.org
 formulae.brew.sh
 hub.docker.com
 index.docker.io

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
   "words": [
     "assertname",
     "awsapps",
+    "azureedge",
     "boardsource",
     "cdkw",
     "cleanupworkspace",


### PR DESCRIPTION
## Summary

Investigated the blocked clearance hosts and expanded the starter egress allowlist with public, generic developer-tooling endpoints: Conda, mise versions, Playwright legacy Microsoft CDN host, and Terraform Registry. The InfluxDB Cloud regional endpoint, FFmpeg website, npmmirror registry, and broad Google Cloud Storage endpoint were reviewed but left out.

## Validation

- node --run verify
- pre-push node --run verify

## Notes

Skipped hosts:
- eu-central-1-1.aws.cloud2.influxdata.com: InfluxDB Cloud data/API endpoint, not generic starter tooling.
- ffmpeg.org: not required for the starter allowlist.
- registry.npmmirror.com: non-official npm mirror; official npm registry is already allowed.
- storage.googleapis.com: broad object-storage host that clearance cannot scope to specific buckets/paths.

Agent session: `codex resume 019e85c1-076e-7011-b81a-06b65123d334`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>