### PR TITLE
feat: scripted sparse-checkout provisioner with optional workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ There is no `linear` config block. Groundcrew reads `GROUNDCREW_LINEAR_API_KEY` 
 
 ## Reference
 
-- [Configuration](./docs/configuration.md): discovery order, repo layout, full config table, prompt customization.
+- [Configuration](./docs/configuration.md): discovery order, repo layout, scripted/sparse-checkout (graft) worktrees, full config table, prompt customization.
 - [Runners](./docs/runners.md): Safehouse, Docker Sandboxes, and the `none` escape hatch.
 - [Credentials](./docs/credentials.md): Linear API keys, 1Password, build secrets, and `preLaunch`.
 - [Prepare worktree hooks](./docs/setup-hooks.md): `.groundcrew/config.json` `hooks.prepareWorktree` for per-repo dependency setup.

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -48,7 +48,7 @@ export default {
     // Set up graft once outside groundcrew:
     //   graft repo add ~/dev/owner/monorepo
     //   graft alias add billing services/billing libs/common
-    // `crew doctor` then checks `graft` is on the host PATH.
+    // `crew doctor` does not parse or validate these shell templates.
   },
   models: {
     default: "claude",

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -26,6 +26,29 @@ export default {
     // form to point a repo at a different parent directory:
     //   { name: "other-org/other-repo", projectDirOverride: "~/work" }
     knownRepositories: ["your-org/your-repo"],
+    // A knownRepositories entry can also be an object that provisions the
+    // worktree with a custom command instead of `git worktree add` — e.g. a
+    // sparse checkout via `graft`. `repo` is a logical name (task token +
+    // worktree dir basename); the physical clone is the command's concern.
+    // Templates interpolate ${branch} ${dir} ${baseRef} ${repo} ${task}.
+    //
+    //   {
+    //     name: "billing",
+    //     provision: {
+    //       create: "graft new ${branch} billing --from ${baseRef} --dir ${dir}",
+    //       remove: "graft rm ${branch} -f",
+    //     },
+    //     // Optional: run the agent, prepareWorktree hook, and
+    //     // .groundcrew/config.json lookup in this subdirectory of the
+    //     // checkout (relative, no ".."). Use it when the checkout is a
+    //     // monorepo whose project lives in a subdir.
+    //     workdir: "services/billing",
+    //   },
+    //
+    // Set up graft once outside groundcrew:
+    //   graft repo add ~/dev/owner/monorepo
+    //   graft alias add billing services/billing libs/common
+    // `crew doctor` then checks `graft` is on the host PATH.
   },
   models: {
     default: "claude",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ graft repo add ~/dev/owner/monorepo
 graft alias add billing services/billing libs/common
 ```
 
-`crew doctor` then verifies the first token of each `provision.create` template (e.g. `graft`) is on the host PATH.
+`crew doctor` does not parse or validate provisioner templates; if your setup is more than a simple command, put it in a wrapper script and call that from `provision.create` / `provision.remove`.
 
 ## Config Discovery
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,42 @@ Clean up existing worktrees before switching it, or temporarily unset
 `worktreeDir` when you need `crew cleanup` to find worktrees created beside the
 repos.
 
+## Scripted Worktrees (Sparse Checkouts)
+
+A `workspace.knownRepositories` entry can be an **object** instead of a string when you want groundcrew to provision the worktree with a custom command — for example a sparse checkout via `graft` — instead of `git worktree add`:
+
+```ts
+workspace: {
+  projectDir: "~/dev/groundcrew",
+  knownRepositories: [
+    "your-org/your-repo",
+    {
+      name: "billing",
+      provision: {
+        create: "graft new ${branch} billing --from ${baseRef} --dir ${dir}",
+        remove: "graft rm ${branch} -f",
+      },
+      workdir: "services/billing",
+    },
+  ],
+},
+```
+
+- **`name`** is a logical name — it is the token matched in task descriptions and the basename of the per-task worktree directory. The physical clone is the command's concern, so several scripted entries can share one underlying clone.
+- **`provision`** marks the entry as scripted. **`provision.create`** runs in place of `git worktree add`; **`provision.remove`** runs in place of `git worktree remove`. Both are required — a `provision` block missing either is rejected at config load. `projectDirOverride` (the per-repo source-directory override for native entries) cannot be combined with `provision`; a scripted entry has no groundcrew-managed clone, so it is rejected at config load.
+- Both templates run on the host via `sh -c` with the working directory set to the worktree root (`worktreeDir`, defaulting to `projectDir`). They interpolate `${branch}`, `${dir}`, `${baseRef}` (`<remote>/<defaultBranch>`), `${repo}`, and `${task}`; each value is shell-quoted.
+- **`workdir`** (optional) is a relative subdirectory of the worktree. When set, the agent's working directory, the `prepareWorktree` hook, and the `.groundcrew/config.json` lookup all re-root to `<worktree>/<workdir>` — use it when a sparse checkout materializes a monorepo whose project lives in a subdirectory (e.g. `uv sync` must run there). The worktree root is unchanged: it is still what create/remove/list operate on, and a sandboxed agent keeps full read/write access to the whole checkout. `workdir` must be relative with no `..` segments; if it is missing after checkout, `crew` fails fast.
+- A dirty scripted worktree is still protected from data loss: `crew cleanup` refuses to run `remove` unless you pass `--force`. Orphan and branch cleanup are delegated to your `remove` template, since groundcrew does not track the scripted clone.
+
+Set `graft` (or whatever tool your templates call) up once, outside groundcrew:
+
+```bash
+graft repo add ~/dev/owner/monorepo
+graft alias add billing services/billing libs/common
+```
+
+`crew doctor` then verifies the first token of each `provision.create` template (e.g. `graft`) is on the host PATH.
+
 ## Config Discovery
 
 Resolution order:

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -34,6 +34,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
       ...overrides.workspace,
     },
     orchestrator: {

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -76,6 +76,7 @@ const config: ResolvedConfig = {
   workspace: {
     projectDir: "/work",
     knownRepositories: ["repo-a"],
+    repositories: [{ name: "repo-a" }],
   },
   orchestrator: {
     maximumInProgress: 4,

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -39,6 +39,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b"],
+      repositories: [{ name: "repo-a" }, { name: "repo-b" }],
       ...overrides.workspace,
     },
     orchestrator: {
@@ -342,7 +343,9 @@ describe(createDispatcher, () => {
     it("renders empty known repositories in the missing repository warning", async () => {
       const board = makeBoard();
       const dispatcher = createDispatcher({
-        config: makeConfig({ workspace: { projectDir: "/work", knownRepositories: [] } }),
+        config: makeConfig({
+          workspace: { projectDir: "/work", knownRepositories: [], repositories: [] },
+        }),
         board,
       });
 

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -114,6 +114,10 @@ describe(createDispatcher, () => {
     vi.clearAllMocks();
   });
 
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("slot math", () => {
     it("starts a Todo task and marks it In Progress", async () => {
       const board = makeBoard();

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string -- scripted-repo fixtures use literal `${branch}` templates */
 import { existsSync, statSync } from "node:fs";
 
 import { type Board, createBoard } from "../lib/board.ts";
@@ -780,29 +779,5 @@ describe(doctor, () => {
     const lines = consoleLog.output();
     expect(lines).toMatch(/requested=cmux/);
     expect(lines).toContain("cmux binary is not on PATH");
-  });
-
-  it("fails when a recipe's create binary is missing from PATH", async () => {
-    loadConfigMock.mockResolvedValue({
-      ...makeConfig(),
-      workspace: {
-        projectDir: "/work",
-        knownRepositories: ["billing"],
-        repositories: [
-          {
-            name: "billing",
-            provision: { create: "graft new ${branch}", remove: "graft rm ${branch}" },
-          },
-        ],
-      },
-    });
-    mockWhichEmpty("graft");
-
-    const actual = await doctor();
-
-    expect(actual).toBe(false);
-    expect(consoleLog.output()).toContain(
-      "[--] graft  — required by a workspace.knownRepositories provision.create template",
-    );
   });
 });

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string -- scripted-repo fixtures use literal `${branch}` templates */
 import { existsSync, statSync } from "node:fs";
 
 import { type Board, createBoard } from "../lib/board.ts";
@@ -111,6 +112,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
     },
     orchestrator: {
       maximumInProgress: 4,
@@ -359,7 +361,12 @@ describe(doctor, () => {
   it("reports a failing worktreeDir check when worktreeDir is configured but missing", async () => {
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      workspace: { projectDir: "/work", worktreeDir: "/wt", knownRepositories: ["repo-a"] },
+      workspace: {
+        projectDir: "/work",
+        worktreeDir: "/wt",
+        knownRepositories: ["repo-a"],
+        repositories: [{ name: "repo-a" }],
+      },
     });
     mockMissingPath("/wt");
 
@@ -773,5 +780,29 @@ describe(doctor, () => {
     const lines = consoleLog.output();
     expect(lines).toMatch(/requested=cmux/);
     expect(lines).toContain("cmux binary is not on PATH");
+  });
+
+  it("fails when a recipe's create binary is missing from PATH", async () => {
+    loadConfigMock.mockResolvedValue({
+      ...makeConfig(),
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["billing"],
+        repositories: [
+          {
+            name: "billing",
+            provision: { create: "graft new ${branch}", remove: "graft rm ${branch}" },
+          },
+        ],
+      },
+    });
+    mockWhichEmpty("graft");
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain(
+      "[--] graft  — required by a workspace.knownRepositories provision.create template",
+    );
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -148,22 +148,6 @@ function gatherToolTargets(config: ResolvedConfig): ToolCheckTarget[] {
   return [...all].map(([token, hint]) => (hint === undefined ? { token } : { token, hint }));
 }
 
-/** First whitespace-delimited token of each distinct `provision.create` template. */
-function provisionerBinaries(config: ResolvedConfig): string[] {
-  const binaries = new Set<string>();
-  for (const recipe of config.workspace.repositories) {
-    if (recipe.provision === undefined) {
-      continue;
-    }
-    const [binary] = recipe.provision.create.trim().split(/\s+/);
-    /* v8 ignore next @preserve -- config normalization guarantees `provision.create` is a trimmed, non-empty string, so the first token is always present and non-empty */
-    if (binary !== undefined && binary.length > 0) {
-      binaries.add(binary);
-    }
-  }
-  return [...binaries];
-}
-
 function agentCliHint(agentName: string, token: string): string | undefined {
   if (token !== agentName) {
     return undefined;
@@ -242,17 +226,6 @@ export async function doctor(): Promise<boolean> {
     // oxlint-disable-next-line no-await-in-loop -- doctor reports tools in deterministic order
     const check = await checkCmd(token, required, required ? hint : "required for local runs");
     checks.push(check);
-  }
-
-  for (const binary of provisionerBinaries(config)) {
-    checks.push(
-      // oxlint-disable-next-line no-await-in-loop -- sequential PATH probes mirror the existing tool-check loop
-      await checkCmd(
-        binary,
-        true,
-        "required by a workspace.knownRepositories provision.create template",
-      ),
-    );
   }
 
   const usageGatedAgents = gatedAgents(config);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -148,6 +148,22 @@ function gatherToolTargets(config: ResolvedConfig): ToolCheckTarget[] {
   return [...all].map(([token, hint]) => (hint === undefined ? { token } : { token, hint }));
 }
 
+/** First whitespace-delimited token of each distinct `provision.create` template. */
+function provisionerBinaries(config: ResolvedConfig): string[] {
+  const binaries = new Set<string>();
+  for (const recipe of config.workspace.repositories) {
+    if (recipe.provision === undefined) {
+      continue;
+    }
+    const [binary] = recipe.provision.create.trim().split(/\s+/);
+    /* v8 ignore next @preserve -- config normalization guarantees `provision.create` is a trimmed, non-empty string, so the first token is always present and non-empty */
+    if (binary !== undefined && binary.length > 0) {
+      binaries.add(binary);
+    }
+  }
+  return [...binaries];
+}
+
 function agentCliHint(agentName: string, token: string): string | undefined {
   if (token !== agentName) {
     return undefined;
@@ -226,6 +242,17 @@ export async function doctor(): Promise<boolean> {
     // oxlint-disable-next-line no-await-in-loop -- doctor reports tools in deterministic order
     const check = await checkCmd(token, required, required ? hint : "required for local runs");
     checks.push(check);
+  }
+
+  for (const binary of provisionerBinaries(config)) {
+    checks.push(
+      // oxlint-disable-next-line no-await-in-loop -- sequential PATH probes mirror the existing tool-check loop
+      await checkCmd(
+        binary,
+        true,
+        "required by a workspace.knownRepositories provision.create template",
+      ),
+    );
   }
 
   const usageGatedAgents = gatedAgents(config);

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -28,6 +28,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b"],
+      repositories: [{ name: "repo-a" }, { name: "repo-b" }],
       ...overrides.workspace,
     },
     orchestrator: {

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -61,7 +61,11 @@ function makeConfig(): ResolvedConfig {
     sources: [],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main" },
-    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
+    },
     orchestrator: {
       maximumInProgress: 4,
       pollIntervalMilliseconds: 1000,

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -98,6 +98,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b", "api", "api-admin"],
+      repositories: [
+        { name: "repo-a" },
+        { name: "repo-b" },
+        { name: "api" },
+        { name: "api-admin" },
+      ],
       ...overrides.workspace,
     },
     orchestrator: {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -77,6 +77,24 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     },
   };
 });
+const runCommandMock = vi.hoisted(() =>
+  vi.fn<(cmd: string, arguments_: readonly string[]) => string>(),
+);
+vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, runCommand: runCommandMock };
+});
+
+// buildAndStageSrtLaunch resolves the sandbox's gitCommonDir from the worktree
+// via `git rev-parse --git-common-dir`; the worktree dir here is a fixture path,
+// so stub the probe to a non-empty path and return "" for anything else.
+function stubRunCommand(): void {
+  runCommandMock.mockImplementation((cmd: string, arguments_: readonly string[]) =>
+    cmd === "git" && arguments_.includes("--git-common-dir")
+      ? "/tmp/groundcrew-resume-team-1-x/.git"
+      : "",
+  );
+}
 
 const mkdtempMock = vi.mocked(mkdtempSync);
 const rmSyncMock = vi.mocked(rmSync);
@@ -149,7 +167,11 @@ function makeConfig(): ResolvedConfig {
     sources: [{ kind: "linear" }],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main" },
-    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
+    },
     orchestrator: {
       maximumInProgress: 4,
       pollIntervalMilliseconds: 1000,
@@ -213,6 +235,7 @@ describe(resumeWorkspace, () => {
 
   beforeEach(() => {
     mkdtempMock.mockReturnValue("/tmp/groundcrew-resume-team-1-x");
+    stubRunCommand();
     mockLinearIssue();
     readRunStateMock.mockReturnValue(makeRunState());
     findByTaskMock.mockReturnValue([makeWorktree()]);
@@ -368,6 +391,21 @@ describe(resumeWorkspace, () => {
       /sandbox-runtime\/dist\/cli\.js' --settings .*agent-settings\.json/,
     );
     expect(launchScript).not.toContain("safehouse-clearance");
+  });
+
+  it("cds into the configured workdir subproject on resume", async () => {
+    const cfg = makeConfig();
+    cfg.workspace.repositories = [
+      {
+        name: "repo-a",
+        provision: { create: "graft new x", remove: "graft rm x" },
+        workdir: "services/api",
+      },
+    ];
+
+    await resumeWorkspace(cfg, { task: "team-1" });
+
+    expect(stagedLaunchScript()).toContain("cd '/work/repo-a-team-1/services/api'");
   });
 
   it("cleans up the staged srt settings dir when the resumed launch fails to open", async () => {

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -181,19 +181,22 @@ export async function resumeWorkspace(
   const secretsFile = stageBuildSecrets(stagedPrompt.directory);
   // Resume stages srt settings exactly like setup (a relocating agent such as
   // codex needs its config home re-seeded to authenticate on the resumed launch).
-  const { launchCommand, srtSettingsDir } = composeAgentLaunch({
-    runner,
-    task,
-    definition,
-    promptFile: stagedPrompt.file,
-    worktreeDir,
-    workingDir: launchDir,
-    secretsFile,
-    sandboxName,
-  });
-  const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
-
+  // Composition runs inside the try so a pre-launch failure still cleans up the
+  // staged prompt (and any srt settings) dir.
+  let srtSettingsDir: string | undefined;
   try {
+    let launchCommand: string;
+    ({ launchCommand, srtSettingsDir } = composeAgentLaunch({
+      runner,
+      task,
+      definition,
+      promptFile: stagedPrompt.file,
+      worktreeDir,
+      workingDir: launchDir,
+      secretsFile,
+      sandboxName,
+    }));
+    const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({
       config,
       name: task,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -2,10 +2,8 @@ import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { isLinearEnabled } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
-import { buildLaunchCommand } from "../lib/launchCommand.ts";
+import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
-import { buildAndStageSrtLaunch } from "../lib/srtLaunch.ts";
 import {
   removeStagedPrompt,
   stageBuildSecrets,
@@ -14,7 +12,7 @@ import {
 } from "../lib/stagedLaunch.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 export interface ResumeWorkspaceOptions {
   task: string;
@@ -173,43 +171,25 @@ export async function resumeWorkspace(
   });
   await ensureReady();
 
+  const worktreeDir = context.worktree.dir;
+  const launchDir = resolveLaunchDir(config, context.repository, worktreeDir);
   const stagedPrompt = stagePromptText({
     prefix: "groundcrew-resume",
     task,
     text: renderResumePrompt(context),
   });
   const secretsFile = stageBuildSecrets(stagedPrompt.directory);
-  // Resume must stage srt settings exactly like setup, or `buildLaunchCommand`
-  // throws under the srt runner — and a relocating agent (codex) needs its
-  // config home re-seeded so it authenticates on the resumed launch.
-  let srtPrepareSettingsFile: string | undefined;
-  let srtAgentSettingsFile: string | undefined;
-  let srtSettingsDir: string | undefined;
-  let srtAgentConfigDirEnv: { name: string; value: string } | undefined;
-  if (runner === "srt") {
-    const staged = buildAndStageSrtLaunch({
-      config,
-      repository: context.repository,
-      task,
-      worktreeDir: context.worktree.dir,
-      definition,
-    });
-    srtPrepareSettingsFile = staged.prepareFile;
-    srtAgentSettingsFile = staged.agentFile;
-    srtSettingsDir = staged.directory;
-    srtAgentConfigDirEnv = staged.agentConfigDirEnv;
-  }
-  const launchCommand = buildLaunchCommand({
+  // Resume stages srt settings exactly like setup (a relocating agent such as
+  // codex needs its config home re-seeded to authenticate on the resumed launch).
+  const { launchCommand, srtSettingsDir } = composeAgentLaunch({
+    runner,
+    task,
     definition,
     promptFile: stagedPrompt.file,
-    worktreeDir: context.worktree.dir,
+    worktreeDir,
+    workingDir: launchDir,
     secretsFile,
-    runner,
     sandboxName,
-    srtPrepareSettingsFile,
-    srtAgentSettingsFile,
-    srtSettingsDir,
-    srtAgentConfigDirEnv,
   });
   const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
 
@@ -217,7 +197,7 @@ export async function resumeWorkspace(
     await openAgentWorkspace({
       config,
       name: task,
-      cwd: context.worktree.dir,
+      cwd: launchDir,
       command: launchCmd,
       agent: context.agent,
       color: definition.color,

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -186,6 +186,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
     },
     orchestrator: {
       maximumInProgress: 4,
@@ -220,10 +221,22 @@ function isCmuxNewWorkspace(cmd: string, arguments_: readonly string[]): boolean
   return cmd === "cmux" && arguments_.includes("new-workspace");
 }
 
+// buildAndStageSrtLaunch resolves the sandbox's gitCommonDir from the worktree
+// via `git rev-parse --git-common-dir`; stub it to a non-empty path so the srt
+// policy validates under the runCommand mock.
+const STUB_GIT_COMMON_DIR = "/tmp/groundcrew-team-1-x/.git";
+
+function isGitCommonDirProbe(cmd: string, arguments_: readonly string[]): boolean {
+  return cmd === "git" && arguments_.includes("--git-common-dir");
+}
+
 function mockCmuxNewWorkspaceOutput(output: string): void {
-  runCommandMock.mockImplementation((cmd, arguments_) =>
-    isCmuxNewWorkspace(cmd, arguments_) ? output : "",
-  );
+  runCommandMock.mockImplementation((cmd, arguments_) => {
+    if (isGitCommonDirProbe(cmd, arguments_)) {
+      return STUB_GIT_COMMON_DIR;
+    }
+    return isCmuxNewWorkspace(cmd, arguments_) ? output : "";
+  });
 }
 
 function mockCmuxFailure(): void {
@@ -455,6 +468,30 @@ describe(setupWorkspace, () => {
     expect(command).not.toContain("prompt.txt");
     expect(launchScript).toContain("safehouse-clearance");
     expect(launchScript).toContain("_p=$(cat '/tmp/groundcrew-team-1-x/prompt.txt')");
+  });
+
+  it("cds into the configured workdir subproject", async () => {
+    const config = makeConfig();
+    config.workspace.repositories = [
+      {
+        name: "repo-a",
+        provision: { create: "graft new x", remove: "graft rm x" },
+        workdir: "services/api",
+      },
+    ];
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      task: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(launchScript).toContain("cd '/work/repo-a-team-1/services/api'");
+    // Run state records the worktree root, not the workdir subproject.
+    expect(lastRecordedRunState().worktreeDir).toBe("/work/repo-a-team-1");
   });
 
   it("stages neutral prepare + full agent srt settings and wraps the agent under the agent policy when runner=srt", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -1,12 +1,10 @@
 import { rmSync } from "node:fs";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
+import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import { buildLaunchCommand } from "../lib/launchCommand.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
-import { buildAndStageSrtLaunch } from "../lib/srtLaunch.ts";
 import {
   stageBuildSecrets,
   stagePromptFromTemplate,
@@ -16,7 +14,12 @@ import {
 import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
-import { isWorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import {
+  isWorktreeAlreadyExistsError,
+  resolveLaunchDir,
+  type WorktreeEntry,
+  worktrees,
+} from "../lib/worktrees.ts";
 
 export interface TaskDetails {
   title: string;
@@ -89,7 +92,8 @@ export async function setupWorkspace(
     }
     throw error;
   }
-  const { branchName, dir: launchDir } = created;
+  const { branchName, dir: worktreeDir } = created;
+  const launchDir = resolveLaunchDir(config, repository, worktreeDir);
   const worktreeName = `${repository}-${task}`;
 
   // Anything that fails after the worktree is on disk must roll it back
@@ -117,40 +121,23 @@ export async function setupWorkspace(
     promptDir = stagedPrompt.directory;
 
     const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
-      worktreeDir: launchDir,
+      worktreeDir,
       defaultHooks: config.defaults.hooks,
     });
     const secretsFile =
       prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
-    let srtPrepareSettingsFile: string | undefined;
-    let srtAgentSettingsFile: string | undefined;
-    let srtAgentConfigDirEnv: { name: string; value: string } | undefined;
-    if (runner === "srt") {
-      const staged = buildAndStageSrtLaunch({
-        config,
-        repository,
-        task,
-        worktreeDir: launchDir,
-        definition,
-      });
-      srtPrepareSettingsFile = staged.prepareFile;
-      srtAgentSettingsFile = staged.agentFile;
-      srtSettingsDir = staged.directory;
-      srtAgentConfigDirEnv = staged.agentConfigDirEnv;
-    }
-    const launchCommand = buildLaunchCommand({
+    const { launchCommand, srtSettingsDir: stagedSrtSettingsDir } = composeAgentLaunch({
+      runner,
+      task,
       definition,
       promptFile: stagedPrompt.file,
-      worktreeDir: launchDir,
+      worktreeDir,
+      workingDir: launchDir,
       secretsFile,
       prepareWorktreeCommand,
-      runner,
       sandboxName,
-      srtPrepareSettingsFile,
-      srtAgentSettingsFile,
-      srtSettingsDir,
-      srtAgentConfigDirEnv,
     });
+    srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);
 
     debug("Opening workspace...");
@@ -168,7 +155,7 @@ export async function setupWorkspace(
       task,
       repository,
       agent,
-      worktreeDir: launchDir,
+      worktreeDir,
       branchName,
       workspaceName: task,
       state: "running",
@@ -189,7 +176,7 @@ export async function setupWorkspace(
       task,
       repository,
       agent,
-      worktreeDir: launchDir,
+      worktreeDir,
       branchName,
       workspaceName: task,
       state: "failed-to-launch",

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -121,7 +121,7 @@ export async function setupWorkspace(
     promptDir = stagedPrompt.directory;
 
     const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
-      worktreeDir,
+      worktreeDir: launchDir,
       defaultHooks: config.defaults.hooks,
     });
     const secretsFile =

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -33,7 +33,11 @@ function makeConfig(): ResolvedConfig {
     sources: [],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main" },
-    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
+    },
     orchestrator: {
       maximumInProgress: 4,
       pollIntervalMilliseconds: 1000,

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -139,6 +139,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b"],
+      repositories: [{ name: "repo-a" }, { name: "repo-b" }],
       ...overrides.workspace,
     },
     orchestrator: {

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -31,7 +31,11 @@ function makeConfig(): ResolvedConfig {
     sources: [],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main" },
-    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
+    },
     orchestrator: {
       maximumInProgress: 4,
       pollIntervalMilliseconds: 1000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   Config,
   HookCommands,
   AgentDefinition,
+  KnownRepository,
   ResolvedConfig,
   SourceConfig,
 } from "./lib/config.ts";

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -28,6 +28,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
       ...overrides.workspace,
     },
     orchestrator: {
@@ -101,6 +102,7 @@ function createConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["ClipboardHealth/api", "ClipboardHealth/web"],
+      repositories: [{ name: "ClipboardHealth/api" }, { name: "ClipboardHealth/web" }],
       ...overrides.workspace,
     },
     agents: {

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -50,6 +50,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b", "api", "api-admin"],
+      repositories: [
+        { name: "repo-a" },
+        { name: "repo-b" },
+        { name: "api" },
+        { name: "api-admin" },
+      ],
       ...overrides.workspace,
     },
     orchestrator: {
@@ -678,7 +684,11 @@ describe(resolveRepositoryFor, () => {
 
   it("canonicalizes a bare repo mention to the full owner/repo entry from config", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/api"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/api"],
+        repositories: [{ name: "acme/api" }],
+      },
     });
     expect(resolveRepositoryFor({ description: "api is sad", config })).toStrictEqual({
       kind: "ok",
@@ -688,7 +698,11 @@ describe(resolveRepositoryFor, () => {
 
   it("returns missing when a bare repo mention matches multiple configured repos", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/api", "beta/api"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/api", "beta/api"],
+        repositories: [{ name: "acme/api" }, { name: "beta/api" }],
+      },
     });
     expect(resolveRepositoryFor({ description: "api is sad", config })).toStrictEqual({
       kind: "missing",

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -15,6 +15,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a", "repo-b", "api", "api-admin"],
+      repositories: [
+        { name: "repo-a" },
+        { name: "repo-b" },
+        { name: "api" },
+        { name: "api-admin" },
+      ],
       ...overrides.workspace,
     },
     orchestrator: {
@@ -43,7 +49,11 @@ describe(parseRepository, () => {
 
   it("returns the matched known repository when it is in knownRepositories", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["org/repo-a", "repo-b"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a", "repo-b"],
+        repositories: [{ name: "org/repo-a" }, { name: "repo-b" }],
+      },
     });
     const result = parseRepository({
       description: "fix the org/repo-a bug",
@@ -56,7 +66,11 @@ describe(parseRepository, () => {
 
   it("returns the asserted name as-is when the match is not in knownRepositories", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["other-repo"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["other-repo"],
+        repositories: [{ name: "other-repo" }],
+      },
     });
     const result = parseRepository({
       description: "touches repo-a somewhere",
@@ -72,6 +86,7 @@ describe(parseRepository, () => {
       workspace: {
         projectDir: "/work",
         knownRepositories: ["org1/repo-a", "org2/repo-a"],
+        repositories: [{ name: "org1/repo-a" }, { name: "org2/repo-a" }],
       },
     });
     expect(() =>
@@ -86,7 +101,11 @@ describe(parseRepository, () => {
 
   it("throws RepositoryResolutionError when the description is empty", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["repo-a"],
+        repositories: [{ name: "repo-a" }],
+      },
     });
     expect(() =>
       parseRepository({
@@ -100,7 +119,11 @@ describe(parseRepository, () => {
 
   it("throws RepositoryResolutionError when no repo name appears in the description", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["repo-a"],
+        repositories: [{ name: "repo-a" }],
+      },
     });
     expect(() =>
       parseRepository({
@@ -116,7 +139,11 @@ describe(parseRepository, () => {
 describe(resolveRepositoryFor, () => {
   it("returns the repository when the description mentions a known one", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/widgets"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/widgets"],
+        repositories: [{ name: "acme/widgets" }],
+      },
     });
     const result = resolveRepositoryFor({
       description: "fix the acme/widgets bug",
@@ -127,21 +154,33 @@ describe(resolveRepositoryFor, () => {
 
   it("returns missing when no known repo is in the description", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/widgets"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/widgets"],
+        repositories: [{ name: "acme/widgets" }],
+      },
     });
     expect(resolveRepositoryFor({ description: "nothing here", config }).kind).toBe("missing");
   });
 
   it("returns missing on empty description", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/widgets"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/widgets"],
+        repositories: [{ name: "acme/widgets" }],
+      },
     });
     expect(resolveRepositoryFor({ description: "", config }).kind).toBe("missing");
   });
 
   it("returns missing on undefined description", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/widgets"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/widgets"],
+        repositories: [{ name: "acme/widgets" }],
+      },
     });
     expect(resolveRepositoryFor({ description: undefined, config }).kind).toBe("missing");
   });
@@ -152,7 +191,7 @@ describe(resolveRepositoryFor, () => {
     // dispatch / single-task / doctor paths would all emit a bogus
     // { kind: "ok", repository: "" }.
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: [] },
+      workspace: { projectDir: "/work", knownRepositories: [], repositories: [] },
     });
     expect(resolveRepositoryFor({ description: "anything at all", config }).kind).toBe("missing");
   });
@@ -163,7 +202,11 @@ describe(resolveRepositoryFor, () => {
     // launches against the correct worktree path. Without this canonicalization
     // the single-task flow would launch against a bare `repo-a` directory.
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["org/repo-a"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a"],
+        repositories: [{ name: "org/repo-a" }],
+      },
     });
     const result = resolveRepositoryFor({
       description: "fix the repo-a bug",
@@ -180,6 +223,7 @@ describe(resolveRepositoryFor, () => {
       workspace: {
         projectDir: "/work",
         knownRepositories: ["org1/repo-a", "org2/repo-a"],
+        repositories: [{ name: "org1/repo-a" }, { name: "org2/repo-a" }],
       },
     });
     expect(resolveRepositoryFor({ description: "touches repo-a somewhere", config }).kind).toBe(
@@ -246,7 +290,11 @@ describe(buildRepositoryRegex, () => {
 
   it("produces a regex that matches a full org/repo path", () => {
     const config = makeConfig({
-      workspace: { projectDir: "/work", knownRepositories: ["acme/widgets"] },
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["acme/widgets"],
+        repositories: [{ name: "acme/widgets" }],
+      },
     });
     const regex = buildRepositoryRegex(config);
     const match = regex.exec("fix the acme/widgets bug");

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -7,10 +7,55 @@ import {
   type ResolvedConfig,
 } from "./config.ts";
 import { detectHostCapabilities } from "./host.ts";
+import { buildLaunchCommand } from "./launchCommand.ts";
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "./localRunner.ts";
 import { sandboxNameFor } from "./sandboxName.ts";
+import { buildAndStageSrtLaunch } from "./srtLaunch.ts";
 import { debug, sleep } from "./util.ts";
 import { workspaces } from "./workspaces.ts";
+
+/**
+ * Stage any srt settings and build the workspace launch command — the assembly
+ * shared verbatim by `setupWorkspace` (fresh runs) and `resumeWorkspace`
+ * (resumes). `worktreeDir` is the checkout root (srt grants + `{{worktree}}`);
+ * `workingDir` is the agent cwd (the worktree root, or its `workdir` subproject).
+ * Returns `srtSettingsDir` so callers can tear it down on a pre-launch failure.
+ */
+export function composeAgentLaunch(input: {
+  runner: LocalRunner;
+  task: string;
+  definition: AgentDefinition;
+  promptFile: string;
+  worktreeDir: string;
+  workingDir: string;
+  secretsFile?: string | undefined;
+  prepareWorktreeCommand?: string | undefined;
+  sandboxName?: string | undefined;
+}): { launchCommand: string; srtSettingsDir: string | undefined } {
+  const staged =
+    input.runner === "srt"
+      ? buildAndStageSrtLaunch({
+          task: input.task,
+          worktreeDir: input.worktreeDir,
+          definition: input.definition,
+        })
+      : undefined;
+  const launchCommand = buildLaunchCommand({
+    definition: input.definition,
+    promptFile: input.promptFile,
+    worktreeDir: input.worktreeDir,
+    workingDir: input.workingDir,
+    secretsFile: input.secretsFile,
+    prepareWorktreeCommand: input.prepareWorktreeCommand,
+    runner: input.runner,
+    sandboxName: input.sandboxName,
+    srtPrepareSettingsFile: staged?.prepareFile,
+    srtAgentSettingsFile: staged?.agentFile,
+    srtSettingsDir: staged?.directory,
+    srtAgentConfigDirEnv: staged?.agentConfigDirEnv,
+  });
+  return { launchCommand, srtSettingsDir: staged?.directory };
+}
 
 interface PreparedAgentLaunch {
   runner: LocalRunner;

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -11,6 +11,7 @@ import {
   repositoryBaseDir,
   worktreeBaseDir,
   type Config,
+  type KnownRepository,
   type LoadedConfig,
   type ResolvedConfig,
 } from "./config.ts";
@@ -1477,6 +1478,52 @@ describe("loadConfig", () => {
     );
   });
 
+  it("fails when provision sets create without remove", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      `export default { workspace: { projectDir: ${JSON.stringify(temporary)}, knownRepositories: [{ name: "billing", provision: { create: "graft new x" } }] } };\n`,
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(/must define both `create` and `remove`/);
+  });
+
+  it("normalizes a workdir on a repo entry", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: temporary,
+          knownRepositories: [{ name: "billing", provision: scripted, workdir: "sub" }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    const [recipe] = config.workspace.repositories;
+    expect(recipe).toStrictEqual({ name: "billing", provision: scripted, workdir: "sub" });
+  });
+
+  const scripted = { create: "a", remove: "b" };
+  const invalidEntries: [KnownRepository, RegExp][] = [
+    [{ name: "b", provision: scripted, workdir: "/etc" }, /workdir.*must be a relative path/],
+    [{ name: "b", provision: scripted, workdir: ".." }, /workdir.*must not contain '\.\.'/],
+    [{ name: "b", projectDirOverride: "~/d", provision: scripted }, /cannot be combined/],
+  ];
+  it.each(invalidEntries)(
+    "rejects an invalid knownRepositories entry %#",
+    async (entry, expected) => {
+      const configPath = writeConfigFile(
+        temporary,
+        validConfigSource({ workspace: { projectDir: temporary, knownRepositories: [entry] } }),
+      );
+      setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+      const { loadConfig } = await loadFreshConfig();
+      await expect(loadConfig()).rejects.toThrow(expected);
+    },
+  );
+
   it("fails when sessionLimitPercentage is out of range", async () => {
     const configPath = writeConfigFile(
       temporary,
@@ -1890,11 +1937,18 @@ describe("loadConfigWithSource", () => {
   });
 });
 
-function resolvedConfigWithWorkspace(workspace: ResolvedConfig["workspace"]): ResolvedConfig {
+function resolvedConfigWithWorkspace(
+  workspace: Omit<ResolvedConfig["workspace"], "repositories"> & {
+    repositories?: ResolvedConfig["workspace"]["repositories"];
+  },
+): ResolvedConfig {
   return {
     sources: [],
     git: { remote: "origin", defaultBranch: "main" },
-    workspace,
+    workspace: {
+      ...workspace,
+      repositories: workspace.repositories ?? workspace.knownRepositories.map((name) => ({ name })),
+    },
     defaults: { hooks: {} },
     orchestrator: {
       maximumInProgress: 4,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -160,13 +160,42 @@ type UserAgentDefinition = EnabledUserAgentDefinition;
  * `started` workflow states; unmatched statuses fall back to `state.type`.
  */
 /**
+ * Scripted provisioning templates for a repository. Both run via `sh -c` in
+ * place of the native git porcelain: `create` replaces `git worktree add`,
+ * `remove` replaces `git worktree remove`. Grouping them in one object makes the
+ * native/scripted split structural — an entry either has `provision` (scripted)
+ * or it doesn't (native) — and removes the need for a both-or-neither check.
+ */
+export interface ProvisionScripts {
+  /** Shell template run in place of `git worktree add`. */
+  create: string;
+  /** Shell template run in place of `git worktree remove`. */
+  remove: string;
+}
+
+/**
  * A configured repository. The bare-string form keeps the repo under
  * `workspace.projectDir`; the object form's optional `projectDirOverride`
- * overrides that parent directory so repos can live in more than one place.
+ * overrides that parent directory so repos can live in more than one place. When
+ * a `provision` block is present (a *scripted* entry), groundcrew runs its
+ * templates via `sh -c` in place of `git worktree add`/`remove`; the `name` is
+ * then a logical handle and the physical clone is the template's concern (e.g.
+ * graft's own registry).
  */
 export interface KnownRepository {
+  /** Logical repo name: the token tickets reference and the worktree dir basename. */
   name: string;
+  /** Overrides the parent directory the source repo lives under (defaults to `projectDir`). */
   projectDirOverride?: string;
+  /** Scripted provisioning templates; presence marks this a scripted entry. Mutually exclusive with `projectDirOverride`. */
+  provision?: ProvisionScripts;
+  /**
+   * Project subdirectory within the worktree. When set, the agent cwd, the
+   * `prepareWorktree` hook, and the `.groundcrew/config.json` lookup re-root to
+   * `<worktree>/<workdir>`. The worktree root itself (identity, sandbox access)
+   * is unchanged. Relative, no `..`.
+   */
+  workdir?: string;
 }
 
 export interface Config {
@@ -271,8 +300,10 @@ export interface ResolvedConfig {
     projectDir: string;
     /** Resolved worktree root; unset means "use projectDir". */
     worktreeDir?: string;
-    /** Repository names only — the union's `projectDirOverride`s are lifted out. */
+    /** Repository names only — derived; what name-matching consumers read. */
     knownRepositories: string[];
+    /** Normalized full entries carrying any `projectDirOverride`/`provision`. */
+    repositories: KnownRepository[];
     /** name -> resolved parent dir, only for entries that override projectDir. */
     repositoryDirs?: Record<string, string>;
   };
@@ -854,56 +885,69 @@ function normalizeSources(raw: unknown): SourceConfig[] {
  * `projectDirOverride` overrides that parent directory. This is the seam later
  * per-repo options hang off — add new `KnownRepository` fields here.
  */
-function normalizeKnownRepository(
-  entry: string | KnownRepository,
-  index: number,
-): { name: string; projectDirOverride?: string } {
+function normalizeKnownRepository(entry: string | KnownRepository, index: number): KnownRepository {
+  const label = `workspace.knownRepositories[${index}]`;
   if (typeof entry === "string") {
+    requireString(entry, label);
     return { name: entry };
   }
-  requireObject(entry, `workspace.knownRepositories[${index}]`);
-  requireString(entry.name, `workspace.knownRepositories[${index}].name`);
-  if (entry.projectDirOverride === undefined) {
-    return { name: entry.name };
+  requireObject(entry, label);
+  requireString(entry.name, `${label}.name`);
+  const recipe: KnownRepository = { name: entry.name };
+  if (entry.projectDirOverride !== undefined) {
+    requireString(entry.projectDirOverride, `${label}.projectDirOverride`);
+    recipe.projectDirOverride = expandHome(entry.projectDirOverride);
   }
-  requireString(
-    entry.projectDirOverride,
-    `workspace.knownRepositories[${index}].projectDirOverride`,
-  );
-  return { name: entry.name, projectDirOverride: expandHome(entry.projectDirOverride) };
+  if (entry.provision !== undefined) {
+    requireObject(entry.provision, `${label}.provision`);
+    const create = normalizeOptionalString(entry.provision.create, `${label}.provision.create`);
+    const remove = normalizeOptionalString(entry.provision.remove, `${label}.provision.remove`);
+    if (create === undefined || remove === undefined) {
+      fail(`${label}.provision must define both \`create\` and \`remove\` templates`);
+    }
+    recipe.provision = { create, remove };
+  }
+  const workdir = normalizeOptionalString(entry.workdir, `${label}.workdir`);
+  if (workdir !== undefined) {
+    recipe.workdir = workdir;
+  }
+  return recipe;
 }
 
 /**
  * Flatten the loose `(string | KnownRepository)[]` union into the strict
  * resolved shape: a `string[]` of names every downstream consumer reads, plus
  * a separate `repositoryDirs` map holding only the entries that override
- * `projectDir`. Types are validated here, at the resolution edge, before any
- * `expandHome` runs (which would otherwise throw a raw TypeError on a
- * non-string `worktreeDir`).
+ * `projectDir`. Types are validated at the resolution edge: every path is
+ * `requireString`-checked before its `expandHome` runs (here for `projectDir`/
+ * `worktreeDir`, and in `normalizeKnownRepository` for `projectDirOverride`),
+ * which would otherwise throw a raw TypeError on a non-string value.
  */
 function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["workspace"] {
   requireObject(workspace, "workspace");
   requireString(workspace.projectDir, "workspace.projectDir");
+  const entries = workspace.knownRepositories;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    fail("workspace.knownRepositories must be a non-empty array");
+  }
+  const repositories = entries.map((entry, index) => normalizeKnownRepository(entry, index));
   // Track the first index each name was seen at so a duplicate (which would
   // silently overwrite its `projectDirOverride` in `repositoryDirs`) fails
   // loudly instead of resolving order-dependently.
   const seen = new Map<string, number>();
   const repositoryDirs: Record<string, string> = {};
