### PR TITLE
feat: sort todo tickets by priority before slot assignment

### DIFF
--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -329,6 +329,62 @@ describe(createDispatcher, () => {
     });
   });
 
+  describe("priority ordering", () => {
+    let board: ReturnType<typeof makeBoard>;
+    let dispatcher: ReturnType<typeof createDispatcher>;
+
+    beforeEach(() => {
+      board = makeBoard();
+      dispatcher = createDispatcher({
+        config: makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1,
+            sessionLimitPercentage: 85,
+          },
+        }),
+        board,
+      });
+    });
+
+    it("starts the highest-priority ticket first when slots are limited", async () => {
+      const urgent = todoIssue({ id: "linear:team-urgent", priority: 1 });
+      const medium = todoIssue({ id: "linear:team-medium", priority: 3 });
+      const noPriority = todoIssue({ id: "linear:team-none" });
+
+      await dispatcher.runOnce({
+        state: boardOf([noPriority, medium, urgent]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).toHaveBeenCalledTimes(1);
+      expect(setupMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ticket: "team-urgent" }),
+      );
+    });
+
+    it("treats undefined priority (no priority) as lower than priority=4 (Low)", async () => {
+      const low = todoIssue({ id: "linear:team-low", priority: 4 });
+      const noPriority = todoIssue({ id: "linear:team-none" });
+
+      await dispatcher.runOnce({
+        state: boardOf([noPriority, low]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).toHaveBeenCalledTimes(1);
+      expect(setupMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ticket: "team-low" }),
+      );
+    });
+  });
+
   describe("blocker classification", () => {
     it("skips a ticket whose blocker is not in a terminal state", async () => {
       const board = makeBoard();

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -172,9 +172,12 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     const slots = config.orchestrator.maximumInProgress - activeCount;
     // Narrow Todo to tickets that opted in via an `agent-*` label.
     // Unlabeled tickets are not groundcrew's concern even when in Todo.
-    const todo: readonly GroundcrewIssue[] = state.issues.filter(
-      (issue): issue is GroundcrewIssue => issue.status === "todo" && isGroundcrewIssue(issue),
-    );
+    // Sort by priority so higher-priority tickets fill slots first.
+    const todo: readonly GroundcrewIssue[] = state.issues
+      .filter(
+        (issue): issue is GroundcrewIssue => issue.status === "todo" && isGroundcrewIssue(issue),
+      )
+      .toSorted((a, b) => prioritySortKey(a.priority) - prioritySortKey(b.priority));
 
     if (slots <= 0) {
       log(
@@ -300,6 +303,11 @@ function formatUsageExhaustion(exhaustion: ModelUsageExhaustion): string {
     return `${exhaustion.model} session at ${exhaustion.usedPercentage.toFixed(0)}% (> ${exhaustion.limitPercentage}%), resets in ${mins}m — skipping its tickets`;
   }
   return `${exhaustion.model} weekly at ${exhaustion.usedPercentage.toFixed(1)}% (> ${exhaustion.allowedPercentage.toFixed(1)}% paced budget), resets in ${exhaustion.resetMinutes}m — skipping its tickets`;
+}
+
+/** Undefined priority sorts last. */
+function prioritySortKey(priority: number | undefined): number {
+  return priority ?? Number.POSITIVE_INFINITY;
 }
 
 export function formatActiveSlotList(active: readonly Issue[]): string {

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -59,6 +59,7 @@ function linearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
     blockers: overrides.blockers ?? [],
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
     url: overrides.url ?? "https://linear.app/example/issue/TEAM-1",
+    priority: overrides.priority ?? 0,
   };
 }
 

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -131,6 +131,7 @@ export function toCanonicalIssue(
     blockers: linearIssue.blockers.map((b) => toCanonicalBlocker(b, sourceName, statusNames)),
     hasMoreBlockers: linearIssue.hasMoreBlockers,
     url: linearIssue.url,
+    ...(linearIssue.priority === 0 ? {} : { priority: linearIssue.priority }),
     sourceRef,
   };
 }

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -22,6 +22,7 @@ interface IssueNodeStub {
   title: string;
   description?: string | undefined;
   updatedAt: string;
+  priority?: number;
   state?: { id: string; name: string; type: string } | null;
   team?: { id: string; key: string } | null;
   assignee?: { name: string } | null;
@@ -78,6 +79,7 @@ function issueNode(overrides: Partial<IssueNodeStub>): IssueNodeStub {
     title: overrides.title ?? "Title",
     description: "description" in overrides ? overrides.description : "Touches repo-a.",
     updatedAt: overrides.updatedAt ?? "2025-01-01T00:00:00.000Z",
+    priority: overrides.priority ?? 0,
     state:
       overrides.state === undefined
         ? { id: "state-todo", name: "Todo", type: "unstarted" }

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -69,6 +69,8 @@ export interface Issue {
   hasMoreBlockers: boolean;
   /** Linear `Issue.url` — direct web link to the ticket. */
   url: string;
+  /** Linear priority: 1=Urgent, 2=High, 3=Medium, 4=Low, 0=No priority. */
+  priority: number;
 }
 
 /**
@@ -167,6 +169,7 @@ interface IssueNode {
   description?: string;
   updatedAt: string;
   url: string;
+  priority: number;
   state?: { id: string; name: string; type: string };
   team?: { id: string; key: string };
   assignee?: { name: string } | null;
@@ -218,6 +221,7 @@ async function fetchBoard(client: LinearClient, config: ResolvedConfig): Promise
             description
             updatedAt
             url
+            priority
             state { id name type }
             team { id key }
             assignee { name }
@@ -331,6 +335,7 @@ function buildLinearIssue(input: {
   model: string | undefined;
   teamId: string;
   url: string;
+  priority: number;
   inverseRelations: { nodes: IssueRelationNode[]; pageInfo: { hasNextPage: boolean } } | undefined;
 }): Issue {
   return {
@@ -348,6 +353,7 @@ function buildLinearIssue(input: {
     model: input.model,
     teamId: input.teamId,
     url: input.url,
+    priority: input.priority,
     blockers: blockersFromRelations(input.inverseRelations?.nodes ?? []),
     hasMoreBlockers: input.inverseRelations?.pageInfo.hasNextPage ?? false,
   };
@@ -382,6 +388,7 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
     model,
     teamId: node.team?.id ?? "",
     url: node.url,
+    priority: node.priority,
     inverseRelations: node.inverseRelations,
   });
 }

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -77,6 +77,12 @@ export interface Issue {
    * branched on.
    */
   url?: string;
+  /**
+   * Source-native priority. Lower values sort first; `undefined` means no
+   * priority and sorts last. Dispatcher uses this to order Todo tickets before
+   * slot assignment.
+   */
+  priority?: number;
   /** Adapter-private. Consumers MUST NOT inspect; only the producing adapter reads it. */
   sourceRef: unknown;
 }


### PR DESCRIPTION
## Summary

Groundcrew previously picked up Todo tickets in whatever order the Linear API returned them. Now the dispatcher sorts todo tickets by priority before filling slots, so Urgent (1) → High (2) → Medium (3) → Low (4) → no priority. The Linear adapter normalises Linear's raw "no priority" sentinel (0) to \`undefined\` at the adapter boundary, keeping the canonical \`Issue\` layer clean.

## Validation

- \`node --run verify\` passes: 1207 tests, 100% coverage, all lint/format checks clean.

Agent session: \`claude --resume 9726e2ea-cd66-4ed5-932e-3059c5af2b1f\`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>