### PR TITLE
feat: list in-progress tickets with no local worktree in crew status

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,7 +4,7 @@
 
 `crew status <TICKET>` prints a read-only snapshot for one ticket: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the ticket status from the configured ticket source.
 
-`crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local diagnostics are printed before ticket-source fetches complete. When the source fetch succeeds, status also prints slot usage plus Queue/Blocked sections for eligible Todo tickets. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
+`crew status` with no ticket prints the current inventory: known worktrees with cached ticket metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local diagnostics are printed before ticket-source fetches complete. When the source fetch succeeds, status also prints any in-progress source tickets with no local worktree, slot usage, and Queue/Blocked sections for eligible Todo tickets. Worktree-less in-progress rows include the ticket title, URL when the source provides one, and repository when the source resolves one. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
 
 Status is informational only. Use `crew cleanup <TICKET>` to tear down stale worktrees and `crew resume <TICKET>` to reopen preserved work.
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -796,6 +796,81 @@ describe(status, () => {
     expect(consoleLog.output()).toContain("slots: 2/4 used");
   });
 
+  it("lists in-progress tickets with no local worktree so the slot count is explainable", async () => {
+    // team-901 is in-progress AND has a local worktree, so it already shows in
+    // the Worktrees section. team-902 is in-progress with no local worktree
+    // (its worktree was removed or lives outside this config's scope) — it
+    // counts toward the slot total but is otherwise invisible, so it belongs
+    // in the new section.
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-901", repository: "repo-a" })]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({ id: "linear:team-901", status: "in-progress" }),
+        sourceIssue({
+          id: "linear:team-902",
+          status: "in-progress",
+          title: "Type the boundary",
+          repository: "repo-b",
+          url: "https://linear.app/example/issue/TEAM-902",
+        }),
+        sourceIssue({ id: "linear:team-903", status: "todo" }),
+      ]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("In progress (no local worktree)\n-------------------------------");
+    expect(output).toContain("team-902  https://linear.app/example/issue/TEAM-902");
+    expect(output).toContain("  title:     Type the boundary");
+    expect(output).toContain("  repo:      repo-b");
+    expect(output).toContain("slots: 2/4 used");
+    // team-901 has a worktree, so it belongs in the Worktrees section only and
+    // must not be duplicated under the new section (which sits just above the
+    // slots line).
+    const sectionStart = output.indexOf("In progress (no local worktree)");
+    const section = output.slice(sectionStart, output.indexOf("slots:", sectionStart));
+    expect(section).toContain("team-902");
+    expect(section).not.toContain("team-901");
+  });
+
+  it("hides the in-progress-without-worktree section when every in-progress ticket has a worktree", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-901", repository: "repo-a" })]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-901", status: "in-progress" })]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    expect(consoleLog.output()).not.toContain("In progress (no local worktree)");
+  });
+
+  it("omits the repo line for an in-progress ticket with no repository", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({
+          id: "linear:team-905",
+          status: "in-progress",
+          title: "Ticket without a repo",
+          repository: undefined,
+        }),
+      ]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-905");
+    expect(output).toContain("  title:     Ticket without a repo");
+    const sectionStart = output.indexOf("In progress (no local worktree)");
+    const section = output.slice(sectionStart, output.indexOf("slots:", sectionStart));
+    expect(section).not.toContain("repo:");
+  });
+
   it("omits the slots line when the source fetch fails", async () => {
     listWorktreesMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
@@ -906,9 +981,14 @@ describe(status, () => {
     expect(output).toContain("Blocked\n-------");
     expect(output).toContain("team-102  https://linear.app/example/issue/TEAM-102");
     expect(output).toContain("  blocked by:  team-50 (In Progress)");
-    // Ineligible / non-Todo issues never appear.
+    // team-103 is an ineligible Todo (no repo/model) — surfaced nowhere.
     expect(output).not.toContain("team-103");
-    expect(output).not.toContain("team-104");
+    // team-104 is in-progress, so it's excluded from the Queue but now appears
+    // in the "In progress (no local worktree)" section above the slots line.
+    const queueSection = output.slice(output.indexOf("Queue\n-----"));
+    expect(queueSection).not.toContain("team-104");
+    expect(output).toContain("In progress (no local worktree)");
+    expect(output).toContain("team-104");
   });
 
   it("hides the Queue section when the source has only non-Todo issues", async () => {
@@ -920,7 +1000,11 @@ describe(status, () => {
 
     await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
 
-    expect(consoleLog.output()).not.toContain("Queue");
+    // No eligible Todos -> no Queue section. (The lone in-progress ticket
+    // surfaces in the "In progress (no local worktree)" section instead, so
+    // match the Queue section header rather than the bare word "Queue", which
+    // also appears in the default "Queued ticket" title.)
+    expect(consoleLog.output()).not.toContain("Queue\n-----");
   });
 
   it("separates multiple Queue and Blocked rows with blank lines", async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -560,6 +560,52 @@ function inProgressCount(issues: readonly SourceIssue[]): number {
   return issues.filter((issue) => issue.status === "in-progress").length;
 }
 
+/**
+ * In-progress board issues that have no local worktree. These count toward the
+ * `slots: N/M used` total but are absent from the Worktrees section (their
+ * worktree was removed, or lives outside this config's projectDir /
+ * knownRepositories), so without this they'd be counted yet invisible. Worktree
+ * tickets are lowercased, so the natural id is lowercased before matching.
+ */
+function inProgressWithoutWorktree(
+  issues: readonly SourceIssue[],
+  worktreeTickets: ReadonlySet<string>,
+): SourceIssue[] {
+  return issues
+    .filter((issue) => issue.status === "in-progress")
+    .filter((issue) => !worktreeTickets.has(naturalIdFromCanonical(issue.id).toLowerCase()))
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+function writeInProgressIssue(issue: SourceIssue): void {
+  const naturalId = naturalIdFromCanonical(issue.id);
+  writeOutput(issue.url === undefined ? naturalId : `${naturalId}  ${issue.url}`);
+  writeOutput(inventoryField("title", issue.title));
+  if (issue.repository !== undefined) {
+    writeOutput(inventoryField("repo", issue.repository));
+  }
+}
+
+function writeInProgressWithoutWorktree(
+  boardResult: BoardFetchResult,
+  worktreeTickets: ReadonlySet<string>,
+): void {
+  if (boardResult.kind !== "ok") {
+    return;
+  }
+  const issues = inProgressWithoutWorktree(boardResult.issues, worktreeTickets);
+  if (issues.length === 0) {
+    return;
+  }
+  writeSection("In progress (no local worktree)");
+  for (const [index, issue] of issues.entries()) {
+    if (index > 0) {
+      writeOutput();
+    }
+    writeInProgressIssue(issue);
+  }
+}
+
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
   // Banner ("groundcrew status\n=================") dropped: the command
   // you just ran already tells you what report you're looking at, and the
@@ -571,6 +617,7 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
   writeStraySessions(probe, worktreeTickets);
 
   const boardResult = await boardResultPromise;
+  writeInProgressWithoutWorktree(boardResult, worktreeTickets);
   if (boardResult.kind === "ok") {
     const used = inProgressCount(boardResult.issues);
     writeOutput();


### PR DESCRIPTION
## Summary

`crew status` reported a `slots: N/M used` count that didn't match the worktrees it listed — e.g. `slots: 2/4 used` with only one worktree shown. The count is derived from the board (in-progress issues, including an implicit Linear source), while the Worktrees section lists only worktrees discoverable on local disk under the current config's `projectDir` + `knownRepositories`. In-progress tickets whose worktree was removed, or lives outside that scope, were counted toward the slot total yet never displayed — so the count looked inconsistent and there was no way to see what was holding the slots.

This adds an **"In progress (no local worktree)"** section to the inventory view, rendered just above the `slots:` line, listing each in-progress board ticket whose id is not among the local worktrees (ticket id + URL, title, and repo when known). Worktree tickets are lowercased, so the natural id is lowercased before matching. The command docs now describe that section and clarify that the `repo:` line appears only when the source resolves a repository.

## Validation

- `node --run verify`: local run failed only `knip`; `architecture:check`, `build`, `cpd`, `format:check`, `lint`, `markdown:lint`, `spell:check`, `syncpack:lint`, and `test` all passed.
- `test`: 1080 tests pass, 100% coverage (statements/branches/functions/lines).
- `knip` local failure reports existing package metadata findings (`src/index.ts` redundant entry pattern, unused devDependencies, and unlisted binaries); this is unrelated to the status/docs changes.
- 3 new unit tests (lists worktree-less in-progress tickets; hides the section when every in-progress ticket has a worktree; omits the `repo:` line when the repository is unknown). Two pre-existing tests were updated whose assertions predated this section.

## Notes

- This is **PR 1 of 2**. PR 2 (separate branch) will address a related issue surfaced during diagnosis: the per-ticket `crew status <ticket>` view reports `run: running` for finished/abandoned runs (stale run-state), and `crew cleanup` can't clear an orphaned run-state when no worktree is found.
- No Linear ticket — this came from a bug report ("crew status doesn't show in-progress tickets").

Agent session: `codex resume 019e8911-7563-7410-8658-3fba8c202636`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>
