### PR TITLE
fix: reconcile crew status run: line with workspace probe and clear orphaned run-state

### DIFF
--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -1,6 +1,7 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, removeRunState, type RunState } from "../lib/runState.ts";
 import { setVerbose } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
@@ -29,12 +30,23 @@ vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
     removeRunState: vi.fn<typeof removeRunState>(),
   };
 });
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      probe: vi.fn<typeof actual.workspaces.probe>(),
+    },
+  };
+});
 
 const loadConfigMock = vi.mocked(loadConfig);
 const findByTicketMock = vi.mocked(worktrees.findByTicket);
 const teardownMock = vi.mocked(worktrees.teardown);
 const readRunStateMock = vi.mocked(readRunState);
 const removeRunStateMock = vi.mocked(removeRunState);
+const workspaceProbeMock = vi.mocked(workspaces.probe);
 
 const hostEntry: WorktreeEntry = {
   repository: "repo-a",
@@ -86,6 +98,7 @@ describe(cleanupWorkspace, () => {
   beforeEach(() => {
     consoleLog = captureConsoleLog();
     teardownMock.mockResolvedValue(emptyTeardownResult());
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
     // `readRunStateMock` defaults to returning undefined (no orphaned
     // run-state); cases exercising the orphan path override it per-test.
     // Teardown sub-steps (Closed workspace, Worktree removed) and best-effort
@@ -127,6 +140,7 @@ describe(cleanupWorkspace, () => {
     expect(teardownMock).not.toHaveBeenCalled();
     expect(consoleLog.output()).toContain("nothing to clean up");
     expect(removeRunStateMock).not.toHaveBeenCalled();
+    expect(workspaceProbeMock).not.toHaveBeenCalled();
   });
 
   it("clears an orphaned run-state when no worktree is found", async () => {
@@ -139,6 +153,28 @@ describe(cleanupWorkspace, () => {
     expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
     expect(consoleLog.output()).toContain("cleared stale run-state");
     expect(consoleLog.output()).not.toContain("nothing to clean up");
+  });
+
+  it("leaves run-state intact when no worktree is found but a workspace is present", async () => {
+    findByTicketMock.mockReturnValue([]);
+    readRunStateMock.mockReturnValue(orphanRunState);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await cleanupWorkspace(config, { ticket: "team-1" });
+
+    expect(removeRunStateMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("workspace still present; leaving run-state intact");
+  });
+
+  it("leaves run-state intact when no worktree is found and workspace probing is unavailable", async () => {
+    findByTicketMock.mockReturnValue([]);
+    readRunStateMock.mockReturnValue(orphanRunState);
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await cleanupWorkspace(config, { ticket: "team-1" });
+
+    expect(removeRunStateMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("workspace probe unavailable, leaving run-state intact");
   });
 
   it("clears an orphaned run-state without requiring --force", async () => {

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -1,5 +1,5 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { removeRunState } from "../lib/runState.ts";
+import { readRunState, removeRunState, type RunState } from "../lib/runState.ts";
 import { setVerbose } from "../lib/util.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -23,12 +23,17 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
 });
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, removeRunState: vi.fn<typeof removeRunState>() };
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    removeRunState: vi.fn<typeof removeRunState>(),
+  };
 });
 
 const loadConfigMock = vi.mocked(loadConfig);
 const findByTicketMock = vi.mocked(worktrees.findByTicket);
 const teardownMock = vi.mocked(worktrees.teardown);
+const readRunStateMock = vi.mocked(readRunState);
 const removeRunStateMock = vi.mocked(removeRunState);
 
 const hostEntry: WorktreeEntry = {
@@ -37,6 +42,19 @@ const hostEntry: WorktreeEntry = {
   branchName: "dev-team-1",
   dir: "/work/repo-a-team-1",
   kind: "host",
+};
+
+const orphanRunState: RunState = {
+  ticket: "team-1",
+  repository: "repo-a",
+  model: "claude",
+  worktreeDir: "/work/repo-a-team-1",
+  branchName: "dev-team-1",
+  workspaceName: "team-1",
+  state: "running",
+  createdAt: "2026-05-26T00:00:00.000Z",
+  updatedAt: "2026-05-26T00:01:00.000Z",
+  resumeCount: 0,
 };
 
 const config: ResolvedConfig = {
@@ -68,6 +86,8 @@ describe(cleanupWorkspace, () => {
   beforeEach(() => {
     consoleLog = captureConsoleLog();
     teardownMock.mockResolvedValue(emptyTeardownResult());
+    // `readRunStateMock` defaults to returning undefined (no orphaned
+    // run-state); cases exercising the orphan path override it per-test.
     // Teardown sub-steps (Closed workspace, Worktree removed) and best-effort
     // run-state-cleanup failures are diagnostic (debug-tier), reaching the
     // console only under verbose — these cases assert that wording.
@@ -105,6 +125,41 @@ describe(cleanupWorkspace, () => {
     await cleanupWorkspace(config, { ticket: "team-1" });
 
     expect(teardownMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("nothing to clean up");
+    expect(removeRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("clears an orphaned run-state when no worktree is found", async () => {
+    findByTicketMock.mockReturnValue([]);
+    readRunStateMock.mockReturnValue(orphanRunState);
+
+    await cleanupWorkspace(config, { ticket: "team-1" });
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
+    expect(consoleLog.output()).toContain("cleared stale run-state");
+    expect(consoleLog.output()).not.toContain("nothing to clean up");
+  });
+
+  it("clears an orphaned run-state without requiring --force", async () => {
+    findByTicketMock.mockReturnValue([]);
+    readRunStateMock.mockReturnValue(orphanRunState);
+
+    await cleanupWorkspace(config, { ticket: "team-1", force: false });
+
+    expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
+  });
+
+  it("is idempotent: a second cleanup of the same orphan reports nothing to clean up", async () => {
+    findByTicketMock.mockReturnValue([]);
+    // Second call falls through to the default undefined return.
+    readRunStateMock.mockReturnValueOnce(orphanRunState);
+
+    await cleanupWorkspace(config, { ticket: "team-1" });
+    await cleanupWorkspace(config, { ticket: "team-1" });
+
+    expect(removeRunStateMock).toHaveBeenCalledTimes(1);
+    expect(consoleLog.output()).toContain("cleared stale run-state");
     expect(consoleLog.output()).toContain("nothing to clean up");
   });
 

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -2,6 +2,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, removeRunState } from "../lib/runState.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { log } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
 import { worktrees } from "../lib/worktrees.ts";
 import { logTeardown } from "./teardownReporter.ts";
 
@@ -41,13 +42,19 @@ export async function cleanupWorkspace(
   const entries = worktrees.findByTicket(config, ticket);
 
   if (entries.length === 0) {
-    // No worktree to tear down, but a run-state record can outlive its
-    // worktree (removed out-of-band, or created under a since-changed
-    // projectDir/repo that `findByTicket` no longer scans). Clearing a local
-    // record is low-risk, so do it regardless of `--force` to give a manual
-    // escape hatch for an otherwise-immortal stale run-state.
     if (readRunState(config, ticket) === undefined) {
       log(`No worktree found for ${ticket}; nothing to clean up.`);
+      return;
+    }
+    const workspaceProbe = await workspaces.probe(config);
+    if (workspaceProbe.kind === "unavailable") {
+      log(
+        `No worktree found for ${ticket}; workspace probe unavailable, leaving run-state intact.`,
+      );
+      return;
+    }
+    if (workspaceProbe.names.has(ticket)) {
+      log(`No worktree found for ${ticket}; workspace still present; leaving run-state intact.`);
       return;
     }
     removeRunState(config, ticket);

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -1,4 +1,5 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { readRunState, removeRunState } from "../lib/runState.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { log } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
@@ -40,7 +41,17 @@ export async function cleanupWorkspace(
   const entries = worktrees.findByTicket(config, ticket);
 
   if (entries.length === 0) {
-    log(`No worktree found for ${ticket}; nothing to clean up.`);
+    // No worktree to tear down, but a run-state record can outlive its
+    // worktree (removed out-of-band, or created under a since-changed
+    // projectDir/repo that `findByTicket` no longer scans). Clearing a local
+    // record is low-risk, so do it regardless of `--force` to give a manual
+    // escape hatch for an otherwise-immortal stale run-state.
+    if (readRunState(config, ticket) === undefined) {
+      log(`No worktree found for ${ticket}; nothing to clean up.`);
+      return;
+    }
+    removeRunState(config, ticket);
+    log(`No worktree found for ${ticket}; cleared stale run-state.`);
     return;
   }
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -355,6 +355,72 @@ describe(status, () => {
     expect(consoleLog.output()).toContain("spawn failed");
   });
 
+  it("flags the per-ticket run: line as `session dead` when running but no session is live", async () => {
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    expect(consoleLog.output()).toContain(
+      "run: running (session dead); model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0",
+    );
+  });
+
+  it("flags the per-ticket run: line as `session exited` when the kept tmux window has exited", async () => {
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    expect(consoleLog.output()).toContain(
+      "run: running (session exited); model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0",
+    );
+  });
+
+  it("leaves the per-ticket run: line as bare `running` when the session is live", async () => {
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("run: running; model=claude;");
+    expect(output).not.toContain("session dead");
+    expect(output).not.toContain("session exited");
+  });
+
+  it("leaves the per-ticket run: line unflagged when the workspace probe is unavailable", async () => {
+    readRunStateMock.mockReturnValue(runState({ state: "running" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("run: running; model=claude;");
+    expect(output).not.toContain("session dead");
+    expect(output).not.toContain("session exited");
+  });
+
+  it("keeps the per-ticket run: line as `(none)` when a stray session is live but no run-state exists", async () => {
+    // With no run-state, the `run:` line stays `(none)` even though the probe
+    // sees a live session for this ticket. The stray-session disagreement is
+    // surfaced by the `workspace: live` line (and the inventory view's
+    // `hint: crew cleanup`), not by decorating the per-ticket `run:` line.
+    readRunStateMock.mockReset();
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await status(makeConfig(), { ticket: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("run: (none)");
+    expect(output).not.toContain("stray session");
+    expect(output).toContain("workspace: live");
+  });
+
   it("surfaces the cached ticket title at the top of the per-ticket view", async () => {
     readRunStateMock.mockReturnValue(runState({ title: "Improve crew status command" }));
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -99,11 +99,14 @@ function isWorkspaceExited(probe: WorkspaceProbe, ticket: string): boolean {
   return probe.kind === "ok" && probe.exitedNames?.has(ticket) === true;
 }
 
-function formatRunState(state: RunState | undefined): string {
+function formatRunState(state: RunState | undefined, flags: readonly string[] = []): string {
   if (state === undefined) {
     return "(none)";
   }
-  const summary = `${state.state}; model=${state.model}; updated=${state.updatedAt}; resumes=${state.resumeCount}`;
+  // Only the leading lifecycle token gains the reconciliation flags; the
+  // `;`-separated detail (model/updated/resumes/reason) is preserved verbatim.
+  const lifecycle = flags.length === 0 ? state.state : `${state.state} (${flags.join(", ")})`;
+  const summary = `${lifecycle}; model=${state.model}; updated=${state.updatedAt}; resumes=${state.resumeCount}`;
   const detail = state.reason ?? state.detail;
   return detail === undefined ? summary : `${summary}; ${detail}`;
 }
@@ -223,7 +226,7 @@ async function writeTicketStatus(config: ResolvedConfig, rawTicket: string): Pro
   const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, ticket);
   writeOutput(formatTicketLine(ticket, runState, sourceStatus));
   writeTicketTitle(runState, sourceStatus);
-  writeOutput(`run: ${formatRunState(runState)}`);
+  writeOutput(`run: ${formatRunState(runState, runProbeFlags(runState, workspaceProbe, ticket))}`);
   writeOutput(`workspace: ${ticketWorkspaceText(workspaceProbe, ticket)}`);
   if (accessHint !== undefined) {
     writeOutput(`attach: ${accessHint.command}`);
@@ -275,13 +278,41 @@ function formatDuration(ms: number): string {
 }
 
 /**
+ * Probe-reconciliation flags shared by the inventory row and the per-ticket
+ * `run:` line. Flags the two interesting disagreements between the recorded
+ * RunState lifecycle and the live workspace probe: a running/resumed dispatch
+ * with a missing or exited session, and an idle row with a stray live or
+ * exited session. `probe.kind === "unavailable"` is "we don't know" and yields
+ * no flags. Excludes the duration token, which only the inventory row appends.
+ */
+function runProbeFlags(
+  runState: RunState | undefined,
+  probe: WorkspaceProbe,
+  ticket: string,
+): string[] {
+  if (probe.kind !== "ok") {
+    return [];
+  }
+  const lifecycle = runState?.state ?? "idle";
+  const sessionPresent = probe.names.has(ticket);
+  const sessionExited = isWorkspaceExited(probe, ticket);
+  const flags: string[] = [];
+  if (lifecycle === "idle" && sessionPresent) {
+    flags.push(sessionExited ? "stray exited session" : "stray session");
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
+    flags.push("session exited");
+  } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
+    flags.push("session dead");
+  }
+  return flags;
+}
+
+/**
  * Combined human-readable state for the inventory row. Surfaces RunState
  * lifecycle and flags the two interesting disagreements with the workspace
- * probe. A recorded running dispatch can have a missing or exited session;
- * an idle row can have a stray live or exited session. `probe.kind ===
- * "unavailable"` is treated as "we don't know" and never produces a suffix.
- * When the row is actively running, appends the elapsed wall-clock time since
- * dispatch.
+ * probe via `runProbeFlags`. When the row is actively running, appends the
+ * elapsed wall-clock time since dispatch.
  */
 function inventoryStateText(
   runState: RunState | undefined,
@@ -290,20 +321,8 @@ function inventoryStateText(
   now: Date,
 ): string {
   const lifecycle = runState?.state ?? "idle";
+  const flags = runProbeFlags(runState, probe, ticket);
   const duration = runStateDurationMs(runState, now);
-  const flags: string[] = [];
-  if (probe.kind === "ok") {
-    const sessionPresent = probe.names.has(ticket);
-    const sessionExited = isWorkspaceExited(probe, ticket);
-    if (lifecycle === "idle" && sessionPresent) {
-      flags.push(sessionExited ? "stray exited session" : "stray session");
-    }
-    if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
-      flags.push("session exited");
-    } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
-      flags.push("session dead");
-    }
-  }
   if (duration !== undefined) {
     flags.push(formatDuration(duration));
   }


### PR DESCRIPTION
## Why

A ticket that has finished or been abandoned still reported as `running`, and there was no way to clear it. Real session:

```
> crew cleanup --force hrd-456
No worktree found for hrd-456; nothing to clean up.

> crew status HRD-456
ticket: hrd-456  done  https://linear.app/...
run: running; model=claude; updated=2026-05-27T02:26:05.224Z; resumes=0
workspace: not live
```

The ticket is **Done** in Linear, has **no worktree**, and **no live workspace**, yet the per-ticket view said `run: running` — and `crew cleanup` refused to clear it.

There is intentionally **no terminal `RunLifecycleState`**, so a clean agent exit never transitions the run-state off `running`. Rather than add one (deferred — see Non-goals), this PR makes the display truthful and gives a manual escape hatch.

## What

**Defect B1 — per-ticket `run:` line now reconciles against the live workspace probe.**
The inventory row already cross-referenced the probe (appending `session dead` / `session exited`); the per-ticket `run:` line printed the raw lifecycle verbatim. Extracted the probe-reconciliation logic out of `inventoryStateText` into a shared `runProbeFlags` helper (behavior-preserving for the inventory row) and fed it into the per-ticket line via a new optional `flags` arg on `formatRunState`:

- session live → `run: running` (unchanged)
- run-state running but no session → `run: running (session dead)`
- kept tmux window exited → `run: running (session exited)`
- probe unavailable → `run: running` (no flag — we don't know)
- no run-state → `run: (none)` (unchanged)

**Defect B2 — `crew cleanup <ticket>` clears an orphaned run-state when no worktree is found.**
A run-state can outlive its worktree (removed out-of-band, or created under a since-changed `projectDir`/repo that `findByTicket` no longer scans). Previously the no-worktree branch returned `nothing to clean up` without touching the record, leaving it immortal. Now it removes the orphaned run-state (regardless of `--force`) only after the workspace probe confirms there is no session for the ticket. If a workspace is still present, or the probe is unavailable, cleanup leaves the run-state intact and reports why. The clear path stays idempotent (a second run reports `nothing to clean up`).

## Decisions

- **`run: (none)` stays bare even when a stray session is live (no run-state).** The spec lists "No run-state: `run: (none)` (unchanged)". The stray-session disagreement is surfaced by the `workspace: live` line and the inventory view's `hint:` (which already points to `crew cleanup`), so the per-ticket `run:` line is left undecorated. Added a characterization test to lock this in. (Alternative considered: emit `(none) (stray session)` for view consistency — rejected as out of scope and contrary to the spec's stated output shape.)
- **Run-state clearing in cleanup is not gated behind `--force`, but it is gated behind the workspace probe.** Plain `crew cleanup <ticket>` can clear a stale local record when no worktree and no workspace exist. If a workspace is still present, or the probe is unavailable, cleanup preserves the run-state instead of dropping metadata for a session that may still need cleanup.

## Non-goals (deliberately excluded)

- No terminal/`completed` `RunLifecycleState` and no terminal write on agent exit (deferred).
- No change to the slot-count source (it reads the board, not run-state — verified empirically).
- No broadening of worktree discovery (`projectDir`/`knownRepositories` scoping).
- No change to Linear status mapping.

## Validation

- `node --run test -- --coverage.enabled=false src/commands/cleanupWorkspace.test.ts` → green: **22 tests pass**.
- `node --run verify` on `2d46ae25` → tests/build/lint/format/architecture/knip/spell/syncpack pass; full local completion is blocked by local auxiliary git worktrees being scanned by `cpd` from the primary checkout and by `knip` when run inside linked-worktree paths. Full test run in that verify attempt: **1087 tests pass, 100% coverage**.
- Original validation before the follow-up commit: `node --run verify` → green: **1085 tests pass, 100% coverage** (statements/branches/functions/lines), plus lint/build/architecture/knip/spell.
- Red-green-refactor TDD for both defects and the follow-up cleanup guard.

> Source: implementation plan `2026-06-02-pr-2-crew-status-should-not-report-running-for.md`. PR 2 of a 2-PR split; independent of PR 1.


Agent session: `codex resume 019e8911-67ca-74d2-b40e-93d34cae86f3`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>