-  const entries = Array.isArray(workspace.knownRepositories) ? workspace.knownRepositories : [];
-  entries.forEach((entry, index) => {
-    const { name, projectDirOverride } = normalizeKnownRepository(entry, index);
-    const previous = seen.get(name);
+  repositories.forEach((recipe, index) => {
+    const previous = seen.get(recipe.name);
     if (previous !== undefined) {
       fail(
-        `workspace.knownRepositories[${index}] duplicates ${JSON.stringify(name)} from workspace.knownRepositories[${previous}]. Configure distinct repository names.`,
+        `workspace.knownRepositories[${index}] duplicates ${JSON.stringify(recipe.name)} from workspace.knownRepositories[${previous}]. Configure distinct repository names.`,
       );
     }
-    seen.set(name, index);
-    if (projectDirOverride !== undefined) {
-      repositoryDirs[name] = projectDirOverride;
+    seen.set(recipe.name, index);
+    if (recipe.projectDirOverride !== undefined) {
+      repositoryDirs[recipe.name] = recipe.projectDirOverride;
     }
   });
-  const names = [...seen.keys()];
   let worktreeDir: string | undefined;
   if (workspace.worktreeDir !== undefined) {
     requireString(workspace.worktreeDir, "workspace.worktreeDir");
@@ -912,7 +956,8 @@ function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["wor
   return {
     projectDir: expandHome(workspace.projectDir),
     ...(worktreeDir === undefined ? {} : { worktreeDir }),
-    knownRepositories: names,
+    knownRepositories: repositories.map((recipe) => recipe.name),
+    repositories,
     ...(Object.keys(repositoryDirs).length === 0 ? {} : { repositoryDirs }),
   };
 }
@@ -994,14 +1039,21 @@ function validate(config: ResolvedConfig): void {
 
   requireString(config.workspace.projectDir, "workspace.projectDir");
 
-  if (
-    !Array.isArray(config.workspace.knownRepositories) ||
-    config.workspace.knownRepositories.length === 0
-  ) {
-    fail("workspace.knownRepositories must be a non-empty array");
-  }
-  config.workspace.knownRepositories.forEach((repository, index) => {
-    requireString(repository, `workspace.knownRepositories[${index}]`);
+  config.workspace.repositories.forEach((recipe, index) => {
+    const label = `workspace.knownRepositories[${index}]`;
+    if (recipe.projectDirOverride !== undefined && recipe.provision !== undefined) {
+      fail(
+        `${label}.projectDirOverride cannot be combined with \`provision\`: a scripted entry has no groundcrew-managed clone, so \`projectDirOverride\` would be ignored`,
+      );
+    }
+    if (recipe.workdir !== undefined) {
+      if (path.isAbsolute(recipe.workdir)) {
+        fail(`${label}.workdir must be a relative path`);
+      }
+      if (recipe.workdir.split("/").includes("..")) {
+        fail(`${label}.workdir must not contain '..' segments`);
+      }
+    }
   });
 
   requirePositiveInt(config.orchestrator.maximumInProgress, "orchestrator.maximumInProgress");

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -14,10 +14,12 @@ import {
 function arguments_(
   overrides: Partial<Parameters<typeof buildLaunchCommand>[0]> = {},
 ): Parameters<typeof buildLaunchCommand>[0] {
+  const worktreeDir = overrides.worktreeDir ?? "/work/repo-a-team-1";
   return {
     definition: { cmd: "claude", color: "#fff" } satisfies AgentDefinition,
     promptFile: "/tmp/prompt-team-1/prompt.txt",
-    worktreeDir: "/work/repo-a-team-1",
+    worktreeDir,
+    workingDir: worktreeDir,
     runner: "safehouse",
     ...overrides,
   };
@@ -510,6 +512,23 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("safehouse-clearance");
       expect(out).not.toContain("--enable=all-agents");
       expect(out).toMatch(/exec claude "\$_p"$/);
+    });
+
+    it("cds into workingDir while {{worktree}} still expands to the worktree root", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          definition: { cmd: "agent --root {{worktree}}", color: "#fff" },
+          worktreeDir: "/work/repo-a-team-1",
+          workingDir: "/work/repo-a-team-1/services/api",
+          runner: "none",
+        }),
+      );
+
+      // cwd is the subproject…
+      expect(out).toContain("cd '/work/repo-a-team-1/services/api'");
+      // …but {{worktree}} substitution stays the checkout root.
+      expect(out).toContain("--root '/work/repo-a-team-1'");
+      expect(out).not.toContain("cd '/work/repo-a-team-1' &&");
     });
 
     it("sources and clears build secrets on the host (no sandbox to forward into)", () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -139,12 +139,13 @@ function trapCleanupLine(promptDir: string): string {
 /**
  * Shared head of every host-shell `&&` chain: arm the `EXIT` trap that wipes
  * `promptDir` (must come before any link that can fail, including the `cd`),
- * then `cd` into the worktree. Kept separate from secret sourcing so the
- * safehouse path can splice `preLaunch` between the `cd` and the secrets
- * source — preLaunch must never see build-time secrets in env.
+ * then `cd` into the working directory (the worktree root, or its `workdir`
+ * subproject). Kept separate from secret sourcing so the safehouse path can
+ * splice `preLaunch` between the `cd` and the secrets source — preLaunch must
+ * never see build-time secrets in env.
  */
-function hostTrapAndCd(arguments_: { worktreeDir: string; promptDir: string }): string[] {
-  return [trapCleanupLine(arguments_.promptDir), `cd ${shellSingleQuote(arguments_.worktreeDir)}`];
+function hostTrapAndCd(arguments_: { workingDir: string; promptDir: string }): string[] {
+  return [trapCleanupLine(arguments_.promptDir), `cd ${shellSingleQuote(arguments_.workingDir)}`];
 }
 
 /**
@@ -318,6 +319,13 @@ interface LaunchCommandArguments {
   promptFile: string;
   worktreeDir: string;
   /**
+   * Directory the agent and prepareWorktree hook cwd into (the `cd`/`-w`
+   * target). Equals `worktreeDir` unless the repo recipe sets a `workdir`, in
+   * which case it is the subproject dir. The `{{worktree}}` template and the srt
+   * filesystem grants keep using `worktreeDir` (the whole checkout).
+   */
+  workingDir: string;
+  /**
    * Optional path to a `KEY='value'` env file containing build-time
    * secrets (see `BUILD_SECRET_NAMES`). Sourced on the host shell before
    * prepareWorktree; for the sdx runner the names are propagated into the sandbox
@@ -439,7 +447,7 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
   });
 
   const lines = [
-    ...hostTrapAndCd({ worktreeDir: arguments_.worktreeDir, promptDir }),
+    ...hostTrapAndCd({ workingDir: arguments_.workingDir, promptDir }),
     ...hostSourceSecrets(arguments_.secretsFile),
   ];
   if (arguments_.prepareWorktreeCommand !== undefined) {
@@ -515,7 +523,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   const shimAndPromptCleanup = `rm -rf "$_safehouse_shim_dir"; rm -rf ${shellSingleQuote(promptDir)}`;
   const shimAndPromptTrap = `trap ${shellSingleQuote(shimAndPromptCleanup)} EXIT`;
 
-  const lines = hostTrapAndCd({ worktreeDir: arguments_.worktreeDir, promptDir });
+  const lines = hostTrapAndCd({ workingDir: arguments_.workingDir, promptDir });
   // Scrub inherited env before preLaunch (build secrets are copied out of
   // `process.env`, which the launch shell inherits), then source secrets and
   // read the staged prompt. See `hostPreLaunchSourceAndReadPrompt`.
@@ -652,7 +660,7 @@ function buildSrtLaunchCommand(arguments_: LaunchCommandArguments): string {
   const cleanup = `rm -rf ${shellSingleQuote(arguments_.srtSettingsDir)}; rm -rf ${shellSingleQuote(promptDir)}`;
   const lines = [
     `trap ${shellSingleQuote(cleanup)} EXIT`,
-    `cd ${shellSingleQuote(arguments_.worktreeDir)}`,
+    `cd ${shellSingleQuote(arguments_.workingDir)}`,
     ...hostPreLaunchSourceAndReadPrompt({
       definition: arguments_.definition,
       worktreeDir: arguments_.worktreeDir,
@@ -703,7 +711,7 @@ function buildSdxLaunchCommand(arguments_: LaunchCommandArguments): string {
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,
     `rm -rf ${shellSingleQuote(promptDir)}`,
-    `exec sbx exec -it ${sbxEnvironmentFlags}-w ${shellSingleQuote(arguments_.worktreeDir)} ${shellSingleQuote(arguments_.sandboxName)} sh -c ${shellSingleQuote(innerCommand)} sh "$_p"`,
+    `exec sbx exec -it ${sbxEnvironmentFlags}-w ${shellSingleQuote(arguments_.workingDir)} ${shellSingleQuote(arguments_.sandboxName)} sh -c ${shellSingleQuote(innerCommand)} sh "$_p"`,
   );
   return lines.join(" && ");
 }

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -21,6 +21,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
     },
     orchestrator: {
       maximumInProgress: 4,

--- a/src/lib/srtLaunch.test.ts
+++ b/src/lib/srtLaunch.test.ts
@@ -4,18 +4,9 @@ import path from "node:path";
 
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 
-import type { AgentDefinition, ResolvedConfig } from "./config.ts";
+import { runCommand } from "./commandRunner.ts";
+import type { AgentDefinition } from "./config.ts";
 import { buildAndStageSrtLaunch } from "./srtLaunch.ts";
-
-function config(projectDir: string, repositoryDirs?: Record<string, string>): ResolvedConfig {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the helper only reads workspace.{projectDir,repositoryDirs} off config
-  return {
-    workspace: {
-      projectDir,
-      ...(repositoryDirs === undefined ? {} : { repositoryDirs }),
-    },
-  } as unknown as ResolvedConfig;
-}
 
 function definition(cmd: string): AgentDefinition {
   return { cmd, color: "#fff" };
@@ -43,12 +34,19 @@ describe(buildAndStageSrtLaunch, () => {
     staged.length = 0;
   });
 
+  // A real git worktree dir — buildAndStageSrtLaunch reads its git common dir
+  // off the checkout itself, so the staged dir must be an actual repo.
+  function initWorktree(name: string): string {
+    const dir = path.join(workspaceRoot, name);
+    mkdirSync(dir, { recursive: true });
+    runCommand("git", ["-C", dir, "init", "-q"]);
+    return dir;
+  }
+
   function stage(cmd: string): ReturnType<typeof buildAndStageSrtLaunch> {
     const result = buildAndStageSrtLaunch({
-      config: config(workspaceRoot),
-      repository: "repo-a",
       task: "team-1",
-      worktreeDir: path.join(workspaceRoot, "repo-a-team-1"),
+      worktreeDir: initWorktree("repo-a-team-1"),
       definition: definition(cmd),
       homeDir: fakeHome,
     });
@@ -93,10 +91,8 @@ describe(buildAndStageSrtLaunch, () => {
 
   it("defaults to the real home dir when none is injected (read-only agent, no seeding side effects)", () => {
     const result = buildAndStageSrtLaunch({
-      config: config(workspaceRoot),
-      repository: "repo-a",
       task: "team-1",
-      worktreeDir: path.join(workspaceRoot, "repo-a-team-1"),
+      worktreeDir: initWorktree("repo-a-team-1"),
       definition: definition("claude --permission-mode auto"),
     });
     staged.push(result.directory);
@@ -107,22 +103,34 @@ describe(buildAndStageSrtLaunch, () => {
     expect(readSettings(result.agentFile).allowPty).toBe(true);
   });
 
-  it("resolves gitCommonDir under the repo's per-repo dir override", () => {
-    const other = mkdtempSync(path.join(os.tmpdir(), "srt-launch-other-"));
-    staged.push(other);
+  it("derives the sandbox gitCommonDir from the worktree, not a <projectDir>/<repo> clone", () => {
+    // A scripted/sparse-checkout worktree: an external provisioner owns the
+    // checkout, it lives at <worktreeDir>/<alias>-<task>, and there is no
+    // <projectDir>/<alias> clone — `name` is just an alias. The sandbox must
+    // fence off the worktree's real git common dir, not a phantom path built
+    // from the alias.
+    const worktreeDir = initWorktree("billing-team-1");
+    const realCommonDir = runCommand("git", [
+      "-C",
+      worktreeDir,
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir",
+    ]);
+
     const result = buildAndStageSrtLaunch({
-      config: config(workspaceRoot, { "owner/repo": other }),
-      repository: "owner/repo",
-      task: "team-9",
-      worktreeDir: path.join(workspaceRoot, "owner", "repo-team-9"),
+      task: "team-1",
+      worktreeDir,
       definition: definition("claude --permission-mode auto"),
       homeDir: fakeHome,
     });
     staged.push(result.directory);
 
-    // gitCommonDir is <repoDir>/.git == <other>/owner/repo/.git, not under projectDir.
-    const expectedGitDir = path.join(other, "owner", "repo", ".git");
-    expect(JSON.stringify(readSettings(result.agentFile))).toContain(expectedGitDir);
+    const reads = readSettings(result.agentFile).filesystem.allowRead;
+    expect(reads).toContain(realCommonDir);
+    // The old behavior granted <projectDir>/billing/.git — a path that doesn't
+    // exist for a scripted worktree. It must never appear.
+    expect(reads).not.toContain(path.join(workspaceRoot, "billing", ".git"));
   });
 
   it("skips missing seed files (best-effort) so a not-logged-in agent still stages", () => {

--- a/src/lib/srtLaunch.ts
+++ b/src/lib/srtLaunch.ts
@@ -3,7 +3,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { collectAllowedDomains } from "./clearanceHosts.ts";
-import { type AgentDefinition, type ResolvedConfig, repositoryBaseDir } from "./config.ts";
+import { runCommand } from "./commandRunner.ts";
+import type { AgentDefinition } from "./config.ts";
 import { inferAgentCommandName } from "./launchCommand.ts";
 import { agentConfigRelocation, buildSrtSettings } from "./srtPolicy.ts";
 import { readEnvironmentVariable } from "./util.ts";
@@ -21,6 +22,27 @@ export interface StagedSrtLaunch {
    * Undefined for read-only agents (claude), which run with a read-only home.
    */
   agentConfigDirEnv?: { name: string; value: string };
+}
+
+/**
+ * Resolve the worktree's real git common dir — the shared `.git` the srt policy
+ * fences off (read-grant + narrow write-allow + write-denies). Derived from the
+ * worktree itself rather than assuming a `<projectDir>/<repo>/.git` clone, so
+ * scripted/sparse-checkout worktrees — whose checkout is owned by an external
+ * provisioner and whose `repo` is just an alias with no clone on disk — get the
+ * correct dir instead of a phantom path that breaks git access and leaves the
+ * real common dir unfenced. For native worktrees this returns the same
+ * `<projectDir>/<repo>/.git` as before. `--path-format=absolute` keeps the path
+ * absolute regardless of git version or cwd.
+ */
+function resolveGitCommonDir(worktreeDir: string): string {
+  return runCommand("git", [
+    "-C",
+    worktreeDir,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-common-dir",
+  ]);
 }
 
 /**
@@ -43,8 +65,6 @@ export interface StagedSrtLaunch {
  * command tears the whole dir down after srt exits.
  */
 export function buildAndStageSrtLaunch(input: {
-  config: ResolvedConfig;
-  repository: string;
   task: string;
   worktreeDir: string;
   definition: AgentDefinition;
@@ -53,10 +73,9 @@ export function buildAndStageSrtLaunch(input: {
 }): StagedSrtLaunch {
   const agent = inferAgentCommandName(input.definition.cmd);
   const homeDir = input.homeDir ?? os.homedir();
-  const repoDir = path.resolve(repositoryBaseDir(input.config, input.repository), input.repository);
   const base = {
     worktreeDir: input.worktreeDir,
-    gitCommonDir: path.join(repoDir, ".git"),
+    gitCommonDir: resolveGitCommonDir(input.worktreeDir),
     allowedDomains: collectAllowedDomains({
       hosts: readEnvironmentVariable("CLEARANCE_ALLOW_HOSTS"),
       files: readEnvironmentVariable("CLEARANCE_ALLOW_HOSTS_FILES"),

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -51,6 +51,7 @@ function makeConfig(
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
     },
     orchestrator: {
       maximumInProgress: 4,

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -81,6 +81,7 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
     workspace: {
       projectDir: "/work",
       knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
     },
     orchestrator: {
       maximumInProgress: 4,

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -101,6 +101,20 @@ function makeUserInfo(username: string): ReturnType<typeof userInfo> {
   return { username, uid: 0, gid: 0, shell: null, homedir: "/tmp" };
 }
 
+function makeBillingWorkdirConfig(projectDir: string): ResolvedConfig {
+  return makeConfig({
+    projectDir,
+    knownRepositories: ["billing"],
+    repositories: [
+      {
+        name: "billing",
+        provision: { create: "create ${dir}", remove: "remove ${dir}" },
+        workdir: "services/api",
+      },
+    ],
+  });
+}
+
 function hasArguments(arguments_: readonly string[], ...needles: readonly string[]): boolean {
   return needles.every((needle) => arguments_.includes(needle));
 }
@@ -697,18 +711,16 @@ describe(create, () => {
     );
   });
 
-  it("fails fast when the configured workdir is missing after create", async () => {
+  it("removes the worktree when the configured workdir is missing after create", async () => {
     runCommandMock.mockReturnValue("");
-    const config = makeConfig({
-      projectDir,
-      knownRepositories: ["billing"],
-      repositories: [
-        { name: "billing", provision: { create: "true", remove: "true" }, workdir: "services/api" },
-      ],
-    });
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    const config = makeBillingWorkdirConfig(projectDir);
 
     await expect(create(config, { repository: "billing", task: "team-220" })).rejects.toThrow(
       /workdir "services\/api" not found/,
+    );
+    expect(runCommandMock.mock.calls.map((call) => call[1][1])).toContain(
+      `remove '${worktreeDir}'`,
     );
   });
 
@@ -732,23 +744,22 @@ describe(create, () => {
     expect(entry.dir).toBe(path.join(projectDir, "billing-team-220"));
   });
 
-  it("fails fast when the configured workdir is a file after create", async () => {
-    const config = makeConfig({
-      projectDir,
-      knownRepositories: ["billing"],
-      repositories: [
-        { name: "billing", provision: { create: "true", remove: "true" }, workdir: "services/api" },
-      ],
-    });
-    // The create template leaves a file (not a directory) at the workdir path.
-    runCommandMock.mockImplementation(() => {
-      mkdirSync(path.join(projectDir, "billing-team-220", "services"), { recursive: true });
-      writeFileSync(path.join(projectDir, "billing-team-220", "services", "api"), "");
-      return "";
-    });
+  it("removes the worktree when the configured workdir is a file after create", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    const config = makeBillingWorkdirConfig(projectDir);
+    runCommandMock
+      .mockImplementationOnce(() => {
+        mkdirSync(path.join(worktreeDir, "services"), { recursive: true });
+        writeFileSync(path.join(worktreeDir, "services", "api"), "");
+        return "";
+      })
+      .mockReturnValue("");
 
     await expect(create(config, { repository: "billing", task: "team-220" })).rejects.toThrow(
       /workdir "services\/api" not found/,
+    );
+    expect(runCommandMock.mock.calls.map((call) => call[1][1])).toContain(
+      `remove '${worktreeDir}'`,
     );
   });
 });

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -886,7 +886,7 @@ describe(remove, () => {
     expect(runCommandMock).not.toHaveBeenCalledWith("sh", expect.anything(), expect.anything());
   });
 
-  it("remove skips the template when the scripted worktree directory is absent", async () => {
+  it("remove runs the template for provisioner cleanup when the worktree directory is absent", async () => {
     userInfoMock.mockReturnValue(makeUserInfo("paul"));
     runCommandMock.mockReturnValue("");
 
@@ -909,8 +909,15 @@ describe(remove, () => {
       kind: "host",
     });
 
-    // No template (and no git) runs for a worktree that is already gone.
-    expect(runCommandMock).not.toHaveBeenCalled();
+    // The remove template still runs (graft owns branch/metadata cleanup beyond
+    // the checkout dir), but the dirtiness probe (git) is skipped — there is no
+    // dir to inspect.
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "graft rm 'paul-team-220' -f"],
+      expect.objectContaining({ cwd: projectDir, timeoutMs: 0 }),
+    );
+    expect(runCommandMock).not.toHaveBeenCalledWith("git", expect.anything(), expect.anything());
   });
 
   it("remove with --force runs the template without a dirtiness probe", async () => {

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -917,7 +917,7 @@ describe(remove, () => {
       ["-c", "graft rm 'paul-team-220' -f"],
       expect.objectContaining({ cwd: projectDir, timeoutMs: 0 }),
     );
-    expect(runCommandMock).not.toHaveBeenCalledWith("git", expect.anything(), expect.anything());
+    expect(runCommandMock.mock.calls.map((call) => call[0])).not.toContain("git");
   });
 
   it("remove with --force runs the template without a dirtiness probe", async () => {

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string -- ${branch}-style placeholders appear as literal strings in RepoRecipe create/remove command templates; they're NOT JS template literals */
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeOs from "node:os";
 import { tmpdir, userInfo } from "node:os";
@@ -9,7 +10,7 @@ import { runCommandAsync, type RunCommandOptions } from "./commandRunner.ts";
 import type { ResolvedConfig } from "./config.ts";
 import { setVerbose } from "./util.ts";
 import { workspaces } from "./workspaces.ts";
-import { type WorktreeEntry, worktrees } from "./worktrees.ts";
+import { resolveLaunchDir, type WorktreeEntry, worktrees } from "./worktrees.ts";
 
 const { create, findByTask, list, remove, teardown } = worktrees;
 
@@ -64,6 +65,7 @@ function makeConfig(overrides: {
   knownRepositories?: string[];
   repositoryDirs?: Record<string, string>;
   agents?: ResolvedConfig["agents"]["definitions"];
+  repositories?: ResolvedConfig["workspace"]["repositories"];
 }): ResolvedConfig {
   const knownRepositories = overrides.knownRepositories ?? ["repo-a"];
   const agents = overrides.agents ?? {
@@ -77,6 +79,7 @@ function makeConfig(overrides: {
       projectDir: overrides.projectDir,
       ...(overrides.worktreeDir === undefined ? {} : { worktreeDir: overrides.worktreeDir }),
       knownRepositories,
+      repositories: overrides.repositories ?? knownRepositories.map((name) => ({ name })),
       ...(overrides.repositoryDirs === undefined
         ? {}
         : { repositoryDirs: overrides.repositoryDirs }),
@@ -627,10 +630,275 @@ describe(create, () => {
       }),
     ).rejects.toThrow(/Could not determine OS username/);
   });
+
+  it("create runs the create template via sh and skips git fetch/worktree add", async () => {
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockReturnValue("");
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: {
+            create: "graft new ${branch} billing --from ${baseRef} --dir ${dir}",
+            remove: "graft rm ${branch} -f",
+          },
+        },
+      ],
+    });
+    const controller = new AbortController();
+
+    const entry = await create(
+      config,
+      { repository: "billing", task: "team-220" },
+      controller.signal,
+    );
+
+    expect(entry.dir).toBe(path.join(projectDir, "billing-team-220"));
+    expect(entry.branchName).toBe("paul-team-220");
+
+    // No git fetch / worktree add — only the sh -c template, with the abort
+    // signal forwarded.
+    const commands = runCommandMock.mock.calls.map((call) => call[0]);
+    expect(commands).not.toContain("git");
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sh",
+      [
+        "-c",
+        `graft new 'paul-team-220' billing --from 'origin/main' --dir '${path.join(projectDir, "billing-team-220")}'`,
+      ],
+      expect.objectContaining({ cwd: projectDir, timeoutMs: 0, signal: controller.signal }),
+    );
+  });
+
+  it("streams create template output (stdio inherit) under verbose", async () => {
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockReturnValue("");
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+    setVerbose(true);
+
+    await create(config, { repository: "billing", task: "team-220" });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "graft new 'paul-team-220'"],
+      expect.objectContaining({ cwd: projectDir, stdio: "inherit", timeoutMs: 0 }),
+    );
+  });
+
+  it("fails fast when the configured workdir is missing after create", async () => {
+    runCommandMock.mockReturnValue("");
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        { name: "billing", provision: { create: "true", remove: "true" }, workdir: "services/api" },
+      ],
+    });
+
+    await expect(create(config, { repository: "billing", task: "team-220" })).rejects.toThrow(
+      /workdir "services\/api" not found/,
+    );
+  });
+
+  it("returns the entry when the configured workdir exists after create", async () => {
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        { name: "billing", provision: { create: "true", remove: "true" }, workdir: "services/api" },
+      ],
+    });
+    // The create template materializes the subproject as it runs (after the
+    // worktree-already-exists scan, before the workdir-present assertion).
+    runCommandMock.mockImplementation(() => {
+      mkdirSync(path.join(projectDir, "billing-team-220", "services", "api"), { recursive: true });
+      return "";
+    });
+
+    const entry = await create(config, { repository: "billing", task: "team-220" });
+
+    expect(entry.dir).toBe(path.join(projectDir, "billing-team-220"));
+  });
+});
+
+describe(resolveLaunchDir, () => {
+  setupTempProjectDir();
+
+  it("returns the worktree root when the repo has no workdir", () => {
+    const config = makeConfig({ projectDir });
+    const root = path.join(projectDir, "repo-a-team-1");
+    expect(resolveLaunchDir(config, "repo-a", root)).toBe(root);
+  });
+
+  it("joins the repo's workdir onto the worktree root", () => {
+    const config = makeConfig({
+      projectDir,
+      repositories: [{ name: "repo-a", workdir: "services/api" }],
+    });
+    const root = path.join(projectDir, "repo-a-team-1");
+    expect(resolveLaunchDir(config, "repo-a", root)).toBe(path.join(root, "services", "api"));
+  });
 });
 
 describe(remove, () => {
   setupTempProjectDir();
+
+  it("remove runs the remove template instead of git worktree remove", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockReturnValue(""); // clean dirty-probe + template
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await remove(config, {
+      repository: "billing",
+      task: "team-220",
+      branchName: "paul-team-220",
+      dir: worktreeDir,
+      kind: "host",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "graft rm 'paul-team-220' -f"],
+      expect.objectContaining({ cwd: projectDir, timeoutMs: 0 }),
+    );
+    // No `git worktree remove` and no `git branch -D`.
+    const gitSubcommands = runCommandMock.mock.calls
+      .filter((call) => call[0] === "git")
+      .map((call) => call[1][2]);
+    expect(gitSubcommands).not.toContain("remove");
+    expect(gitSubcommands).not.toContain("-D");
+  });
+
+  it("remove refuses a dirty scripted worktree without force", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // git status --porcelain reports one modified file.
+    runCommandMock.mockImplementation((command, arguments_) =>
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the dirty-probe discriminator reports a modified file
+      command === "git" && arguments_.includes("status") ? " M file.ts" : "",
+    );
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await expect(
+      remove(config, {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      }),
+    ).rejects.toThrow(/crew cleanup --force team-220/);
+
+    // The remove template never ran.
+    expect(runCommandMock).not.toHaveBeenCalledWith("sh", expect.anything(), expect.anything());
+  });
+
+  it("remove skips the template when the scripted worktree directory is absent", async () => {
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockReturnValue("");
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await remove(config, {
+      repository: "billing",
+      task: "team-220",
+      branchName: "paul-team-220",
+      dir: path.join(projectDir, "billing-team-220"), // never created
+      kind: "host",
+    });
+
+    // No template (and no git) runs for a worktree that is already gone.
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("remove with --force runs the template without a dirtiness probe", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // Even if probed, the worktree would read as dirty — --force must skip it.
+    runCommandMock.mockImplementation((command, arguments_) =>
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- guards against an unexpected dirty-probe shell-out
+      command === "git" && arguments_.includes("status") ? " M file.ts" : "",
+    );
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await remove(
+      config,
+      {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      },
+      { force: true },
+    );
+
+    // The template ran; the dirtiness probe (git status) was skipped.
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "sh",
+      ["-c", "graft rm 'paul-team-220' -f"],
+      expect.objectContaining({ cwd: projectDir, timeoutMs: 0 }),
+    );
+    const gitSubcommands = runCommandMock.mock.calls
+      .filter((call) => call[0] === "git")
+      .map((call) => call[1]);
+    expect(gitSubcommands).toStrictEqual([]);
+  });
 
   it("runs git worktree remove for a host entry whose dir exists", async () => {
     mkdirSync(path.join(projectDir, "repo-a"));

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -731,6 +731,26 @@ describe(create, () => {
 
     expect(entry.dir).toBe(path.join(projectDir, "billing-team-220"));
   });
+
+  it("fails fast when the configured workdir is a file after create", async () => {
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        { name: "billing", provision: { create: "true", remove: "true" }, workdir: "services/api" },
+      ],
+    });
+    // The create template leaves a file (not a directory) at the workdir path.
+    runCommandMock.mockImplementation(() => {
+      mkdirSync(path.join(projectDir, "billing-team-220", "services"), { recursive: true });
+      writeFileSync(path.join(projectDir, "billing-team-220", "services", "api"), "");
+      return "";
+    });
+
+    await expect(create(config, { repository: "billing", task: "team-220" })).rejects.toThrow(
+      /workdir "services\/api" not found/,
+    );
+  });
 });
 
 describe(resolveLaunchDir, () => {
@@ -823,6 +843,44 @@ describe(remove, () => {
         kind: "host",
       }),
     ).rejects.toThrow(/crew cleanup --force team-220/);
+
+    // The remove template never ran.
+    expect(runCommandMock).not.toHaveBeenCalledWith("sh", expect.anything(), expect.anything());
+  });
+
+  it("remove fails closed when scripted worktree dirtiness cannot be determined", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // The dirtiness probe (git status) fails, so cleanliness is unknown.
+    runCommandMock.mockImplementation((command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the status probe throws to force an "unknown" dirtiness
+      if (command === "git" && arguments_.includes("status")) {
+        throw new Error("git status failed");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await expect(
+      remove(config, {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      }),
+    ).rejects.toThrow(/Could not verify .* is clean/);
 
     // The remove template never ran.
     expect(runCommandMock).not.toHaveBeenCalledWith("sh", expect.anything(), expect.anything());

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -637,7 +637,12 @@ async function create(
     throw new WorktreeAlreadyExistsError(existing.dir);
   }
   const entry = await createWorktree(config, spec, signal);
-  assertWorkdirPresent(config, entry);
+  try {
+    assertWorkdirPresent(config, entry);
+  } catch (error) {
+    await removeWorktree(config, entry, { force: true, ...signalProperty(signal) });
+    throw error;
+  }
   return entry;
 }
 

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -449,16 +449,15 @@ async function removeScriptedWorktree(
   options: { force: boolean; signal?: AbortSignal },
 ): Promise<void> {
   const worktreeRoot = path.resolve(worktreeBaseDir(config));
-  if (!existsSync(entry.dir)) {
-    debug(`Worktree directory ${entry.dir} not found; skipping remove template.`);
-    return;
-  }
-  // Keep the data-loss guard: a dirty worktree is not removed without --force.
-  // Orphan/branch handling is delegated to the template (e.g. `graft rm`),
-  // since groundcrew does not track the scripted clone.
-  if (!options.force) {
-    // Fail closed: if the dirtiness probe can't confirm the worktree is clean,
-    // do not let the remove template run — that would bypass the data-loss guard.
+  // A scripted worktree's teardown lives in the remove template (e.g. `graft rm`),
+  // which owns provisioner-side branch/metadata beyond the checkout dir. Run it
+  // even when the dir is already gone so that state is still cleaned up; only the
+  // dirtiness guard — which needs the dir to inspect — is skipped in that case.
+  const worktreeExists = existsSync(entry.dir);
+  if (worktreeExists && !options.force) {
+    // Keep the data-loss guard: a dirty worktree is not removed without --force.
+    // Fail closed when the dirtiness probe can't confirm the worktree is clean,
+    // so the remove template never runs over uncommitted work.
     const dirtiness = await throwIfWorktreeDirty(entry, options.signal);
     if (dirtiness.kind !== "clean") {
       throw new Error(

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -13,8 +13,14 @@ import { type Dirent, existsSync, readdirSync, rmSync } from "node:fs";
 import { userInfo } from "node:os";
 import path from "node:path";
 
+import { applySubstitutions } from "./adapters/shell/invoke.ts";
 import { runCommandAsync } from "./commandRunner.ts";
-import { type ResolvedConfig, repositoryBaseDir, worktreeBaseDir } from "./config.ts";
+import {
+  type KnownRepository,
+  type ResolvedConfig,
+  repositoryBaseDir,
+  worktreeBaseDir,
+} from "./config.ts";
 import { resolveDefaultBranch } from "./defaultBranch.ts";
 import { assertPlainTaskId, isPlainTaskId } from "./taskId.ts";
 import { debug, errorMessage, isVerbose } from "./util.ts";
@@ -70,17 +76,96 @@ function branchNameForTask(config: ResolvedConfig, task: string): string {
   return `${branchPrefix(config)}-${task}`;
 }
 
+// Membership in knownRepositories is enforced by recipeFor (called first in
+// basePaths), so this resolves the clone dir for a repo already known to exist
+// in config and only guards against the clone being absent on disk.
 function repoDirFor(config: ResolvedConfig, repository: string): string {
-  if (!config.workspace.knownRepositories.includes(repository)) {
-    throw new Error(
-      `Repository "${repository}" is not in workspace.knownRepositories: ${config.workspace.knownRepositories.join(", ")}`,
-    );
-  }
   const repoDir = path.resolve(repositoryBaseDir(config, repository), repository);
   if (!existsSync(repoDir)) {
     throw new Error(`Repository not found: ${repoDir}`);
   }
   return repoDir;
+}
+
+function recipeFor(config: ResolvedConfig, repository: string): KnownRepository {
+  const recipe = config.workspace.repositories.find((entry) => entry.name === repository);
+  if (recipe === undefined) {
+    throw new Error(
+      `Repository "${repository}" is not in workspace.knownRepositories: ${config.workspace.knownRepositories.join(", ")}`,
+    );
+  }
+  return recipe;
+}
+
+/**
+ * The directory the agent and its setup hooks actually run in. Equals the
+ * worktree root unless the repo recipe sets a `workdir`, in which case it is
+ * `<worktreeDir>/<workdir>` — a monorepo subproject inside a sparse checkout.
+ * Pure path resolution; existence is enforced at create time by
+ * assertWorkdirPresent.
+ */
+export function resolveLaunchDir(
+  config: ResolvedConfig,
+  repository: string,
+  worktreeDir: string,
+): string {
+  const recipe = recipeFor(config, repository);
+  return recipe.workdir === undefined ? worktreeDir : path.resolve(worktreeDir, recipe.workdir);
+}
+
+function assertWorkdirPresent(config: ResolvedConfig, entry: WorktreeEntry): void {
+  const recipe = recipeFor(config, entry.repository);
+  if (recipe.workdir === undefined) {
+    return;
+  }
+  const launchDir = path.resolve(entry.dir, recipe.workdir);
+  if (!existsSync(launchDir)) {
+    throw new Error(
+      `Configured workdir "${recipe.workdir}" not found in worktree ${entry.dir}; the create template must produce it (looked for ${launchDir}).`,
+    );
+  }
+}
+
+function provisionerSubstitutions(
+  config: ResolvedConfig,
+  arguments_: { branchName: string; dir: string; task: string; repository: string },
+): Record<string, string> {
+  return {
+    branch: arguments_.branchName,
+    dir: arguments_.dir,
+    baseRef: `${config.git.remote}/${config.git.defaultBranch}`,
+    repo: arguments_.repository,
+    task: arguments_.task,
+  };
+}
+
+/**
+ * Runs a provisioner template (`create`/`remove`) with no timeout. Mirrors
+ * runLongGitCommand: under --verbose the child streams live; otherwise it is
+ * captured and discarded on success (failures still carry stderr via the
+ * thrown error).
+ */
+async function runLongShellCommand(
+  command: string,
+  cwd: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const signalOption = signal === undefined ? {} : { signal };
+  if (isVerbose()) {
+    await runCommandAsync("sh", ["-c", command], {
+      cwd,
+      stdio: "inherit",
+      timeoutMs: 0,
+      ...signalOption,
+    });
+    return;
+  }
+  await runCommandAsync("sh", ["-c", command], {
+    cwd,
+    stdio: "captured",
+    timeoutMs: 0,
+    ...signalOption,
+  });
 }
 
 interface BasePaths {
@@ -97,7 +182,13 @@ function basePaths(config: ResolvedConfig, repository: string, task: string): Ba
   // This also rejects traversal tokens before they reach path.resolve().
   assertPlainTaskId(task);
 
-  const repoDir = repoDirFor(config, repository);
+  const recipe = recipeFor(config, repository);
+  // Scripted entries have no source clone — graft owns the checkout — so run
+  // templates with cwd = the worktree root and never resolve a clone dir.
+  const repoDir =
+    recipe.provision === undefined
+      ? repoDirFor(config, repository)
+      : path.resolve(worktreeBaseDir(config));
   const hostWorktreeName = `${repository}-${task}`;
   const hostWorktreeDir = path.resolve(worktreeBaseDir(config), hostWorktreeName);
 
@@ -178,6 +269,27 @@ async function createWorktree(
   signal?: AbortSignal,
 ): Promise<WorktreeEntry> {
   const base = basePaths(config, spec.repository, spec.task);
+  const recipe = recipeFor(config, spec.repository);
+  if (recipe.provision !== undefined) {
+    const command = applySubstitutions(
+      recipe.provision.create,
+      provisionerSubstitutions(config, {
+        branchName: base.branchName,
+        dir: base.hostWorktreeDir,
+        task: spec.task,
+        repository: spec.repository,
+      }),
+    );
+    debug(`Provisioning worktree ${spec.repository}-${spec.task} via create template...`);
+    await runLongShellCommand(command, base.repoDir, signal);
+    return {
+      repository: spec.repository,
+      task: spec.task,
+      branchName: base.branchName,
+      dir: base.hostWorktreeDir,
+      kind: "host",
+    };
+  }
   const defaultBranch = await resolveDefaultBranch({
     repoDir: base.repoDir,
     remote: config.git.remote,
@@ -263,6 +375,11 @@ async function removeWorktree(
   entry: WorktreeEntry,
   options: { force: boolean; signal?: AbortSignal },
 ): Promise<void> {
+  const recipe = recipeFor(config, entry.repository);
+  if (recipe.provision !== undefined) {
+    await removeScriptedWorktree(config, entry, recipe.provision.remove, options);
+    return;
+  }
   const repoDir = path.resolve(repositoryBaseDir(config, entry.repository), entry.repository);
 
   if (existsSync(entry.dir)) {
@@ -297,18 +414,7 @@ async function removeWorktree(
         }
         removeOrphanWorktreeDirectory(config, entry);
       } else {
-        const dirtiness = await probeWorktreeDirtiness(entry.dir, options.signal);
-        if (dirtiness.kind === "dirty") {
-          throw new Error(
-            describeDirtyWorktree({
-              task: entry.task,
-              dir: entry.dir,
-              modified: dirtiness.modified,
-              untracked: dirtiness.untracked,
-            }),
-            { cause: error },
-          );
-        }
+        const dirtiness = await throwIfWorktreeDirty(entry, options.signal, error);
         if (dirtiness.kind === "unknown") {
           const registration = await probeWorktreeRegistration({
             repoDir,
@@ -334,6 +440,36 @@ async function removeWorktree(
     branchName: entry.branchName,
     ...signalProperty(options.signal),
   });
+}
+
+async function removeScriptedWorktree(
+  config: ResolvedConfig,
+  entry: WorktreeEntry,
+  removeTemplate: string,
+  options: { force: boolean; signal?: AbortSignal },
+): Promise<void> {
+  const worktreeRoot = path.resolve(worktreeBaseDir(config));
+  if (!existsSync(entry.dir)) {
+    debug(`Worktree directory ${entry.dir} not found; skipping remove template.`);
+    return;
+  }
+  // Keep the data-loss guard: a dirty worktree is not removed without --force.
+  // Orphan/branch handling is delegated to the template (e.g. `graft rm`),
+  // since groundcrew does not track the scripted clone.
+  if (!options.force) {
+    await throwIfWorktreeDirty(entry, options.signal);
+  }
+  const command = applySubstitutions(
+    removeTemplate,
+    provisionerSubstitutions(config, {
+      branchName: entry.branchName,
+      dir: entry.dir,
+      task: entry.task,
+      repository: entry.repository,
+    }),
+  );
+  debug(`Removing worktree ${entry.dir} via remove template...`);
+  await runLongShellCommand(command, worktreeRoot, options.signal);
 }
 
 export type WorktreeDirtiness =
@@ -371,6 +507,29 @@ async function probeWorktreeDirtiness(
     return { kind: "clean" };
   }
   return { kind: "dirty", modified, untracked };
+}
+
+/**
+ * Probe a worktree and, when it has uncommitted work, throw the data-loss guard
+ * error. Returns the dirtiness so the git-native path can still branch on
+ * `unknown`. `cause` chains the underlying git failure when called from a catch.
+ */
+async function throwIfWorktreeDirty(
+  entry: WorktreeEntry,
+  signal: AbortSignal | undefined,
+  cause?: unknown,
+): Promise<WorktreeDirtiness> {
+  const dirtiness = await probeWorktreeDirtiness(entry.dir, signal);
+  if (dirtiness.kind === "dirty") {
+    const message = describeDirtyWorktree({
+      task: entry.task,
+      dir: entry.dir,
+      modified: dirtiness.modified,
+      untracked: dirtiness.untracked,
+    });
+    throw cause === undefined ? new Error(message) : new Error(message, { cause });
+  }
+  return dirtiness;
 }
 
 function describeDirtyWorktree(arguments_: {
@@ -471,7 +630,9 @@ async function create(
   if (existing !== undefined) {
     throw new WorktreeAlreadyExistsError(existing.dir);
   }
-  return await createWorktree(config, spec, signal);
+  const entry = await createWorktree(config, spec, signal);
+  assertWorkdirPresent(config, entry);
+  return entry;
 }
 
 async function remove(

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -9,7 +9,7 @@
  * worktree-remove paired) so callers don't reach into git directly.
  */
 
-import { type Dirent, existsSync, readdirSync, rmSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { userInfo } from "node:os";
 import path from "node:path";
 
@@ -119,7 +119,7 @@ function assertWorkdirPresent(config: ResolvedConfig, entry: WorktreeEntry): voi
     return;
   }
   const launchDir = path.resolve(entry.dir, recipe.workdir);
-  if (!existsSync(launchDir)) {
+  if (!existsSync(launchDir) || !statSync(launchDir).isDirectory()) {
     throw new Error(
       `Configured workdir "${recipe.workdir}" not found in worktree ${entry.dir}; the create template must produce it (looked for ${launchDir}).`,
     );
@@ -457,7 +457,14 @@ async function removeScriptedWorktree(
   // Orphan/branch handling is delegated to the template (e.g. `graft rm`),
   // since groundcrew does not track the scripted clone.
   if (!options.force) {
-    await throwIfWorktreeDirty(entry, options.signal);
+    // Fail closed: if the dirtiness probe can't confirm the worktree is clean,
+    // do not let the remove template run — that would bypass the data-loss guard.
+    const dirtiness = await throwIfWorktreeDirty(entry, options.signal);
+    if (dirtiness.kind !== "clean") {
+      throw new Error(
+        `Could not verify ${entry.dir} is clean; rerun with --force after manual inspection.`,
+      );
+    }
   }
   const command = applySubstitutions(
     removeTemplate,


### PR DESCRIPTION
## What

Lets a `workspace.knownRepositories` entry carry a **`provision` block** (`create`/`remove` command templates) so a worktree is set up by a custom command — e.g. a sparse checkout via [`graft`](https://github.com/graft) — instead of `git worktree add`, enabling **sparse-checkout repositories**. Adds an optional **`workdir`** to run the agent inside a monorepo subproject of the checkout.

## Why

For a monorepo checked out sparsely via graft, there is no `<projectDir>/<repo>` clone for groundcrew to `git worktree add` from, and the project you actually work on lives in a **subdirectory** of the checkout. This PR teaches groundcrew to (a) provision/tear down the worktree with your own command, and (b) re-root the working directory to the subproject.

## Config example

```ts
workspace: {
  projectDir: "~/dev/groundcrew",
  knownRepositories: [
    "your-org/your-repo",
    {
      name: "billing",
      provision: {
        create: "graft new ${branch} billing --from ${baseRef} --dir ${dir}",
        remove: "graft rm ${branch} -f",
      },
      workdir: "services/billing",
    },
  ],
},
```

Per-entry shapes (`projectDirOverride` and `worktreeDir` already shipped separately):

| Fields | Meaning |
| --- | --- |
| `{ name }` / `{ name, projectDirOverride }` | native clone (optionally at a custom parent dir) |
| `{ name, projectDirOverride, workdir }` | native monorepo clone (custom dir) + subproject cwd |
| `{ name, provision: { create, remove }, workdir? }` | scripted checkout (graft) + optional subproject cwd |

- `projectDirOverride` pairs with **native** entries; `provision` **replaces** it (a scripted entry has no groundcrew-managed clone). Setting both is **rejected at config load**.
- `workdir` is orthogonal — it works with native or scripted entries.
- In a scripted template, `${dir}` expands to the worktree path, `${baseRef}` to `<remote>/<defaultBranch>`, plus `${branch}` / `${repo}` / `${task}` (each shell-quoted). The template runs with cwd = the worktree root.

## How it works

### Scripted provisioning
- A `KnownRepository` object entry may set a `provision` block with `create` and `remove` shell templates (both required — presence of `provision` is the native/scripted discriminator). When present, groundcrew runs them via `sh -c` in place of `git worktree add`/`remove`, with cwd = the worktree root.
- The dirty-worktree data-loss guard still applies: `crew cleanup` refuses `remove` without `--force`. Orphan/branch cleanup is delegated to your `remove` template.
- If the checkout is created but the configured `workdir` is missing or not a directory, groundcrew now attempts forced teardown through the same remove path before returning the validation error.
- **srt sandbox:** the policy's `gitCommonDir` is now derived from the worktree via `git rev-parse --git-common-dir` instead of assuming a `<projectDir>/<repo>/.git` clone — so a sparse-checkout worktree fences off its *real* git dir (and the old behavior, which left it unfenced, is fixed for native worktrees too).

### `workdir`
- Optional relative subpath on a `KnownRepository`. When set, the **agent cwd**, the **`prepareWorktree` hook**, and the **`.groundcrew/config.json` lookup** all re-root to `<worktree>/<workdir>`.
- The worktree root is unchanged: it is still what create/remove/list/dirty-checks operate on, and a sandboxed agent keeps **full read/write access to the whole checkout** (only the cwd moves). This is the `workingDir` (cwd) vs `worktreeDir` (root/grants/`{{worktree}}`) split in `launchCommand`.
- Validated as relative with no `..`; if the subdir is missing after checkout, `crew` **fails fast** with a clear error.

## Changes
- **config:** `KnownRepository` gains `provision` (`ProvisionScripts`) and `workdir`; validation covers the workdir path and the `projectDirOverride`-vs-`provision` exclusivity. Grouping the templates under `provision` makes the native/scripted split structural, so no both-or-neither check is needed.
- **worktrees:** scripted create/remove provisioning; `resolveLaunchDir` + `assertWorkdirPresent`; failed post-create `workdir` validation rolls back through forced worktree removal.
- **launch:** `composeAgentLaunch` shares the srt-staging + launch assembly between `setupWorkspace` and `resumeWorkspace`; `workingDir`/`worktreeDir` split.
- **doctor/docs:** `crew doctor` does not parse arbitrary provisioner shell templates; docs recommend wrapper scripts for complex provisioners.
- **tests:** dispatcher restores mocks in `afterAll` so mocked `setupWorkspace.ts` bindings are unwound before Vitest environment teardown.
- **docs:** `README`, `docs/configuration.md`, `crew.config.example.ts`.

## Testing

- `npx vitest run src/lib/worktrees.test.ts src/commands/doctor.test.ts` (122 tests)
- `npx vitest run src/commands/dispatcher.test.ts` (47 tests)
- `node --run verify` (1559 tests, 100% coverage)
- Pre-push hook reran `node --run verify` successfully.

## Notes
- Rebased onto `main` after #179 (multi-project-dir / separate-worktree-dir) merged, so this PR is now standalone — its diff is just the scripted-provisioner + `workdir` feature.
- Your graft sparse-checkout set must include the `workdir` subtree, or `assertWorkdirPresent` fails the setup with a clear message and attempts rollback.

Agent session: `codex resume 019eb230-53f1-7c00-b7d2-852a9f4db090`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>