### PR TITLE
docs: explain local and interactive agents, add prepareWorktree placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  Dispatch your ticket backlog to AI coding agents. One git worktree per ticket, sandboxed by default.
+  Dispatch your ticket backlog to local, interactive AI coding agents. One git worktree per ticket, sandboxed by default.
 </p>
 
 <p align="center">
@@ -28,9 +28,11 @@ Groundcrew watches assigned tickets, creates isolated worktrees, launches agent 
 
 ## Why
 
+- **Local.** Agents run on your machine with your tools, shell, and credentials. That makes them more steerable than remote agents, and easy to nudge when they drift.
+- **Interactive.** Each ticket launches the real `claude` or `codex` CLI in its own terminal pane, not a wrapper that approximates it. Watch any session live and take over when you need to.
 - **One worktree per ticket.** Agents work in parallel without stepping on each other.
+- **Sandboxed by default.** Safehouse or Docker Sandboxes isolate each agent on the host; `none` is an explicit escape hatch.
 - **Pluggable ticket sources.** Linear by default; Jira and local files via [ticket sources](./docs/ticket-sources.md).
-- **Local-first isolation.** Safehouse, Docker Sandboxes, or an explicit `none` escape hatch.
 - **Multi-agent routing.** Ships `claude` and `codex` presets; bring your own CLI in config.
 
 ## Prerequisites
@@ -117,6 +119,12 @@ export default {
     default: "claude",
     definitions: {
       claude: {},
+    },
+  },
+  defaults: {
+    hooks: {
+      // No-op placeholder; replace with your repo's setup, e.g. "npm ci".
+      prepareWorktree: "true",
     },
   },
 } satisfies Config;

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -35,6 +35,15 @@ export default {
       // },
     },
   },
+  // Repo-preparation hook: runs after each worktree is created and before the
+  // agent launches. The default below is a no-op placeholder. Replace it with
+  // your repo's setup, e.g. "npm ci" or "uv sync --dev --frozen". A repo-local
+  // `.groundcrew/config.json` hooks.prepareWorktree overrides this per repo.
+  defaults: {
+    hooks: {
+      prepareWorktree: "true",
+    },
+  },
   // Everything below is optional — defaults shown for reference. Uncomment
   // and edit to override.
   //
@@ -58,14 +67,6 @@ export default {
   // ],
   //
   // git: { remote: "origin", defaultBranch: "main" },
-  //
-  // // Fallback repo-preparation hook for repos that do not define
-  // // `.groundcrew/config.json` hooks.prepareWorktree. Repo-local config wins.
-  // defaults: {
-  //   hooks: {
-  //     prepareWorktree: "test ! -f package-lock.json || npm ci",
-  //   },
-  // },
   //
   // orchestrator: {
   //   maximumInProgress: 4,


### PR DESCRIPTION
## Summary

Surface the launch post's two headline differentiators in the README so they're discoverable, and make the `prepareWorktree` hook easy to adopt.

- **Why local / why interactive.** The README Why section now leads with **Local** (agents run on your machine with your tools and credentials, so they're steerable and easy to nudge) and **Interactive** (the real `claude`/`codex` CLI in terminal panes you can watch and take over). The tagline mirrors this, and the old "Local-first isolation" bullet is renamed "Sandboxed by default" so it no longer overlaps the new Local bullet.
- **prepareWorktree placeholder.** Both the README config block and `crew.config.example.ts` now ship an active no-op `defaults.hooks.prepareWorktree: "true"`, replacing the buried commented example. Since `crew init` renders the example verbatim, a scaffolded config exposes an obvious, editable hook to swap for repo setup (e.g. `npm ci`).
- **Repo metadata (already applied).** The GitHub repo description is mirrored to the new tagline, and topics expanded to 20 (added `agentic`, `local-first`, `claude-code`, `sandbox`, `worktrees`, `parallel`, `cmux`, `jira`) for discoverability.

## Validation

- `node --run verify` and the pre-push hook passed: 1077 tests, 100% coverage, markdownlint 0 errors; architecture, format, spell, knip, and syncpack clean.
- Repo description and topics applied via `gh repo edit` and confirmed with `gh repo view`.

## Notes

- No Linear ticket; this was an ad-hoc README/discoverability request.
- The "why local" / "why interactive" wording is grounded in the companion post's stated reasoning, not invented.

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>
