### PR TITLE
chore: add releases.hashicorp.com to allowed hosts

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -88,5 +88,6 @@ mise-versions.jdx.dev
 nx.dev
 playwright.azureedge.net
 registry.terraform.io
+releases.hashicorp.com
 sourcegraph.com
 vitest.dev


### PR DESCRIPTION
Agent might need to download terraform binary to validate the change