### PR TITLE
feat: distinguish Linear in-review statuses

### DIFF
--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -4,10 +4,11 @@ import type { Config } from "@clipboard-health/groundcrew";
 export default {
   // Groundcrew's built-in Linear adapter is implicit and needs no config:
   // it picks up every Linear issue assigned to your API key's viewer that
-  // carries an `agent-*` label. There is no project / view / status
-  // block — Linear's workflow `state.type` (`unstarted` → todo,
-  // `started` → in progress, `completed`/`canceled`/`duplicate` →
-  // terminal) is the single source of truth, so renamed columns Just Work.
+  // carries an `agent-*` label. There is no project / view block. The default
+  // Linear status names `In Progress` and `In Review` disambiguate Linear's
+  // `started` workflow states; other statuses fall back to workflow
+  // `state.type` (`unstarted` → todo, `started` → in progress,
+  // `completed`/`canceled`/`duplicate` → terminal).
   //
   // Opt a ticket in: assign it to yourself and add an `agent-<model>`
   // label (e.g. `agent-claude`, `agent-any`).
@@ -53,6 +54,15 @@ export default {
   // // See the shell adapter's ShellIssue schema for the JSON contract
   // // `fetch` / `resolveOne` must emit.
   // sources: [
+  //   // Optional: explicitly declare Linear only when you need custom status
+  //   // names. Omitted fields keep their defaults.
+  //   {
+  //     kind: "linear",
+  //     statuses: {
+  //       inProgress: ["Doing"],
+  //       inReview: ["Code Review"],
+  //     },
+  //   },
   //   {
   //     kind: "shell",
   //     name: "jira",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Workspace settings and at least one enabled model are required; everything else 
 | `workspace.knownRepositories` | Repos searched for in ticket descriptions to infer where work belongs. |
 | `models.definitions`          | Enabled model set. Built-in presets can be enabled with `{}`.          |
 
-The branch prefix (`<prefix>-<TICKET>`) defaults to `os.userInfo().username`; override it with `git.branchPrefix` (see the full reference below). Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. There is no `linear` config block. Groundcrew picks up every issue assigned to your API key's viewer that carries an `agent-*` label across every visible team and project, governed by a single `orchestrator.maximumInProgress` budget.
+The branch prefix (`<prefix>-<TICKET>`) defaults to `os.userInfo().username`; override it with `git.branchPrefix` (see the full reference below). Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. Groundcrew picks up every issue assigned to your API key's viewer that carries an `agent-*` label across every visible team and project, governed by a single `orchestrator.maximumInProgress` budget.
 
 ## Repository Layout
 
@@ -48,7 +48,25 @@ The "Loaded config from ..." line at startup tells you which config won.
 - No `agent-*` label is ignored by `crew run`. Dispatch on demand with `crew start <TICKET>`, which falls back to `models.default`.
 - Todo tickets blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
 
-Status classification uses Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so renamed status columns work without configuration. Parent issues with children are ignored; sub-issues are the work items.
+Status classification uses Linear's default status names `In Progress` and `In Review` to disambiguate multiple `started` workflow states. Statuses that do not match those names fall back to Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so broad lifecycle classification still works without configuration. Parent issues with children are ignored; sub-issues are the work items.
+
+If your Linear workflow uses different names, explicitly declare the built-in Linear source and override only the names you need:
+
+```ts
+export default {
+  sources: [
+    {
+      kind: "linear",
+      statuses: {
+        inProgress: ["Doing"],
+        inReview: ["Code Review"],
+      },
+    },
+  ],
+};
+```
+
+Configured names replace the default for that status; omitted fields keep their defaults. Matching is case-insensitive and trims surrounding whitespace.
 
 ## Enabling Model Presets
 
@@ -130,7 +148,7 @@ and hook contract.
 
 | Key                                      | Default              | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sources`                                | `[]`                 | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`.                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `sources`                                | `[]`                 | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`. Declare `{ kind: "linear", statuses: { ... } }` only to override Linear status names used for `in-progress` / `in-review` disambiguation.                                                                                                                                                                                                                                                         |
 | `git.remote`                             | `"origin"`           | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `git.defaultBranch`                      | `"main"`             | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `git.branchPrefix`                       | OS username          | Prefix groundcrew puts before the ticket id when naming a worktree branch (`<branchPrefix>-<ticket>`). Must be a slash-free slug of letters, digits, `.`, `_`, or `-`. Defaults to the OS account username. Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. Prefer a per-user config for personal prefixes — a committed `git.branchPrefix` gives every contributor the same branch prefix.                                                           |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ This applies to the tmux backend only.
 
 ## Tickets Stay In-Progress
 
-Groundcrew sets a ticket to `Started`, the first workflow state with `type === "started"` on that team, when it provisions a workspace and never advances it. The next transition, typically "In Review" when a PR opens, is left to your Linear automation rules.
+Groundcrew marks a ticket `In Progress` when it provisions a workspace. When a PR opens on that worktree branch, the reviewer pass attempts to mark the ticket `In Review`. Linear's default `In Review` status works out of the box; if your team renamed it, configure `sources: [{ kind: "linear", statuses: { inReview: ["Code Review"] } }]`.
 
 ## Claude Launches In Auto Mode By Default
 

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -845,7 +845,7 @@ describe(orchestrate, () => {
     expect(setupMock).not.toHaveBeenCalled();
     const out = consoleLog.output();
     expect(out).toContain("event=dispatch outcome=skipped reason=blocked ticket=team-1");
-    // After main's #110: state.type drives classification; "started" maps to "in-progress".
+    // Unmatched started blockers still fall back to canonical in-progress.
     expect(out).toContain("blockers=linear:team-0:in-progress");
   });
 

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -97,6 +97,22 @@ describe(toCanonicalIssue, () => {
     expect(result.status).toBe("in-progress");
   });
 
+  it("canonicalizes default Linear In Review as in-review", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "In Review", stateType: "started" }),
+      "linear",
+    );
+    expect(result.status).toBe("in-review");
+  });
+
+  it("does not let a review status name override a terminal state.type", () => {
+    const result = toCanonicalIssue(
+      linearIssue({ status: "In Review", stateType: "completed" }),
+      "linear",
+    );
+    expect(result.status).toBe("done");
+  });
+
   it("maps state.type 'completed' to canonical 'done'", () => {
     const result = toCanonicalIssue(
       linearIssue({ status: "Shipped", stateType: "completed" }),
@@ -139,12 +155,19 @@ describe(toCanonicalIssue, () => {
       blockers: [
         { id: "team-2", title: "Block A", status: "Done", stateType: "completed" },
         { id: "team-3", title: "Block B", status: "Todo", stateType: "unstarted" },
+        { id: "team-4", title: "Block C", status: "In Review", stateType: "started" },
       ],
     });
     const result = toCanonicalIssue(issue, "linear");
     expect(result.blockers).toStrictEqual([
       { id: "linear:team-2", title: "Block A", status: "done", nativeStatus: "Done" },
       { id: "linear:team-3", title: "Block B", status: "todo", nativeStatus: "Todo" },
+      {
+        id: "linear:team-4",
+        title: "Block C",
+        status: "in-review",
+        nativeStatus: "In Review",
+      },
     ]);
   });
 
@@ -161,6 +184,18 @@ describe(toCanonicalIssue, () => {
         statusReason: "missing",
         nativeStatus: "Done",
       },
+    ]);
+  });
+
+  it("falls back to state.type when a started blocker has no native status", () => {
+    const issue = linearIssue({
+      blockers: [{ id: "team-2", title: "Block A", status: undefined, stateType: "started" }],
+    });
+
+    const result = toCanonicalIssue(issue, "linear");
+
+    expect(result.blockers).toStrictEqual([
+      { id: "linear:team-2", title: "Block A", status: "in-progress" },
     ]);
   });
 
@@ -246,6 +281,42 @@ describe(createLinearTicketSource, () => {
     const issues = await source.fetch();
     expect(issues.map((i) => i.id)).toStrictEqual(["linear:team-1", "linear:team-2"]);
     expect(issues[1]?.status).toBe("in-progress");
+  });
+
+  it("uses configured Linear status names before falling back to state.type", async () => {
+    const innerFetch = vi.fn<() => Promise<boardSource.BoardState>>().mockResolvedValue({
+      timestamp: "2026-01-01T00:00:00Z",
+      issues: [
+        linearIssue({ id: "team-1", status: "Doing", stateType: "started" }),
+        linearIssue({ id: "team-2", status: "Code Review", stateType: "started" }),
+        linearIssue({ id: "team-3", status: "Waiting", stateType: "started" }),
+      ],
+      parentSkips: [],
+    });
+    vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
+      verify: vi.fn<() => Promise<void>>(),
+      fetch: innerFetch,
+    });
+    const source = createLinearTicketSource(
+      {
+        kind: "linear",
+        statuses: {
+          inProgress: ["Doing"],
+          inReview: ["Code Review"],
+        },
+      },
+      {
+        globalConfig: makeConfig(),
+      } satisfies AdapterContext,
+    );
+
+    const issues = await source.fetch();
+
+    expect(issues.map((issue) => issue.status)).toStrictEqual([
+      "in-progress",
+      "in-review",
+      "in-progress",
+    ]);
   });
 
   it("fetchParentSkips() returns canonical (source-prefixed) ids", async () => {
@@ -334,6 +405,10 @@ describe(createLinearTicketSource, () => {
       id: "linear:team-1",
       uuid: "uuid-1",
       teamId: "team-default",
+    });
+    expect(linearIssueStatus.createLinearIssueStatusUpdater).toHaveBeenCalledWith({
+      client: fakeClient,
+      statusNames: { inProgress: ["In Progress"], inReview: ["In Review"] },
     });
   });
 

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -5,9 +5,9 @@
  * ./client.ts) and converts Linear-specific shapes into the canonical
  * Issue/Blocker types consumers (via Board) speak.
  *
- * State classification is driven by Linear's workflow `state.type` — never
- * by status name — so workspaces with renamed columns Just Work without
- * per-team config.
+ * Status names disambiguate Linear's multiple `started` states ("In Progress"
+ * vs "In Review"). Unmatched statuses fall back to workflow `state.type` so
+ * renamed or custom columns still preserve the broad lifecycle behavior.
  *
  * Description is populated on both `fetch()` Issues and `resolveOne()` Issues.
  */
@@ -28,10 +28,15 @@ import {
   type Blocker as LinearBlocker,
   createBoardSource,
   fetchResolvedIssue,
-  isTerminalStateType,
   type Issue as LinearIssue,
   type ParentSkip as LinearParentSkip,
 } from "./fetch.ts";
+import {
+  canonicalStatusFromLinearState,
+  DEFAULT_LINEAR_STATUS_NAMES,
+  resolveLinearStatusNames,
+  type LinearStatusNames,
+} from "./statusNames.ts";
 import { createLinearIssueStatusUpdater } from "./writeback.ts";
 
 /**
@@ -48,69 +53,38 @@ export interface LinearSourceRef {
   nativeStatus: string;
 }
 
-function canonicalStatusFromStateType(stateType: string | undefined): CanonicalStatus {
-  /* v8 ignore next 3 @preserve -- LinearIssue.stateType is non-optional; this guard is defensive for the resolveOne path */
-  if (stateType === undefined) {
-    return "other";
-  }
-  switch (stateType) {
-    case "unstarted": {
-      return "todo";
-    }
-    case "started": {
-      return "in-progress";
-    }
-    case "completed":
-    case "canceled":
-    case "duplicate": {
-      return "done";
-    }
-    default: {
-      return "other";
-    }
-  }
-}
-
-function canonicalBlockerStatus(blocker: LinearBlocker): {
+function canonicalBlockerStatus(
+  blocker: LinearBlocker,
+  statusNames: LinearStatusNames,
+): {
   status: CanonicalStatus;
   statusReason?: "missing" | "unmapped";
   nativeStatus?: string;
 } {
-  if (blocker.stateType === undefined) {
+  const status = canonicalStatusFromLinearState({
+    nativeStatus: blocker.status,
+    stateType: blocker.stateType,
+    statusNames,
+  });
+  if (status !== "other") {
     return {
-      status: "other",
-      statusReason: "missing",
+      status,
       ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
     };
   }
-  if (isTerminalStateType(blocker.stateType)) {
-    return {
-      status: "done",
-      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
-    };
-  }
-  if (blocker.stateType === "started") {
-    return {
-      status: "in-progress",
-      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
-    };
-  }
-  if (blocker.stateType === "unstarted") {
-    return {
-      status: "todo",
-      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
-    };
-  }
-  // backlog / triage / anything else falls through as "other"
   return {
-    status: "other",
-    statusReason: "unmapped",
+    status,
+    statusReason: blocker.stateType === undefined ? "missing" : "unmapped",
     ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
   };
 }
 
-function toCanonicalBlocker(blocker: LinearBlocker, sourceName: string): CanonicalBlocker {
-  const { status, statusReason, nativeStatus } = canonicalBlockerStatus(blocker);
+function toCanonicalBlocker(
+  blocker: LinearBlocker,
+  sourceName: string,
+  statusNames: LinearStatusNames,
+): CanonicalBlocker {
+  const { status, statusReason, nativeStatus } = canonicalBlockerStatus(blocker, statusNames);
   return {
     id: toCanonicalId(sourceName, blocker.id),
     title: blocker.title,
@@ -128,7 +102,11 @@ function toCanonicalParentSkip(skip: LinearParentSkip, sourceName: string): Cano
   };
 }
 
-export function toCanonicalIssue(linearIssue: LinearIssue, sourceName: string): CanonicalIssue {
+export function toCanonicalIssue(
+  linearIssue: LinearIssue,
+  sourceName: string,
+  statusNames: LinearStatusNames = DEFAULT_LINEAR_STATUS_NAMES,
+): CanonicalIssue {
   const sourceRef: LinearSourceRef = {
     uuid: linearIssue.uuid,
     statusId: linearIssue.statusId,
@@ -141,12 +119,16 @@ export function toCanonicalIssue(linearIssue: LinearIssue, sourceName: string): 
     source: sourceName,
     title: linearIssue.title,
     description: linearIssue.description,
-    status: canonicalStatusFromStateType(linearIssue.stateType),
+    status: canonicalStatusFromLinearState({
+      nativeStatus: linearIssue.status,
+      stateType: linearIssue.stateType,
+      statusNames,
+    }),
     repository: linearIssue.repository,
     model: linearIssue.model,
     assignee: linearIssue.assignee,
     updatedAt: linearIssue.updatedAt,
-    blockers: linearIssue.blockers.map((b) => toCanonicalBlocker(b, sourceName)),
+    blockers: linearIssue.blockers.map((b) => toCanonicalBlocker(b, sourceName, statusNames)),
     hasMoreBlockers: linearIssue.hasMoreBlockers,
     url: linearIssue.url,
     sourceRef,
@@ -158,6 +140,7 @@ export function createLinearTicketSource(
   context: AdapterContext,
 ): TicketSource {
   const sourceName = config.name ?? "linear";
+  const statusNames = resolveLinearStatusNames(config.statuses);
   const { globalConfig } = context;
   // Lazy: deferring `getLinearClient()` (and the sub-modules that depend on
   // it) until first method use means `createLinearTicketSource` can be
@@ -178,6 +161,7 @@ export function createLinearTicketSource(
   function getIssueStatusUpdater(): ReturnType<typeof createLinearIssueStatusUpdater> {
     cachedIssueStatusUpdater ??= createLinearIssueStatusUpdater({
       client: getClient(),
+      statusNames,
     });
     return cachedIssueStatusUpdater;
   }
@@ -192,7 +176,9 @@ export function createLinearTicketSource(
     async fetch(): Promise<CanonicalIssue[]> {
       const state = await getBoardSource().fetch();
       lastParentSkips = state.parentSkips.map((skip) => toCanonicalParentSkip(skip, sourceName));
-      return state.issues.map((linearIssue) => toCanonicalIssue(linearIssue, sourceName));
+      return state.issues.map((linearIssue) =>
+        toCanonicalIssue(linearIssue, sourceName, statusNames),
+      );
     },
     async fetchParentSkips(): Promise<readonly CanonicalParentSkip[]> {
       return lastParentSkips;
@@ -215,7 +201,11 @@ export function createLinearTicketSource(
         source: sourceName,
         title: resolved.title,
         description: resolved.description,
-        status: canonicalStatusFromStateType(resolved.stateType),
+        status: canonicalStatusFromLinearState({
+          nativeStatus: resolved.status,
+          stateType: resolved.stateType,
+          statusNames,
+        }),
         repository: resolved.repository,
         model: resolved.model,
         assignee: "Unassigned",

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -1,12 +1,11 @@
 /**
  * Linear adapter — GraphQL fetch helpers for board/issue data.
  *
- * There is no project / view / status configuration: the only server-side
- * filter is "assigned to the API key's viewer AND carries an `agent-*`
- * label." State classification is driven by Linear's workflow `state.type`
- * (`unstarted` | `started` | `completed` | `canceled` | `duplicate`) —
- * never by status name — so workspaces with renamed columns (Todo -> To Do,
- * Done -> Shipped, etc.) Just Work without per-team config.
+ * There is no project or view configuration: the only server-side filter is
+ * "assigned to the API key's viewer AND carries an `agent-*` label." This
+ * module returns Linear's native status name plus workflow `state.type`; the
+ * ticket-source factory applies status-name disambiguation and state-type
+ * fallback when building canonical issues.
  */
 
 import type { LinearClient } from "@linear/sdk";
@@ -39,8 +38,8 @@ export interface Blocker {
   status: string | undefined;
   /**
    * Linear workflow `state.type` for the blocker (`unstarted` | `started` |
-   * `completed` | `canceled` | `duplicate` | `backlog` | `triage`). All
-   * canonical classification — todo / in-progress / terminal — keys off this.
+   * `completed` | `canceled` | `duplicate` | `backlog` | `triage`). Canonical
+   * classification uses this as a fallback after configured status names.
    */
   stateType: string | undefined;
 }
@@ -52,7 +51,7 @@ export interface Issue {
   description: string;
   status: string;
   statusId: string;
-  /** Linear workflow `state.type` — the source of truth for canonical classification. */
+  /** Linear workflow `state.type` — canonical classification fallback after status-name matching. */
   stateType: string;
   assignee: string;
   updatedAt: string;

--- a/src/lib/adapters/linear/schema.test.ts
+++ b/src/lib/adapters/linear/schema.test.ts
@@ -1,0 +1,30 @@
+import { linearAdapterConfigSchema } from "./schema.ts";
+
+describe("Linear adapter config schema", () => {
+  it("accepts configured Linear status names", () => {
+    const actual = linearAdapterConfigSchema.parse({
+      kind: "linear",
+      statuses: {
+        inProgress: ["Doing"],
+        inReview: ["Code Review", "Review"],
+      },
+    });
+
+    expect(actual).toStrictEqual({
+      kind: "linear",
+      statuses: {
+        inProgress: ["Doing"],
+        inReview: ["Code Review", "Review"],
+      },
+    });
+  });
+
+  it("rejects an empty configured status-name list", () => {
+    const actual = linearAdapterConfigSchema.safeParse({
+      kind: "linear",
+      statuses: { inReview: [] },
+    });
+
+    expect(actual.success).toBe(false);
+  });
+});

--- a/src/lib/adapters/linear/schema.ts
+++ b/src/lib/adapters/linear/schema.ts
@@ -1,16 +1,25 @@
 /**
  * Zod schema for the Linear adapter's per-source config block. The built-in
  * Linear adapter is implicit and derives scope from the API key's viewer plus
- * `agent-*` labels, so the source config only needs an optional display name.
+ * `agent-*` labels. Source config is only needed to override display name or
+ * Linear status names that disambiguate multiple `started` workflow states.
  */
 
 import { z } from "zod";
+
+const statusNamesSchema = z.array(z.string().trim().min(1)).min(1);
 
 export const linearAdapterConfigSchema = z.object({
   kind: z.literal("linear"),
   name: z
     .string()
     .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)")
+    .optional(),
+  statuses: z
+    .object({
+      inProgress: statusNamesSchema.optional(),
+      inReview: statusNamesSchema.optional(),
+    })
     .optional(),
 });
 

--- a/src/lib/adapters/linear/statusNames.ts
+++ b/src/lib/adapters/linear/statusNames.ts
@@ -1,0 +1,94 @@
+import type { CanonicalStatus } from "../../ticketSource.ts";
+import type { LinearAdapterConfig } from "./schema.ts";
+
+export interface LinearStatusNames {
+  inProgress: readonly string[];
+  inReview: readonly string[];
+}
+
+export interface LinearWorkflowState {
+  id: string;
+  name: string;
+  type: string;
+  position: number;
+}
+
+export const DEFAULT_LINEAR_STATUS_NAMES = {
+  inProgress: ["In Progress"],
+  inReview: ["In Review"],
+} as const satisfies LinearStatusNames;
+
+export function resolveLinearStatusNames(
+  config: LinearAdapterConfig["statuses"] | undefined,
+): LinearStatusNames {
+  return {
+    inProgress: config?.inProgress ?? DEFAULT_LINEAR_STATUS_NAMES.inProgress,
+    inReview: config?.inReview ?? DEFAULT_LINEAR_STATUS_NAMES.inReview,
+  };
+}
+
+export function canonicalStatusFromLinearState(arguments_: {
+  nativeStatus: string | undefined;
+  stateType: string | undefined;
+  statusNames: LinearStatusNames;
+}): CanonicalStatus {
+  const { nativeStatus, stateType, statusNames } = arguments_;
+  if (stateType === "started") {
+    if (matchesLinearStatusName(nativeStatus, statusNames.inReview)) {
+      return "in-review";
+    }
+    if (matchesLinearStatusName(nativeStatus, statusNames.inProgress)) {
+      return "in-progress";
+    }
+  }
+  return canonicalStatusFromStateType(stateType);
+}
+
+export function findLinearWorkflowStateByName(
+  states: readonly LinearWorkflowState[],
+  names: readonly string[],
+): LinearWorkflowState | undefined {
+  return states.find((state) => matchesLinearStatusName(state.name, names));
+}
+
+export function formatLinearStatusNames(names: readonly string[]): string {
+  return names.map((name) => `"${name}"`).join(" or ");
+}
+
+function canonicalStatusFromStateType(stateType: string | undefined): CanonicalStatus {
+  /* v8 ignore next 3 @preserve -- LinearIssue.stateType is non-optional; this guard is defensive for the resolveOne path */
+  if (stateType === undefined) {
+    return "other";
+  }
+  switch (stateType) {
+    case "unstarted": {
+      return "todo";
+    }
+    case "started": {
+      return "in-progress";
+    }
+    case "completed":
+    case "canceled":
+    case "duplicate": {
+      return "done";
+    }
+    default: {
+      return "other";
+    }
+  }
+}
+
+function matchesLinearStatusName(
+  nativeStatus: string | undefined,
+  configuredNames: readonly string[],
+): boolean {
+  if (nativeStatus === undefined) {
+    return false;
+  }
+  const normalizedStatus = normalizeStatusName(nativeStatus);
+  return configuredNames.some((name) => normalizeStatusName(name) === normalizedStatus);
+}
+
+function normalizeStatusName(name: string): string {
+  return name.trim().toLowerCase();
+}

--- a/src/lib/adapters/linear/writeback.test.ts
+++ b/src/lib/adapters/linear/writeback.test.ts
@@ -53,19 +53,86 @@ describe(createLinearIssueStatusUpdater, () => {
     vi.clearAllMocks();
   });
 
-  it("markInReview reports unsupported without calling Linear", async () => {
-    const client = makeClient();
+  it("markInReview targets the default 'In Review' state", async () => {
+    const client = makeClient({
+      states: [
+        { id: "state-in-progress", name: "In Progress", type: "started", position: 1 },
+        { id: "state-in-review", name: "In Review", type: "started", position: 2 },
+      ],
+    });
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await expect(
+      updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
+    ).resolves.toStrictEqual({ outcome: "applied" });
+
+    expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-in-review" });
+  });
+
+  it("markInReview targets a configured review state name", async () => {
+    const client = makeClient({
+      states: [
+        { id: "state-doing", name: "Doing", type: "started", position: 1 },
+        { id: "state-code-review", name: "Code Review", type: "started", position: 2 },
+      ],
+    });
+    const updater = createLinearIssueStatusUpdater({
+      client: asLinearClient(client),
+      statusNames: { inProgress: ["Doing"], inReview: ["Code Review"] },
+    });
+
+    await expect(
+      updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
+    ).resolves.toStrictEqual({ outcome: "applied" });
+
+    expect(client.updateIssue).toHaveBeenCalledWith("uuid-1", { stateId: "state-code-review" });
+  });
+
+  it("markInReview reports unsupported when no configured review state exists", async () => {
+    const client = makeClient({
+      states: [{ id: "state-in-progress", name: "In Progress", type: "started", position: 1 }],
+    });
     const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
 
     await expect(
       updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" }),
     ).resolves.toStrictEqual({
       outcome: "unsupported",
-      reason: "Linear in-review writeback is not implemented",
+      reason: 'Could not find a Linear workflow state named "In Review" for team shared',
+    });
+
+    expect(client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("markInReview reports unsupported without fetching states when teamId is missing", async () => {
+    const client = makeClient();
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await expect(
+      updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "" }),
+    ).resolves.toStrictEqual({
+      outcome: "unsupported",
+      reason: 'Could not find a Linear workflow state named "In Review" for team ?',
     });
 
     expect(client.team).not.toHaveBeenCalled();
     expect(client.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("caches the review state across multiple tickets in the same team", async () => {
+    const client = makeClient({
+      states: [
+        { id: "state-in-progress", name: "In Progress", type: "started", position: 1 },
+        { id: "state-in-review", name: "In Review", type: "started", position: 2 },
+      ],
+    });
+    const updater = createLinearIssueStatusUpdater({ client: asLinearClient(client) });
+
+    await updater.markInReview({ id: "team-1", uuid: "uuid-1", teamId: "shared" });
+    await updater.markInReview({ id: "team-2", uuid: "uuid-2", teamId: "shared" });
+
+    expect(client.team).toHaveBeenCalledTimes(1);
+    expect(client.updateIssue).toHaveBeenCalledTimes(2);
   });
 
   it("fetches the started-type state once across multiple tickets in the same team", async () => {

--- a/src/lib/adapters/linear/writeback.ts
+++ b/src/lib/adapters/linear/writeback.ts
@@ -2,6 +2,13 @@ import type { LinearClient } from "@linear/sdk";
 
 import type { MarkInReviewResult } from "../../ticketSource.ts";
 import { debug } from "../../util.ts";
+import {
+  DEFAULT_LINEAR_STATUS_NAMES,
+  findLinearWorkflowStateByName,
+  formatLinearStatusNames,
+  type LinearStatusNames,
+  type LinearWorkflowState,
+} from "./statusNames.ts";
 
 interface LinearIssueReference {
   id: string;
@@ -14,21 +21,11 @@ interface LinearIssueStatusUpdater {
   markInReview(issue: LinearIssueReference): Promise<MarkInReviewResult>;
 }
 
-// Linear maps every `started` workflow state to canonical in-progress today,
-// so it cannot prove a successful in-review transition. Report unsupported
-// until read/write sides can distinguish "In Review" from generic started.
-async function markInReviewUnsupported(issue: LinearIssueReference): Promise<MarkInReviewResult> {
-  debug(`markInReview is unsupported for ${issue.id} (Linear in-review not yet implemented)`);
-  return {
-    outcome: "unsupported",
-    reason: "Linear in-review writeback is not implemented",
-  };
-}
-
 export function createLinearIssueStatusUpdater(arguments_: {
   client: LinearClient;
+  statusNames?: LinearStatusNames;
 }): LinearIssueStatusUpdater {
-  const { client } = arguments_;
+  const { client, statusNames = DEFAULT_LINEAR_STATUS_NAMES } = arguments_;
   // Positive cache only. Keyed by teamId because the in-progress-state
   // resolution yields a single stateId per team — independent of which
   // project the ticket belongs to. State ids don't change for misconfig
@@ -41,6 +38,13 @@ export function createLinearIssueStatusUpdater(arguments_: {
   // every failing attempt costs at most a handful of extra Linear API calls
   // per tick.
   const inProgressStateByTeam = new Map<string, string>();
+  const inReviewStateByTeam = new Map<string, string>();
+
+  async function fetchWorkflowStates(teamId: string): Promise<readonly LinearWorkflowState[]> {
+    const team = await client.team(teamId);
+    const states = await team.states();
+    return states.nodes;
+  }
 
   async function getInProgressStateId(teamId: string): Promise<string | undefined> {
     if (teamId.length === 0) {
@@ -50,24 +54,39 @@ export function createLinearIssueStatusUpdater(arguments_: {
     if (cached !== undefined) {
       return cached;
     }
-    const team = await client.team(teamId);
-    const states = await team.states();
     // Linear's default workflow has MULTIPLE `started`-type states — both
     // "In Progress" and "In Review" are `started`. `team.states()` orders by
     // updatedAt (the connection has no position ordering), so array order
-    // can't disambiguate them. Prefer the state literally named "In Progress";
-    // otherwise fall back to the lowest-position (leftmost) `started` column,
-    // which by Linear convention is the in-progress one. This survives teams
-    // that rename the column ("Doing", "WIP", ...).
-    const startedStates = states.nodes.filter((state) => state.type === "started");
+    // can't disambiguate them. Prefer configured/default in-progress names;
+    // otherwise fall back to the lowest-position (leftmost) `started` column.
+    const states = await fetchWorkflowStates(teamId);
+    const startedStates = states.filter((state) => state.type === "started");
     const inProgress =
-      startedStates.find((state) => state.name.trim().toLowerCase() === "in progress") ??
+      findLinearWorkflowStateByName(startedStates, statusNames.inProgress) ??
       startedStates.toSorted((a, b) => a.position - b.position).at(0);
     if (inProgress?.id === undefined) {
       return undefined;
     }
     inProgressStateByTeam.set(teamId, inProgress.id);
     return inProgress.id;
+  }
+
+  async function getInReviewStateId(teamId: string): Promise<string | undefined> {
+    if (teamId.length === 0) {
+      return undefined;
+    }
+    const cached = inReviewStateByTeam.get(teamId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const states = await fetchWorkflowStates(teamId);
+    const startedStates = states.filter((state) => state.type === "started");
+    const inReview = findLinearWorkflowStateByName(startedStates, statusNames.inReview);
+    if (inReview?.id === undefined) {
+      return undefined;
+    }
+    inReviewStateByTeam.set(teamId, inReview.id);
+    return inReview.id;
   }
 
   async function markInProgress(issue: LinearIssueReference): Promise<void> {
@@ -81,5 +100,18 @@ export function createLinearIssueStatusUpdater(arguments_: {
     debug(`Marked ${issue.id} as in progress`);
   }
 
-  return { markInProgress, markInReview: markInReviewUnsupported };
+  async function markInReview(issue: LinearIssueReference): Promise<MarkInReviewResult> {
+    const stateId = await getInReviewStateId(issue.teamId);
+    if (stateId === undefined) {
+      return {
+        outcome: "unsupported",
+        reason: `Could not find a Linear workflow state named ${formatLinearStatusNames(statusNames.inReview)} for team ${issue.teamId.length > 0 ? issue.teamId : "?"}`,
+      };
+    }
+    await client.updateIssue(issue.uuid, { stateId });
+    debug(`Marked ${issue.id} as in review`);
+    return { outcome: "applied" };
+  }
+
+  return { markInProgress, markInReview };
 }

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -100,13 +100,13 @@ describe(buildSources, () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────
-// Cross-source independence: a user with `linear.projects=[…]` and an
-// explicit `sources=[{kind:"shell"}]` block must be able to construct
-// both adapters even when no Linear API key is in env. The Linear
-// adapter's eager `getLinearClient()` call used to crash buildSources
-// on the missing key, which broke `crew doctor --ticket <shell-id>`
-// and any other shell-only operation. These tests pin that behavior
-// using the REAL production adapter registry (no spies, no fakes).
+// Cross-source independence: a user with an explicit
+// `sources=[{kind:"shell"}]` block must be able to construct both adapters
+// even when no Linear API key is in env. The Linear adapter's eager
+// `getLinearClient()` call used to crash buildSources on the missing key,
+// which broke `crew doctor --ticket <shell-id>` and any other shell-only
+// operation. These tests pin that behavior using the REAL production adapter
+// registry (no spies, no fakes).
 // ─────────────────────────────────────────────────────────────────────────
 
 function makeMixedConfig(): ResolvedConfig {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -152,9 +152,9 @@ type UserModelDefinition = EnabledUserModelDefinition;
  *
  * Groundcrew's built-in Linear adapter is implicit and needs no config:
  * it picks up every Linear issue assigned to the API key's viewer that
- * carries an `agent-*` label. There is no project / view / status
- * configuration — Linear's workflow `state.type` is the source of truth
- * for todo / in-progress / terminal classification.
+ * carries an `agent-*` label. There is no project or view configuration.
+ * Linear's default "In Progress" / "In Review" status names disambiguate
+ * `started` workflow states; unmatched statuses fall back to `state.type`.
  */
 export interface Config {
   /**
@@ -722,7 +722,8 @@ function failOnLegacyLinearShape(user: Record<string, unknown>): void {
     [
       "The `linear` config block is no longer supported.",
       "Groundcrew now picks up every Linear issue assigned to your API key's viewer that carries an `agent-*` label —",
-      "no project / view / status configuration needed. Remove the `linear: { ... }` block from your config.",
+      "remove the `linear: { ... }` block from your config.",
+      'To customize Linear status names, declare `sources: [{ kind: "linear", statuses: { ... } }]` instead.',
       "If you only want a subset of your Linear tickets to be picked up, leave the unwanted tickets unassigned or remove their `agent-*` label.",
     ].join("\n"),
   );

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -12,12 +12,12 @@
  * Source-neutral status enum every adapter normalises its native vocabulary
  * to. Consumers branch on these values, never on a source's native names.
  *
- * - `todo` / `in-progress` / `done`: the only canonical states the built-in
- *   Linear adapter produces today (mapped from Linear's workflow `state.type`).
- * - `in-review`: produced only by adapters whose schema declares an in-review
- *   mapping. The shell adapter's JSON contract accepts it; the built-in Linear
- *   adapter does not yet map any native state to it. Reserved here so
- *   consumers' branch logic doesn't change when that follow-up lands.
+ * - `todo` / `in-progress` / `done`: broad lifecycle states mapped from each
+ *   source's native vocabulary.
+ * - `in-review`: review-stage work that should no longer consume a dispatch
+ *   slot but should not be cleaned up as terminal. The built-in Linear adapter
+ *   maps default/configured review status names here; the shell adapter's JSON
+ *   contract accepts it directly.
  * - `other`: anything an adapter sees but can't classify (Linear tickets in
  *   `backlog`/`triage`, blockers with no resolvable state).
  */
@@ -37,8 +37,8 @@ export interface Blocker {
    *   (e.g., Linear had no state on the blocker; shell script omitted
    *   the field).
    * - `"unmapped"`: the source returned a status that isn't in the
-   *   source's known mapping (e.g., a Linear column not in
-   *   `linear.projects[*].statuses`, or an unrecognized shell value).
+   *   source's known mapping (e.g., a Linear column not covered by
+   *   `sources[*].statuses`, or an unrecognized shell value).
    *
    * MUST be undefined when `status !== "other"`.
    */


### PR DESCRIPTION
## Summary

Adds Linear status-name disambiguation so the default `In Review` workflow status maps to canonical `in-review` instead of continuing to consume an in-progress dispatch slot. Linear still falls back to `state.type` for unmatched statuses, so broad lifecycle handling remains conservative.

Also makes Linear `markInReview` a real writeback capability by targeting the default/configured review status name, while reporting `unsupported` when that status cannot be found.

## Validation

- `npx vitest run src/lib/adapters/linear/factory.test.ts src/lib/adapters/linear/writeback.test.ts src/lib/adapters/linear/schema.test.ts`
- `node --run verify`

## Notes

Rebased onto `origin/main` after PR 165 merged.

Agent session: `codex resume 019e9877-7904-7382-9470-e4e232516572`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
