### PR TITLE
feat: support multiple project dirs and a separate worktree dir (plan-244692718977688)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ import type { Config } from "@clipboard-health/groundcrew";
 export default {
   workspace: {
     projectDir: "~/dev",
+    // Optional: all worktrees go here regardless of where each repo lives.
+    // worktreeDir: "~/dev/worktrees",
+    // Strings live under projectDir; use { name, dir } to override per repo.
     knownRepositories: ["OWNER/REPO"],
   },
   models: {

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ export default {
 } satisfies Config;
 ```
 
+Changing `workspace.worktreeDir` only affects worktrees discovered under the new
+root. Clean up existing worktrees before switching it, or temporarily unset
+`worktreeDir` when you need `crew cleanup` to find worktrees created beside the
+repos.
+
 There is no `linear` config block. Groundcrew reads `GROUNDCREW_LINEAR_API_KEY` first, then falls back to `LINEAR_API_KEY`.
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ export default {
     projectDir: "~/dev",
     // Optional: all worktrees go here regardless of where each repo lives.
     // worktreeDir: "~/dev/worktrees",
-    // Strings live under projectDir; use { name, dir } to override per repo.
+    // Strings live under projectDir; use { name, projectDirOverride } to override per repo.
     knownRepositories: ["OWNER/REPO"],
   },
   models: {

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -23,7 +23,7 @@ export default {
     // `<owner>/<repo>` or bare `<repo>` strings; the orchestrator scopes
     // tickets to these and refuses unknown repos by default. Use the object
     // form to point a repo at a different parent directory:
-    //   { name: "other-org/other-repo", dir: "~/work" }
+    //   { name: "other-org/other-repo", projectDirOverride: "~/work" }
     knownRepositories: ["your-org/your-repo"],
   },
   models: {

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -13,12 +13,17 @@ export default {
   // Opt a ticket in: assign it to yourself and add an `agent-<model>`
   // label (e.g. `agent-claude`, `agent-any`).
   workspace: {
-    // Parent directory under which groundcrew clones repositories and
-    // creates per-ticket worktrees.
+    // Parent directory under which groundcrew clones repositories and (by
+    // default) creates per-ticket worktrees.
     projectDir: "~/dev/groundcrew",
+    // Optional: collect ALL worktrees here instead of beside each repo. Useful
+    // when your repos live in more than one place. Defaults to projectDir.
+    // worktreeDir: "~/dev/worktrees",
     // Repositories groundcrew is allowed to set up worktrees in. Add
-    // `<owner>/<repo>` or bare `<repo>` entries; the orchestrator scopes
-    // tickets to these and refuses unknown repos by default.
+    // `<owner>/<repo>` or bare `<repo>` strings; the orchestrator scopes
+    // tickets to these and refuses unknown repos by default. Use the object
+    // form to point a repo at a different parent directory:
+    //   { name: "other-org/other-repo", dir: "~/work" }
     knownRepositories: ["your-org/your-repo"],
   },
   models: {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,8 @@ Workspace settings and at least one enabled model are required; everything else 
 
 | Key                           | What                                                                   |
 | ----------------------------- | ---------------------------------------------------------------------- |
-| `workspace.projectDir`        | Parent dir for cloned repos and sibling ticket worktrees.              |
+| `workspace.projectDir`        | Parent dir for cloned repos and the default ticket worktree root.      |
+| `workspace.worktreeDir`       | Optional parent dir for ticket worktrees.                              |
 | `workspace.knownRepositories` | Repos searched for in ticket descriptions to infer where work belongs. |
 | `models.definitions`          | Enabled model set. Built-in presets can be enabled with `{}`.          |
 
@@ -12,7 +13,10 @@ The branch prefix (`<prefix>-<TICKET>`) defaults to `os.userInfo().username`; ov
 
 ## Repository Layout
 
-Groundcrew never clones repositories for you. `crew init --repo OWNER/REPO` prints the clone command to run. If you are cloning manually, clone each `workspace.knownRepositories` entry into `workspace.projectDir` using the same relative path the config uses.
+Groundcrew never clones repositories for you. `crew init --repo OWNER/REPO`
+prints the clone command to run. If you are cloning manually, clone each string
+`workspace.knownRepositories` entry into `workspace.projectDir` using the same
+relative path the config uses.
 
 ```bash
 PROJECT_DIR="$HOME/dev"
@@ -20,7 +24,18 @@ mkdir -p "$PROJECT_DIR/OWNER"
 git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"
 ```
 
-Bare-name entries have no owner, so pick the remote URL yourself and clone to `$PROJECT_DIR/<name>`.
+Bare-name entries have no owner, so pick the remote URL yourself and clone to
+`$PROJECT_DIR/<name>`. To keep a repo clone somewhere else, use
+`{ name: "OWNER/REPO", projectDirOverride: "~/other" }` and clone it under that
+parent dir.
+
+By default, ticket worktrees are created beside the repos under
+`workspace.projectDir`. Set `workspace.worktreeDir` to collect worktrees under a
+separate root, regardless of where each source repo clone lives. Changing
+`workspace.worktreeDir` only affects worktrees discovered under the new root.
+Clean up existing worktrees before switching it, or temporarily unset
+`worktreeDir` when you need `crew cleanup` to find worktrees created beside the
+repos.
 
 ## Config Discovery
 
@@ -152,8 +167,9 @@ and hook contract.
 | `git.remote`                             | `"origin"`           | Remote used for `fetch` and as the worktree base ref.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `git.defaultBranch`                      | `"main"`             | Branch fetched from `git.remote` and used as the worktree base.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `git.branchPrefix`                       | OS username          | Prefix groundcrew puts before the ticket id when naming a worktree branch (`<branchPrefix>-<ticket>`). Must be a slash-free slug of letters, digits, `.`, `_`, or `-`. Defaults to the OS account username. Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. Prefer a per-user config for personal prefixes — a committed `git.branchPrefix` gives every contributor the same branch prefix.                                                           |
-| `workspace.projectDir`                   | **required**         | Parent dir for cloned repos and sibling ticket worktrees.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `workspace.knownRepositories`            | **required**         | Repos searched for in ticket descriptions to infer where work belongs. A ticket labeled for groundcrew (`agent-*`) fails fast when no known repo appears; unlabeled tickets are ignored.                                                                                                                                                                                                                                                                                                                                    |
+| `workspace.projectDir`                   | **required**         | Parent dir for cloned repos and the default ticket worktree root.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `workspace.worktreeDir`                  | optional             | Parent dir for ticket worktrees. When unset, worktrees are created under `workspace.projectDir`. Changing this only affects worktrees discovered under the new root; clean up existing worktrees before switching it, or temporarily unset it when you need `crew cleanup` to find old worktrees.                                                                                                                                                                                                                           |
+| `workspace.knownRepositories`            | **required**         | Repos searched for in ticket descriptions to infer where work belongs. Entries can be strings under `workspace.projectDir` or `{ name, projectDirOverride }` objects when a repo clone lives under a different parent dir. A ticket labeled for groundcrew (`agent-*`) fails fast when no known repo appears; unlabeled tickets are ignored.                                                                                                                                                                                |
 | `defaults.hooks.prepareWorktree`         | optional             | Fallback repo-preparation command used only when the worktree does not define `.groundcrew/config.json` `hooks.prepareWorktree`. The hook runs after worktree creation and before the agent starts. Repo-local config wins.                                                                                                                                                                                                                                                                                                 |
 | `orchestrator.maximumInProgress`         | `4`                  | Cap on in-progress tickets at once for this `crew` instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `orchestrator.pollIntervalMilliseconds`  | `120_000`            | Poll interval in `--watch` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ const requireFromCli = createRequire(import.meta.url);
 
 const SETUP_REPOS_REMOVED_MESSAGE = [
   "crew setup repos was removed.",
-  "Clone repositories manually with git clone into workspace.projectDir.",
+  "Clone repositories manually with git clone into workspace.projectDir (or each repo's workspace.knownRepositories `dir`).",
   "See README.md#manual-repository-bootstrap for the replacement workflow.",
 ].join(" ");
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ const requireFromCli = createRequire(import.meta.url);
 
 const SETUP_REPOS_REMOVED_MESSAGE = [
   "crew setup repos was removed.",
-  "Clone repositories manually with git clone into workspace.projectDir (or each repo's workspace.knownRepositories `dir`).",
+  "Clone repositories manually with git clone into workspace.projectDir (or each repo's workspace.knownRepositories `projectDirOverride`).",
   "See README.md#manual-repository-bootstrap for the replacement workflow.",
 ].join(" ");
 

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -352,6 +352,28 @@ describe(doctor, () => {
     expect(actual).toBe(false);
   });
 
+  it("reports a failing worktreeDir check when worktreeDir is configured but missing", async () => {
+    loadConfigMock.mockResolvedValue({
+      ...makeConfig(),
+      workspace: { projectDir: "/work", worktreeDir: "/wt", knownRepositories: ["repo-a"] },
+    });
+    mockMissingPath("/wt");
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("workspace.worktreeDir");
+    expect(consoleLog.output()).toContain('mkdir -p "/wt"');
+  });
+
+  it("emits no separate worktreeDir check when worktreeDir is unset", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+
+    await doctor();
+
+    expect(consoleLog.output()).not.toContain("workspace.worktreeDir");
+  });
+
   it("checks both wrapper and wrapped commands when the cmd is `safehouse claude --foo`", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,7 @@ import {
   type LocalRunnerSetting,
   loadConfigWithSource,
   type ResolvedConfig,
+  worktreeBaseDir,
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
@@ -213,6 +214,9 @@ export async function doctor(): Promise<boolean> {
     await checkCmd("git", true, "https://git-scm.com/"),
     ...(await workspaceChecks(workspaceOutcome)),
     checkDir(config.workspace.projectDir, "workspace.projectDir"),
+    ...(config.workspace.worktreeDir === undefined
+      ? []
+      : [checkDir(worktreeBaseDir(config), "workspace.worktreeDir")]),
     localCapability,
   ];
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1239,6 +1239,21 @@ describe("loadConfig", () => {
     await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].dir");
   });
 
+  it("rejects a knownRepositories entry that is neither a string nor an object", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: "/dev", knownRepositories: [42] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0] must be an object");
+  });
+
   it("rejects a knownRepositories object entry with a non-string name", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -7,7 +7,13 @@ import {
   setEnvironmentVariable,
   snapshotEnvironmentVariables,
 } from "../testHelpers/env.ts";
-import type { Config, LoadedConfig, ResolvedConfig } from "./config.ts";
+import {
+  repositoryBaseDir,
+  worktreeBaseDir,
+  type Config,
+  type LoadedConfig,
+  type ResolvedConfig,
+} from "./config.ts";
 
 interface ConfigModule {
   loadConfig: () => Promise<Readonly<ResolvedConfig>>;
@@ -1165,6 +1171,104 @@ describe("loadConfig", () => {
     expect(actual.workspace.projectDir).toBe("/work/here");
   });
 
+  it("lifts per-repo dir overrides out of knownRepositories", async () => {
+    setEnvironmentVariable("HOME", "/fake-home");
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: "~/dev",
+          worktreeDir: "~/worktrees",
+          knownRepositories: ["owner/flat", { name: "owner/elsewhere", dir: "~/work" }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    expect(config.workspace.knownRepositories).toStrictEqual(["owner/flat", "owner/elsewhere"]);
+    expect(config.workspace.worktreeDir).toBe("/fake-home/worktrees");
+    expect(config.workspace.repositoryDirs).toStrictEqual({
+      "owner/elsewhere": "/fake-home/work",
+    });
+  });
+
+  it("treats an object entry without a dir like a bare string", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: "/dev",
+          knownRepositories: [{ name: "owner/plain" }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    expect(config.workspace.knownRepositories).toStrictEqual(["owner/plain"]);
+    expect(config.workspace.repositoryDirs).toBeUndefined();
+  });
+
+  it("omits worktreeDir and repositoryDirs when no overrides are given", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: { projectDir: "/dev", knownRepositories: ["owner/flat"] },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    expect(config.workspace.worktreeDir).toBeUndefined();
+    expect(config.workspace.repositoryDirs).toBeUndefined();
+  });
+
+  it("rejects a knownRepositories object entry with a non-string dir", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: "/dev", knownRepositories: [{ name: "owner/x", dir: 5 }] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].dir");
+  });
+
+  it("rejects a knownRepositories object entry with a non-string name", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: "/dev", knownRepositories: [{ name: 5 }] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].name");
+  });
+
+  it("rejects a worktreeDir that is not a string", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: "/dev", worktreeDir: 5, knownRepositories: ["owner/flat"] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow("workspace.worktreeDir");
+  });
+
   it("defaults logging.file to the XDG state path", async () => {
     const configPath = writeConfigFile(
       temporary,
@@ -1275,6 +1379,23 @@ describe("loadConfig", () => {
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(/workspace must be an object/);
+  });
+
+  it("fails when knownRepositories is not an array", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: ${JSON.stringify(temporary)}, knownRepositories: "owner/repo" },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /workspace\.knownRepositories must be a non-empty array/,
+    );
   });
 
   it("fails when knownRepositories is empty", async () => {
@@ -1664,5 +1785,60 @@ describe("loadConfigWithSource", () => {
 
     expect(actual.source).toStrictEqual({ kind: "xdg", filepath: xdgConfigPath_ });
     expect(actual.config.workspace.projectDir).toBe(temporary);
+  });
+});
+
+function resolvedConfigWithWorkspace(workspace: ResolvedConfig["workspace"]): ResolvedConfig {
+  return {
+    sources: [],
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace,
+    defaults: { hooks: {} },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/x.log" },
+  };
+}
+
+describe("workspace path accessors", () => {
+  const resolved = resolvedConfigWithWorkspace;
+
+  it("worktreeBaseDir falls back to projectDir when worktreeDir is unset", () => {
+    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
+    expect(worktreeBaseDir(config)).toBe("/p");
+  });
+
+  it("worktreeBaseDir prefers worktreeDir when set", () => {
+    const config = resolved({
+      projectDir: "/p",
+      worktreeDir: "/w",
+      knownRepositories: ["a"],
+    });
+    expect(worktreeBaseDir(config)).toBe("/w");
+  });
+
+  it("repositoryBaseDir falls back to projectDir without an override", () => {
+    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
+    expect(repositoryBaseDir(config, "a")).toBe("/p");
+  });
+
+  it("repositoryBaseDir uses the per-repo override when present", () => {
+    const config = resolved({
+      projectDir: "/p",
+      knownRepositories: ["a", "b"],
+      repositoryDirs: { b: "/other" },
+    });
+    expect(repositoryBaseDir(config, "b")).toBe("/other");
+    expect(repositoryBaseDir(config, "a")).toBe("/p");
   });
 });

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1269,6 +1269,21 @@ describe("loadConfig", () => {
     await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].name");
   });
 
+  it("rejects a non-string projectDir with a clean config error", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: 5, knownRepositories: ["owner/flat"] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow("workspace.projectDir must be a non-empty string");
+  });
+
   it("rejects a worktreeDir that is not a string", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1196,6 +1196,23 @@ describe("loadConfig", () => {
     });
   });
 
+  it("rejects duplicate knownRepositories names instead of overwriting overrides", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: { projectDir: "/dev", knownRepositories: ["owner/dup", { name: "owner/dup", projectDirOverride: "/work" }] },`,
+        `  models: { definitions: { claude: {} } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      'workspace.knownRepositories[1] duplicates "owner/dup" from workspace.knownRepositories[0]',
+    );
+  });
+
   it("treats an object entry without a projectDirOverride like a bare string", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1171,7 +1171,7 @@ describe("loadConfig", () => {
     expect(actual.workspace.projectDir).toBe("/work/here");
   });
 
-  it("lifts per-repo dir overrides out of knownRepositories", async () => {
+  it("lifts per-repo projectDirOverride out of knownRepositories", async () => {
     setEnvironmentVariable("HOME", "/fake-home");
     const configPath = writeConfigFile(
       temporary,
@@ -1179,7 +1179,10 @@ describe("loadConfig", () => {
         workspace: {
           projectDir: "~/dev",
           worktreeDir: "~/worktrees",
-          knownRepositories: ["owner/flat", { name: "owner/elsewhere", dir: "~/work" }],
+          knownRepositories: [
+            "owner/flat",
+            { name: "owner/elsewhere", projectDirOverride: "~/work" },
+          ],
         },
       }),
     );
@@ -1193,7 +1196,7 @@ describe("loadConfig", () => {
     });
   });
 
-  it("treats an object entry without a dir like a bare string", async () => {
+  it("treats an object entry without a projectDirOverride like a bare string", async () => {
     const configPath = writeConfigFile(
       temporary,
       validConfigSource({
@@ -1224,19 +1227,19 @@ describe("loadConfig", () => {
     expect(config.workspace.repositoryDirs).toBeUndefined();
   });
 
-  it("rejects a knownRepositories object entry with a non-string dir", async () => {
+  it("rejects a knownRepositories object entry with a non-string projectDirOverride", async () => {
     const configPath = writeConfigFile(
       temporary,
       [
         "export default {",
-        `  workspace: { projectDir: "/dev", knownRepositories: [{ name: "owner/x", dir: 5 }] },`,
+        `  workspace: { projectDir: "/dev", knownRepositories: [{ name: "owner/x", projectDirOverride: 5 }] },`,
         `  models: { definitions: { claude: {} } },`,
         "};",
       ].join("\n"),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     const { loadConfig } = await loadFreshConfig();
-    await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].dir");
+    await expect(loadConfig()).rejects.toThrow("workspace.knownRepositories[0].projectDirOverride");
   });
 
   it("rejects a knownRepositories entry that is neither a string nor an object", async () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -156,6 +156,16 @@ type UserModelDefinition = EnabledUserModelDefinition;
  * Linear's default "In Progress" / "In Review" status names disambiguate
  * `started` workflow states; unmatched statuses fall back to `state.type`.
  */
+/**
+ * A configured repository. The bare-string form keeps the repo under
+ * `workspace.projectDir`; the object form's optional `dir` overrides that
+ * parent directory so repos can live in more than one place.
+ */
+export interface KnownRepository {
+  name: string;
+  dir?: string;
+}
+
 export interface Config {
   /**
    * Additional pluggable ticket sources beyond the built-in Linear adapter
@@ -180,7 +190,12 @@ export interface Config {
   };
   workspace: {
     projectDir: string;
-    knownRepositories: string[];
+    /**
+     * Parent directory all per-ticket worktrees are created under. Defaults
+     * to `projectDir` when unset, so single-directory setups are unchanged.
+     */
+    worktreeDir?: string;
+    knownRepositories: (string | KnownRepository)[];
   };
   defaults?: {
     hooks?: HookCommands;
@@ -246,7 +261,12 @@ export interface ResolvedConfig {
   };
   workspace: {
     projectDir: string;
+    /** Resolved worktree root; unset means "use projectDir". */
+    worktreeDir?: string;
+    /** Repository names only — the union's `dir` overrides are lifted out. */
     knownRepositories: string[];
+    /** name -> resolved parent dir, only for entries that override projectDir. */
+    repositoryDirs?: Record<string, string>;
   };
   defaults: {
     hooks: HookCommands;
@@ -279,6 +299,23 @@ export interface ResolvedConfig {
   logging: {
     file: string;
   };
+}
+
+/**
+ * Parent directory under which a repository's clone lives. The per-repo
+ * `dir` override wins; otherwise repos sit under `projectDir`.
+ */
+export function repositoryBaseDir(config: ResolvedConfig, repository: string): string {
+  return config.workspace.repositoryDirs?.[repository] ?? config.workspace.projectDir;
+}
+
+/**
+ * Parent directory all worktrees are created under, independent of where the
+ * source repositories live. Falls back to `projectDir` when `worktreeDir` is
+ * unset.
+ */
+export function worktreeBaseDir(config: ResolvedConfig): string {
+  return config.workspace.worktreeDir ?? config.workspace.projectDir;
 }
 
 export type ConfigSourceKind = "env" | "project" | "xdg";
@@ -790,6 +827,61 @@ function normalizeSources(raw: unknown): SourceConfig[] {
   return raw as SourceConfig[];
 }
 
+/**
+ * Resolve one `knownRepositories` entry to its name and (optional) resolved
+ * base dir. Bare strings live under `projectDir`; the object form's `dir`
+ * overrides that parent directory. This is the seam later per-repo options
+ * hang off — add new `KnownRepository` fields here.
+ */
+function normalizeKnownRepository(
+  entry: string | KnownRepository,
+  index: number,
+): { name: string; dir?: string } {
+  if (typeof entry === "string") {
+    return { name: entry };
+  }
+  requireObject(entry, `workspace.knownRepositories[${index}]`);
+  requireString(entry.name, `workspace.knownRepositories[${index}].name`);
+  if (entry.dir === undefined) {
+    return { name: entry.name };
+  }
+  requireString(entry.dir, `workspace.knownRepositories[${index}].dir`);
+  return { name: entry.name, dir: expandHome(entry.dir) };
+}
+
+/**
+ * Flatten the loose `(string | KnownRepository)[]` union into the strict
+ * resolved shape: a `string[]` of names every downstream consumer reads, plus
+ * a separate `repositoryDirs` map holding only the entries that override
+ * `projectDir`. Types are validated here, at the resolution edge, before any
+ * `expandHome` runs (which would otherwise throw a raw TypeError on a
+ * non-string `worktreeDir`).
+ */
+function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["workspace"] {
+  requireObject(workspace, "workspace");
+  const names: string[] = [];
+  const repositoryDirs: Record<string, string> = {};
+  const entries = Array.isArray(workspace.knownRepositories) ? workspace.knownRepositories : [];
+  entries.forEach((entry, index) => {
+    const { name, dir } = normalizeKnownRepository(entry, index);
+    names.push(name);
+    if (dir !== undefined) {
+      repositoryDirs[name] = dir;
+    }
+  });
+  let worktreeDir: string | undefined;
+  if (workspace.worktreeDir !== undefined) {
+    requireString(workspace.worktreeDir, "workspace.worktreeDir");
+    worktreeDir = expandHome(workspace.worktreeDir);
+  }
+  return {
+    projectDir: expandHome(workspace.projectDir),
+    ...(worktreeDir === undefined ? {} : { worktreeDir }),
+    knownRepositories: names,
+    ...(Object.keys(repositoryDirs).length === 0 ? {} : { repositoryDirs }),
+  };
+}
+
 function applyDefaults(user: Config): ResolvedConfig {
   // Guard the top-level shape before reading nested fields, so a
   // malformed runtime config produces a `groundcrew config: ...` error
@@ -825,10 +917,7 @@ function applyDefaults(user: Config): ResolvedConfig {
       ...user.git,
       ...(branchPrefix === undefined ? {} : { branchPrefix }),
     },
-    workspace: {
-      projectDir: expandHome(user.workspace.projectDir),
-      knownRepositories: user.workspace.knownRepositories,
-    },
+    workspace: normalizeWorkspace(user.workspace),
     defaults: normalizeDefaults((user as { defaults?: unknown }).defaults),
     orchestrator: { ...DEFAULT_ORCHESTRATOR, ...user.orchestrator },
     models: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -859,6 +859,7 @@ function normalizeKnownRepository(
  */
 function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["workspace"] {
   requireObject(workspace, "workspace");
+  requireString(workspace.projectDir, "workspace.projectDir");
   const names: string[] = [];
   const repositoryDirs: Record<string, string> = {};
   const entries = Array.isArray(workspace.knownRepositories) ? workspace.knownRepositories : [];

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -836,7 +836,7 @@ function normalizeSources(raw: unknown): SourceConfig[] {
 function normalizeKnownRepository(
   entry: string | KnownRepository,
   index: number,
-): { name: string; dir?: string } {
+): { name: string; projectDirOverride?: string } {
   if (typeof entry === "string") {
     return { name: entry };
   }
@@ -849,7 +849,7 @@ function normalizeKnownRepository(
     entry.projectDirOverride,
     `workspace.knownRepositories[${index}].projectDirOverride`,
   );
-  return { name: entry.name, dir: expandHome(entry.projectDirOverride) };
+  return { name: entry.name, projectDirOverride: expandHome(entry.projectDirOverride) };
 }
 
 /**
@@ -870,7 +870,7 @@ function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["wor
   const repositoryDirs: Record<string, string> = {};
   const entries = Array.isArray(workspace.knownRepositories) ? workspace.knownRepositories : [];
   entries.forEach((entry, index) => {
-    const { name, dir } = normalizeKnownRepository(entry, index);
+    const { name, projectDirOverride } = normalizeKnownRepository(entry, index);
     const previous = seen.get(name);
     if (previous !== undefined) {
       fail(
@@ -878,8 +878,8 @@ function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["wor
       );
     }
     seen.set(name, index);
-    if (dir !== undefined) {
-      repositoryDirs[name] = dir;
+    if (projectDirOverride !== undefined) {
+      repositoryDirs[name] = projectDirOverride;
     }
   });
   const names = [...seen.keys()];

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -863,16 +863,26 @@ function normalizeKnownRepository(
 function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["workspace"] {
   requireObject(workspace, "workspace");
   requireString(workspace.projectDir, "workspace.projectDir");
-  const names: string[] = [];
+  // Track the first index each name was seen at so a duplicate (which would
+  // silently overwrite its `projectDirOverride` in `repositoryDirs`) fails
+  // loudly instead of resolving order-dependently.
+  const seen = new Map<string, number>();
   const repositoryDirs: Record<string, string> = {};
   const entries = Array.isArray(workspace.knownRepositories) ? workspace.knownRepositories : [];
   entries.forEach((entry, index) => {
     const { name, dir } = normalizeKnownRepository(entry, index);
-    names.push(name);
+    const previous = seen.get(name);
+    if (previous !== undefined) {
+      fail(
+        `workspace.knownRepositories[${index}] duplicates ${JSON.stringify(name)} from workspace.knownRepositories[${previous}]. Configure distinct repository names.`,
+      );
+    }
+    seen.set(name, index);
     if (dir !== undefined) {
       repositoryDirs[name] = dir;
     }
   });
+  const names = [...seen.keys()];
   let worktreeDir: string | undefined;
   if (workspace.worktreeDir !== undefined) {
     requireString(workspace.worktreeDir, "workspace.worktreeDir");

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -158,12 +158,12 @@ type UserModelDefinition = EnabledUserModelDefinition;
  */
 /**
  * A configured repository. The bare-string form keeps the repo under
- * `workspace.projectDir`; the object form's optional `dir` overrides that
- * parent directory so repos can live in more than one place.
+ * `workspace.projectDir`; the object form's optional `projectDirOverride`
+ * overrides that parent directory so repos can live in more than one place.
  */
 export interface KnownRepository {
   name: string;
-  dir?: string;
+  projectDirOverride?: string;
 }
 
 export interface Config {
@@ -263,7 +263,7 @@ export interface ResolvedConfig {
     projectDir: string;
     /** Resolved worktree root; unset means "use projectDir". */
     worktreeDir?: string;
-    /** Repository names only — the union's `dir` overrides are lifted out. */
+    /** Repository names only — the union's `projectDirOverride`s are lifted out. */
     knownRepositories: string[];
     /** name -> resolved parent dir, only for entries that override projectDir. */
     repositoryDirs?: Record<string, string>;
@@ -829,9 +829,9 @@ function normalizeSources(raw: unknown): SourceConfig[] {
 
 /**
  * Resolve one `knownRepositories` entry to its name and (optional) resolved
- * base dir. Bare strings live under `projectDir`; the object form's `dir`
- * overrides that parent directory. This is the seam later per-repo options
- * hang off — add new `KnownRepository` fields here.
+ * base dir. Bare strings live under `projectDir`; the object form's
+ * `projectDirOverride` overrides that parent directory. This is the seam later
+ * per-repo options hang off — add new `KnownRepository` fields here.
  */
 function normalizeKnownRepository(
   entry: string | KnownRepository,
@@ -842,11 +842,14 @@ function normalizeKnownRepository(
   }
   requireObject(entry, `workspace.knownRepositories[${index}]`);
   requireString(entry.name, `workspace.knownRepositories[${index}].name`);
-  if (entry.dir === undefined) {
+  if (entry.projectDirOverride === undefined) {
     return { name: entry.name };
   }
-  requireString(entry.dir, `workspace.knownRepositories[${index}].dir`);
-  return { name: entry.name, dir: expandHome(entry.dir) };
+  requireString(
+    entry.projectDirOverride,
+    `workspace.knownRepositories[${index}].projectDirOverride`,
+  );
+  return { name: entry.name, dir: expandHome(entry.projectDirOverride) };
 }
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -303,7 +303,7 @@ export interface ResolvedConfig {
 
 /**
  * Parent directory under which a repository's clone lives. The per-repo
- * `dir` override wins; otherwise repos sit under `projectDir`.
+ * `projectDirOverride` wins; otherwise repos sit under `projectDir`.
  */
 export function repositoryBaseDir(config: ResolvedConfig, repository: string): string {
   return config.workspace.repositoryDirs?.[repository] ?? config.workspace.projectDir;

--- a/src/lib/srtLaunch.test.ts
+++ b/src/lib/srtLaunch.test.ts
@@ -7,9 +7,14 @@ import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { ModelDefinition, ResolvedConfig } from "./config.ts";
 import { buildAndStageSrtLaunch } from "./srtLaunch.ts";
 
-function config(projectDir: string): ResolvedConfig {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the helper only reads workspace.projectDir off config
-  return { workspace: { projectDir } } as unknown as ResolvedConfig;
+function config(projectDir: string, repositoryDirs?: Record<string, string>): ResolvedConfig {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the helper only reads workspace.{projectDir,repositoryDirs} off config
+  return {
+    workspace: {
+      projectDir,
+      ...(repositoryDirs === undefined ? {} : { repositoryDirs }),
+    },
+  } as unknown as ResolvedConfig;
 }
 
 function definition(cmd: string): ModelDefinition {
@@ -100,6 +105,24 @@ describe(buildAndStageSrtLaunch, () => {
     // copying anything out of it.
     expect(result.agentConfigDirEnv).toBeUndefined();
     expect(readSettings(result.agentFile).allowPty).toBe(true);
+  });
+
+  it("resolves gitCommonDir under the repo's per-repo dir override", () => {
+    const other = mkdtempSync(path.join(os.tmpdir(), "srt-launch-other-"));
+    staged.push(other);
+    const result = buildAndStageSrtLaunch({
+      config: config(workspaceRoot, { "owner/repo": other }),
+      repository: "owner/repo",
+      ticket: "team-9",
+      worktreeDir: path.join(workspaceRoot, "owner", "repo-team-9"),
+      definition: definition("claude --permission-mode auto"),
+      homeDir: fakeHome,
+    });
+    staged.push(result.directory);
+
+    // gitCommonDir is <repoDir>/.git == <other>/owner/repo/.git, not under projectDir.
+    const expectedGitDir = path.join(other, "owner", "repo", ".git");
+    expect(JSON.stringify(readSettings(result.agentFile))).toContain(expectedGitDir);
   });
 
   it("skips missing seed files (best-effort) so a not-logged-in agent still stages", () => {

--- a/src/lib/srtLaunch.ts
+++ b/src/lib/srtLaunch.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { collectAllowedDomains } from "./clearanceHosts.ts";
-import type { ModelDefinition, ResolvedConfig } from "./config.ts";
+import { type ModelDefinition, type ResolvedConfig, repositoryBaseDir } from "./config.ts";
 import { inferAgentCommandName } from "./launchCommand.ts";
 import { agentConfigRelocation, buildSrtSettings } from "./srtPolicy.ts";
 import { readEnvironmentVariable } from "./util.ts";
@@ -53,7 +53,7 @@ export function buildAndStageSrtLaunch(input: {
 }): StagedSrtLaunch {
   const agent = inferAgentCommandName(input.definition.cmd);
   const homeDir = input.homeDir ?? os.homedir();
-  const repoDir = path.resolve(input.config.workspace.projectDir, input.repository);
+  const repoDir = path.resolve(repositoryBaseDir(input.config, input.repository), input.repository);
   const base = {
     worktreeDir: input.worktreeDir,
     gitCommonDir: path.join(repoDir, ".git"),

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1456,4 +1456,60 @@ describe("multi-directory worktrees", () => {
       }),
     ]);
   });
+
+  it("force-removes an orphan worktree under worktreeDir, probing the override repo dir", async () => {
+    const projectsDir = path.join(root, "projects");
+    const other = path.join(root, "elsewhere");
+    const worktreeDir = path.join(root, "worktrees");
+    const repoDir = path.join(other, "owner", "repo");
+    const orphanDir = path.join(worktreeDir, "owner", "repo-team-4");
+    mkdirSync(repoDir, { recursive: true });
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(path.join(orphanDir, "leftover.log"), "leftover");
+    const config = makeConfig({
+      projectDir: projectsDir,
+      worktreeDir,
+      knownRepositories: ["owner/repo"],
+      repositoryDirs: { "owner/repo": other },
+    });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- forced worktree remove fails after Git has already deregistered the path.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("fatal: is not a working tree");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the override repo no longer lists the orphaned worktree path.
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${repoDir}\nHEAD abc123\nbranch refs/heads/main\n`;
+      }
+      return "";
+    });
+
+    await remove(
+      config,
+      {
+        repository: "owner/repo",
+        ticket: "team-4",
+        branchName: "tester-team-4",
+        dir: orphanDir,
+        kind: "host",
+      },
+      { force: true },
+    );
+
+    expect(existsSync(orphanDir)).toBe(false);
+    // The registration probe and branch deletion both run against the override repo dir.
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", repoDir, "worktree", "list", "--porcelain"],
+      {},
+    );
+    expect(runCommandMock).toHaveBeenCalledWith("git", [
+      "-C",
+      repoDir,
+      "branch",
+      "-D",
+      "tester-team-4",
+    ]);
+  });
 });

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -59,8 +59,10 @@ const userInfoMock = vi.mocked(userInfo);
 
 function makeConfig(overrides: {
   projectDir: string;
+  worktreeDir?: string;
   git?: ResolvedConfig["git"];
   knownRepositories?: string[];
+  repositoryDirs?: Record<string, string>;
   models?: ResolvedConfig["models"]["definitions"];
 }): ResolvedConfig {
   const knownRepositories = overrides.knownRepositories ?? ["repo-a"];
@@ -73,7 +75,11 @@ function makeConfig(overrides: {
     git: overrides.git ?? { remote: "origin", defaultBranch: "main" },
     workspace: {
       projectDir: overrides.projectDir,
+      ...(overrides.worktreeDir === undefined ? {} : { worktreeDir: overrides.worktreeDir }),
       knownRepositories,
+      ...(overrides.repositoryDirs === undefined
+        ? {}
+        : { repositoryDirs: overrides.repositoryDirs }),
     },
     orchestrator: {
       maximumInProgress: 4,
@@ -1357,5 +1363,97 @@ describe("worktrees.probeWorkingTree", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("multi-directory worktrees", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "groundcrew-multi-dir-"));
+    vi.stubEnv("XDG_STATE_HOME", path.join(root, "state"));
+    runCommandMock.mockReset();
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        return "origin/main\n";
+      }
+      return "";
+    });
+    userInfoMock.mockReturnValue(makeUserInfo("tester"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  function findAddCall(): readonly string[] | undefined {
+    return runCommandMock.mock.calls.find((call) => call[1].includes("add"))?.[1];
+  }
+
+  it("creates a worktree under worktreeDir, not the repo's dir", async () => {
+    const projectsDir = path.join(root, "projects");
+    const worktreeDir = path.join(root, "worktrees");
+    mkdirSync(path.join(projectsDir, "owner", "repo"), { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    const config = makeConfig({
+      projectDir: projectsDir,
+      worktreeDir,
+      knownRepositories: ["owner/repo"],
+    });
+
+    const entry = await create(config, { repository: "owner/repo", ticket: "team-1" });
+
+    expect(entry.dir).toBe(path.join(worktreeDir, "owner", "repo-team-1"));
+    const addArguments = findAddCall();
+    expect(addArguments).toStrictEqual(
+      expect.arrayContaining(["-C", path.join(projectsDir, "owner", "repo")]),
+    );
+    expect(addArguments).toContain(path.join(worktreeDir, "owner", "repo-team-1"));
+  });
+
+  it("locates a repo via its per-repo dir override", async () => {
+    const projectsDir = path.join(root, "projects");
+    const other = path.join(root, "elsewhere");
+    const worktreeDir = path.join(root, "worktrees");
+    mkdirSync(path.join(other, "owner", "repo"), { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    const config = makeConfig({
+      projectDir: projectsDir,
+      worktreeDir,
+      knownRepositories: ["owner/repo"],
+      repositoryDirs: { "owner/repo": other },
+    });
+
+    await create(config, { repository: "owner/repo", ticket: "team-2" });
+
+    expect(findAddCall()).toStrictEqual(
+      expect.arrayContaining(["-C", path.join(other, "owner", "repo")]),
+    );
+  });
+
+  it("lists worktrees from worktreeDir regardless of repo location", () => {
+    const projectsDir = path.join(root, "projects");
+    const other = path.join(root, "elsewhere");
+    const worktreeDir = path.join(root, "worktrees");
+    mkdirSync(path.join(other, "owner", "repo"), { recursive: true });
+    mkdirSync(path.join(worktreeDir, "owner", "repo-team-3"), { recursive: true });
+    const config = makeConfig({
+      projectDir: projectsDir,
+      worktreeDir,
+      knownRepositories: ["owner/repo"],
+      repositoryDirs: { "owner/repo": other },
+    });
+
+    const entries = list(config);
+
+    expect(entries).toStrictEqual([
+      expect.objectContaining({
+        repository: "owner/repo",
+        ticket: "team-3",
+        dir: path.join(worktreeDir, "owner", "repo-team-3"),
+      }),
+    ]);
   });
 });

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -1,11 +1,12 @@
 /**
  * Worktree lifecycle — manages host git worktrees for tickets.
  *
- * A worktree is a `git worktree add`'d sibling at
- * `<projectDir>/<repo>-<TICKET>/`. Callers go through the `worktrees`
- * namespace; the module owns creation, listing, removal, and teardown
- * (workspace-close + worktree-remove paired) so callers don't reach into
- * git directly.
+ * A worktree is a `git worktree add`'d directory at
+ * `<worktreeDir>/<repo>-<TICKET>/` (where `worktreeDir` defaults to
+ * `projectDir`). The source repo it is cut from may live under a different
+ * per-repo `dir`. Callers go through the `worktrees` namespace; the module
+ * owns creation, listing, removal, and teardown (workspace-close +
+ * worktree-remove paired) so callers don't reach into git directly.
  */
 
 import { type Dirent, existsSync, readdirSync, rmSync } from "node:fs";
@@ -13,7 +14,7 @@ import { userInfo } from "node:os";
 import path from "node:path";
 
 import { runCommandAsync } from "./commandRunner.ts";
-import type { ResolvedConfig } from "./config.ts";
+import { type ResolvedConfig, repositoryBaseDir, worktreeBaseDir } from "./config.ts";
 import { resolveDefaultBranch } from "./defaultBranch.ts";
 import { debug, errorMessage, isVerbose } from "./util.ts";
 import { type WorkspaceProbe, workspaces } from "./workspaces.ts";
@@ -77,7 +78,7 @@ function repoDirFor(config: ResolvedConfig, repository: string): string {
       `Repository "${repository}" is not in workspace.knownRepositories: ${config.workspace.knownRepositories.join(", ")}`,
     );
   }
-  const repoDir = path.resolve(config.workspace.projectDir, repository);
+  const repoDir = path.resolve(repositoryBaseDir(config, repository), repository);
   if (!existsSync(repoDir)) {
     throw new Error(`Repository not found: ${repoDir}`);
   }
@@ -85,7 +86,6 @@ function repoDirFor(config: ResolvedConfig, repository: string): string {
 }
 
 interface BasePaths {
-  projectDir: string;
   repoDir: string;
   ticket: string;
   branchName: string;
@@ -101,13 +101,11 @@ function basePaths(config: ResolvedConfig, repository: string, ticket: string): 
     throw new Error(`Invalid ticket "${ticket}": must be a plain ticket id`);
   }
 
-  const projectDir = path.resolve(config.workspace.projectDir);
   const repoDir = repoDirFor(config, repository);
   const hostWorktreeName = `${repository}-${ticket}`;
-  const hostWorktreeDir = path.resolve(projectDir, hostWorktreeName);
+  const hostWorktreeDir = path.resolve(worktreeBaseDir(config), hostWorktreeName);
 
   return {
-    projectDir,
     repoDir,
     ticket,
     branchName: branchNameForTicket(config, ticket),
@@ -190,19 +188,20 @@ async function createWorktree(
 }
 
 function listWorktrees(config: ResolvedConfig): WorktreeEntry[] {
-  const projectDir = path.resolve(config.workspace.projectDir);
+  const worktreeRoot = path.resolve(worktreeBaseDir(config));
   const entries: WorktreeEntry[] = [];
 
-  // Worktrees live at `projectDir/<repository>-<ticket>`. When `repository`
+  // Worktrees live at `worktreeRoot/<repository>-<ticket>`. When `repository`
   // contains a slash (e.g. "owner/repo"), `path.resolve()` nests one level
-  // deeper, so the worktree path is `projectDir/owner/repo-<ticket>`.
-  // Scan each known repository's parent directory rather than the project
-  // root, so nested worktrees are discovered alongside bare ones.
+  // deeper, so the worktree path is `worktreeRoot/owner/repo-<ticket>`.
+  // Scan each known repository's parent directory under the worktree root
+  // rather than the root itself, so nested worktrees are discovered alongside
+  // bare ones.
   const reposByParent = new Map<string, Map<string, string>>();
   for (const repository of config.workspace.knownRepositories) {
     const lastSlash = repository.lastIndexOf("/");
     const parentDir =
-      lastSlash === -1 ? projectDir : path.resolve(projectDir, repository.slice(0, lastSlash));
+      lastSlash === -1 ? worktreeRoot : path.resolve(worktreeRoot, repository.slice(0, lastSlash));
     const basename = lastSlash === -1 ? repository : repository.slice(lastSlash + 1);
     let repoByBasename = reposByParent.get(parentDir);
     if (repoByBasename === undefined) {
@@ -254,8 +253,7 @@ async function removeWorktree(
   entry: WorktreeEntry,
   options: { force: boolean; signal?: AbortSignal },
 ): Promise<void> {
-  const projectDir = path.resolve(config.workspace.projectDir);
-  const repoDir = path.resolve(projectDir, entry.repository);
+  const repoDir = path.resolve(repositoryBaseDir(config, entry.repository), entry.repository);
 
   if (existsSync(entry.dir)) {
     debug(`Removing worktree ${entry.dir}${options.force ? " (--force)" : ""}...`);
@@ -419,7 +417,7 @@ function describeOrphanWorktree(arguments_: { ticket: string; dir: string }): st
 }
 
 function expectedHostWorktreeDir(config: ResolvedConfig, entry: WorktreeEntry): string {
-  return path.resolve(config.workspace.projectDir, `${entry.repository}-${entry.ticket}`);
+  return path.resolve(worktreeBaseDir(config), `${entry.repository}-${entry.ticket}`);
 }
 
 function isInsideDirectory(parentDir: string, childDir: string): boolean {
@@ -432,10 +430,10 @@ function isInsideDirectory(parentDir: string, childDir: string): boolean {
 }
 
 function removeOrphanWorktreeDirectory(config: ResolvedConfig, entry: WorktreeEntry): void {
-  const projectDir = path.resolve(config.workspace.projectDir);
+  const worktreeRoot = path.resolve(worktreeBaseDir(config));
   const expectedDir = expectedHostWorktreeDir(config, entry);
   const targetDir = path.resolve(entry.dir);
-  if (targetDir !== expectedDir || !isInsideDirectory(projectDir, targetDir)) {
+  if (targetDir !== expectedDir || !isInsideDirectory(worktreeRoot, targetDir)) {
     throw new Error(
       `Refusing to force-delete ${entry.dir}: expected groundcrew worktree path ${expectedDir}.`,
     );

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -4,8 +4,8 @@
  * A worktree is a `git worktree add`'d directory at
  * `<worktreeDir>/<repo>-<TICKET>/` (where `worktreeDir` defaults to
  * `projectDir`). The source repo it is cut from may live under a different
- * per-repo `dir`. Callers go through the `worktrees` namespace; the module
- * owns creation, listing, removal, and teardown (workspace-close +
+ * per-repo `projectDirOverride`. Callers go through the `worktrees` namespace;
+ * the module owns creation, listing, removal, and teardown (workspace-close +
  * worktree-remove paired) so callers don't reach into git directly.
  */
 


### PR DESCRIPTION
## Summary

Today `workspace.projectDir` plays two roles: the base directory for locating repo clones **and** the base directory for creating worktrees. This PR splits those roles so that:

- **Repos can live in more than one place** — each `knownRepositories` entry may now be either a bare `string` (lives under `projectDir`, unchanged) or an object `{ name, projectDirOverride }` whose optional `projectDirOverride` overrides the parent directory for that repo's clone.
- **Worktrees can be collected in one location** — a new optional `workspace.worktreeDir` makes all per-ticket worktrees get created under one root, independent of where each source repo lives. Defaults to `projectDir` when unset, so single-directory setups are unchanged.

Linear ticket: `plan-244692718977688` — Multiple Project Directories + Separate Worktree Directory.

## How it works

The loose, user-facing `Config.workspace` accepts the ergonomic union `(string | KnownRepository)[]` plus optional `worktreeDir`. At resolve time, `applyDefaults` -> `normalizeWorkspace` flattens that union into the strict resolved shape every downstream consumer already reads:

- `knownRepositories: string[]` — **names only**, so the ~8 existing string consumers (`repositoryValidation`, `ticketSource`, the Linear adapter, `dispatcher`, ...) are untouched.
- `repositoryDirs?: Record<string, string>` — name -> resolved parent dir, populated **only** for entries that override `projectDir`.

Two pure accessors centralize the fallback logic and are the only readers of the new fields for path math:

- `repositoryBaseDir(config, repo)` -> `repositoryDirs[repo] ?? projectDir`
- `worktreeBaseDir(config)` -> `worktreeDir ?? projectDir`

Every path computation in `worktrees.ts` (create / list / remove / orphan-cleanup) and `srtLaunch.ts` (sandbox `gitCommonDir`) routes through these accessors. `doctor` gains a conditional `checkDir` for `workspace.worktreeDir` when it is configured.

New `ResolvedConfig.workspace` fields are optional, so existing test config builders compile unchanged and existing single-directory configs behave identically.

## Config parameters

The new `workspace` options as documented in `crew.config.example.ts`:

```ts
workspace: {
  // Parent directory under which groundcrew clones repositories and (by
  // default) creates per-ticket worktrees.
  projectDir: "~/dev/groundcrew",

  // NEW (optional): collect ALL worktrees here instead of beside each repo.
  // Useful when your repos live in more than one place. Defaults to projectDir.
  worktreeDir: "~/dev/worktrees",

  // knownRepositories entries may now be a bare string OR an object.
  // Strings live under projectDir; the object form's `projectDirOverride` (NEW, optional)
  // overrides the parent directory for that repo's clone.
  knownRepositories: [
    "your-org/your-repo",                              // lives under projectDir
    { name: "other-org/other-repo", projectDirOverride: "~/work" },   // NEW: lives under ~/work
  ],
},
```

Resolved shape (`ResolvedConfig.workspace`, after `applyDefaults`):

```ts
workspace: {
  projectDir: string;                       // expanded; unchanged
  worktreeDir?: string;                      // NEW; unset => fall back to projectDir
  knownRepositories: string[];              // names only — unchanged for all consumers
  repositoryDirs?: Record<string, string>;  // NEW; name -> base dir, overrides only
}
```

Both new resolved fields are optional, so existing configs and test builders are unchanged.

## Changes

- `src/lib/config.ts` — `KnownRepository` type, optional `worktreeDir` / `repositoryDirs`, `normalizeWorkspace` + `normalizeKnownRepository` resolution helpers, and the two accessors.
- `src/lib/worktrees.ts` — worktrees created/discovered/removed under `worktreeBaseDir`; repo clones located via `repositoryBaseDir`; orphan-removal safety guard now bounds against the worktree root.
- `src/lib/srtLaunch.ts` — sandbox repo dir resolved via `repositoryBaseDir`.
- `src/commands/doctor.ts` — conditional `workspace.worktreeDir` directory check.
- `crew.config.example.ts`, `README.md`, `docs/configuration.md`, `src/cli.ts` — document the new options.

## Decisions (please push back if I guessed wrong)

- **`worktreeDir` type validation lives in `normalizeWorkspace`, not `validate()`.** The plan suggested validating `worktreeDir` in `validate()`, but `validate()` runs *after* `applyDefaults`, by which point `expandHome` would already have thrown a raw `TypeError` on a non-string value. Validating at the resolution edge (before `expandHome`) yields the clean `groundcrew config: ...` message instead. The per-repo `projectDirOverride` and `name` are validated the same way, inside `normalizeKnownRepository`.
- **A non-array `knownRepositories` is normalized to `[]` and then rejected by the existing `validate()` "must be a non-empty array" check**, rather than failing with a distinct "must be an array" message in `normalizeWorkspace`. This keeps the existing error path/message and avoids duplicating validation; the message already names "array".
- **Tasks 1 and 2 from the plan were committed together.** The plan committed them separately, but the repo's pre-commit hook runs a full typecheck and Task 1's union type does not typecheck until Task 2 updates `applyDefaults`. They are genuinely coupled, so a single commit keeps every commit green.
- **Extra tests beyond the plan** (non-string `name`, non-string `worktreeDir`, a non-object array entry `[42]`, and a split-dir orphan-removal case) were added to keep branch coverage at 100% and lock the validation/path behavior.

## Test plan

- `node --run verify` is fully green: build/typecheck, format, lint, markdownlint, syncpack, and **1226 tests at 100% statement/branch/function/line coverage**.
- New behavioral tests cover: both accessors' fallback/override, union flattening (lift overrides, omit when absent, object-without-projectDirOverride, malformed entries), worktree create/list/orphan-removal under a separate `worktreeDir` with a per-repo `projectDirOverride` override, sandbox `gitCommonDir` resolution via the override, and the conditional doctor check.
- An independent sub-agent reviewed the diff across two passes; both converged with no remaining substantive findings.

## To continue work on this

`tmux attach -t groundcrew:plan-244692718977688`




Agent session: `codex resume 019e9e2d-2295-7421-9779-1cb5ff90e86b`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
