### PR TITLE
fix(clearance): allow mcp-proxy.anthropic.com and mcp.datadoghq.com for MCP connectivity

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -23,6 +23,8 @@ api.slack.com
 app.incident.io
 developers.notion.com
 linear.app
+mcp-proxy.anthropic.com
+mcp.datadoghq.com
 mcp.incident.io
 mcp.linear.app
 mcp.notion.com


### PR DESCRIPTION
## Why

Groundcrew's starter egress allowlist (`clearance-allow-hosts`) denied two MCP **control-path** hosts, silently breaking MCP servers inside the sandbox. Surfaced while debugging a wall of `DENY` lines in `~/.cache/clearance/clearance.log` from groundcrew sessions.

- **`mcp-proxy.anthropic.com`** — the gateway that *all* claude.ai-managed connectors (Linear, Slack, Datadog, Atlassian, Gmail, …) tunnel through. The allowlist only listed direct provider hosts (`mcp.linear.app`, etc.), so every claude.ai connector was denied and kept retrying (180+ DENY lines).
- **`mcp.datadoghq.com`** — endpoint for the directly-configured `datadog-mcp` server (`https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`). It was stuck in "needs auth" because it couldn't reach its own endpoint to complete the handshake (115 DENY lines).

Both are first-party, OAuth-gated MCP control paths — the same trust class as the already-allowed `mcp.linear.app` / `mcp.notion.com` / `mcp.slack.com` / `mcp.incident.io`.

## Deliberately NOT added

- **`http-intake.logs.us5.datadoghq.com`** (5480 DENY lines) — Datadog log-shipping/ingestion, i.e. a telemetry-**egress** pipe, not a control path. Nothing functional depends on it (the Datadog client drops failures); the noise is an SDK retry loop, best addressed by disabling log-shipping in the sandbox env. Leaving it blocked preserves the file's existing "no `http-intake.logs.*` wildcard" intent.
- **`downloads.claude.ai`** — Claude Code asset/update fetch; harmless to block.

## Validation

Patched the live allowlist, restarted the clearance daemon, and confirmed via proxy `CONNECT`:

| Host | clearance verdict |
|------|-------------------|
| `mcp-proxy.anthropic.com` | ALLOW ✓ |
| `mcp.datadoghq.com` | ALLOW ✓ |
| `http-intake.logs.us5.datadoghq.com` | DENY ✓ (intended) |

No Linear ticket — incidental fix found while debugging MCP egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
