### PR TITLE
feat: auto-advance in-progress tickets to in-review on PR open

### DIFF
--- a/docs/ticket-sources.md
+++ b/docs/ticket-sources.md
@@ -15,14 +15,23 @@ export default {
         fetch: "~/.config/groundcrew/jira-fetch.sh",
         resolveOne: "~/.config/groundcrew/jira-resolve.sh ${id}",
         markInProgress: "jira issue move ${id} 'In Progress'",
+        markInReview: "jira issue move ${id} 'In Review'",
       },
-      timeouts: { fetch: 60_000 },
+      timeouts: { fetch: 60_000, markInReview: 15_000 },
     },
   ],
 };
 ```
 
-`commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when set, must print one issue, print nothing for "not found", or exit `3` for "not found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as JSON on stdin. `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
+`commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when
+set, must print one issue, print nothing for "not found", or exit `3` for "not
+found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as
+JSON on stdin. `commands.markInReview`, when set, receives the same `sourceRef`
+and is run after groundcrew sees an open or merged PR on the ticket's worktree
+branch. If `commands.markInReview` is omitted, groundcrew treats in-review
+advancement as unsupported for that source and does not claim the transition
+succeeded. `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted
+before substitution.
 
 ```json
 [

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -85,6 +85,7 @@ function stubBoard(): Board {
     fetch: vi.fn<Board["fetch"]>(),
     resolveOne: vi.fn<Board["resolveOne"]>(),
     markInProgress: vi.fn<Board["markInProgress"]>(),
+    markInReview: vi.fn<Board["markInReview"]>(),
   };
 }
 
@@ -95,6 +96,7 @@ function stubSource(name: string): TicketSource {
     fetch: vi.fn<TicketSource["fetch"]>(),
     resolveOne: vi.fn<TicketSource["resolveOne"]>(),
     markInProgress: vi.fn<TicketSource["markInProgress"]>(),
+    markInReview: vi.fn<TicketSource["markInReview"]>(),
   };
 }
 

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1242,36 +1242,66 @@ describe(orchestrate, () => {
     expect(client.team).toHaveBeenCalledTimes(1);
   });
 
-  it("advances an in-progress ticket to in-review when its worktree has an open PR", async () => {
-    // The reviewer is wired into the tick between cleaner and dispatcher. An
-    // in-progress ticket whose worktree has an open PR is advanced via
-    // board.markInReview (a no-op for the Linear adapter, but the reviewer's
-    // success log proves the step ran end-to-end through the orchestrator).
-    listMock.mockReturnValue([hostEntryFor("repo-a", "team-1")]);
-    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
-    findPullRequestsMock.mockResolvedValue([
-      { url: "https://github.com/x/y/pull/3", number: 3, state: "open", title: "PR" },
-    ]);
-    const client = makeClient({
-      pages: [
-        [
-          issue({
-            identifier: "TEAM-1",
-            id: "uuid-1",
-            state: { id: "state-active", name: "In Progress", type: "started" },
-          }),
-        ],
-      ],
-    });
-    mockLinearClient(client);
+  it("advances an in-progress shell ticket to in-review when its worktree has an open PR", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "orchestrate-shell-review-"));
+    try {
+      const reviewMarker = path.join(dir, "review-ran");
+      const fetchScript = path.join(dir, "fetch.sh");
+      const reviewScript = path.join(dir, "review.sh");
+      writeFileSync(
+        fetchScript,
+        `#!/usr/bin/env bash
+cat <<'JSON'
+[
+  {
+    "id": "X-1",
+    "title": "Reviewable shell ticket",
+    "description": "Touches repo-a.",
+    "status": "in-progress",
+    "repository": "repo-a",
+    "model": "claude",
+    "assignee": "Alice",
+    "updatedAt": "2026-01-01T00:00:00Z",
+    "blockers": [],
+    "sourceRef": { "nativeId": "x-1" }
+  }
+]
+JSON
+`,
+      );
+      writeFileSync(reviewScript, `#!/usr/bin/env bash\ncat > "${reviewMarker}"\n`);
+      chmodSync(fetchScript, 0o755);
+      chmodSync(reviewScript, 0o755);
+      loadConfigMock.mockResolvedValue(
+        makeConfig({
+          sources: [
+            {
+              kind: "shell",
+              name: "test-source",
+              commands: { fetch: fetchScript, markInReview: reviewScript },
+            },
+          ],
+        }),
+      );
+      listMock.mockReturnValue([hostEntryFor("repo-a", "x-1")]);
+      workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["x-1"]) });
+      findPullRequestsMock.mockResolvedValue([
+        { url: "https://github.com/x/y/pull/3", number: 3, state: "open", title: "PR" },
+      ]);
+      const client = makeClient({ pages: [[]] });
+      mockLinearClient(client);
 
-    await orchestrate({ watch: false, dryRun: false });
+      await orchestrate({ watch: false, dryRun: false });
 
-    expect(findPullRequestsMock).toHaveBeenCalledWith({
-      cwd: "/work/repo-a-team-1",
-      branchName: "dev-team-1",
-    });
-    expect(consoleLog.output()).toContain("Advanced team-1 to in-review");
+      expect(findPullRequestsMock).toHaveBeenCalledWith({
+        cwd: "/work/repo-a-x-1",
+        branchName: "dev-x-1",
+      });
+      expect(existsSync(reviewMarker)).toBe(true);
+      expect(consoleLog.output()).toContain("Advanced x-1 to in-review");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("hands a Done worktree to teardown", async () => {

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -6,6 +6,7 @@ import type { LinearClient } from "@linear/sdk";
 
 import type * as configModule from "../lib/config.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { getUsageByModel } from "../lib/usage.ts";
 import type * as utilModule from "../lib/util.ts";
 import { setVerbose, sleep } from "../lib/util.ts";
@@ -65,6 +66,10 @@ vi.mock(import("../lib/usage.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, getUsageByModel: vi.fn<typeof getUsageByModel>() };
 });
+vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, findPullRequestsForBranch: vi.fn<typeof findPullRequestsForBranch>() };
+});
 vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, setupWorkspace: vi.fn<typeof setupWorkspace>() };
@@ -83,6 +88,7 @@ const teardownMock = vi.mocked(worktrees.teardown);
 const usageMock = vi.mocked(getUsageByModel);
 const setupMock = vi.mocked(setupWorkspace);
 const workspacesProbeMock = vi.mocked(workspaces.probe);
