### PR TITLE
feat: disable implicit Linear source via config sentinel

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -4,6 +4,7 @@
   "ignore": [
     ".agents",
     ".nx",
+    ".remember",
     ".agents",
     "AGENTS.md",
     "**/vitest.config.mts",

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -5,7 +5,6 @@
     ".agents",
     ".nx",
     ".remember",
-    ".agents",
     "AGENTS.md",
     "**/vitest.config.mts",
     "**/tsconfig.spec.json",

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -63,6 +63,9 @@ export default {
   //       inReview: ["Code Review"],
   //     },
   //   },
+  //   // Optional: disable the built-in Linear source entirely for shell-only
+  //   // setups (no Linear API key needed). Replaces the block above.
+  //   // { kind: "linear", enabled: false },
   //   {
   //     kind: "shell",
   //     name: "jira",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,23 @@ export default {
 
 Configured names replace the default for that status; omitted fields keep their defaults. Matching is case-insensitive and trims surrounding whitespace.
 
+Linear is implicit-on, but you can turn it off entirely with the opt-out sentinel `{ kind: "linear", enabled: false }`. This suppresses the built-in Linear source so no adapter is constructed and no API key is required — useful for shell-only setups, where a failing Linear probe would otherwise mark the whole queue unavailable:
+
+```ts
+export default {
+  sources: [
+    { kind: "linear", enabled: false },
+    {
+      kind: "shell",
+      name: "plans",
+      commands: {
+        fetch: "~/.config/groundcrew/plans-fetch.sh",
+      },
+    },
+  ],
+};
+```
+
 ## Enabling Model Presets
 
 Groundcrew ships built-in presets for `claude` and `codex`, but models are not enabled by default. List the models you want in `models.definitions`:
@@ -148,7 +165,7 @@ and hook contract.
 
 | Key                                      | Default              | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sources`                                | `[]`                 | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`. Declare `{ kind: "linear", statuses: { ... } }` only to override Linear status names used for `in-progress` / `in-review` disambiguation.                                                                                                                                                                                                                                                         |
+| `sources`                                | `[]`                 | Additional pluggable ticket sources, dispatched alongside the built-in Linear adapter. Built-in kinds: `shell`, `linear`. Declare `{ kind: "linear", statuses: { ... } }` only to override Linear status names used for `in-progress` / `in-review` disambiguation. Disable the implicit Linear source with `{ kind: "linear", enabled: false }` (no API key required) — useful for shell-only setups.                                                                                                                      |
 | `git.remote`                             | `"origin"`           | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `git.defaultBranch`                      | `"main"`             | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `git.branchPrefix`                       | OS username          | Prefix groundcrew puts before the ticket id when naming a worktree branch (`<branchPrefix>-<ticket>`). Must be a slash-free slug of letters, digits, `.`, `_`, or `-`. Defaults to the OS account username. Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. Prefer a per-user config for personal prefixes — a committed `git.branchPrefix` gives every contributor the same branch prefix.                                                           |

--- a/src/lib/adapters/linear/schema.test.ts
+++ b/src/lib/adapters/linear/schema.test.ts
@@ -27,4 +27,22 @@ describe("Linear adapter config schema", () => {
 
     expect(actual.success).toBe(false);
   });
+
+  it("accepts the explicit opt-out sentinel enabled: false", () => {
+    const actual = linearAdapterConfigSchema.parse({ kind: "linear", enabled: false });
+
+    expect(actual).toStrictEqual({ kind: "linear", enabled: false });
+  });
+
+  it("accepts enabled: true", () => {
+    const actual = linearAdapterConfigSchema.parse({ kind: "linear", enabled: true });
+
+    expect(actual).toStrictEqual({ kind: "linear", enabled: true });
+  });
+
+  it("rejects a non-boolean enabled", () => {
+    const actual = linearAdapterConfigSchema.safeParse({ kind: "linear", enabled: "no" });
+
+    expect(actual.success).toBe(false);
+  });
 });

