### PR TITLE
fix: resolve PR links from worktree remote

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -562,8 +562,13 @@ describe(status, () => {
 
   it("omits only the failed pull request row when one PR lookup rejects", async () => {
     listWorktreesMock.mockReturnValue([
-      worktree({ ticket: "team-1", repository: "repo-a" }),
-      worktree({ ticket: "team-2", repository: "repo-b", branchName: "dev-team-2" }),
+      worktree({ ticket: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
+      worktree({
+        ticket: "team-2",
+        repository: "repo-b",
+        dir: "/work/repo-b-team-2",
+        branchName: "dev-team-2",
+      }),
     ]);
     findPullRequestsMock.mockRejectedValueOnce(new Error("gh rate limited")).mockResolvedValueOnce([
       {
@@ -752,7 +757,9 @@ describe(status, () => {
   });
 
   it("renders a `pr:` line in inventory rows when gh finds a pull request", async () => {
-    listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
+    ]);
     findPullRequestsMock.mockResolvedValue([
       {
         url: "https://github.com/acme/widgets/pull/42",
@@ -768,7 +775,7 @@ describe(status, () => {
       "  pr:        https://github.com/acme/widgets/pull/42 (open)",
     );
     expect(findPullRequestsMock).toHaveBeenCalledWith({
-      repository: "repo-a",
+      cwd: "/work/repo-a-team-1",
       branchName: "dev-team-1",
     });
   });
@@ -812,6 +819,10 @@ describe(status, () => {
     await status(makeConfig(), { ticket: "team-1" });
 
     expect(consoleLog.output()).toContain("  pr: https://github.com/acme/widgets/pull/99 (open)");
+    expect(findPullRequestsMock).toHaveBeenCalledWith({
+      cwd: "/work/repo-a-team-1",
+      branchName: "dev-team-1",
+    });
   });
 
   it("renders the cached ticket url next to the inventory ticket id", async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -64,7 +64,7 @@ async function writeTicketWorktrees(config: ResolvedConfig, ticket: string): Pro
     });
     // oxlint-disable-next-line no-await-in-loop -- one gh lookup per worktree is acceptable; multi-worktree-per-ticket is rare.
     const prs = await findPullRequestsForBranch({
-      repository: entry.repository,
+      cwd: entry.dir,
       branchName: entry.branchName,
     });
     writeOutput(`- ${entry.repository} ${entry.kind}`);
@@ -401,10 +401,10 @@ async function writeInventoryWorktrees(
     }
     const runState = runStates.get(entry.ticket);
     const accessHint = accessHints.get(entry.ticket);
-    // `collectPullRequests` guarantees an entry for every (repo, branch)
-    // pair seen in `entries`; the lookup always returns the array.
+    // `collectPullRequests` guarantees an entry for every worktree dir seen
+    // in `entries`; the lookup always returns the array.
     /* v8 ignore next @preserve -- defensive fallback for a Map key that collectPullRequests always populates */
-    const prs = pullRequests.get(pullRequestKey(entry.repository, entry.branchName)) ?? [];
+    const prs = pullRequests.get(entry.dir) ?? [];
     if (index > 0) {
       writeOutput();
     }
@@ -428,10 +428,6 @@ async function writeInventoryWorktrees(
   }
 }
 
-function pullRequestKey(repository: string, branchName: string): string {
-  return `${repository} ${branchName}`;
-}
-
 async function collectAccessHints(
   config: ResolvedConfig,
   entries: readonly { ticket: string }[],
@@ -449,28 +445,25 @@ async function collectAccessHints(
 }
 
 async function collectPullRequests(
-  entries: readonly { repository: string; branchName: string }[],
+  entries: readonly { dir: string; branchName: string }[],
 ): Promise<Map<string, readonly PullRequestSummary[]>> {
-  // Same-(repo, branch) entries collapse to one lookup; later inserts
-  // overwrite earlier ones with the same identifier, which is fine because
-  // gh would return the same PR list for both.
-  const uniqueKeys = new Map<string, { repository: string; branchName: string }>();
+  // Each worktree dir is unique, so keying by dir collapses nothing in
+  // practice; the Map removes duplicates defensively if the same dir
+  // appears twice.
+  const uniqueByDir = new Map<string, { dir: string; branchName: string }>();
   for (const entry of entries) {
-    uniqueKeys.set(pullRequestKey(entry.repository, entry.branchName), {
-      repository: entry.repository,
-      branchName: entry.branchName,
-    });
+    uniqueByDir.set(entry.dir, { dir: entry.dir, branchName: entry.branchName });
   }
   const results = await Promise.allSettled(
-    [...uniqueKeys.entries()].map(async ([key, { repository, branchName }]) => {
-      const prs = await findPullRequestsForBranch({ repository, branchName });
-      return [key, prs] as const;
+    [...uniqueByDir.entries()].map(async ([dir, { branchName }]) => {
+      const prs = await findPullRequestsForBranch({ cwd: dir, branchName });
+      return [dir, prs] as const;
     }),
   );
   return new Map(
-    [...uniqueKeys.keys()].map((key, index) => {
+    [...uniqueByDir.keys()].map((dir, index) => {
       const result = results[index];
-      return [key, result?.status === "fulfilled" ? result.value[1] : []] as const;
+      return [dir, result?.status === "fulfilled" ? result.value[1] : []] as const;
     }),
   );
 }

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -36,7 +36,7 @@ describe(findPullRequestsForBranch, () => {
     );
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "feature/auth",
     });
 
@@ -48,11 +48,25 @@ describe(findPullRequestsForBranch, () => {
         title: "Wire up auth",
       },
     ]);
+  });
+
+  it("runs gh in the worktree dir and omits --repo so gh resolves the remote", async () => {
+    runCommandMock.mockResolvedValueOnce("[]");
+
+    await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "feature/auth",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
     expect(runCommandMock).toHaveBeenCalledWith(
       "gh",
-      expect.arrayContaining(["pr", "list", "--repo", "acme/widgets", "--head", "feature/auth"]),
-      {},
+      expect.arrayContaining(["pr", "list", "--head", "feature/auth"]),
+      { cwd: "/work/widgets-team-1" },
     );
+    expect(runCommandMock).toHaveBeenCalledWith("gh", expect.not.arrayContaining(["--repo"]), {
+      cwd: "/work/widgets-team-1",
+    });
   });
 
   it("normalises MERGED and CLOSED states to lowercase", async () => {
@@ -64,7 +78,7 @@ describe(findPullRequestsForBranch, () => {
     );
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
@@ -75,7 +89,7 @@ describe(findPullRequestsForBranch, () => {
     runCommandMock.mockRejectedValueOnce(new Error("gh: command not found"));
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
@@ -86,7 +100,7 @@ describe(findPullRequestsForBranch, () => {
     runCommandMock.mockResolvedValueOnce("not json at all");
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
@@ -97,7 +111,7 @@ describe(findPullRequestsForBranch, () => {
     runCommandMock.mockResolvedValueOnce("null");
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
@@ -114,24 +128,27 @@ describe(findPullRequestsForBranch, () => {
     );
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
     expect(prs.map((p) => p.number)).toStrictEqual([1]);
   });
 
-  it("forwards the AbortSignal to runCommandAsync when provided", async () => {
+  it("forwards the AbortSignal to runCommandAsync alongside cwd when provided", async () => {
     runCommandMock.mockResolvedValueOnce("[]");
     const { signal } = new AbortController();
 
     await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
       signal,
     });
 
-    expect(runCommandMock).toHaveBeenCalledWith("gh", expect.any(Array), { signal });
+    expect(runCommandMock).toHaveBeenCalledWith("gh", expect.any(Array), {
+      cwd: "/work/widgets-team-1",
+      signal,
+    });
   });
 
   it("forwards a lowercased unknown state value verbatim", async () => {
@@ -140,7 +157,7 @@ describe(findPullRequestsForBranch, () => {
     );
 
     const prs = await findPullRequestsForBranch({
-      repository: "acme/widgets",
+      cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -3,6 +3,11 @@
  * `gh` CLI. `crew status` uses this to surface PR links inline; failures
  * (gh not on PATH, not authenticated, non-GitHub remote) are silent — the
  * caller falls back to omitting the row.
+ *
+ * The lookup runs with `cwd` set to the worktree directory and lets `gh`
+ * resolve the GitHub repo from that checkout's own `origin` remote. This
+ * handles bare config names, full `owner/repo` slugs, forks, and SSH/HTTPS
+ * remotes uniformly — we never reconstruct the slug ourselves.
  */
 
 import { runCommandAsync } from "./commandRunner.ts";
@@ -23,8 +28,8 @@ const STATE_MAP: Record<string, string> = {
 };
 
 interface LookupArgs {
-  /** GitHub `owner/repo` slug. */
-  repository: string;
+  /** Worktree directory; `gh` resolves the GitHub repo from its git remote. */
+  cwd: string;
   /** Branch name to filter PRs by. */
   branchName: string;
   signal?: AbortSignal;
@@ -79,15 +84,13 @@ function isRawPullRequest(value: unknown): value is RawPullRequest {
 export async function findPullRequestsForBranch(
   arguments_: LookupArgs,
 ): Promise<readonly PullRequestSummary[]> {
-  const { repository, branchName, signal } = arguments_;
+  const { cwd, branchName, signal } = arguments_;
   try {
     const output = await runCommandAsync(
       "gh",
       [
         "pr",
         "list",
-        "--repo",
-        repository,
         "--head",
         branchName,
         "--state",
@@ -97,7 +100,7 @@ export async function findPullRequestsForBranch(
         "--json",
         "url,number,state,title",
       ],
-      signal === undefined ? {} : { signal },
+      signal === undefined ? { cwd } : { cwd, signal },
     );
     return parsePullRequests(output);
   } catch {


### PR DESCRIPTION
## Summary

`crew status` now runs `gh pr list` from each worktree directory and omits `--repo`, letting the GitHub CLI resolve the repository from that checkout's remote. This fixes bare `workspace.knownRepositories` entries such as `herds`, which previously made `gh --repo herds` fail and silently hid existing PR links.

The PR lookup remains best-effort: when `gh` is unavailable, unauthenticated, or returns unusable output, status still omits the `pr:` line rather than rendering per-row lookup failures.

## Validation

- `node --run verify`

## Notes

- Rebased onto current `origin/main` and squashed the PR branch to one commit.
- The local PR worktree needed its own `npm ci` before `knip` would pass because the worktree was created inside `.worktrees/` with an initially empty `node_modules`.

Agent session: `codex resume 019e8b06-a6f6-75c1-af79-c0c3eacbee62`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
