### PR TITLE
feat: show config source in crew doctor

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -4,9 +4,9 @@ import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, type sourcesFromConfig } from "../lib/buildSources.ts";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import {
-  type ConfigResolution,
-  loadConfig,
-  resolveConfigSource,
+  type ConfigSource,
+  type LoadedConfig,
+  loadConfigWithSource,
   type ResolvedConfig,
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
@@ -30,8 +30,7 @@ vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    loadConfig: vi.fn<typeof loadConfig>(),
-    resolveConfigSource: vi.fn<typeof resolveConfigSource>(),
+    loadConfigWithSource: vi.fn<typeof loadConfigWithSource>(),
   };
 });
 vi.mock(import("../lib/host.ts"), async (importOriginal) => {
@@ -71,10 +70,10 @@ const existsMock = vi.mocked(existsSync);
 const statMock = vi.mocked(statSync);
 const buildSourcesMock = vi.mocked(buildSources);
 const createBoardMock = vi.mocked(createBoard);
-const loadConfigMock = vi.mocked(loadConfig);
-const resolveConfigSourceMock = vi.mocked(resolveConfigSource);
+const loadConfigWithSourceMock = vi.mocked(loadConfigWithSource);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const boardVerifyMock = vi.fn<Board["verify"]>();
+const DEFAULT_CONFIG_SOURCE: ConfigSource = { kind: "project", filepath: "/work/crew.config.ts" };
 
 /**
  * A minimal Board whose `verify()` is the controllable mock. The other
@@ -127,16 +126,24 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
   };
 }
 
-function projectResolution(filepath = "/work/crew.config.ts"): ConfigResolution {
+function makeLoadedConfig(
+  config: ResolvedConfig,
+  source: ConfigSource = DEFAULT_CONFIG_SOURCE,
+): LoadedConfig {
   return {
-    steps: [
-      { kind: "env", status: "miss", detail: "not set" },
-      { kind: "project", status: "hit", detail: filepath },
-      { kind: "xdg", status: "not-reached", detail: "not reached" },
-    ],
-    resolved: { kind: "project", filepath },
+    config,
+    source,
   };
 }
+
+const loadConfigMock = {
+  mockResolvedValue(config: ResolvedConfig): void {
+    loadConfigWithSourceMock.mockResolvedValue(makeLoadedConfig(config));
+  },
+  mockRejectedValue(error: unknown): void {
+    loadConfigWithSourceMock.mockRejectedValue(error);
+  },
+};
 
 function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
   return {
@@ -199,7 +206,6 @@ describe(doctor, () => {
     existsMock.mockReturnValue(true);
     statMock.mockReturnValue(statsWithDirectoryValue(true));
     detectHostMock.mockResolvedValue(host());
-    resolveConfigSourceMock.mockResolvedValue(projectResolution());
     buildSourcesMock.mockResolvedValue([stubSource("linear")]);
     createBoardMock.mockReturnValue(stubBoard());
     boardVerifyMock.mockResolvedValue();
@@ -214,58 +220,25 @@ describe(doctor, () => {
     vi.resetAllMocks();
   });
 
-  it("renders the config resolution section with the winning path", async () => {
-    loadConfigMock.mockResolvedValue(makeConfig());
-    resolveConfigSourceMock.mockResolvedValue(projectResolution("/work/crew.config.ts"));
+  it("renders the config source with the load verdict", async () => {
+    loadConfigWithSourceMock.mockResolvedValue(
+      makeLoadedConfig(makeConfig(), { kind: "env", filepath: "/work/crew.config.ts" }),
+    );
 
     const actual = await doctor();
 
     expect(actual).toBe(true);
     const output = consoleLog.output();
-    expect(output).toContain("Config resolution");
-    expect(output).toContain("project search (from cwd)");
-    expect(output).toContain("✓ /work/crew.config.ts");
-    expect(output).toContain("GROUNDCREW_CONFIG env var");
-    expect(output).toContain("[ok] config loaded");
-  });
-
-  it("reports no config found and skips loadConfig when nothing resolves", async () => {
-    resolveConfigSourceMock.mockResolvedValue({
-      steps: [
-        { kind: "env", status: "miss", detail: "not set" },
-        { kind: "project", status: "miss", detail: "no match (searched up from /work)" },
-        {
-          kind: "xdg",
-          status: "miss",
-          detail: "not found (/home/u/.config/groundcrew/crew.config.ts)",
-        },
-      ],
-    });
-
-    const actual = await doctor();
-
-    expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain("[--] no config found");
-    expect(loadConfigMock).not.toHaveBeenCalled();
-  });
-
-  it("reports a config error when resolution throws on a malformed config", async () => {
-    resolveConfigSourceMock.mockRejectedValue(new Error("parse blew up"));
-
-    const actual = await doctor();
-
-    expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain("config: parse blew up");
-    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(output).toContain("[ok] config loaded — /work/crew.config.ts (GROUNDCREW_CONFIG)");
   });
 
   it("returns false when config loading fails", async () => {
-    loadConfigMock.mockRejectedValue(new Error("bad config"));
+    loadConfigMock.mockRejectedValue(new Error("GROUNDCREW_CONFIG=/missing.ts not found"));
 
     const actual = await doctor();
 
     expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain("config: bad config");
+    expect(consoleLog.output()).toContain("config: GROUNDCREW_CONFIG=/missing.ts not found");
   });
 
   it("returns false when host-capability probing throws", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -3,7 +3,12 @@ import { existsSync, statSync } from "node:fs";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, type sourcesFromConfig } from "../lib/buildSources.ts";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import {
+  type ConfigResolution,
+  loadConfig,
+  resolveConfigSource,
+  type ResolvedConfig,
+} from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import type { TicketSource } from "../lib/ticketSource.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -23,7 +28,11 @@ vi.mock(
 );
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+  return {
+    ...actual,
+    loadConfig: vi.fn<typeof loadConfig>(),
+    resolveConfigSource: vi.fn<typeof resolveConfigSource>(),
+  };
 });
 vi.mock(import("../lib/host.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -63,6 +72,7 @@ const statMock = vi.mocked(statSync);
 const buildSourcesMock = vi.mocked(buildSources);
 const createBoardMock = vi.mocked(createBoard);
 const loadConfigMock = vi.mocked(loadConfig);
+const resolveConfigSourceMock = vi.mocked(resolveConfigSource);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const boardVerifyMock = vi.fn<Board["verify"]>();
 
@@ -114,6 +124,17 @@ function makeConfig(overrides: Partial<ResolvedConfig["models"]> = {}): Resolved
     workspaceKind: "auto",
     local: { runner: "auto" },
     logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function projectResolution(filepath = "/work/crew.config.ts"): ConfigResolution {
+  return {
+    steps: [
+      { kind: "env", status: "miss", detail: "not set" },
+      { kind: "project", status: "hit", detail: filepath },
+      { kind: "xdg", status: "not-reached", detail: "not reached" },
+    ],
+    resolved: { kind: "project", filepath },
   };
 }
 
@@ -178,6 +199,7 @@ describe(doctor, () => {
     existsMock.mockReturnValue(true);
     statMock.mockReturnValue(statsWithDirectoryValue(true));
     detectHostMock.mockResolvedValue(host());
+    resolveConfigSourceMock.mockResolvedValue(projectResolution());
     buildSourcesMock.mockResolvedValue([stubSource("linear")]);
     createBoardMock.mockReturnValue(stubBoard());
     boardVerifyMock.mockResolvedValue();
@@ -190,6 +212,51 @@ describe(doctor, () => {
   afterEach(() => {
     consoleLog.restore();
     vi.resetAllMocks();
+  });
+
+  it("renders the config resolution section with the winning path", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    resolveConfigSourceMock.mockResolvedValue(projectResolution("/work/crew.config.ts"));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const output = consoleLog.output();
+    expect(output).toContain("Config resolution");
+    expect(output).toContain("project search (from cwd)");
+    expect(output).toContain("✓ /work/crew.config.ts");
+    expect(output).toContain("GROUNDCREW_CONFIG env var");
+    expect(output).toContain("[ok] config loaded");
+  });
+
+  it("reports no config found and skips loadConfig when nothing resolves", async () => {
+    resolveConfigSourceMock.mockResolvedValue({
+      steps: [
+        { kind: "env", status: "miss", detail: "not set" },
+        { kind: "project", status: "miss", detail: "no match (searched up from /work)" },
+        {
+          kind: "xdg",
+          status: "miss",
+          detail: "not found (/home/u/.config/groundcrew/crew.config.ts)",
+        },
+      ],
+    });
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("[--] no config found");
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a config error when resolution throws on a malformed config", async () => {
+    resolveConfigSourceMock.mockRejectedValue(new Error("parse blew up"));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("config: parse blew up");
+    expect(loadConfigMock).not.toHaveBeenCalled();
   });
 
   it("returns false when config loading fails", async () => {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,10 +8,13 @@ import { existsSync, statSync } from "node:fs";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import {
+  type ConfigResolution,
+  type ConfigSourceKind,
   type LocalRunner,
   type LocalRunnerSetting,
   loadConfig,
   type ResolvedConfig,
+  resolveConfigSource,
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
@@ -23,6 +26,27 @@ import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspace
 // catch wrapper + wrapped CLI commands like `safehouse claude --foo`.
 const MAX_TOKENS_PER_CMD = 2;
 const BUILT_IN_MODEL_NAMES = ["claude", "codex"] as const;
+
+const CONFIG_SOURCE_LABELS: Record<ConfigSourceKind, string> = {
+  env: "GROUNDCREW_CONFIG env var",
+  project: "project search (from cwd)",
+  xdg: "global XDG fallback",
+};
+
+// Widest label ("GROUNDCREW_CONFIG env var" / "project search (from cwd)" are
+// both 25) plus a two-space gutter, so the detail column lines up.
+const CONFIG_LABEL_WIDTH = 27;
+
+function reportConfigResolution(resolution: ConfigResolution): void {
+  writeOutput();
+  writeOutput("Config resolution");
+  writeOutput("-----------------");
+  for (const step of resolution.steps) {
+    const label = CONFIG_SOURCE_LABELS[step.kind].padEnd(CONFIG_LABEL_WIDTH);
+    const marker = step.status === "hit" ? "✓ " : "";
+    writeOutput(`  ${label}${marker}${step.detail}`);
+  }
+}
 
 interface Check {
   name: string;
@@ -171,6 +195,21 @@ function format(check: Check): string {
 export async function doctor(): Promise<boolean> {
   writeOutput("groundcrew doctor");
   writeOutput("=================");
+
+  let resolution: ConfigResolution;
+  try {
+    resolution = await resolveConfigSource();
+  } catch (error) {
+    // A malformed *discovered* project config makes cosmiconfig's search throw
+    // during resolution. Fall back to the existing config-error verdict.
+    writeOutput(`[--] config: ${errorMessage(error)}`);
+    return false;
+  }
+  reportConfigResolution(resolution);
+  if (resolution.resolved === undefined) {
+    writeOutput("[--] no config found");
+    return false;
+  }
 
   let config: ResolvedConfig;
   try {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,13 +8,11 @@ import { existsSync, statSync } from "node:fs";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import {
-  type ConfigResolution,
   type ConfigSourceKind,
   type LocalRunner,
   type LocalRunnerSetting,
-  loadConfig,
+  loadConfigWithSource,
   type ResolvedConfig,
-  resolveConfigSource,
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
@@ -28,25 +26,10 @@ const MAX_TOKENS_PER_CMD = 2;
 const BUILT_IN_MODEL_NAMES = ["claude", "codex"] as const;
 
 const CONFIG_SOURCE_LABELS: Record<ConfigSourceKind, string> = {
-  env: "GROUNDCREW_CONFIG env var",
-  project: "project search (from cwd)",
-  xdg: "global XDG fallback",
+  env: "GROUNDCREW_CONFIG",
+  project: "project",
+  xdg: "global XDG",
 };
-
-// Widest label ("GROUNDCREW_CONFIG env var" / "project search (from cwd)" are
-// both 25) plus a two-space gutter, so the detail column lines up.
-const CONFIG_LABEL_WIDTH = 27;
-
-function reportConfigResolution(resolution: ConfigResolution): void {
-  writeOutput();
-  writeOutput("Config resolution");
-  writeOutput("-----------------");
-  for (const step of resolution.steps) {
-    const label = CONFIG_SOURCE_LABELS[step.kind].padEnd(CONFIG_LABEL_WIDTH);
-    const marker = step.status === "hit" ? "✓ " : "";
-    writeOutput(`  ${label}${marker}${step.detail}`);
-  }
-}
 
 interface Check {
   name: string;
@@ -196,25 +179,12 @@ export async function doctor(): Promise<boolean> {
   writeOutput("groundcrew doctor");
   writeOutput("=================");
 
-  let resolution: ConfigResolution;
-  try {
-    resolution = await resolveConfigSource();
-  } catch (error) {
-    // A malformed *discovered* project config makes cosmiconfig's search throw
-    // during resolution. Fall back to the existing config-error verdict.
-    writeOutput(`[--] config: ${errorMessage(error)}`);
-    return false;
-  }
-  reportConfigResolution(resolution);
-  if (resolution.resolved === undefined) {
-    writeOutput("[--] no config found");
-    return false;
-  }
-
   let config: ResolvedConfig;
   try {
-    config = await loadConfig();
-    writeOutput("[ok] config loaded");
+    const { config: loadedConfig, source } = await loadConfigWithSource();
+    config = loadedConfig;
+    const sourceLabel = CONFIG_SOURCE_LABELS[source.kind];
+    writeOutput(`[ok] config loaded — ${source.filepath} (${sourceLabel})`);
   } catch (error) {
     writeOutput(`[--] config: ${errorMessage(error)}`);
     return false;

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -7,15 +7,22 @@ import {
   setEnvironmentVariable,
   snapshotEnvironmentVariables,
 } from "../testHelpers/env.ts";
-import type { Config, ResolvedConfig } from "./config.ts";
+import type { Config, ConfigResolution, ResolvedConfig } from "./config.ts";
 
 interface ConfigModule {
   loadConfig: () => Promise<Readonly<ResolvedConfig>>;
+  resolveConfigSource: () => Promise<ConfigResolution>;
 }
 
 async function loadFreshConfig(): Promise<ConfigModule> {
   vi.resetModules();
   return await import("./config.ts");
+}
+
+async function freshResolveConfigSource(): Promise<() => Promise<ConfigResolution>> {
+  vi.resetModules();
+  const module_ = await import("./config.ts");
+  return module_.resolveConfigSource;
 }
 
 const VALID_WORKSPACE = (projectDir: string) => ({
@@ -1489,5 +1496,114 @@ describe("loadConfig", () => {
   it("fails with a discovery error when no config exists anywhere", async () => {
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(/no crew config found/);
+  });
+});
+
+describe("resolveConfigSource", () => {
+  const originalEnvironment = snapshotEnvironmentVariables();
+  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME"] as const;
+  let temporary: string;
+
+  beforeEach(() => {
+    temporary = mkdtempSync(path.join(tmpdir(), "groundcrew-resolve-"));
+    for (const key of ENV_KEYS) {
+      deleteEnvironmentVariable(key);
+    }
+    setEnvironmentVariable("XDG_CONFIG_HOME", path.join(temporary, "xdg-config"));
+    setEnvironmentVariable("XDG_STATE_HOME", path.join(temporary, "xdg-state"));
+    vi.spyOn(process, "cwd").mockReturnValue(temporary);
+  });
+
+  afterEach(() => {
+    rmSync(temporary, { recursive: true, force: true });
+    for (const key of ENV_KEYS) {
+      const original = originalEnvironment[key];
+      if (original === undefined) {
+        deleteEnvironmentVariable(key);
+      } else {
+        setEnvironmentVariable(key, original);
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("reports an env-override hit and marks later strategies not-reached", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const resolveConfigSource = await freshResolveConfigSource();
+    const resolution = await resolveConfigSource();
+
+    expect(resolution.resolved).toStrictEqual({ kind: "env", filepath: path.resolve(configPath) });
+    expect(resolution.steps.map((s) => s.kind)).toStrictEqual(["env", "project", "xdg"]);
+    expect(resolution.steps[0]).toStrictEqual({
+      kind: "env",
+      status: "hit",
+      detail: path.resolve(configPath),
+    });
+    expect(resolution.steps[1]?.status).toBe("not-reached");
+    expect(resolution.steps[2]?.status).toBe("not-reached");
+  });
+
+  it("treats a set-but-missing env override as a fatal miss that stops resolution", async () => {
+    const missingPath = path.join(temporary, "does-not-exist.ts");
+    setEnvironmentVariable("GROUNDCREW_CONFIG", missingPath);
+
+    const resolveConfigSource = await freshResolveConfigSource();
+    const resolution = await resolveConfigSource();
+
+    expect(resolution.resolved).toBeUndefined();
+    expect(resolution.steps[0]).toStrictEqual({
+      kind: "env",
+      status: "miss",
+      detail: `set but not found: ${path.resolve(missingPath)}`,
+    });
+    expect(resolution.steps[1]?.status).toBe("not-reached");
+    expect(resolution.steps[2]?.status).toBe("not-reached");
+  });
+
+  it("reports a project-search hit when a crew.config.ts sits in the cwd", async () => {
+    const projectConfigPath = path.join(temporary, "crew.config.ts");
+    writeFileSync(projectConfigPath, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
+
+    const resolveConfigSource = await freshResolveConfigSource();
+    const resolution = await resolveConfigSource();
+
+    expect(resolution.resolved?.kind).toBe("project");
+    expect(resolution.resolved?.filepath).toBe(projectConfigPath);
+    expect(resolution.steps[0]).toStrictEqual({ kind: "env", status: "miss", detail: "not set" });
+    expect(resolution.steps[1]?.status).toBe("hit");
+    expect(resolution.steps[2]?.status).toBe("not-reached");
+  });
+
+  it("falls back to the XDG config when no env override or project config exists", async () => {
+    const xdgDir = path.join(temporary, "xdg-config", "groundcrew");
+    mkdirSync(xdgDir, { recursive: true });
+    const xdgConfigPath_ = path.join(xdgDir, "crew.config.ts");
+    writeFileSync(xdgConfigPath_, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
+
+    const resolveConfigSource = await freshResolveConfigSource();
+    const resolution = await resolveConfigSource();
+
+    expect(resolution.resolved?.kind).toBe("xdg");
+    expect(resolution.resolved?.filepath).toBe(xdgConfigPath_);
+    expect(resolution.steps[1]?.status).toBe("miss");
+    expect(resolution.steps[1]?.detail).toContain(`searched up from ${temporary}`);
+    expect(resolution.steps[2]?.status).toBe("hit");
+  });
+
+  it("returns no resolution and three miss/not-reached steps when nothing is found", async () => {
+    const resolveConfigSource = await freshResolveConfigSource();
+    const resolution = await resolveConfigSource();
+
+    expect(resolution.resolved).toBeUndefined();
+    expect(resolution.steps.map((s) => s.kind)).toStrictEqual(["env", "project", "xdg"]);
+    expect(resolution.steps[0]?.detail).toBe("not set");
+    expect(resolution.steps[1]?.status).toBe("miss");
+    expect(resolution.steps[2]?.status).toBe("miss");
+    expect(resolution.steps[2]?.detail).toContain("not found (");
   });
 });

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -7,22 +7,16 @@ import {
   setEnvironmentVariable,
   snapshotEnvironmentVariables,
 } from "../testHelpers/env.ts";
-import type { Config, ConfigResolution, ResolvedConfig } from "./config.ts";
+import type { Config, LoadedConfig, ResolvedConfig } from "./config.ts";
 
 interface ConfigModule {
   loadConfig: () => Promise<Readonly<ResolvedConfig>>;
-  resolveConfigSource: () => Promise<ConfigResolution>;
+  loadConfigWithSource: () => Promise<Readonly<LoadedConfig>>;
 }
 
 async function loadFreshConfig(): Promise<ConfigModule> {
   vi.resetModules();
   return await import("./config.ts");
-}
-
-async function freshResolveConfigSource(): Promise<() => Promise<ConfigResolution>> {
-  vi.resetModules();
-  const module_ = await import("./config.ts");
-  return module_.resolveConfigSource;
 }
 
 const VALID_WORKSPACE = (projectDir: string) => ({
@@ -1499,9 +1493,9 @@ describe("loadConfig", () => {
   });
 });
 
-describe("resolveConfigSource", () => {
+describe("loadConfigWithSource", () => {
   const originalEnvironment = snapshotEnvironmentVariables();
-  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME"] as const;
+  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME"] as const;
   let temporary: string;
 
   beforeEach(() => {
@@ -1510,7 +1504,6 @@ describe("resolveConfigSource", () => {
       deleteEnvironmentVariable(key);
     }
     setEnvironmentVariable("XDG_CONFIG_HOME", path.join(temporary, "xdg-config"));
-    setEnvironmentVariable("XDG_STATE_HOME", path.join(temporary, "xdg-state"));
     vi.spyOn(process, "cwd").mockReturnValue(temporary);
   });
 
@@ -1527,83 +1520,41 @@ describe("resolveConfigSource", () => {
     vi.restoreAllMocks();
   });
 
-  it("reports an env-override hit and marks later strategies not-reached", async () => {
+  it("reports an env-override source", async () => {
     const configPath = writeConfigFile(
       temporary,
       validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
 
-    const resolveConfigSource = await freshResolveConfigSource();
-    const resolution = await resolveConfigSource();
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
 
-    expect(resolution.resolved).toStrictEqual({ kind: "env", filepath: path.resolve(configPath) });
-    expect(resolution.steps.map((s) => s.kind)).toStrictEqual(["env", "project", "xdg"]);
-    expect(resolution.steps[0]).toStrictEqual({
-      kind: "env",
-      status: "hit",
-      detail: path.resolve(configPath),
-    });
-    expect(resolution.steps[1]?.status).toBe("not-reached");
-    expect(resolution.steps[2]?.status).toBe("not-reached");
+    expect(actual.source).toStrictEqual({ kind: "env", filepath: path.resolve(configPath) });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
   });
 
-  it("treats a set-but-missing env override as a fatal miss that stops resolution", async () => {
-    const missingPath = path.join(temporary, "does-not-exist.ts");
-    setEnvironmentVariable("GROUNDCREW_CONFIG", missingPath);
-
-    const resolveConfigSource = await freshResolveConfigSource();
-    const resolution = await resolveConfigSource();
-
-    expect(resolution.resolved).toBeUndefined();
-    expect(resolution.steps[0]).toStrictEqual({
-      kind: "env",
-      status: "miss",
-      detail: `set but not found: ${path.resolve(missingPath)}`,
-    });
-    expect(resolution.steps[1]?.status).toBe("not-reached");
-    expect(resolution.steps[2]?.status).toBe("not-reached");
-  });
-
-  it("reports a project-search hit when a crew.config.ts sits in the cwd", async () => {
+  it("reports a project-search source", async () => {
     const projectConfigPath = path.join(temporary, "crew.config.ts");
     writeFileSync(projectConfigPath, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
 
-    const resolveConfigSource = await freshResolveConfigSource();
-    const resolution = await resolveConfigSource();
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
 
-    expect(resolution.resolved?.kind).toBe("project");
-    expect(resolution.resolved?.filepath).toBe(projectConfigPath);
-    expect(resolution.steps[0]).toStrictEqual({ kind: "env", status: "miss", detail: "not set" });
-    expect(resolution.steps[1]?.status).toBe("hit");
-    expect(resolution.steps[2]?.status).toBe("not-reached");
+    expect(actual.source).toStrictEqual({ kind: "project", filepath: projectConfigPath });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
   });
 
-  it("falls back to the XDG config when no env override or project config exists", async () => {
+  it("reports an XDG fallback source", async () => {
     const xdgDir = path.join(temporary, "xdg-config", "groundcrew");
     mkdirSync(xdgDir, { recursive: true });
     const xdgConfigPath_ = path.join(xdgDir, "crew.config.ts");
     writeFileSync(xdgConfigPath_, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
 
-    const resolveConfigSource = await freshResolveConfigSource();
-    const resolution = await resolveConfigSource();
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
 
-    expect(resolution.resolved?.kind).toBe("xdg");
-    expect(resolution.resolved?.filepath).toBe(xdgConfigPath_);
-    expect(resolution.steps[1]?.status).toBe("miss");
-    expect(resolution.steps[1]?.detail).toContain(`searched up from ${temporary}`);
-    expect(resolution.steps[2]?.status).toBe("hit");
-  });
-
-  it("returns no resolution and three miss/not-reached steps when nothing is found", async () => {
-    const resolveConfigSource = await freshResolveConfigSource();
-    const resolution = await resolveConfigSource();
-
-    expect(resolution.resolved).toBeUndefined();
-    expect(resolution.steps.map((s) => s.kind)).toStrictEqual(["env", "project", "xdg"]);
-    expect(resolution.steps[0]?.detail).toBe("not set");
-    expect(resolution.steps[1]?.status).toBe("miss");
-    expect(resolution.steps[2]?.status).toBe("miss");
-    expect(resolution.steps[2]?.detail).toContain("not found (");
+    expect(actual.source).toStrictEqual({ kind: "xdg", filepath: xdgConfigPath_ });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -271,6 +271,38 @@ export interface ResolvedConfig {
   };
 }
 
+/**
+ * Which of `discoverUserConfig`'s three strategies produced (or would
+ * produce) the active config: the `GROUNDCREW_CONFIG` env override, the
+ * cosmiconfig project search, or the global XDG fallback.
+ */
+export type ConfigSourceKind = "env" | "project" | "xdg";
+
+/**
+ * Outcome of one resolution strategy.
+ * - `hit`: this strategy won; `detail` is the resolved absolute path.
+ * - `miss`: tried, found nothing; `detail` is human-readable miss text.
+ * - `not-reached`: an earlier strategy already won (or an authoritative env
+ *   override stopped resolution); `detail` is `"not reached"`.
+ */
+export interface ConfigResolutionStep {
+  kind: ConfigSourceKind;
+  status: "hit" | "miss" | "not-reached";
+  detail: string;
+}
+
+/**
+ * Existence-based trace of config discovery. Mirrors `discoverUserConfig`'s
+ * priority order without parsing or validating, so `crew doctor` can show
+ * where config comes from even when no file exists. `steps` is always length
+ * three (env, project, xdg). `resolved` is the winner, or `undefined` when
+ * nothing resolved.
+ */
+export interface ConfigResolution {
+  steps: ConfigResolutionStep[];
+  resolved?: { kind: ConfigSourceKind; filepath: string };
+}
+
 const DEFAULT_GIT: ResolvedConfig["git"] = {
   remote: "origin",
   defaultBranch: "main",
@@ -986,6 +1018,64 @@ function findXdgConfigFile(): string | undefined {
   return XDG_FALLBACK_NAMES.map((name) => xdgConfigPath("groundcrew", name)).find((p) =>
     existsSync(p),
   );
+}
+
+/**
+ * Existence-based, parse-free trace of config discovery for `crew doctor`.
+ * Mirrors `discoverUserConfig`'s priority order (env override → project
+ * search → XDG fallback) but never throws "no config found": absence is
+ * represented by `resolved === undefined` plus miss/not-reached steps. The
+ * env override is authoritative — set-but-missing stops resolution rather
+ * than falling through, matching `discoverUserConfig` where a bad override
+ * is fatal.
+ *
+ * The one place it can throw is the project step: cosmiconfig's `search`
+ * parses as it finds, so a malformed discovered project config surfaces
+ * here. `doctor` catches that and reports it via the existing config-error
+ * path.
+ */
+export async function resolveConfigSource(): Promise<ConfigResolution> {
+  const steps: ConfigResolutionStep[] = [];
+
+  const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
+  if (override !== undefined && override.length > 0) {
+    const overridePath = path.resolve(override);
+    if (existsSync(overridePath)) {
+      steps.push({ kind: "env", status: "hit", detail: overridePath });
+      steps.push({ kind: "project", status: "not-reached", detail: "not reached" });
+      steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
+      return { steps, resolved: { kind: "env", filepath: overridePath } };
+    }
+    steps.push({ kind: "env", status: "miss", detail: `set but not found: ${overridePath}` });
+    steps.push({ kind: "project", status: "not-reached", detail: "not reached" });
+    steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
+    return { steps };
+  }
+  steps.push({ kind: "env", status: "miss", detail: "not set" });
+
+  const project = await explorer.search(process.cwd());
+  if (project !== null && project.isEmpty !== true) {
+    steps.push({ kind: "project", status: "hit", detail: project.filepath });
+    steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
+    return { steps, resolved: { kind: "project", filepath: project.filepath } };
+  }
+  steps.push({
+    kind: "project",
+    status: "miss",
+    detail: `no match (searched up from ${process.cwd()})`,
+  });
+
+  const xdgPath = findXdgConfigFile();
+  if (xdgPath !== undefined) {
+    steps.push({ kind: "xdg", status: "hit", detail: xdgPath });
+    return { steps, resolved: { kind: "xdg", filepath: xdgPath } };
+  }
+  steps.push({
+    kind: "xdg",
+    status: "miss",
+    detail: `not found (${xdgConfigPath("groundcrew", "crew.config.ts")})`,
+  });
+  return { steps };
 }
 
 async function discoverUserConfig(): Promise<DiscoveredConfig> {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -271,36 +271,16 @@ export interface ResolvedConfig {
   };
 }
 
-/**
- * Which of `discoverUserConfig`'s three strategies produced (or would
- * produce) the active config: the `GROUNDCREW_CONFIG` env override, the
- * cosmiconfig project search, or the global XDG fallback.
- */
 export type ConfigSourceKind = "env" | "project" | "xdg";
 
-/**
- * Outcome of one resolution strategy.
- * - `hit`: this strategy won; `detail` is the resolved absolute path.
- * - `miss`: tried, found nothing; `detail` is human-readable miss text.
- * - `not-reached`: an earlier strategy already won (or an authoritative env
- *   override stopped resolution); `detail` is `"not reached"`.
- */
-export interface ConfigResolutionStep {
+export interface ConfigSource {
   kind: ConfigSourceKind;
-  status: "hit" | "miss" | "not-reached";
-  detail: string;
+  filepath: string;
 }
 
-/**
- * Existence-based trace of config discovery. Mirrors `discoverUserConfig`'s
- * priority order without parsing or validating, so `crew doctor` can show
- * where config comes from even when no file exists. `steps` is always length
- * three (env, project, xdg). `resolved` is the winner, or `undefined` when
- * nothing resolved.
- */
-export interface ConfigResolution {
-  steps: ConfigResolutionStep[];
-  resolved?: { kind: ConfigSourceKind; filepath: string };
+export interface LoadedConfig {
+  config: Readonly<ResolvedConfig>;
+  source: Readonly<ConfigSource>;
 }
 
 const DEFAULT_GIT: ResolvedConfig["git"] = {
@@ -1002,9 +982,14 @@ const explorer = cosmiconfig(COSMICONFIG_MODULE_NAME, {
   },
 });
 
-type DiscoveredConfig = NonNullable<CosmiconfigResult>;
+type CosmiconfigDiscovery = NonNullable<CosmiconfigResult>;
 
-async function loadAt(filepath: string): Promise<DiscoveredConfig> {
+interface DiscoveredConfig {
+  result: CosmiconfigDiscovery;
+  source: ConfigSource;
+}
+
+async function loadAt(filepath: string): Promise<CosmiconfigDiscovery> {
   const result = await explorer.load(filepath);
   if (result === null) {
     fail(
@@ -1020,64 +1005,6 @@ function findXdgConfigFile(): string | undefined {
   );
 }
 
-/**
- * Existence-based, parse-free trace of config discovery for `crew doctor`.
- * Mirrors `discoverUserConfig`'s priority order (env override → project
- * search → XDG fallback) but never throws "no config found": absence is
- * represented by `resolved === undefined` plus miss/not-reached steps. The
- * env override is authoritative — set-but-missing stops resolution rather
- * than falling through, matching `discoverUserConfig` where a bad override
- * is fatal.
- *
- * The one place it can throw is the project step: cosmiconfig's `search`
- * parses as it finds, so a malformed discovered project config surfaces
- * here. `doctor` catches that and reports it via the existing config-error
- * path.
- */
-export async function resolveConfigSource(): Promise<ConfigResolution> {
-  const steps: ConfigResolutionStep[] = [];
-
-  const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
-  if (override !== undefined && override.length > 0) {
-    const overridePath = path.resolve(override);
-    if (existsSync(overridePath)) {
-      steps.push({ kind: "env", status: "hit", detail: overridePath });
-      steps.push({ kind: "project", status: "not-reached", detail: "not reached" });
-      steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
-      return { steps, resolved: { kind: "env", filepath: overridePath } };
-    }
-    steps.push({ kind: "env", status: "miss", detail: `set but not found: ${overridePath}` });
-    steps.push({ kind: "project", status: "not-reached", detail: "not reached" });
-    steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
-    return { steps };
-  }
-  steps.push({ kind: "env", status: "miss", detail: "not set" });
-
-  const project = await explorer.search(process.cwd());
-  if (project !== null && project.isEmpty !== true) {
-    steps.push({ kind: "project", status: "hit", detail: project.filepath });
-    steps.push({ kind: "xdg", status: "not-reached", detail: "not reached" });
-    return { steps, resolved: { kind: "project", filepath: project.filepath } };
-  }
-  steps.push({
-    kind: "project",
-    status: "miss",
-    detail: `no match (searched up from ${process.cwd()})`,
-  });
-
-  const xdgPath = findXdgConfigFile();
-  if (xdgPath !== undefined) {
-    steps.push({ kind: "xdg", status: "hit", detail: xdgPath });
-    return { steps, resolved: { kind: "xdg", filepath: xdgPath } };
-  }
-  steps.push({
-    kind: "xdg",
-    status: "miss",
-    detail: `not found (${xdgConfigPath("groundcrew", "crew.config.ts")})`,
-  });
-  return { steps };
-}
-
 async function discoverUserConfig(): Promise<DiscoveredConfig> {
   const override = readEnvironmentVariable("GROUNDCREW_CONFIG");
   if (override !== undefined && override.length > 0) {
@@ -1085,17 +1012,19 @@ async function discoverUserConfig(): Promise<DiscoveredConfig> {
     if (!existsSync(overridePath)) {
       fail(`GROUNDCREW_CONFIG=${overridePath} not found`);
     }
-    return await loadAt(overridePath);
+    const result = await loadAt(overridePath);
+    return { result, source: { kind: "env", filepath: result.filepath } };
   }
 
   const project = await explorer.search(process.cwd());
   if (project !== null && project.isEmpty !== true) {
-    return project;
+    return { result: project, source: { kind: "project", filepath: project.filepath } };
   }
 
   const xdgPath = findXdgConfigFile();
   if (xdgPath !== undefined) {
-    return await loadAt(xdgPath);
+    const result = await loadAt(xdgPath);
+    return { result, source: { kind: "xdg", filepath: result.filepath } };
   }
 
   // Throw directly so oxlint's `consistent-return` rule sees a
@@ -1108,14 +1037,14 @@ async function discoverUserConfig(): Promise<DiscoveredConfig> {
   );
 }
 
-let cached: Readonly<ResolvedConfig> | undefined;
+let cached: Readonly<LoadedConfig> | undefined;
 
-export async function loadConfig(): Promise<Readonly<ResolvedConfig>> {
+export async function loadConfigWithSource(): Promise<Readonly<LoadedConfig>> {
   if (cached) {
     return cached;
   }
 
-  const result = await discoverUserConfig();
+  const { result, source } = await discoverUserConfig();
   const { filepath, isEmpty } = result;
   const userConfig: unknown = result.config;
   if (isEmpty === true || !isPlainObject(userConfig)) {
@@ -1132,6 +1061,14 @@ export async function loadConfig(): Promise<Readonly<ResolvedConfig>> {
 
   setLogFile(resolved.logging.file);
 
-  cached = Object.freeze(resolved);
+  cached = Object.freeze({
+    config: Object.freeze(resolved),
+    source: Object.freeze(source),
+  });
   return cached;
+}
+
+export async function loadConfig(): Promise<Readonly<ResolvedConfig>> {
+  const loadedConfig = await loadConfigWithSource();
+  return loadedConfig.config;
 }


### PR DESCRIPTION
## Summary

`crew doctor` now prints the config file path that the existing config loader actually loaded, including whether it came from `GROUNDCREW_CONFIG`, project search, or the global XDG fallback.

This keeps `discoverUserConfig` as the single source of truth: the loader now exposes source metadata through `loadConfigWithSource()`, while `loadConfig()` keeps its existing return shape for other callers. Missing, malformed, or set-but-missing config paths still flow through the original loader error path.

Example output:

```text
[ok] config loaded — /Users/paul/dev/groundcrew/crew.config.ts (project)
```

## Validation

- `node --run verify` — failed only on `knip`; build, lint, format, architecture, and the full test suite passed. Tests: 1081 passed, 100% statements/branches/functions/lines coverage.
- `node --run lint` — passed.
- `node --run test -- src/lib/config.test.ts src/commands/doctor.test.ts` — focused tests passed; command exited nonzero because subset coverage does not meet this repo's global 100% coverage threshold.

## Notes

`node --run knip` fails without changes to `package.json`/`knip.json` with existing package/tooling metadata findings: unused devDependencies, unlisted binaries, and a redundant `src/index.ts` entry hint.

Agent session: `codex resume 019e8911-9556-7671-8353-03c7bd0f5b34`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