+const findPullRequestsMock = vi.mocked(findPullRequestsForBranch);
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
@@ -333,6 +339,7 @@ describe(orchestrate, () => {
     usageMock.mockResolvedValue({});
     setupMock.mockResolvedValue();
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    findPullRequestsMock.mockResolvedValue([]);
     // Telemetry (event= lines) and teardown sub-steps are diagnostic, surfacing
     // on the console only under verbose — several cases assert that wording.
     setVerbose(true);
@@ -1233,6 +1240,38 @@ describe(orchestrate, () => {
     await orchestrate({ watch: false, dryRun: false });
 
     expect(client.team).toHaveBeenCalledTimes(1);
+  });
+
+  it("advances an in-progress ticket to in-review when its worktree has an open PR", async () => {
+    // The reviewer is wired into the tick between cleaner and dispatcher. An
+    // in-progress ticket whose worktree has an open PR is advanced via
+    // board.markInReview (a no-op for the Linear adapter, but the reviewer's
+    // success log proves the step ran end-to-end through the orchestrator).
+    listMock.mockReturnValue([hostEntryFor("repo-a", "team-1")]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    findPullRequestsMock.mockResolvedValue([
+      { url: "https://github.com/x/y/pull/3", number: 3, state: "open", title: "PR" },
+    ]);
+    const client = makeClient({
+      pages: [
+        [
+          issue({
+            identifier: "TEAM-1",
+            id: "uuid-1",
+            state: { id: "state-active", name: "In Progress", type: "started" },
+          }),
+        ],
+      ],
+    });
+    mockLinearClient(client);
+
+    await orchestrate({ watch: false, dryRun: false });
+
+    expect(findPullRequestsMock).toHaveBeenCalledWith({
+      cwd: "/work/repo-a-team-1",
+      branchName: "dev-team-1",
+    });
+    expect(consoleLog.output()).toContain("Advanced team-1 to in-review");
   });
 
   it("hands a Done worktree to teardown", async () => {

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -1,19 +1,21 @@
 /**
  * groundcrew orchestrator — polls Linear projects and spins up workspace +
  * git-worktree pairs for ready tickets. Each tick fetches the board, runs
- * the cleaner, and runs the dispatcher; logging from those modules is the
- * orchestrator's user-facing output.
+ * the cleaner, the reviewer, and the dispatcher; logging from those modules is
+ * the orchestrator's user-facing output.
  */
 
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { type BoardState, RepositoryResolutionError } from "../lib/ticketSource.ts";
 import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
 import { errorMessage, log, sleep } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
 import { type Cleaner, createCleaner } from "./cleaner.ts";
 import { createDispatcher, type Dispatcher } from "./dispatcher.ts";
+import { createReviewer, type Reviewer } from "./reviewer.ts";
 
 const RATE_LIMIT_DELAY_MS = 60_000;
 const RETRY_BASE_DELAY_MS = 1000;
@@ -91,6 +93,10 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
   await board.verify();
 
   const cleaner: Cleaner = createCleaner({ config });
+  const reviewer: Reviewer = createReviewer({
+    board,
+    findPullRequests: findPullRequestsForBranch,
+  });
   const dispatcher: Dispatcher = createDispatcher({ config, board });
 
   // Folded into the dispatcher's idle log lines in watch mode so each idle
@@ -111,6 +117,8 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
     };
 
     await cleaner.runOnce(tickArguments);
+
+    await reviewer.runOnce(tickArguments);
 
     await dispatcher.runOnce({
       ...tickArguments,

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -2,7 +2,7 @@ import { setVerbose } from "../lib/util.ts";
 import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
 import type { Board } from "../lib/board.ts";
 import type { PullRequestSummary } from "../lib/pullRequests.ts";
-import type { BoardState, Issue } from "../lib/ticketSource.ts";
+import type { BoardState, Issue, MarkInReviewResult } from "../lib/ticketSource.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { makeBoard } from "../testHelpers/boardFixtures.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -12,8 +12,13 @@ function boardOf(issues: BoardState["issues"]): BoardState {
   return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
 }
 
-function inProgressIssue(naturalId: string): Issue {
-  return canonicalLinearIssue({ naturalId, status: "in-progress" });
+function inProgressIssue(naturalId: string, overrides: Partial<Issue> = {}): Issue {
+  return canonicalLinearIssue({
+    naturalId,
+    status: "in-progress",
+    repository: "repo-a",
+    ...overrides,
+  });
 }
 
 function hostEntryFor(ticket: string, overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
@@ -42,12 +47,14 @@ function findReturning(prs: readonly PullRequestSummary[]): FindPullRequests {
 
 describe(createReviewer, () => {
   let consoleLog: ConsoleCapture;
-  let markInReviewMock: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
+  let markInReviewMock: ReturnType<typeof vi.fn<(issue: Issue) => Promise<MarkInReviewResult>>>;
   let board: Board;
 
   beforeEach(() => {
     consoleLog = captureConsoleLog();
-    markInReviewMock = vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue();
+    markInReviewMock = vi
+      .fn<(issue: Issue) => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" });
     board = makeBoard({ markInReview: markInReviewMock });
     // review telemetry (event= lines) is diagnostic — verbose echoes it to the
     // console so these cases can assert the wording.
@@ -163,7 +170,9 @@ describe(createReviewer, () => {
   it("keeps advancing other issues when one issue's write-back fails", async () => {
     // Error isolation: a write-back failure on the first issue must not prevent
     // the second qualifying issue from being advanced in the same tick.
-    markInReviewMock.mockRejectedValueOnce(new Error("team-1 shell error")).mockResolvedValueOnce();
+    markInReviewMock
+      .mockRejectedValueOnce(new Error("team-1 shell error"))
+      .mockResolvedValueOnce({ outcome: "applied" });
     const reviewer = createReviewer({
       board,
       findPullRequests: findReturning([pullRequest({ state: "open" })]),
@@ -209,6 +218,34 @@ describe(createReviewer, () => {
     expect(markInReviewMock).not.toHaveBeenCalled();
   });
 
+  it("skips an in-progress ticket that has no repository", async () => {
+    const findPullRequests = findReturning([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1", { repository: undefined })]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("matches worktrees by ticket and repository", async () => {
+    const findPullRequests = findReturning([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1", { repository: "repo-a" })]),
+      worktreeEntries: [hostEntryFor("team-1", { repository: "repo-b" })],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
   it("dry-run logs the would-advance and does not write back", async () => {
     const reviewer = createReviewer({
       board,
@@ -245,6 +282,30 @@ describe(createReviewer, () => {
     const out = consoleLog.output();
     expect(out).toContain("Failed to advance team-1 to in-review: shell exploded");
     expect(out).toContain("event=review outcome=failed reason=writeback_failed ticket=team-1");
+  });
+
+  it("does not log success when the source does not support in-review writeback", async () => {
+    markInReviewMock.mockResolvedValueOnce({
+      outcome: "unsupported",
+      reason: "source has no in-review transition",
+    });
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open", url: "https://gh/pr/1" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    const out = consoleLog.output();
+    expect(out).toContain(
+      "Skipped advancing team-1 to in-review: source has no in-review transition",
+    );
+    expect(out).toContain("event=review outcome=skipped reason=unsupported ticket=team-1");
+    expect(out).not.toContain("Advanced team-1 to in-review");
   });
 
   it("falls through to a later worktree when the first has no PR", async () => {

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -1,0 +1,323 @@
+import { setVerbose } from "../lib/util.ts";
+import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import type { Board } from "../lib/board.ts";
+import type { PullRequestSummary } from "../lib/pullRequests.ts";
+import type { BoardState, Issue } from "../lib/ticketSource.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
+import { makeBoard } from "../testHelpers/boardFixtures.ts";
+import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { createReviewer, type FindPullRequests } from "./reviewer.ts";
+
+function boardOf(issues: BoardState["issues"]): BoardState {
+  return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
+}
+
+function inProgressIssue(naturalId: string): Issue {
+  return canonicalLinearIssue({ naturalId, status: "in-progress" });
+}
+
+function hostEntryFor(ticket: string, overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
+  return {
+    repository: "repo-a",
+    ticket,
+    branchName: `dev-${ticket}`,
+    dir: `/work/repo-a-${ticket}`,
+    kind: "host",
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Partial<PullRequestSummary> = {}): PullRequestSummary {
+  return {
+    url: overrides.url ?? "https://github.com/x/y/pull/1",
+    number: overrides.number ?? 1,
+    state: overrides.state ?? "open",
+    title: overrides.title ?? "PR title",
+  };
+}
+
+function findReturning(prs: readonly PullRequestSummary[]): FindPullRequests {
+  return vi.fn<FindPullRequests>().mockResolvedValue(prs);
+}
+
+describe(createReviewer, () => {
+  let consoleLog: ConsoleCapture;
+  let markInReviewMock: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
+  let board: Board;
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+    markInReviewMock = vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue();
+    board = makeBoard({ markInReview: markInReviewMock });
+    // review telemetry (event= lines) is diagnostic — verbose echoes it to the
+    // console so these cases can assert the wording.
+    setVerbose(true);
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    setVerbose(false);
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when no issue is in-progress", async () => {
+    const findPullRequests = findReturning([pullRequest()]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([
+        canonicalLinearIssue({ naturalId: "team-1", status: "todo" }),
+        canonicalLinearIssue({ naturalId: "team-2", status: "done" }),
+      ]),
+      worktreeEntries: [hostEntryFor("team-1"), hostEntryFor("team-2")],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("advances an in-progress ticket whose worktree has an open PR", async () => {
+    const issue = inProgressIssue("team-1");
+    const findPullRequests = findReturning([
+      pullRequest({ state: "open", url: "https://gh/pr/7" }),
+    ]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([issue]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).toHaveBeenCalledWith({
+      cwd: "/work/repo-a-team-1",
+      branchName: "dev-team-1",
+    });
+    expect(markInReviewMock).toHaveBeenCalledWith(issue);
+    const out = consoleLog.output();
+    expect(out).toContain("Advanced team-1 to in-review (PR https://gh/pr/7)");
+    expect(out).toContain("event=review outcome=advanced ticket=team-1");
+  });
+
+  it("advances when the PR has already merged between ticks", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markInReviewMock).toHaveBeenCalledTimes(1);
+    expect(consoleLog.output()).toContain("event=review outcome=advanced ticket=team-1 pr");
+  });
+
+  it("skips when the worktree has no PR (or the lookup failed)", async () => {
+    const reviewer = createReviewer({ board, findPullRequests: findReturning([]) });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when the only PR is closed without merging", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "closed" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("skips (does not throw) when the PR lookup itself rejects", async () => {
+    // findPullRequestsForBranch is contracted never to reject, but a misbehaving
+    // injected lookup must not abort the tick — the issue is skipped, retried next tick.
+    const findPullRequests = vi.fn<FindPullRequests>().mockRejectedValue(new Error("gh blew up"));
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await expect(
+      reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [hostEntryFor("team-1")],
+        dryRun: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps advancing other issues when one issue's write-back fails", async () => {
+    // Error isolation: a write-back failure on the first issue must not prevent
+    // the second qualifying issue from being advanced in the same tick.
+    markInReviewMock.mockRejectedValueOnce(new Error("team-1 shell error")).mockResolvedValueOnce();
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1"), inProgressIssue("team-2")]),
+      worktreeEntries: [hostEntryFor("team-1"), hostEntryFor("team-2")],
+      dryRun: false,
+    });
+
+    expect(markInReviewMock).toHaveBeenCalledTimes(2);
+    const out = consoleLog.output();
+    expect(out).toContain("Failed to advance team-1 to in-review");
+    expect(out).toContain("Advanced team-2 to in-review");
+  });
+
+  it("never looks up PRs for a non-in-progress ticket even if it has a worktree", async () => {
+    const findPullRequests = findReturning([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "todo" })]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("skips an in-progress ticket that has no matching worktree", async () => {
+    const findPullRequests = findReturning([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("other-9")],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run logs the would-advance and does not write back", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open", url: "https://gh/pr/9" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: true,
+    });
+
+    expect(markInReviewMock).not.toHaveBeenCalled();
+    const out = consoleLog.output();
+    expect(out).toContain("[dry-run] Would advance team-1 to in-review (PR https://gh/pr/9)");
+    expect(out).toContain("event=review outcome=skipped reason=dry_run ticket=team-1");
+  });
+
+  it("logs and swallows a writeback failure, leaving the ticket for next tick", async () => {
+    markInReviewMock.mockRejectedValue(new Error("shell exploded"));
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open" })]),
+    });
+
+    await expect(
+      reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [hostEntryFor("team-1")],
+        dryRun: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    const out = consoleLog.output();
+    expect(out).toContain("Failed to advance team-1 to in-review: shell exploded");
+    expect(out).toContain("event=review outcome=failed reason=writeback_failed ticket=team-1");
+  });
+
+  it("falls through to a later worktree when the first has no PR", async () => {
+    // First worktree lookup yields no PR; the second has an open one. The
+    // reviewer must keep scanning the issue's worktrees rather than give up.
+    const findPullRequests = vi
+      .fn<FindPullRequests>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [
+        hostEntryFor("team-1", { dir: "/work/repo-a-team-1-first", branchName: "dev-team-1-a" }),
+        hostEntryFor("team-1", { dir: "/work/repo-a-team-1-second", branchName: "dev-team-1-b" }),
+      ],
+      dryRun: false,
+    });
+
+    expect(findPullRequests).toHaveBeenCalledTimes(2);
+    expect(markInReviewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes at most one transition per issue even with multiple reviewable worktrees", async () => {
+    const findPullRequests = findReturning([pullRequest({ state: "open" })]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [
+        hostEntryFor("team-1", { dir: "/work/repo-a-team-1-first", branchName: "dev-team-1-a" }),
+        hostEntryFor("team-1", { dir: "/work/repo-a-team-1-second", branchName: "dev-team-1-b" }),
+      ],
+      dryRun: false,
+    });
+
+    // Stops at the first reviewable worktree: one lookup, one write-back.
+    expect(findPullRequests).toHaveBeenCalledTimes(1);
+    expect(markInReviewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("advances every in-progress ticket that qualifies", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1"), inProgressIssue("team-2")]),
+      worktreeEntries: [hostEntryFor("team-1"), hostEntryFor("team-2")],
+      dryRun: false,
+    });
+
+    expect(markInReviewMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("threads the abort signal into the PR lookup", async () => {
+    const { signal } = new AbortController();
+    const findPullRequests = findReturning([]);
+    const reviewer = createReviewer({ board, findPullRequests });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+      signal,
+    });
+
+    expect(findPullRequests).toHaveBeenCalledWith({
+      cwd: "/work/repo-a-team-1",
+      branchName: "dev-team-1",
+      signal,
+    });
+  });
+});

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -1,9 +1,10 @@
 /**
  * Per-iteration scanner that advances in-progress tickets to in-review once
  * their worktree has an open (or merged) pull request. Sits between the cleaner
- * and the dispatcher in each `orchestrate()` tick. Advancing frees a dispatch
- * slot (the slot math counts only in-progress) while leaving the worktree
- * intact for review, since the cleaner only tears down `done` tickets.
+ * and the dispatcher in each `orchestrate()` tick. A successfully-applied
+ * transition frees a dispatch slot (the slot math counts only in-progress)
+ * while leaving the worktree intact for review, since the cleaner only tears
+ * down `done` tickets.
  *
  * The write-back lands in the ticket source, not the in-memory `BoardState`, so
  * the dispatcher in the SAME tick still sees the ticket as in-progress; the slot
@@ -58,6 +59,20 @@ function isReviewablePullRequest(pr: PullRequestSummary): boolean {
   return pr.state === "open" || pr.state === "merged";
 }
 
+function matchingWorktreeEntries(arguments_: {
+  issue: Issue;
+  worktreeEntries: readonly WorktreeEntry[];
+  ticket: string;
+}): WorktreeEntry[] {
+  const { issue, worktreeEntries, ticket } = arguments_;
+  if (issue.repository === undefined) {
+    return [];
+  }
+  return worktreeEntries.filter(
+    (entry) => entry.ticket === ticket && entry.repository === issue.repository,
+  );
+}
+
 export function createReviewer(deps: ReviewerDeps): Reviewer {
   const { board, findPullRequests } = deps;
 
@@ -80,9 +95,9 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     }
   }
 
-  // Idempotent by construction: once advanced, the issue leaves `in-progress`,
-  // so it never reaches this scan again — no oscillation. At most one
-  // transition per issue per tick (we stop at the first reviewable worktree).
+  // Idempotent after an applied transition: once advanced, the issue leaves
+  // `in-progress`, so it never reaches this scan again. Unsupported writebacks
+  // are skipped without claiming success and may retry on later ticks.
   async function advanceIfReviewable(arguments_: {
     issue: Issue;
     worktreeEntries: readonly WorktreeEntry[];
@@ -91,7 +106,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
   }): Promise<void> {
     const { issue, worktreeEntries, dryRun, signal } = arguments_;
     const ticket = naturalIdFromCanonical(issue.id);
-    const entries = worktreeEntries.filter((entry) => entry.ticket === ticket);
+    const entries = matchingWorktreeEntries({ issue, worktreeEntries, ticket });
 
     for (const entry of entries) {
       // The injected lookup is contracted never to reject (failures resolve to
@@ -135,7 +150,16 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
   }): Promise<void> {
     const { issue, ticket, pullRequest } = arguments_;
     try {
-      await board.markInReview(issue);
+      const result = await board.markInReview(issue);
+      if (result.outcome === "unsupported") {
+        log(`Skipped advancing ${ticket} to in-review: ${result.reason}`);
+        logEvent("review", {
+          outcome: "skipped",
+          reason: "unsupported",
+          ticket,
+        });
+        return;
+      }
       log(`Advanced ${ticket} to in-review (PR ${pullRequest.url})`);
       logEvent("review", {
         outcome: "advanced",

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -1,0 +1,153 @@
+/**
+ * Per-iteration scanner that advances in-progress tickets to in-review once
+ * their worktree has an open (or merged) pull request. Sits between the cleaner
+ * and the dispatcher in each `orchestrate()` tick. Advancing frees a dispatch
+ * slot (the slot math counts only in-progress) while leaving the worktree
+ * intact for review, since the cleaner only tears down `done` tickets.
+ *
+ * The write-back lands in the ticket source, not the in-memory `BoardState`, so
+ * the dispatcher in the SAME tick still sees the ticket as in-progress; the slot
+ * frees on the NEXT tick's `board.fetch()`. That one-tick latency is deliberate
+ * — it keeps the reviewer from mutating shared `BoardState` mid-tick. One per
+ * `orchestrate()`; stateless across iterations. Mirrors `Cleaner`.
+ *
+ * "Worktree has an open PR" is a v1 proxy for "the implementation is finished
+ * and up for review". The detection + the open/merged condition live here in
+ * the core reviewer (a push model) rather than inside any adapter, so a future
+ * per-adapter `shouldAdvanceToReview` predicate is a clean additive change.
+ */
+
+import type { Board } from "../lib/board.ts";
+import type { PullRequestSummary } from "../lib/pullRequests.ts";
+import { type BoardState, type Issue, naturalIdFromCanonical } from "../lib/ticketSource.ts";
+import { debug, errorMessage, log, logEvent } from "../lib/util.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
+
+/**
+ * Injected PR lookup. Matches `findPullRequestsForBranch`'s shape: best-effort,
+ * never rejects — a failed lookup (gh missing, unauthenticated, non-GitHub
+ * remote, network error) resolves to an empty list, indistinguishable from
+ * "no PR yet". Both outcomes mean "skip this issue, retry next tick".
+ */
+export type FindPullRequests = (arguments_: {
+  cwd: string;
+  branchName: string;
+  signal?: AbortSignal;
+}) => Promise<readonly PullRequestSummary[]>;
+
+interface ReviewerDeps {
+  board: Board;
+  findPullRequests: FindPullRequests;
+}
+
+/** Per-tick inputs, mirroring the other orchestrator steps' shape. */
+interface ReviewArguments {
+  state: BoardState;
+  worktreeEntries: readonly WorktreeEntry[];
+  dryRun: boolean;
+  signal?: AbortSignal;
+}
+
+export interface Reviewer {
+  runOnce(arguments_: ReviewArguments): Promise<void>;
+}
+
+// A PR whose lifecycle means the work is up for (or past) review. `merged`
+// catches a PR that merged between ticks, so we still free the slot.
+function isReviewablePullRequest(pr: PullRequestSummary): boolean {
+  return pr.state === "open" || pr.state === "merged";
+}
+
+export function createReviewer(deps: ReviewerDeps): Reviewer {
+  const { board, findPullRequests } = deps;
+
+  async function runOnce(arguments_: ReviewArguments): Promise<void> {
+    const { state, worktreeEntries, dryRun, signal } = arguments_;
+
+    const inProgress = state.issues.filter((issue) => issue.status === "in-progress");
+    if (inProgress.length === 0) {
+      return;
+    }
+
+    for (const issue of inProgress) {
+      // oxlint-disable-next-line no-await-in-loop -- at most maximumInProgress (1-5) issues per tick; sequential keeps gh load low.
+      await advanceIfReviewable({
+        issue,
+        worktreeEntries,
+        dryRun,
+        ...(signal === undefined ? {} : { signal }),
+      });
+    }
+  }
+
+  // Idempotent by construction: once advanced, the issue leaves `in-progress`,
+  // so it never reaches this scan again — no oscillation. At most one
+  // transition per issue per tick (we stop at the first reviewable worktree).
+  async function advanceIfReviewable(arguments_: {
+    issue: Issue;
+    worktreeEntries: readonly WorktreeEntry[];
+    dryRun: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const { issue, worktreeEntries, dryRun, signal } = arguments_;
+    const ticket = naturalIdFromCanonical(issue.id);
+    const entries = worktreeEntries.filter((entry) => entry.ticket === ticket);
+
+    for (const entry of entries) {
+      // The injected lookup is contracted never to reject (failures resolve to
+      // []), but we still guard it so one bad lookup can never abort the tick
+      // and starve the other in-progress issues. A failure means "can't tell
+      // yet" → skip this worktree and retry next tick.
+      let pullRequests: readonly PullRequestSummary[];
+      try {
+        // oxlint-disable-next-line no-await-in-loop -- a ticket almost always has one worktree; sequential lookups are fine.
+        pullRequests = await findPullRequests({
+          cwd: entry.dir,
+          branchName: entry.branchName,
+          ...(signal === undefined ? {} : { signal }),
+        });
+      } catch (error) {
+        debug(`PR lookup failed for ${ticket} (${entry.branchName}): ${errorMessage(error)}`);
+        continue;
+      }
+      const reviewable = pullRequests.find(isReviewablePullRequest);
+      if (reviewable === undefined) {
+        continue;
+      }
+      if (dryRun) {
+        log(`[dry-run] Would advance ${ticket} to in-review (PR ${reviewable.url})`);
+        logEvent("review", { outcome: "skipped", reason: "dry_run", ticket, pr: reviewable.url });
+        return;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- single write-back then return; never iterates past the first reviewable worktree.
+      await advance({ issue, ticket, pullRequest: reviewable });
+      return;
+    }
+  }
+
+  // A writeback failure (shell/Linear error) is logged and swallowed: the
+  // ticket stays in-progress and is retried next tick, exactly like a failed
+  // lookup. We never let one ticket's writeback abort the others' reviews.
+  async function advance(arguments_: {
+    issue: Issue;
+    ticket: string;
+    pullRequest: PullRequestSummary;
+  }): Promise<void> {
+    const { issue, ticket, pullRequest } = arguments_;
+    try {
+      await board.markInReview(issue);
+      log(`Advanced ${ticket} to in-review (PR ${pullRequest.url})`);
+      logEvent("review", {
+        outcome: "advanced",
+        ticket,
+        pr: pullRequest.url,
+        state: pullRequest.state,
+      });
+    } catch (error) {
+      log(`Failed to advance ${ticket} to in-review: ${errorMessage(error)}`);
+      logEvent("review", { outcome: "failed", reason: "writeback_failed", ticket });
+    }
+  }
+
+  return { runOnce };
+}

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -116,6 +116,7 @@ vi.mock(import("../lib/board.ts"), async (importOriginal) => {
         }),
       ),
       markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+      markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
     })),
   };
 });
@@ -1627,6 +1628,7 @@ const buildSourcesMock = vi.mocked(buildSources);
 interface FakeBoard extends ReturnType<typeof createBoard> {
   resolveOne: ReturnType<typeof vi.fn<(id: string) => Promise<Issue | undefined>>>;
   markInProgress: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
+  markInReview: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
 }
 
 function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
@@ -1637,6 +1639,7 @@ function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
       .fn<(id: string) => Promise<Issue | undefined>>()
       .mockResolvedValue(resolvedIssue),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
   };
 }
 

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -7,7 +7,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { recordRunState } from "../lib/runState.ts";
 import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
-import { createBoard } from "../lib/board.ts";
+import { createBoard, type Board } from "../lib/board.ts";
 import type * as boardModule from "../lib/board.ts";
 import { buildSources } from "../lib/buildSources.ts";
 import type * as buildSourcesModule from "../lib/buildSources.ts";
@@ -116,7 +116,7 @@ vi.mock(import("../lib/board.ts"), async (importOriginal) => {
         }),
       ),
       markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
-      markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+      markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
     })),
   };
 });
@@ -1628,7 +1628,7 @@ const buildSourcesMock = vi.mocked(buildSources);
 interface FakeBoard extends ReturnType<typeof createBoard> {
   resolveOne: ReturnType<typeof vi.fn<(id: string) => Promise<Issue | undefined>>>;
   markInProgress: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
-  markInReview: ReturnType<typeof vi.fn<(issue: Issue) => Promise<void>>>;
+  markInReview: ReturnType<typeof vi.fn<Board["markInReview"]>>;
 }
 
 function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
@@ -1639,7 +1639,7 @@ function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
       .fn<(id: string) => Promise<Issue | undefined>>()
       .mockResolvedValue(resolvedIssue),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
-    markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
   };
 }
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -89,6 +89,8 @@ async function noop(): Promise<void> {
   await Promise.resolve();
 }
 
+const markInReview: TicketSource["markInReview"] = async () => ({ outcome: "applied" });
+
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let index = 0; index < count; index += 1) {
     // oxlint-disable-next-line no-await-in-loop -- test helper intentionally drains queued promise work.
@@ -115,7 +117,7 @@ function fakeSource(
     fetch,
     resolveOne,
     markInProgress: noop,
-    markInReview: noop,
+    markInReview,
   };
 }
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -115,6 +115,7 @@ function fakeSource(
     fetch,
     resolveOne,
     markInProgress: noop,
+    markInReview: noop,
   };
 }
 

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -302,6 +302,7 @@ describe(createLinearTicketSource, () => {
     const innerMarkInProgress = vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue();
     vi.spyOn(linearIssueStatus, "createLinearIssueStatusUpdater").mockReturnValue({
       markInProgress: innerMarkInProgress,
+      markInReview: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(),
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -327,6 +328,42 @@ describe(createLinearTicketSource, () => {
       },
     });
     expect(innerMarkInProgress).toHaveBeenCalledWith({
+      id: "linear:team-1",
+      uuid: "uuid-1",
+      teamId: "team-default",
+    });
+  });
+
+  it("markInReview() forwards uuid/teamId from sourceRef", async () => {
+    const innerMarkInReview = vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue();
+    vi.spyOn(linearIssueStatus, "createLinearIssueStatusUpdater").mockReturnValue({
+      markInProgress: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(),
+      markInReview: innerMarkInReview,
+    });
+    const source = createLinearTicketSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+    await source.markInReview({
+      id: "linear:team-1",
+      source: "linear",
+      title: "x",
+      description: "",
+      status: "in-progress",
+      repository: "repo-a",
+      model: "claude",
+      assignee: "Alice",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [],
+      hasMoreBlockers: false,
+      sourceRef: {
+        uuid: "uuid-1",
+        statusId: "s",
+        teamId: "team-default",
+        stateType: "started",
+        nativeStatus: "In Progress",
+      },
+    });
+    expect(innerMarkInReview).toHaveBeenCalledWith({
       id: "linear:team-1",
       uuid: "uuid-1",
       teamId: "team-default",

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -2,6 +2,7 @@ import type { LinearClient } from "@linear/sdk";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import type { ResolvedConfig } from "../../config.ts";
+import type { MarkInReviewResult } from "../../ticketSource.ts";
 import { readEnvironmentVariable } from "../../util.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../../../testHelpers/env.ts";
 import * as boardSource from "./fetch.ts";
@@ -302,7 +303,9 @@ describe(createLinearTicketSource, () => {
     const innerMarkInProgress = vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue();
     vi.spyOn(linearIssueStatus, "createLinearIssueStatusUpdater").mockReturnValue({
       markInProgress: innerMarkInProgress,
-      markInReview: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(),
+      markInReview: vi
+        .fn<(...args: unknown[]) => Promise<MarkInReviewResult>>()
+        .mockResolvedValue({ outcome: "unsupported", reason: "not implemented" }),
     });
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -335,7 +338,9 @@ describe(createLinearTicketSource, () => {
   });
 
   it("markInReview() forwards uuid/teamId from sourceRef", async () => {
-    const innerMarkInReview = vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue();
+    const innerMarkInReview = vi
+      .fn<(...args: unknown[]) => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "unsupported", reason: "not implemented" });
     vi.spyOn(linearIssueStatus, "createLinearIssueStatusUpdater").mockReturnValue({
       markInProgress: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(),
       markInReview: innerMarkInReview,
@@ -343,26 +348,28 @@ describe(createLinearTicketSource, () => {
     const source = createLinearTicketSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
     } satisfies AdapterContext);
-    await source.markInReview({
-      id: "linear:team-1",
-      source: "linear",
-      title: "x",
-      description: "",
-      status: "in-progress",
-      repository: "repo-a",
-      model: "claude",
-      assignee: "Alice",
-      updatedAt: "2026-01-01T00:00:00Z",
-      blockers: [],
-      hasMoreBlockers: false,
-      sourceRef: {
-        uuid: "uuid-1",
-        statusId: "s",
-        teamId: "team-default",
-        stateType: "started",
-        nativeStatus: "In Progress",
-      },
-    });
+    await expect(
+      source.markInReview({
+        id: "linear:team-1",
+        source: "linear",
+        title: "x",
+        description: "",
+        status: "in-progress",
+        repository: "repo-a",
+        model: "claude",
+        assignee: "Alice",
+        updatedAt: "2026-01-01T00:00:00Z",
+        blockers: [],
+        hasMoreBlockers: false,
+        sourceRef: {
+          uuid: "uuid-1",
+          statusId: "s",
+          teamId: "team-default",
+          stateType: "started",
+          nativeStatus: "In Progress",
+        },
+      }),
+    ).resolves.toStrictEqual({ outcome: "unsupported", reason: "not implemented" });
     expect(innerMarkInReview).toHaveBeenCalledWith({
       id: "linear:team-1",
       uuid: "uuid-1",

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -234,5 +234,14 @@ export function createLinearTicketSource(
         teamId: ref.teamId,
       });
     },
+    async markInReview(issue: CanonicalIssue): Promise<void> {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- by the Linear adapter's contract, every Issue it produces carries a LinearSourceRef in sourceRef
+      const ref = issue.sourceRef as LinearSourceRef;
+      await getIssueStatusUpdater().markInReview({
+        id: issue.id,
+        uuid: ref.uuid,
+        teamId: ref.teamId,
+      });
+    },
   };
 }

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -18,6 +18,7 @@ import {
   type Blocker as CanonicalBlocker,
   type CanonicalStatus,
   type Issue as CanonicalIssue,
+  type MarkInReviewResult,
   type ParentSkip as CanonicalParentSkip,
   type TicketSource,
 } from "../../ticketSource.ts";
@@ -234,10 +235,10 @@ export function createLinearTicketSource(
         teamId: ref.teamId,
       });
     },
-    async markInReview(issue: CanonicalIssue): Promise<void> {
+    async markInReview(issue: CanonicalIssue): Promise<MarkInReviewResult> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- by the Linear adapter's contract, every Issue it produces carries a LinearSourceRef in sourceRef
       const ref = issue.sourceRef as LinearSourceRef;
-      await getIssueStatusUpdater().markInReview({
+      return await getIssueStatusUpdater().markInReview({
         id: issue.id,
         uuid: ref.uuid,
         teamId: ref.teamId,

--- a/src/lib/adapters/linear/writeback.test.ts
+++ b/src/lib/adapters/linear/writeback.test.ts
@@ -53,6 +53,18 @@ describe(createLinearIssueStatusUpdater, () => {
     vi.clearAllMocks();
   });
 
+  it("markInReview is a no-op stub — no Linear API call (D1)", async () => {
+    const client = makeClient();
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await expect(
+      updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
+    ).resolves.toBeUndefined();
+
+    expect(client.team).not.toHaveBeenCalled();
+    expect(client.updateIssue).not.toHaveBeenCalled();
+  });
+
   it("fetches the started-type state once across multiple tickets in the same team", async () => {
     const client = makeClient();
     const updater = createLinearIssueStatusUpdater({

--- a/src/lib/adapters/linear/writeback.test.ts
+++ b/src/lib/adapters/linear/writeback.test.ts
@@ -53,13 +53,16 @@ describe(createLinearIssueStatusUpdater, () => {
     vi.clearAllMocks();
   });
 
-  it("markInReview is a no-op stub — no Linear API call (D1)", async () => {
+  it("markInReview reports unsupported without calling Linear", async () => {
     const client = makeClient();
     const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
 
     await expect(
       updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
-    ).resolves.toBeUndefined();
+    ).resolves.toStrictEqual({
+      outcome: "unsupported",
+      reason: "Linear in-review writeback is not implemented",
+    });
 
     expect(client.team).not.toHaveBeenCalled();
     expect(client.updateIssue).not.toHaveBeenCalled();

--- a/src/lib/adapters/linear/writeback.ts
+++ b/src/lib/adapters/linear/writeback.ts
@@ -1,5 +1,6 @@
 import type { LinearClient } from "@linear/sdk";
 
+import type { MarkInReviewResult } from "../../ticketSource.ts";
 import { debug } from "../../util.ts";
 
 interface LinearIssueReference {
@@ -10,18 +11,18 @@ interface LinearIssueReference {
 
 interface LinearIssueStatusUpdater {
   markInProgress(issue: LinearIssueReference): Promise<void>;
-  markInReview(issue: LinearIssueReference): Promise<void>;
+  markInReview(issue: LinearIssueReference): Promise<MarkInReviewResult>;
 }
 
-// D1: no Linear consumer of the in-review transition exists yet — only the
-// plans (shell) adapter produces it. A logged no-op keeps the TicketSource
-// interface generic; the real impl (resolve the team's "In Review" workflow
-// state and move the card, mirroring getInProgressStateId) is additive
-// whenever a Linear user needs it. Module-scoped because it captures no
-// client/cache state, unlike markInProgress.
-async function markInReviewNoop(issue: LinearIssueReference): Promise<void> {
-  await Promise.resolve();
-  debug(`markInReview is a no-op for ${issue.id} (Linear in-review not yet implemented)`);
+// Linear maps every `started` workflow state to canonical in-progress today,
+// so it cannot prove a successful in-review transition. Report unsupported
+// until read/write sides can distinguish "In Review" from generic started.
+async function markInReviewUnsupported(issue: LinearIssueReference): Promise<MarkInReviewResult> {
+  debug(`markInReview is unsupported for ${issue.id} (Linear in-review not yet implemented)`);
+  return {
+    outcome: "unsupported",
+    reason: "Linear in-review writeback is not implemented",
+  };
 }
 
 export function createLinearIssueStatusUpdater(arguments_: {
@@ -80,5 +81,5 @@ export function createLinearIssueStatusUpdater(arguments_: {
     debug(`Marked ${issue.id} as in progress`);
   }
 
-  return { markInProgress, markInReview: markInReviewNoop };
+  return { markInProgress, markInReview: markInReviewUnsupported };
 }

--- a/src/lib/adapters/linear/writeback.ts
+++ b/src/lib/adapters/linear/writeback.ts
@@ -10,6 +10,18 @@ interface LinearIssueReference {
 
 interface LinearIssueStatusUpdater {
   markInProgress(issue: LinearIssueReference): Promise<void>;
+  markInReview(issue: LinearIssueReference): Promise<void>;
+}
+
+// D1: no Linear consumer of the in-review transition exists yet — only the
+// plans (shell) adapter produces it. A logged no-op keeps the TicketSource
+// interface generic; the real impl (resolve the team's "In Review" workflow
+// state and move the card, mirroring getInProgressStateId) is additive
+// whenever a Linear user needs it. Module-scoped because it captures no
+// client/cache state, unlike markInProgress.
+async function markInReviewNoop(issue: LinearIssueReference): Promise<void> {
+  await Promise.resolve();
+  debug(`markInReview is a no-op for ${issue.id} (Linear in-review not yet implemented)`);
 }
 
 export function createLinearIssueStatusUpdater(arguments_: {
@@ -68,5 +80,5 @@ export function createLinearIssueStatusUpdater(arguments_: {
     debug(`Marked ${issue.id} as in progress`);
   }
 
-  return { markInProgress };
+  return { markInProgress, markInReview: markInReviewNoop };
 }

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { z } from "zod";
 
 import type { AdapterDefinition } from "../adapterDefinition.ts";
-import type { TicketSource } from "../ticketSource.ts";
+import type { MarkInReviewResult, TicketSource } from "../ticketSource.ts";
 import {
   adapterRegistry,
   type AdapterLoader,
@@ -22,7 +22,9 @@ function emptySource(name: string): TicketSource {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
-    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi
+      .fn<() => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" }),
   };
 }
 

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -22,6 +22,7 @@ function emptySource(name: string): TicketSource {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
   };
 }
 

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -421,4 +421,56 @@ describe(createShellTicketSource, () => {
     };
     await expect(source.markInProgress(issue)).resolves.toBeUndefined();
   });
+
+  it("markInReview() is a silent no-op when not configured", async () => {
+    const source = createShellTicketSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },
+      fakeContext,
+    );
+    const issue: CanonicalIssue = {
+      id: "test:x-1",
+      source: "test",
+      title: "",
+      description: "",
+      status: "in-progress",
+      repository: undefined,
+      model: undefined,
+      assignee: "",
+      updatedAt: "",
+      blockers: [],
+      hasMoreBlockers: false,
+      sourceRef: {},
+    };
+    await expect(source.markInReview(issue)).resolves.toBeUndefined();
+  });
+
+  it("markInReview() runs the configured command with substituted id and piped sourceRef on stdin", async () => {
+    const stdinCapture = path.join(dir.path, "review-stdin-capture.txt");
+    const reviewScript = dir.writeScript("review.sh", `cat > "${stdinCapture}"; echo "review $1"`);
+    const source = createShellTicketSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", markInReview: `${reviewScript} \${id}` },
+      },
+      fakeContext,
+    );
+    const sourceRef = { path: "/tmp/p.md", extra: { nested: 7 } };
+    const issue: CanonicalIssue = {
+      id: "test:x-1",
+      source: "test",
+      title: "",
+      description: "",
+      status: "in-progress",
+      repository: undefined,
+      model: undefined,
+      assignee: "",
+      updatedAt: "",
+      blockers: [],
+      hasMoreBlockers: false,
+      sourceRef,
+    };
+    await source.markInReview(issue);
+    expect(readFileSync(stdinCapture, "utf8")).toBe(JSON.stringify(sourceRef));
+  });
 });

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -422,7 +422,7 @@ describe(createShellTicketSource, () => {
     await expect(source.markInProgress(issue)).resolves.toBeUndefined();
   });
 
-  it("markInReview() is a silent no-op when not configured", async () => {
+  it("markInReview() reports unsupported when not configured", async () => {
     const source = createShellTicketSource(
       { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },
       fakeContext,
@@ -441,7 +441,10 @@ describe(createShellTicketSource, () => {
       hasMoreBlockers: false,
       sourceRef: {},
     };
-    await expect(source.markInReview(issue)).resolves.toBeUndefined();
+    await expect(source.markInReview(issue)).resolves.toStrictEqual({
+      outcome: "unsupported",
+      reason: 'shell source "test" has no commands.markInReview configured',
+    });
   });
 
   it("markInReview() runs the configured command with substituted id and piped sourceRef on stdin", async () => {
@@ -470,7 +473,7 @@ describe(createShellTicketSource, () => {
       hasMoreBlockers: false,
       sourceRef,
     };
-    await source.markInReview(issue);
+    await expect(source.markInReview(issue)).resolves.toStrictEqual({ outcome: "applied" });
     expect(readFileSync(stdinCapture, "utf8")).toBe(JSON.stringify(sourceRef));
   });
 });

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -10,7 +10,8 @@
  *    most CLI use (crew setup is rare) but users with expensive fetch
  *    commands should configure `resolveOne` explicitly. No cross-call cache
  *    in MVP-2.
- *  - `markInProgress` / `markInReview` absent → silent no-op.
+ *  - `markInProgress` absent → silent no-op.
+ *  - `markInReview` absent → reports unsupported.
  *  - `fetch` is required by the Zod schema.
  */
 
@@ -19,6 +20,7 @@ import {
   toCanonicalId,
   type Blocker as CanonicalBlocker,
   type Issue as CanonicalIssue,
+  type MarkInReviewResult,
   type TicketSource,
 } from "../../ticketSource.ts";
 
@@ -102,8 +104,7 @@ export function createShellTicketSource(
 
   // Shared by markInProgress / markInReview: both pipe the canonical issue's
   // opaque sourceRef to a status-transition script on stdin, with the natural
-  // and canonical ids substituted into the command. A command left unset is a
-  // silent no-op so adapters can adopt either transition independently.
+  // and canonical ids substituted into the command.
   async function invokeWriteback(
     command: string | undefined,
     timeoutMs: number,
@@ -174,8 +175,15 @@ export function createShellTicketSource(
     async markInProgress(issue: CanonicalIssue): Promise<void> {
       await invokeWriteback(config.commands.markInProgress, timeouts.markInProgress, issue);
     },
-    async markInReview(issue: CanonicalIssue): Promise<void> {
+    async markInReview(issue: CanonicalIssue): Promise<MarkInReviewResult> {
+      if (config.commands.markInReview === undefined) {
+        return {
+          outcome: "unsupported",
+          reason: `shell source "${sourceName}" has no commands.markInReview configured`,
+        };
+      }
       await invokeWriteback(config.commands.markInReview, timeouts.markInReview, issue);
+      return { outcome: "applied" };
     },
   };
 }

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -10,7 +10,7 @@
  *    most CLI use (crew setup is rare) but users with expensive fetch
  *    commands should configure `resolveOne` explicitly. No cross-call cache
  *    in MVP-2.
- *  - `markInProgress` absent → silent no-op.
+ *  - `markInProgress` / `markInReview` absent → silent no-op.
  *  - `fetch` is required by the Zod schema.
  */
 
@@ -35,6 +35,7 @@ interface ResolvedShellTimeouts {
   fetch: number;
   resolveOne: number;
   markInProgress: number;
+  markInReview: number;
 }
 
 const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
@@ -42,6 +43,7 @@ const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
   fetch: 30_000,
   resolveOne: 10_000,
   markInProgress: 10_000,
+  markInReview: 10_000,
 };
 
 function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShellTimeouts {
@@ -50,6 +52,7 @@ function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShell
     fetch: overrides?.fetch ?? DEFAULT_TIMEOUTS.fetch,
     resolveOne: overrides?.resolveOne ?? DEFAULT_TIMEOUTS.resolveOne,
     markInProgress: overrides?.markInProgress ?? DEFAULT_TIMEOUTS.markInProgress,
+    markInReview: overrides?.markInReview ?? DEFAULT_TIMEOUTS.markInReview,
   };
 }
 
@@ -97,6 +100,36 @@ export function createShellTicketSource(
     return parsed.map((si) => toCanonicalIssue(si, sourceName));
   }
 
+  // Shared by markInProgress / markInReview: both pipe the canonical issue's
+  // opaque sourceRef to a status-transition script on stdin, with the natural
+  // and canonical ids substituted into the command. A command left unset is a
+  // silent no-op so adapters can adopt either transition independently.
+  async function invokeWriteback(
+    command: string | undefined,
+    timeoutMs: number,
+    issue: CanonicalIssue,
+  ): Promise<void> {
+    if (command === undefined) {
+      return;
+    }
+    const naturalId = issue.id.startsWith(`${sourceName}:`)
+      ? issue.id.slice(sourceName.length + 1)
+      : issue.id;
+    await invokeShellCommand({
+      command,
+      timeoutMs,
+      cwd: config.cwd,
+      env: config.env,
+      substitutions: {
+        id: naturalId,
+        canonicalId: issue.id,
+        name: sourceName,
+      },
+      stdin: JSON.stringify(issue.sourceRef),
+      sourceName,
+    });
+  }
+
   return {
     name: sourceName,
     async verify(): Promise<void> {
@@ -139,26 +172,10 @@ export function createShellTicketSource(
       return toCanonicalIssue(parsed, sourceName);
     },
     async markInProgress(issue: CanonicalIssue): Promise<void> {
-      const markCommand = config.commands.markInProgress;
-      if (markCommand === undefined) {
-        return;
-      }
-      const naturalId = issue.id.startsWith(`${sourceName}:`)
-        ? issue.id.slice(sourceName.length + 1)
-        : issue.id;
-      await invokeShellCommand({
-        command: markCommand,
-        timeoutMs: timeouts.markInProgress,
-        cwd: config.cwd,
-        env: config.env,
-        substitutions: {
-          id: naturalId,
-          canonicalId: issue.id,
-          name: sourceName,
-        },
-        stdin: JSON.stringify(issue.sourceRef),
-        sourceName,
-      });
+      await invokeWriteback(config.commands.markInProgress, timeouts.markInProgress, issue);
+    },
+    async markInReview(issue: CanonicalIssue): Promise<void> {
+      await invokeWriteback(config.commands.markInReview, timeouts.markInReview, issue);
     },
   };
 }

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -187,9 +187,10 @@ describe("shell adapter config schema", () => {
         fetch: "./fetch.sh",
         resolveOne: "./resolve.sh ${id}",
         markInProgress: "jira move ${id} 'In Progress'",
+        markInReview: "jira move ${id} 'In Review'",
       },
       cwd: "/work",
-      timeouts: { fetch: 60_000 },
+      timeouts: { fetch: 60_000, markInReview: 15_000 },
       env: { JIRA_TOKEN: "abc" },
     };
     expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -54,6 +54,7 @@ export const shellAdapterConfigSchema = z.object({
     fetch: z.string(),
     resolveOne: z.string().optional(),
     markInProgress: z.string().optional(),
+    markInReview: z.string().optional(),
   }),
   cwd: z.string().optional(),
   timeouts: z
@@ -65,6 +66,7 @@ export const shellAdapterConfigSchema = z.object({
       fetch: z.number().int().positive().optional(),
       resolveOne: z.number().int().positive().optional(),
       markInProgress: z.number().int().positive().optional(),
+      markInReview: z.number().int().positive().optional(),
     })
     .optional(),
   env: z.record(z.string(), z.string()).optional(),

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -9,6 +9,7 @@ function fakeSource(name: string, overrides: Partial<TicketSource> = {}): Ticket
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<(id: string) => Promise<Issue | undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
     ...overrides,
   };
 }
@@ -225,6 +226,29 @@ describe("Board.markInProgress", () => {
   it("throws when issue.source names an unknown source", async () => {
     const board = createBoard([fakeSource("a")]);
     await expect(board.markInProgress(fakeIssue("nope:1", "nope"))).rejects.toThrow(
+      /unknown source.*nope/,
+    );
+  });
+});
+
+describe("Board.markInReview", () => {
+  it("routes to the adapter named by issue.source", async () => {
+    const aMark = vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue();
+    const bMark = vi
+      .fn<(issue: Issue) => Promise<void>>()
+      .mockRejectedValue(new Error("wrong source"));
+    const board = createBoard([
+      fakeSource("a", { markInReview: aMark }),
+      fakeSource("b", { markInReview: bMark }),
+    ]);
+    await board.markInReview(fakeIssue("a:1", "a"));
+    expect(aMark).toHaveBeenCalledTimes(1);
+    expect(bMark).not.toHaveBeenCalled();
+  });
+
+  it("throws when issue.source names an unknown source", async () => {
+    const board = createBoard([fakeSource("a")]);
+    await expect(board.markInReview(fakeIssue("nope:1", "nope"))).rejects.toThrow(
       /unknown source.*nope/,
     );
   });

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -1,5 +1,5 @@
 import { createBoard } from "./board.ts";
-import type { Issue, ParentSkip, TicketSource } from "./ticketSource.ts";
+import type { Issue, MarkInReviewResult, ParentSkip, TicketSource } from "./ticketSource.ts";
 
 function fakeSource(name: string, overrides: Partial<TicketSource> = {}): TicketSource {
   return {
@@ -9,7 +9,9 @@ function fakeSource(name: string, overrides: Partial<TicketSource> = {}): Ticket
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<(id: string) => Promise<Issue | undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
-    markInReview: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+    markInReview: vi
+      .fn<(issue: Issue) => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" }),
     ...overrides,
   };
 }
@@ -233,15 +235,19 @@ describe("Board.markInProgress", () => {
 
 describe("Board.markInReview", () => {
   it("routes to the adapter named by issue.source", async () => {
-    const aMark = vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue();
+    const aMark = vi
+      .fn<(issue: Issue) => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" });
     const bMark = vi
-      .fn<(issue: Issue) => Promise<void>>()
+      .fn<(issue: Issue) => Promise<MarkInReviewResult>>()
       .mockRejectedValue(new Error("wrong source"));
     const board = createBoard([
       fakeSource("a", { markInReview: aMark }),
       fakeSource("b", { markInReview: bMark }),
     ]);
-    await board.markInReview(fakeIssue("a:1", "a"));
+    await expect(board.markInReview(fakeIssue("a:1", "a"))).resolves.toStrictEqual({
+      outcome: "applied",
+    });
     expect(aMark).toHaveBeenCalledTimes(1);
     expect(bMark).not.toHaveBeenCalled();
   });

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -9,6 +9,7 @@ import {
   AmbiguousTicketError,
   type BoardState,
   type Issue,
+  type MarkInReviewResult,
   type ParentSkip,
   type TicketSource,
 } from "./ticketSource.ts";
@@ -26,9 +27,9 @@ export interface Board {
   /**
    * Advances a ticket to in-review on the adapter whose `name` matches
    * `issue.source`. Unknown source throws. Adapters with no in-review concept
-   * no-op (see `TicketSource.markInReview`).
+   * return `unsupported` (see `TicketSource.markInReview`).
    */
-  markInReview(issue: Issue): Promise<void>;
+  markInReview(issue: Issue): Promise<MarkInReviewResult>;
 }
 
 async function callVerify(source: TicketSource): Promise<void> {
@@ -150,8 +151,8 @@ export function createBoard(sources: readonly TicketSource[]): Board {
       await routeWriteback(byName, issue).markInProgress(issue);
     },
 
-    async markInReview(issue: Issue): Promise<void> {
-      await routeWriteback(byName, issue).markInReview(issue);
+    async markInReview(issue: Issue): Promise<MarkInReviewResult> {
+      return await routeWriteback(byName, issue).markInReview(issue);
     },
   };
 }

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -1,8 +1,8 @@
 /**
- * Board composer — fans `verify` / `fetch` / `resolveOne` / `markInProgress`
- * across N `TicketSource` adapters. Even a single-source config goes through
- * this; the moment we skip the wrapper we grow Linear assumptions back into
- * consumers.
+ * Board composer — fans `verify` / `fetch` / `resolveOne` / `markInProgress` /
+ * `markInReview` across N `TicketSource` adapters. Even a single-source config
+ * goes through this; the moment we skip the wrapper we grow Linear assumptions
+ * back into consumers.
  */
 
 import {
@@ -23,6 +23,12 @@ export interface Board {
   resolveOne(canonicalOrNaturalId: string): Promise<Issue | undefined>;
   /** Routes to the adapter whose `name` matches `issue.source`. Unknown source throws. */
   markInProgress(issue: Issue): Promise<void>;
+  /**
+   * Advances a ticket to in-review on the adapter whose `name` matches
+   * `issue.source`. Unknown source throws. Adapters with no in-review concept
+   * no-op (see `TicketSource.markInReview`).
+   */
+  markInReview(issue: Issue): Promise<void>;
 }
 
 async function callVerify(source: TicketSource): Promise<void> {
@@ -141,11 +147,24 @@ export function createBoard(sources: readonly TicketSource[]): Board {
     },
 
     async markInProgress(issue: Issue): Promise<void> {
-      const source = byName.get(issue.source);
-      if (!source) {
-        throw new Error(`unknown source "${issue.source}" for issue ${issue.id}`);
-      }
-      await source.markInProgress(issue);
+      await routeWriteback(byName, issue).markInProgress(issue);
+    },
+
+    async markInReview(issue: Issue): Promise<void> {
+      await routeWriteback(byName, issue).markInReview(issue);
     },
   };
+}
+
+/**
+ * Resolve the adapter that owns `issue` for a writeback, by its `source` name.
+ * Shared by `markInProgress` / `markInReview` so both route — and fail —
+ * identically. Throws when no adapter claims the source.
+ */
+function routeWriteback(byName: Map<string, TicketSource>, issue: Issue): TicketSource {
+  const source = byName.get(issue.source);
+  if (!source) {
+    throw new Error(`unknown source "${issue.source}" for issue ${issue.id}`);
+  }
+  return source;
 }

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -4,7 +4,7 @@ import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelper
 import type { AdapterContext, AdapterDefinition } from "./adapterDefinition.ts";
 import { buildSources, buildSourcesWith, sourcesFromConfig } from "./buildSources.ts";
 import type { ResolvedConfig } from "./config.ts";
-import type { TicketSource } from "./ticketSource.ts";
+import type { MarkInReviewResult, TicketSource } from "./ticketSource.ts";
 import { readEnvironmentVariable } from "./util.ts";
 
 const fakeContext: AdapterContext = {
@@ -21,7 +21,9 @@ function emptySource(name: string): TicketSource {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
-    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi
+      .fn<() => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" }),
   };
 }
 

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -21,6 +21,7 @@ function emptySource(name: string): TicketSource {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
   };
 }
 

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -111,6 +111,10 @@ export interface BoardState {
   parentSkips: readonly ParentSkip[];
 }
 
+export type MarkInReviewResult =
+  | { outcome: "applied" }
+  | { outcome: "unsupported"; reason: string };
+
 export interface TicketSource {
   /** Stable identifier used as the id prefix and in log lines. Equal to the source's config `name`. */
   readonly name: string;
@@ -127,9 +131,10 @@ export interface TicketSource {
    * worktree has an open PR. Frees a dispatch slot without tripping the
    * cleaner's done-only teardown, so the worktree survives for review. The
    * adapter downcasts `issue.sourceRef` internally. Adapters with no native
-   * in-review concept (or no configured command) MUST no-op rather than throw.
+   * in-review concept (or no configured command) MUST report `unsupported`
+   * rather than pretending the transition happened.
    */
-  markInReview(issue: Issue): Promise<void>;
+  markInReview(issue: Issue): Promise<MarkInReviewResult>;
 
   /**
    * Optional: return parent tickets that were excluded from `fetch()` because

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -122,6 +122,14 @@ export interface TicketSource {
   resolveOne(naturalId: string): Promise<Issue | undefined>;
   /** Writeback. The adapter downcasts `issue.sourceRef` internally. */
   markInProgress(issue: Issue): Promise<void>;
+  /**
+   * Writeback: advance a ticket from in-progress to in-review once its
+   * worktree has an open PR. Frees a dispatch slot without tripping the
+   * cleaner's done-only teardown, so the worktree survives for review. The
+   * adapter downcasts `issue.sourceRef` internally. Adapters with no native
+   * in-review concept (or no configured command) MUST no-op rather than throw.
+   */
+  markInReview(issue: Issue): Promise<void>;
 
   /**
    * Optional: return parent tickets that were excluded from `fetch()` because

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -10,6 +10,7 @@ export function makeBoard(overrides: Partial<Board> = {}): Board {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
     ...overrides,
   };
 }

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -1,5 +1,5 @@
 import type { Board } from "../lib/board.ts";
-import type { BoardState } from "../lib/ticketSource.ts";
+import type { BoardState, MarkInReviewResult } from "../lib/ticketSource.ts";
 
 export function makeBoard(overrides: Partial<Board> = {}): Board {
   return {
@@ -10,7 +10,9 @@ export function makeBoard(overrides: Partial<Board> = {}): Board {
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
-    markInReview: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    markInReview: vi
+      .fn<() => Promise<MarkInReviewResult>>()
+      .mockResolvedValue({ outcome: "applied" }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Adds a reviewer step to the orchestrator tick that advances in-progress tickets to in-review when their worktree branch has an open or merged PR, freeing dispatch slots while preserving worktrees for review.

`markInReview` is now an explicit capability: ticket sources return `applied` only after they actually perform the transition, and return `unsupported` when they cannot. The shell adapter returns `applied` after its configured `commands.markInReview` command runs; an unconfigured shell source and the current Linear adapter report `unsupported`, so the reviewer no longer logs false “Advanced” success for no-op writebacks. Reviewer worktree matching is also repository-aware.

## Validation

- `npx vitest run src/commands/reviewer.test.ts src/commands/orchestrator.test.ts src/lib/board.test.ts src/lib/adapters/shell/factory.test.ts src/lib/adapters/linear/writeback.test.ts src/lib/adapters/linear/factory.test.ts`
- `node --run verify`

## Notes

Linear still does not perform in-review writeback until its read/write path can distinguish “In Review” from generic Linear `started` states. Shell users should configure `commands.markInReview` to enable the transition.

Source plan: `~/plans/groundcrew/2026-06-02-auto-advance-in-progress-to-in-review-on-pr-open.md`

Agent session: `codex resume 019e9877-7904-7382-9470-e4e232516572`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