--- a/src/lib/adapters/linear/schema.ts
+++ b/src/lib/adapters/linear/schema.ts
@@ -11,6 +11,12 @@ const statusNamesSchema = z.array(z.string().trim().min(1)).min(1);
 
 export const linearAdapterConfigSchema = z.object({
   kind: z.literal("linear"),
+  /**
+   * Opt-out sentinel. Set `enabled: false` to disable the built-in Linear
+   * source entirely (no adapter is constructed, no API key required) — see
+   * `sourcesFromConfig` in buildSources.ts. Omitted/`true` keeps Linear active.
+   */
+  enabled: z.boolean().optional(),
   name: z
     .string()
     .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)")

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -175,6 +175,26 @@ describe(`${buildSources.name} — cross-source independence with no Linear API 
     // oxlint-disable-next-line typescript/no-non-null-assertion -- buildSources asserted above
     await expect(linear!.verify()).rejects.toThrow(/GROUNDCREW_LINEAR_API_KEY or LINEAR_API_KEY/);
   });
+
+  it("builds only the shell source when Linear is disabled via the sentinel, with no key", async () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; only the shell source is constructed
+    const config = {
+      sources: [
+        { kind: "linear", enabled: false },
+        { kind: "shell", name: "plans", commands: { fetch: "echo '[]'" } },
+      ],
+      workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    } as unknown as ResolvedConfig;
+
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+
+    // No Linear adapter is built and nothing throws on the missing key.
+    expect(sources.map((s) => s.name)).toStrictEqual(["plans"]);
+
+    const shell = sources.find((s) => s.name === "plans");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    await expect(shell!.fetch()).resolves.toStrictEqual([]);
+  });
 });
 
 describe(sourcesFromConfig, () => {
@@ -236,6 +256,61 @@ describe(sourcesFromConfig, () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "shell", name: "jira", command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([
+      { kind: "linear" },
+      { kind: "shell", name: "jira", command: ["./fetch.sh"] },
+    ]);
+  });
+
+  it("drops Linear entirely when the user disables it via { kind: 'linear', enabled: false }", () => {
+    // The disabled linear entry still counts as "explicit linear" (so the
+    // implicit source is suppressed) AND is filtered out of the kept list,
+    // leaving only the shell source — no Linear adapter is ever constructed.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [
+        { kind: "linear", enabled: false },
+        { kind: "shell", name: "plans", command: ["./fetch.sh"] },
+      ],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([
+      { kind: "shell", name: "plans", command: ["./fetch.sh"] },
+    ]);
+  });
+
+  it("keeps an explicit Linear source when enabled: true", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "linear", enabled: true }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", enabled: true }]);
+  });
+
+  it("drops a disabled linear entry even when it is the only source, leaving no sources", () => {
+    // No implicit linear is synthesized (the disabled entry is explicit
+    // linear), and the entry itself is filtered out — zero sources remain.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "linear", enabled: false }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([]);
+  });
+
+  it("drops any disabled non-linear source while still synthesizing implicit linear", () => {
+    // The `enabled: false` opt-out is generic: a disabled shell source is
+    // filtered out, and because no Linear entry is present the implicit Linear
+    // source is still synthesized.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [
+        { kind: "shell", name: "plans", enabled: false, command: ["./fetch.sh"] },
+        { kind: "shell", name: "jira", command: ["./fetch.sh"] },
+      ],
     } as unknown as ResolvedConfig;
 
     expect(sourcesFromConfig(config)).toStrictEqual([

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -318,4 +318,17 @@ describe(sourcesFromConfig, () => {
       { kind: "shell", name: "jira", command: ["./fetch.sh"] },
     ]);
   });
+
+  it("keeps implicit Linear when a disabled non-linear source is merely named 'linear'", () => {
+    // A source that is Linear only by *name* (e.g. a shell source named
+    // "linear") takes over the Linear slot only while it's enabled. Disabling
+    // it must not suppress the implicit Linear source and leave the queue empty
+    // — only a real `{ kind: "linear" }` sentinel does that.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "shell", name: "linear", enabled: false, command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear" }]);
+  });
 });

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -57,19 +57,38 @@ const sourceShape = z.looseObject({
 });
 
 /**
+ * Read the structural `name` / `kind` / `enabled` fields off a raw source.
+ * `looseObject()` with all-optional fields only fails to parse non-object
+ * inputs (null, primitives); those are rejected downstream by the per-adapter
+ * Zod schema in buildSourcesWith, so we treat a non-object entry as an empty
+ * field set ("no opinion") rather than branching on it at every call site.
+ */
+function sourceFields(raw: unknown): z.infer<typeof sourceShape> {
+  const parsed = sourceShape.safeParse(raw);
+  /* v8 ignore next 3 @preserve -- non-object inputs never reach here in practice (see above); the guard exists only for type-narrowing. */
+  if (!parsed.success) {
+    return {};
+  }
+  return parsed.data;
+}
+
+/**
  * True when `raw` carries the opt-out sentinel `enabled: false`. Used to drop
  * a source the user explicitly disabled — most importantly a
  * `{ kind: "linear", enabled: false }` entry — so its adapter is never
- * constructed. Returns false for malformed entries (rejected downstream by the
- * per-adapter Zod schema) and for any entry without `enabled: false`.
+ * constructed.
  */
 function isSourceDisabled(raw: unknown): boolean {
-  const parsed = sourceShape.safeParse(raw);
-  /* v8 ignore next 3 @preserve -- looseObject() with all-optional fields only fails to parse non-object inputs (null, primitives); those are rejected by the per-adapter Zod schema in buildSourcesWith, so this guard never fires in practice. */
-  if (!parsed.success) {
-    return false;
-  }
-  return parsed.data.enabled === false;
+  return sourceFields(raw).enabled === false;
+}
+
+/**
+ * True when `raw` declares `kind: "linear"`, regardless of `name` or `enabled`.
+ * This is what lets the `{ kind: "linear", enabled: false }` opt-out suppress
+ * the implicit Linear source even though the entry itself is filtered out.
+ */
+function isLinearKindSource(raw: unknown): boolean {
+  return sourceFields(raw).kind === "linear";
 }
 
 /**
@@ -86,12 +105,8 @@ function isSourceDisabled(raw: unknown): boolean {
  * downstream.
  */
 function isExplicitLinearSource(raw: unknown): boolean {
-  const parsed = sourceShape.safeParse(raw);
-  /* v8 ignore next 3 @preserve -- looseObject() with all-optional fields only fails to parse non-object inputs (null, primitives); the same input would be rejected by the per-adapter Zod schema in buildSourcesWith, so this guard never fires in practice. */
-  if (!parsed.success) {
-    return false;
-  }
-  return parsed.data.kind === "linear" || (parsed.data.name ?? parsed.data.kind) === "linear";
+  const { kind, name } = sourceFields(raw);
+  return kind === "linear" || (name ?? kind) === "linear";
 }
 
 /**
@@ -99,9 +114,9 @@ function isExplicitLinearSource(raw: unknown): boolean {
  * implicit Linear source (Linear is always active under the post-#110
  * model — viewer + agent-* label filtering happens at the GraphQL layer)
  * and appends any user-declared `sources`. The implicit source is omitted
- * when the user already declared a Linear source (by `kind` or by runtime
- * name "linear") so they can override its `name` / construction without
- * spawning a duplicate adapter.
+ * when the user already declared a Linear source — by `kind: "linear"`, or by
+ * a surviving (non-disabled) source whose runtime name is "linear" — so they
+ * can override its `name` / construction without spawning a duplicate adapter.
  *
  * Users opt out of Linear entirely with the sentinel
  * `{ kind: "linear", enabled: false }`: it still counts as an explicit Linear
@@ -110,10 +125,14 @@ function isExplicitLinearSource(raw: unknown): boolean {
  * other source with `enabled: false` is likewise dropped from the result.
  */
 export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
-  // Order matters: detect explicit Linear on the *unfiltered* list so a
-  // disabled linear entry still suppresses the implicit source, then drop it.
-  const hasExplicitLinear = config.sources.some(isExplicitLinearSource);
   const kept = config.sources.filter((source) => !isSourceDisabled(source));
+  // A `kind: "linear"` entry suppresses the implicit source even when it is the
+  // disabled opt-out sentinel — it's removed from `kept` above, leaving Linear
+  // off entirely. A source that's Linear only by *name* (e.g. a shell source
+  // named "linear") suppresses the implicit source only while it survives the
+  // filter, so disabling such an entry doesn't silently drop Linear.
+  const hasExplicitLinear =
+    config.sources.some(isLinearKindSource) || kept.some(isExplicitLinearSource);
   if (hasExplicitLinear) {
     return kept;
   }

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -53,7 +53,24 @@ export function buildSourcesWith(
 const sourceShape = z.looseObject({
   name: z.string().optional(),
   kind: z.string().optional(),
+  enabled: z.boolean().optional(),
 });
+
+/**
+ * True when `raw` carries the opt-out sentinel `enabled: false`. Used to drop
+ * a source the user explicitly disabled — most importantly a
+ * `{ kind: "linear", enabled: false }` entry — so its adapter is never
+ * constructed. Returns false for malformed entries (rejected downstream by the
+ * per-adapter Zod schema) and for any entry without `enabled: false`.
+ */
+function isSourceDisabled(raw: unknown): boolean {
+  const parsed = sourceShape.safeParse(raw);
+  /* v8 ignore next 3 @preserve -- looseObject() with all-optional fields only fails to parse non-object inputs (null, primitives); those are rejected by the per-adapter Zod schema in buildSourcesWith, so this guard never fires in practice. */
+  if (!parsed.success) {
+    return false;
+  }
+  return parsed.data.enabled === false;
+}
 
 /**
  * True when `raw` is an explicitly-declared Linear source. Matches either a
@@ -85,11 +102,20 @@ function isExplicitLinearSource(raw: unknown): boolean {
  * when the user already declared a Linear source (by `kind` or by runtime
  * name "linear") so they can override its `name` / construction without
  * spawning a duplicate adapter.
+ *
+ * Users opt out of Linear entirely with the sentinel
+ * `{ kind: "linear", enabled: false }`: it still counts as an explicit Linear
+ * declaration (so the implicit source is suppressed) and is itself filtered
+ * out (so no Linear adapter is constructed and no API key is required). Any
+ * other source with `enabled: false` is likewise dropped from the result.
  */
 export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
+  // Order matters: detect explicit Linear on the *unfiltered* list so a
+  // disabled linear entry still suppresses the implicit source, then drop it.
   const hasExplicitLinear = config.sources.some(isExplicitLinearSource);
+  const kept = config.sources.filter((source) => !isSourceDisabled(source));
   if (hasExplicitLinear) {
-    return [...config.sources];
+    return kept;
   }
-  return [{ kind: "linear" }, ...config.sources];
+  return [{ kind: "linear" }, ...kept];
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1520,6 +1520,20 @@ describe("loadConfig", () => {
     expect(actual.sources).toStrictEqual([{ kind: "shell", name: "jira" }]);
   });
 
+  it("preserves the Linear disabled sentinel through resolution", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        sources: [{ kind: "linear", enabled: false }],
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.sources).toStrictEqual([{ kind: "linear", enabled: false }]);
+  });
+
   it("rejects sources when it isn't an array", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -164,6 +164,11 @@ export interface Config {
    * an external system (Jira, plan-keeper, etc.) by pointing at command
    * templates that emit/consume JSON.
    *
+   * The implicit Linear source can be turned off with the opt-out sentinel
+   * `{ kind: "linear", enabled: false }` — useful for shell-only setups with
+   * no Linear API key, where a failing Linear probe would otherwise take down
+   * the whole queue.
+   *
    * Per-source Zod validation runs at `buildSources` time — config.ts only
    * verifies the structural shape (array of objects with a string `kind`).
    */


### PR DESCRIPTION
## Summary

Groundcrew's built-in Linear source is always implicit under the post-#110 model: `sourcesFromConfig` synthesizes a `{ kind: "linear" }` source unless the user already declared one. Because the Board fans verify/fetch across all sources atomically, a missing `GROUNDCREW_LINEAR_API_KEY` / `LINEAR_API_KEY` made Linear's verify fail and took the **whole** queue "unavailable" — including healthy sources like a plan-keeper `kind: "shell"` source. A shell-only user had no first-class way to turn Linear off (the only workaround was naming a shell source `"linear"`, which is semantically wrong and fragile).

This adds an opt-out sentinel so users can disable the built-in Linear source from `crew.config.ts`:

```ts
sources: [
  { kind: "linear", enabled: false },
  { kind: "shell", name: "plans", commands: { ... } },
]
```

When a Linear entry has `enabled: false`, both the implicit synthesized Linear source **and** that explicit entry are suppressed — no Linear adapter is constructed and no API key is required. `crew status` / `crew doctor` then succeed with only the shell source.

Mechanism: `sourcesFromConfig` computes `hasExplicitLinear` on the *unfiltered* list (so a disabled linear entry still suppresses the implicit source), then filters out any `enabled: false` entry before dispatch. `linearAdapterConfigSchema` gains an optional `enabled` boolean. The opt-out is generic — any source with `enabled: false` is dropped — though per the design scope only Linear's schema declares the field.

## Validation

- `node --run verify` — **All checks passed.** 1215 tests, 100% statement/branch/function/line coverage.
- Red/green/refactor TDD: added failing tests for the schema (`enabled` accepted/rejected) and `sourcesFromConfig` (disable drops Linear, `enabled: true` kept, generic non-Linear disable, real-registry build with no API key), watched them fail, then implemented to green.
- Follow-up review change: added a `loadConfig` regression test that the documented sentinel survives config resolution.

## Notes

**Decisions (made autonomously per the plan):**
- Config surface is the sentinel entry `{ kind: "linear", enabled: false }`, not a top-level `linear: false` flag — keeps everything inside the existing `sources` array and mirrors how an explicit Linear source is already declared. (This was the pre-agreed design in the plan.)
- `enabled` was added only to `linearAdapterConfigSchema`, not the shell schema. The disable path works generically at the `sourcesFromConfig` filter (before per-adapter validation), so a disabled shell source is still dropped; explicitly enabling a non-Linear source with `enabled: true` is out of scope and would be rejected by the strict shell schema. This matches the plan's "keep scope to Linear" guidance.
- Added `.remember` to `.jscpd.json`'s ignore list. `jscpd .` was flagging a self-clone inside a git-ignored, harness-local `.remember/logs/*.log` session file (TypeScript sources have 0 clones). The ignore list already excludes analogous harness/build dirs (`.agents`, `.nx`), and `.remember`'s nested `.gitignore` isn't picked up by jscpd's root-only gitignore handling — so this is consistent maintenance, not scope creep.

**Non-goals:** per-source fault isolation in the Board (a separate, larger change). This PR only adds an explicit opt-out.

Agent session: `claude --resume b9a86f4c-1b1d-4822-b53f-4d6e733b6726`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>