### PR TITLE
fix: advance merged shell-source tickets to done

### DIFF
--- a/docs/ticket-sources.md
+++ b/docs/ticket-sources.md
@@ -16,6 +16,7 @@ export default {
         resolveOne: "~/.config/groundcrew/jira-resolve.sh ${id}",
         markInProgress: "jira issue move ${id} 'In Progress'",
         markInReview: "jira issue move ${id} 'In Review'",
+        markDone: "jira issue move ${id} 'Done'",
       },
       timeouts: { fetch: 60_000, markInReview: 15_000 },
     },
@@ -26,12 +27,15 @@ export default {
 `commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when
 set, must print one issue, print nothing for "not found", or exit `3` for "not
 found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as
-JSON on stdin. `commands.markInReview`, when set, receives the same `sourceRef`
-and is run after groundcrew sees an open or merged PR on the ticket's worktree
-branch. If `commands.markInReview` is omitted, groundcrew treats in-review
-advancement as unsupported for that source and does not claim the transition
-succeeded. `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted
-before substitution.
+JSON on stdin. `commands.markInReview`, when set, receives the same `sourceRef` and is run
+after groundcrew sees an **open** PR on the ticket's worktree branch (in-progress
+tickets only). If omitted, groundcrew treats in-review advancement as unsupported
+for that source and does not claim the transition succeeded. `commands.markDone`,
+when set, receives the same `sourceRef` and is run after groundcrew sees a
+**merged** PR on the ticket's worktree branch (a merged PR never advances to
+in-review). If omitted, groundcrew treats done advancement as unsupported and
+leaves the ticket for the source's own integration to close out. `${id}`,
+`${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
 
 ```json
 [

--- a/docs/ticket-sources.md
+++ b/docs/ticket-sources.md
@@ -18,7 +18,7 @@ export default {
         markInReview: "jira issue move ${id} 'In Review'",
         markDone: "jira issue move ${id} 'Done'",
       },
-      timeouts: { fetch: 60_000, markInReview: 15_000 },
+      timeouts: { fetch: 60_000, markInReview: 15_000, markDone: 15_000 },
     },
   ],
 };

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -86,6 +86,7 @@ function stubBoard(): Board {
     resolveOne: vi.fn<Board["resolveOne"]>(),
     markInProgress: vi.fn<Board["markInProgress"]>(),
     markInReview: vi.fn<Board["markInReview"]>(),
+    markDone: vi.fn<Board["markDone"]>(),
   };
 }
 

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1286,7 +1286,13 @@ JSON
       listMock.mockReturnValue([hostEntryFor("repo-a", "x-1")]);
       workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["x-1"]) });
       findPullRequestsMock.mockResolvedValue([
-        { url: "https://github.com/x/y/pull/3", number: 3, state: "open", title: "PR" },
+        {
+          url: "https://github.com/x/y/pull/3",
+          number: 3,
+          state: "open",
+          title: "PR",
+          headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
       ]);
       const client = makeClient({ pages: [[]] });
       mockLinearClient(client);

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -2,7 +2,7 @@ import { setVerbose } from "../lib/util.ts";
 import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
 import type { Board } from "../lib/board.ts";
 import type { PullRequestSummary } from "../lib/pullRequests.ts";
-import type { BoardState, Issue, MarkInReviewResult } from "../lib/ticketSource.ts";
+import type { BoardState, Issue, MarkDoneResult, MarkInReviewResult } from "../lib/ticketSource.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { makeBoard } from "../testHelpers/boardFixtures.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
@@ -48,6 +48,7 @@ function findReturning(prs: readonly PullRequestSummary[]): FindPullRequests {
 describe(createReviewer, () => {
   let consoleLog: ConsoleCapture;
   let markInReviewMock: ReturnType<typeof vi.fn<(issue: Issue) => Promise<MarkInReviewResult>>>;
+  let markDoneMock: ReturnType<typeof vi.fn<(issue: Issue) => Promise<MarkDoneResult>>>;
   let board: Board;
 
   beforeEach(() => {
@@ -55,7 +56,10 @@ describe(createReviewer, () => {
     markInReviewMock = vi
       .fn<(issue: Issue) => Promise<MarkInReviewResult>>()
       .mockResolvedValue({ outcome: "applied" });
-    board = makeBoard({ markInReview: markInReviewMock });
+    markDoneMock = vi
+      .fn<(issue: Issue) => Promise<MarkDoneResult>>()
+      .mockResolvedValue({ outcome: "applied" });
+    board = makeBoard({ markInReview: markInReviewMock, markDone: markDoneMock });
     // review telemetry (event= lines) is diagnostic — verbose echoes it to the
     // console so these cases can assert the wording.
     setVerbose(true);
@@ -107,7 +111,64 @@ describe(createReviewer, () => {
     expect(out).toContain("event=review outcome=advanced ticket=team-1");
   });
 
-  it("advances when the PR has already merged between ticks", async () => {
+  it("advances a merged PR to done (not in-review)", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged", url: "https://gh/pr/3" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markDoneMock).toHaveBeenCalledTimes(1);
+    expect(markInReviewMock).not.toHaveBeenCalled();
+    const out = consoleLog.output();
+    expect(out).toContain("Advanced team-1 to done (PR https://gh/pr/3)");
+    expect(out).toContain("event=review outcome=advanced ticket=team-1");
+    expect(out).toContain("to=done");
+  });
+
+  it("advances an in-review ticket to done when its PR has merged", async () => {
+    const issue = inProgressIssue("team-1", { status: "in-review" });
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([issue]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markDoneMock).toHaveBeenCalledWith(issue);
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves an in-review ticket alone when it only has an open PR", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1", { status: "in-review" })]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: false,
+    });
+
+    expect(markDoneMock).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to in-review when a merged PR's source cannot mark done", async () => {
+    markDoneMock.mockResolvedValueOnce({
+      outcome: "unsupported",
+      reason: "source has no done transition",
+    });
     const reviewer = createReviewer({
       board,
       findPullRequests: findReturning([pullRequest({ state: "merged" })]),
@@ -119,8 +180,30 @@ describe(createReviewer, () => {
       dryRun: false,
     });
 
-    expect(markInReviewMock).toHaveBeenCalledTimes(1);
-    expect(consoleLog.output()).toContain("event=review outcome=advanced ticket=team-1 pr");
+    expect(markDoneMock).toHaveBeenCalledTimes(1);
+    expect(markInReviewMock).not.toHaveBeenCalled();
+    const out = consoleLog.output();
+    expect(out).toContain("Skipped advancing team-1 to done: source has no done transition");
+    expect(out).not.toContain("Advanced team-1 to");
+  });
+
+  it("dry-run logs a would-advance to done for a merged PR and writes nothing", async () => {
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged", url: "https://gh/pr/5" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1")]),
+      worktreeEntries: [hostEntryFor("team-1")],
+      dryRun: true,
+    });
+
+    expect(markDoneMock).not.toHaveBeenCalled();
+    expect(markInReviewMock).not.toHaveBeenCalled();
+    const out = consoleLog.output();
+    expect(out).toContain("[dry-run] Would advance team-1 to done (PR https://gh/pr/5)");
+    expect(out).toContain("event=review outcome=skipped reason=dry_run ticket=team-1");
   });
 
   it("skips when the worktree has no PR (or the lookup failed)", async () => {

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -71,7 +71,7 @@ describe(createReviewer, () => {
     vi.clearAllMocks();
   });
 
-  it("does nothing when no issue is in-progress", async () => {
+  it("does nothing when there are no in-progress or in-review candidates", async () => {
     const findPullRequests = findReturning([pullRequest()]);
     const reviewer = createReviewer({ board, findPullRequests });
 
@@ -273,7 +273,31 @@ describe(createReviewer, () => {
     expect(out).toContain("Advanced team-2 to in-review");
   });
 
-  it("never looks up PRs for a non-in-progress ticket even if it has a worktree", async () => {
+  it("keeps advancing other merged tickets when one issue's markDone fails", async () => {
+    // Error isolation on the done path: a markDone failure on the first merged
+    // ticket must not prevent the second merged ticket from advancing this tick.
+    markDoneMock
+      .mockRejectedValueOnce(new Error("team-1 shell error"))
+      .mockResolvedValueOnce({ outcome: "applied" });
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+    });
+
+    await reviewer.runOnce({
+      state: boardOf([inProgressIssue("team-1"), inProgressIssue("team-2")]),
+      worktreeEntries: [hostEntryFor("team-1"), hostEntryFor("team-2")],
+      dryRun: false,
+    });
+
+    expect(markDoneMock).toHaveBeenCalledTimes(2);
+    expect(markInReviewMock).not.toHaveBeenCalled();
+    const out = consoleLog.output();
+    expect(out).toContain("Failed to advance team-1 to done");
+    expect(out).toContain("Advanced team-2 to done");
+  });
+
+  it("never looks up PRs for a todo ticket even if it has a worktree", async () => {
     const findPullRequests = findReturning([pullRequest({ state: "open" })]);
     const reviewer = createReviewer({ board, findPullRequests });
 

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -86,6 +86,7 @@ describe(createReviewer, () => {
 
     expect(findPullRequests).not.toHaveBeenCalled();
     expect(markInReviewMock).not.toHaveBeenCalled();
+    expect(markDoneMock).not.toHaveBeenCalled();
   });
 
   it("advances an in-progress ticket whose worktree has an open PR", async () => {

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -38,6 +38,7 @@ function pullRequest(overrides: Partial<PullRequestSummary> = {}): PullRequestSu
     number: overrides.number ?? 1,
     state: overrides.state ?? "open",
     title: overrides.title ?? "PR title",
+    headRefOid: overrides.headRefOid ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   };
 }
 

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -1,26 +1,34 @@
 /**
- * Per-iteration scanner that advances in-progress tickets to in-review once
- * their worktree has an open (or merged) pull request. Sits between the cleaner
- * and the dispatcher in each `orchestrate()` tick. A successfully-applied
- * transition frees a dispatch slot (the slot math counts only in-progress)
- * while leaving the worktree intact for review, since the cleaner only tears
- * down `done` tickets.
+ * Per-iteration scanner that advances a ticket based on its worktree's pull
+ * request state. Sits between the cleaner and the dispatcher in each
+ * `orchestrate()` tick.
  *
- * The write-back lands in the ticket source, not the in-memory `BoardState`, so
- * the dispatcher in the SAME tick still sees the ticket as in-progress; the slot
- * frees on the NEXT tick's `board.fetch()`. That one-tick latency is deliberate
- * — it keeps the reviewer from mutating shared `BoardState` mid-tick. One per
- * `orchestrate()`; stateless across iterations. Mirrors `Cleaner`.
+ * - An **open** PR on an **in-progress** ticket → `markInReview`: frees a
+ *   dispatch slot (slot math counts only in-progress) while leaving the
+ *   worktree intact for review, since the cleaner only tears down `done`.
+ * - A **merged** PR (on an in-progress or in-review ticket) → `markDone`:
+ *   the work has landed, so the ticket is terminal and the cleaner tears the
+ *   worktree down on a later tick. `merged` never routes to `in-review`.
  *
- * "Worktree has an open PR" is a v1 proxy for "the implementation is finished
- * and up for review". The detection + the open/merged condition live here in
- * the core reviewer (a push model) rather than inside any adapter, so a future
- * per-adapter `shouldAdvanceToReview` predicate is a clean additive change.
+ * Sources that don't implement `markDone` (e.g. Linear) return `unsupported`;
+ * the reviewer logs the skip and does nothing — there is no in-review
+ * fallback. (Linear's own GitHub integration moves merged issues to Done,
+ * which groundcrew observes via `fetch()`.)
+ *
+ * The write-back lands in the ticket source, not the in-memory `BoardState`,
+ * so the dispatcher in the SAME tick still sees prior state; the slot frees on
+ * the NEXT tick's `board.fetch()`. That one-tick latency is deliberate. One
+ * per `orchestrate()`; stateless across iterations. Mirrors `Cleaner`.
  */
 
 import type { Board } from "../lib/board.ts";
 import type { PullRequestSummary } from "../lib/pullRequests.ts";
-import { type BoardState, type Issue, naturalIdFromCanonical } from "../lib/ticketSource.ts";
+import {
+  type BoardState,
+  type CanonicalStatus,
+  type Issue,
+  naturalIdFromCanonical,
+} from "../lib/ticketSource.ts";
 import { debug, errorMessage, log, logEvent } from "../lib/util.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 
@@ -53,10 +61,35 @@ export interface Reviewer {
   runOnce(arguments_: ReviewArguments): Promise<void>;
 }
 
-// A PR whose lifecycle means the work is up for (or past) review. `merged`
-// catches a PR that merged between ticks, so we still free the slot.
-function isReviewablePullRequest(pr: PullRequestSummary): boolean {
-  return pr.state === "open" || pr.state === "merged";
+type Transition = "done" | "in-review";
+
+// Maps a worktree's PRs to the transition its ticket should make. A merged PR
+// means the work landed → done; an open PR on an in-progress ticket means it's
+// up for review. `merged` wins over `open`. An open PR on an already in-review
+// ticket is a no-op (returns undefined). Closed-only PRs are ignored.
+function intendedTransition(
+  pullRequests: readonly PullRequestSummary[],
+  status: CanonicalStatus,
+): Transition | undefined {
+  if (pullRequests.some((pr) => pr.state === "merged")) {
+    return "done";
+  }
+  if (status === "in-progress" && pullRequests.some((pr) => pr.state === "open")) {
+    return "in-review";
+  }
+  return undefined;
+}
+
+// The PR to name in logs for a transition: the merged one for `done`, the open
+// one for `in-review`. Guaranteed to exist because intendedTransition only
+// returns a transition when a PR of the matching state is present.
+function pullRequestForTransition(
+  pullRequests: readonly PullRequestSummary[],
+  transition: Transition,
+): PullRequestSummary {
+  const state = transition === "done" ? "merged" : "open";
+  // oxlint-disable-next-line typescript/no-non-null-assertion -- intendedTransition guarantees a PR of this state exists
+  return pullRequests.find((pr) => pr.state === state)!;
 }
 
 function matchingWorktreeEntries(arguments_: {
@@ -79,13 +112,15 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
   async function runOnce(arguments_: ReviewArguments): Promise<void> {
     const { state, worktreeEntries, dryRun, signal } = arguments_;
 
-    const inProgress = state.issues.filter((issue) => issue.status === "in-progress");
-    if (inProgress.length === 0) {
+    const candidates = state.issues.filter(
+      (issue) => issue.status === "in-progress" || issue.status === "in-review",
+    );
+    if (candidates.length === 0) {
       return;
     }
 
-    for (const issue of inProgress) {
-      // oxlint-disable-next-line no-await-in-loop -- at most maximumInProgress (1-5) issues per tick; sequential keeps gh load low.
+    for (const issue of candidates) {
+      // oxlint-disable-next-line no-await-in-loop -- few candidates per tick; sequential keeps gh load low.
       await advanceIfReviewable({
         issue,
         worktreeEntries,
@@ -95,9 +130,10 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     }
   }
 
-  // Idempotent after an applied transition: once advanced, the issue leaves
-  // `in-progress`, so it never reaches this scan again. Unsupported writebacks
-  // are skipped without claiming success and may retry on later ticks.
+  // Idempotent after an applied transition: once advanced, the issue leaves the
+  // in-progress/in-review candidate set, so it never reaches this scan again.
+  // Unsupported writebacks are skipped without claiming success and may retry
+  // on later ticks.
   async function advanceIfReviewable(arguments_: {
     issue: Issue;
     worktreeEntries: readonly WorktreeEntry[];
@@ -111,8 +147,8 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     for (const entry of entries) {
       // The injected lookup is contracted never to reject (failures resolve to
       // []), but we still guard it so one bad lookup can never abort the tick
-      // and starve the other in-progress issues. A failure means "can't tell
-      // yet" → skip this worktree and retry next tick.
+      // and starve the other candidates. A failure means "can't tell yet" →
+      // skip this worktree and retry next tick.
       let pullRequests: readonly PullRequestSummary[];
       try {
         // oxlint-disable-next-line no-await-in-loop -- a ticket almost always has one worktree; sequential lookups are fine.
@@ -125,51 +161,67 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         debug(`PR lookup failed for ${ticket} (${entry.branchName}): ${errorMessage(error)}`);
         continue;
       }
-      const reviewable = pullRequests.find(isReviewablePullRequest);
-      if (reviewable === undefined) {
+      const transition = intendedTransition(pullRequests, issue.status);
+      if (transition === undefined) {
         continue;
       }
+      const pullRequest = pullRequestForTransition(pullRequests, transition);
       if (dryRun) {
-        log(`[dry-run] Would advance ${ticket} to in-review (PR ${reviewable.url})`);
-        logEvent("review", { outcome: "skipped", reason: "dry_run", ticket, pr: reviewable.url });
+        log(`[dry-run] Would advance ${ticket} to ${transition} (PR ${pullRequest.url})`);
+        logEvent("review", {
+          outcome: "skipped",
+          reason: "dry_run",
+          ticket,
+          pr: pullRequest.url,
+          to: transition,
+        });
         return;
       }
-      // oxlint-disable-next-line no-await-in-loop -- single write-back then return; never iterates past the first reviewable worktree.
-      await advance({ issue, ticket, pullRequest: reviewable });
+      // oxlint-disable-next-line no-await-in-loop -- single write-back then return; never iterates past the first actionable worktree.
+      await advance({ issue, ticket, pullRequest, transition });
       return;
     }
   }
 
   // A writeback failure (shell/Linear error) is logged and swallowed: the
-  // ticket stays in-progress and is retried next tick, exactly like a failed
+  // ticket keeps its status and is retried next tick, exactly like a failed
   // lookup. We never let one ticket's writeback abort the others' reviews.
   async function advance(arguments_: {
     issue: Issue;
     ticket: string;
     pullRequest: PullRequestSummary;
+    transition: Transition;
   }): Promise<void> {
-    const { issue, ticket, pullRequest } = arguments_;
+    const { issue, ticket, pullRequest, transition } = arguments_;
     try {
-      const result = await board.markInReview(issue);
+      const result =
+        transition === "done" ? await board.markDone(issue) : await board.markInReview(issue);
       if (result.outcome === "unsupported") {
-        log(`Skipped advancing ${ticket} to in-review: ${result.reason}`);
+        log(`Skipped advancing ${ticket} to ${transition}: ${result.reason}`);
         logEvent("review", {
           outcome: "skipped",
           reason: "unsupported",
           ticket,
+          to: transition,
         });
         return;
       }
-      log(`Advanced ${ticket} to in-review (PR ${pullRequest.url})`);
+      log(`Advanced ${ticket} to ${transition} (PR ${pullRequest.url})`);
       logEvent("review", {
         outcome: "advanced",
         ticket,
         pr: pullRequest.url,
         state: pullRequest.state,
+        to: transition,
       });
     } catch (error) {
-      log(`Failed to advance ${ticket} to in-review: ${errorMessage(error)}`);
-      logEvent("review", { outcome: "failed", reason: "writeback_failed", ticket });
+      log(`Failed to advance ${ticket} to ${transition}: ${errorMessage(error)}`);
+      logEvent("review", {
+        outcome: "failed",
+        reason: "writeback_failed",
+        ticket,
+        to: transition,
+      });
     }
   }
 

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -117,6 +117,7 @@ vi.mock(import("../lib/board.ts"), async (importOriginal) => {
       ),
       markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
       markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
+      markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),
     })),
   };
 });
@@ -1640,6 +1641,7 @@ function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
       .mockResolvedValue(resolvedIssue),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
     markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
+    markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),
   };
 }
 

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -579,6 +579,7 @@ describe(status, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
+        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 
@@ -769,6 +770,7 @@ describe(status, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
+        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 
@@ -786,8 +788,20 @@ describe(status, () => {
   it("joins multiple PRs on one line in inventory rows", async () => {
     listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
     findPullRequestsMock.mockResolvedValue([
-      { url: "https://x/pull/1", number: 1, state: "open", title: "a" },
-      { url: "https://x/pull/2", number: 2, state: "merged", title: "b" },
+      {
+        url: "https://x/pull/1",
+        number: 1,
+        state: "open",
+        title: "a",
+        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      {
+        url: "https://x/pull/2",
+        number: 2,
+        state: "merged",
+        title: "b",
+        headRefOid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
     ]);
 
     await status(makeConfig());
@@ -816,6 +830,7 @@ describe(status, () => {
         number: 99,
         state: "open",
         title: "Something",
+        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -476,4 +476,59 @@ describe(createShellTicketSource, () => {
     await expect(source.markInReview(issue)).resolves.toStrictEqual({ outcome: "applied" });
     expect(readFileSync(stdinCapture, "utf8")).toBe(JSON.stringify(sourceRef));
   });
+
+  it("markDone() reports unsupported when not configured", async () => {
+    const source = createShellTicketSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },
+      fakeContext,
+    );
+    const issue: CanonicalIssue = {
+      id: "test:x-1",
+      source: "test",
+      title: "",
+      description: "",
+      status: "in-review",
+      repository: undefined,
+      model: undefined,
+      assignee: "",
+      updatedAt: "",
+      blockers: [],
+      hasMoreBlockers: false,
+      sourceRef: {},
+    };
+    await expect(source.markDone?.(issue)).resolves.toStrictEqual({
+      outcome: "unsupported",
+      reason: 'shell source "test" has no commands.markDone configured',
+    });
+  });
+
+  it("markDone() runs the configured command with substituted id and piped sourceRef on stdin", async () => {
+    const stdinCapture = path.join(dir.path, "done-stdin-capture.txt");
+    const doneScript = dir.writeScript("done.sh", `cat > "${stdinCapture}"; echo "done $1"`);
+    const source = createShellTicketSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", markDone: `${doneScript} \${id}` },
+      },
+      fakeContext,
+    );
+    const sourceRef = { path: "/tmp/p.md", extra: { nested: 9 } };
+    const issue: CanonicalIssue = {
+      id: "test:x-1",
+      source: "test",
+      title: "",
+      description: "",
+      status: "in-review",
+      repository: undefined,
+      model: undefined,
+      assignee: "",
+      updatedAt: "",
+      blockers: [],
+      hasMoreBlockers: false,
+      sourceRef,
+    };
+    await expect(source.markDone?.(issue)).resolves.toStrictEqual({ outcome: "applied" });
+    expect(readFileSync(stdinCapture, "utf8")).toBe(JSON.stringify(sourceRef));
+  });
 });

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -12,6 +12,7 @@
  *    in MVP-2.
  *  - `markInProgress` absent → silent no-op.
  *  - `markInReview` absent → reports unsupported.
+ *  - `markDone` absent → reports unsupported.
  *  - `fetch` is required by the Zod schema.
  */
 
@@ -20,6 +21,7 @@ import {
   toCanonicalId,
   type Blocker as CanonicalBlocker,
   type Issue as CanonicalIssue,
+  type MarkDoneResult,
   type MarkInReviewResult,
   type TicketSource,
 } from "../../ticketSource.ts";
@@ -38,6 +40,7 @@ interface ResolvedShellTimeouts {
   resolveOne: number;
   markInProgress: number;
   markInReview: number;
+  markDone: number;
 }
 
 const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
@@ -46,6 +49,7 @@ const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
   resolveOne: 10_000,
   markInProgress: 10_000,
   markInReview: 10_000,
+  markDone: 10_000,
 };
 
 function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShellTimeouts {
@@ -55,6 +59,7 @@ function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShell
     resolveOne: overrides?.resolveOne ?? DEFAULT_TIMEOUTS.resolveOne,
     markInProgress: overrides?.markInProgress ?? DEFAULT_TIMEOUTS.markInProgress,
     markInReview: overrides?.markInReview ?? DEFAULT_TIMEOUTS.markInReview,
+    markDone: overrides?.markDone ?? DEFAULT_TIMEOUTS.markDone,
   };
 }
 
@@ -183,6 +188,16 @@ export function createShellTicketSource(
         };
       }
       await invokeWriteback(config.commands.markInReview, timeouts.markInReview, issue);
+      return { outcome: "applied" };
+    },
+    async markDone(issue: CanonicalIssue): Promise<MarkDoneResult> {
+      if (config.commands.markDone === undefined) {
+        return {
+          outcome: "unsupported",
+          reason: `shell source "${sourceName}" has no commands.markDone configured`,
+        };
+      }
+      await invokeWriteback(config.commands.markDone, timeouts.markDone, issue);
       return { outcome: "applied" };
     },
   };

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -225,4 +225,24 @@ describe("shell adapter config schema", () => {
     };
     expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/expected int|integer/i);
   });
+
+  it("accepts commands.markDone and timeouts.markDone", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh", markDone: "jira move ${id} 'Done'" },
+      timeouts: { markDone: 15_000 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it("rejects a zero markDone timeout", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { markDone: 0 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
 });

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -55,6 +55,7 @@ export const shellAdapterConfigSchema = z.object({
     resolveOne: z.string().optional(),
     markInProgress: z.string().optional(),
     markInReview: z.string().optional(),
+    markDone: z.string().optional(),
   }),
   cwd: z.string().optional(),
   timeouts: z
@@ -67,6 +68,7 @@ export const shellAdapterConfigSchema = z.object({
       resolveOne: z.number().int().positive().optional(),
       markInProgress: z.number().int().positive().optional(),
       markInReview: z.number().int().positive().optional(),
+      markDone: z.number().int().positive().optional(),
     })
     .optional(),
   env: z.record(z.string(), z.string()).optional(),

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -1,5 +1,11 @@
 import { createBoard } from "./board.ts";
-import type { Issue, MarkInReviewResult, ParentSkip, TicketSource } from "./ticketSource.ts";
+import type {
+  Issue,
+  MarkDoneResult,
+  MarkInReviewResult,
+  ParentSkip,
+  TicketSource,
+} from "./ticketSource.ts";
 
 function fakeSource(name: string, overrides: Partial<TicketSource> = {}): TicketSource {
   return {
@@ -255,6 +261,34 @@ describe("Board.markInReview", () => {
   it("throws when issue.source names an unknown source", async () => {
     const board = createBoard([fakeSource("a")]);
     await expect(board.markInReview(fakeIssue("nope:1", "nope"))).rejects.toThrow(
+      /unknown source.*nope/,
+    );
+  });
+});
+
+describe("Board.markDone", () => {
+  it("routes to the adapter named by issue.source", async () => {
+    const aMark = vi
+      .fn<(issue: Issue) => Promise<MarkDoneResult>>()
+      .mockResolvedValue({ outcome: "applied" });
+    const board = createBoard([fakeSource("a", { markDone: aMark }), fakeSource("b")]);
+    await expect(board.markDone(fakeIssue("a:1", "a"))).resolves.toStrictEqual({
+      outcome: "applied",
+    });
+    expect(aMark).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports unsupported when the source does not implement markDone", async () => {
+    const board = createBoard([fakeSource("a")]);
+    await expect(board.markDone(fakeIssue("a:1", "a"))).resolves.toStrictEqual({
+      outcome: "unsupported",
+      reason: 'source "a" does not support markDone',
+    });
+  });
+
+  it("throws when issue.source names an unknown source", async () => {
+    const board = createBoard([fakeSource("a")]);
+    await expect(board.markDone(fakeIssue("nope:1", "nope"))).rejects.toThrow(
       /unknown source.*nope/,
     );
   });

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -9,6 +9,7 @@ import {
   AmbiguousTicketError,
   type BoardState,
   type Issue,
+  type MarkDoneResult,
   type MarkInReviewResult,
   type ParentSkip,
   type TicketSource,
@@ -30,6 +31,12 @@ export interface Board {
    * return `unsupported` (see `TicketSource.markInReview`).
    */
   markInReview(issue: Issue): Promise<MarkInReviewResult>;
+  /**
+   * Advances a ticket to done on the adapter whose `name` matches
+   * `issue.source`. Unknown source throws. Sources that don't implement the
+   * optional `markDone` return `unsupported` (see `TicketSource.markDone`).
+   */
+  markDone(issue: Issue): Promise<MarkDoneResult>;
 }
 
 async function callVerify(source: TicketSource): Promise<void> {
@@ -153,6 +160,17 @@ export function createBoard(sources: readonly TicketSource[]): Board {
 
     async markInReview(issue: Issue): Promise<MarkInReviewResult> {
       return await routeWriteback(byName, issue).markInReview(issue);
+    },
+
+    async markDone(issue: Issue): Promise<MarkDoneResult> {
+      const source = routeWriteback(byName, issue);
+      if (source.markDone === undefined) {
+        return {
+          outcome: "unsupported",
+          reason: `source "${source.name}" does not support markDone`,
+        };
+      }
+      return await source.markDone(issue);
     },
   };
 }

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -18,22 +18,55 @@ vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   };
 });
 
+const WORKTREE_HEAD_OID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const STALE_HEAD_OID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+interface RawPullRequestFixture {
+  url: string;
+  number: number;
+  state: string;
+  title: string;
+  headRefOid: string;
+}
+
+function rawPullRequest(overrides: Partial<RawPullRequestFixture> = {}): RawPullRequestFixture {
+  return {
+    url: overrides.url ?? "https://github.com/acme/widgets/pull/42",
+    number: overrides.number ?? 42,
+    state: overrides.state ?? "OPEN",
+    title: overrides.title ?? "Wire up auth",
+    headRefOid: overrides.headRefOid ?? WORKTREE_HEAD_OID,
+  };
+}
+
+function mockSuccessfulLookup(output: string, currentHeadOid = WORKTREE_HEAD_OID): void {
+  runCommandMock.mockImplementation(async (command) => {
+    if (command === "gh") {
+      return output;
+    }
+    if (command === "git") {
+      return currentHeadOid;
+    }
+    throw new Error(`unexpected command: ${command}`);
+  });
+}
+
+function mockFailedGhLookup(): void {
+  runCommandMock.mockImplementation(async (command) => {
+    if (command === "git") {
+      return WORKTREE_HEAD_OID;
+    }
+    throw new Error("gh: command not found");
+  });
+}
+
 describe(findPullRequestsForBranch, () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
 
   it("parses gh's JSON output into typed PR summaries", async () => {
-    runCommandMock.mockResolvedValueOnce(
-      JSON.stringify([
-        {
-          url: "https://github.com/acme/widgets/pull/42",
-          number: 42,
-          state: "OPEN",
-          title: "Wire up auth",
-        },
-      ]),
-    );
+    mockSuccessfulLookup(JSON.stringify([rawPullRequest()]));
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -46,19 +79,19 @@ describe(findPullRequestsForBranch, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
+        headRefOid: WORKTREE_HEAD_OID,
       },
     ]);
   });
 
   it("runs gh in the worktree dir and omits --repo so gh resolves the remote", async () => {
-    runCommandMock.mockResolvedValueOnce("[]");
+    mockSuccessfulLookup("[]");
 
     await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
       branchName: "feature/auth",
     });
 
-    expect(runCommandMock).toHaveBeenCalledTimes(1);
     expect(runCommandMock).toHaveBeenCalledWith(
       "gh",
       expect.arrayContaining(["pr", "list", "--head", "feature/auth"]),
@@ -67,13 +100,16 @@ describe(findPullRequestsForBranch, () => {
     expect(runCommandMock).toHaveBeenCalledWith("gh", expect.not.arrayContaining(["--repo"]), {
       cwd: "/work/widgets-team-1",
     });
+    expect(runCommandMock).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
+      cwd: "/work/widgets-team-1",
+    });
   });
 
   it("normalises MERGED and CLOSED states to lowercase", async () => {
-    runCommandMock.mockResolvedValueOnce(
+    mockSuccessfulLookup(
       JSON.stringify([
-        { url: "https://x/pull/1", number: 1, state: "MERGED", title: "a" },
-        { url: "https://x/pull/2", number: 2, state: "CLOSED", title: "b" },
+        rawPullRequest({ url: "https://x/pull/1", number: 1, state: "MERGED", title: "a" }),
+        rawPullRequest({ url: "https://x/pull/2", number: 2, state: "CLOSED", title: "b" }),
       ]),
     );
 
@@ -85,8 +121,24 @@ describe(findPullRequestsForBranch, () => {
     expect(prs.map((p) => p.state)).toStrictEqual(["merged", "closed"]);
   });
 
+  it("returns only PRs whose head matches the current worktree HEAD", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([
+        rawPullRequest({ number: 1, state: "MERGED", headRefOid: STALE_HEAD_OID }),
+        rawPullRequest({ number: 2, state: "OPEN" }),
+      ]),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([2]);
+  });
+
   it("returns empty when gh fails (not installed / not authenticated / network)", async () => {
-    runCommandMock.mockRejectedValueOnce(new Error("gh: command not found"));
+    mockFailedGhLookup();
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -97,7 +149,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("returns empty when gh emits non-JSON output", async () => {
-    runCommandMock.mockResolvedValueOnce("not json at all");
+    mockSuccessfulLookup("not json at all");
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -108,7 +160,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("returns empty when gh emits a non-array JSON value", async () => {
-    runCommandMock.mockResolvedValueOnce("null");
+    mockSuccessfulLookup("null");
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -119,9 +171,10 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("skips entries that don't match the expected PR shape", async () => {
-    runCommandMock.mockResolvedValueOnce(
+    mockSuccessfulLookup(
       JSON.stringify([
-        { url: "https://x/pull/1", number: 1, state: "OPEN", title: "valid" },
+        rawPullRequest({ url: "https://x/pull/1", number: 1, state: "OPEN", title: "valid" }),
+        { url: "https://x/pull/9", number: 9, state: "OPEN", title: "missing head oid" },
         { url: 42, number: "not a number" }, // malformed; dropped silently
         null, // also dropped
       ]),
@@ -136,7 +189,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("forwards the AbortSignal to runCommandAsync alongside cwd when provided", async () => {
-    runCommandMock.mockResolvedValueOnce("[]");
+    mockSuccessfulLookup("[]");
     const { signal } = new AbortController();
 
     await findPullRequestsForBranch({
@@ -149,12 +202,14 @@ describe(findPullRequestsForBranch, () => {
       cwd: "/work/widgets-team-1",
       signal,
     });
+    expect(runCommandMock).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
+      cwd: "/work/widgets-team-1",
+      signal,
+    });
   });
 
   it("forwards a lowercased unknown state value verbatim", async () => {
-    runCommandMock.mockResolvedValueOnce(
-      JSON.stringify([{ url: "https://x/pull/1", number: 1, state: "DRAFT", title: "wip" }]),
-    );
+    mockSuccessfulLookup(JSON.stringify([rawPullRequest({ state: "DRAFT", title: "wip" })]));
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -18,6 +18,8 @@ export interface PullRequestSummary {
   /** Lowercased lifecycle: "open" | "merged" | "closed". */
   state: string;
   title: string;
+  /** PR head commit SHA used to ignore historical PRs from reused branch names. */
+  headRefOid: string;
 }
 
 const GH_PR_LIST_LIMIT = 5;
@@ -40,6 +42,7 @@ interface RawPullRequest {
   number: number;
   state: string;
   title: string;
+  headRefOid: string;
 }
 
 function parsePullRequests(output: string): PullRequestSummary[] {
@@ -62,6 +65,7 @@ function parsePullRequests(output: string): PullRequestSummary[] {
       number: entry.number,
       state: STATE_MAP[entry.state] ?? entry.state.toLowerCase(),
       title: entry.title,
+      headRefOid: entry.headRefOid,
     });
   }
   return summaries;
@@ -77,7 +81,8 @@ function isRawPullRequest(value: unknown): value is RawPullRequest {
     typeof record["url"] === "string" &&
     typeof record["number"] === "number" &&
     typeof record["state"] === "string" &&
-    typeof record["title"] === "string"
+    typeof record["title"] === "string" &&
+    typeof record["headRefOid"] === "string"
   );
 }
 
@@ -85,26 +90,30 @@ export async function findPullRequestsForBranch(
   arguments_: LookupArgs,
 ): Promise<readonly PullRequestSummary[]> {
   const { cwd, branchName, signal } = arguments_;
+  const options = signal === undefined ? { cwd } : { cwd, signal };
   try {
-    const output = await runCommandAsync(
-      "gh",
-      [
-        "pr",
-        "list",
-        "--head",
-        branchName,
-        "--state",
-        "all",
-        "--limit",
-        String(GH_PR_LIST_LIMIT),
-        "--json",
-        "url,number,state,title",
-      ],
-      signal === undefined ? { cwd } : { cwd, signal },
-    );
-    return parsePullRequests(output);
+    const [output, currentHeadOid] = await Promise.all([
+      runCommandAsync(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--head",
+          branchName,
+          "--state",
+          "all",
+          "--limit",
+          String(GH_PR_LIST_LIMIT),
+          "--json",
+          "url,number,state,title,headRefOid",
+        ],
+        options,
+      ),
+      runCommandAsync("git", ["rev-parse", "HEAD"], options),
+    ]);
+    return parsePullRequests(output).filter((pr) => pr.headRefOid === currentHeadOid);
   } catch {
-    // gh not installed / not authenticated / non-GitHub remote / network
+    // gh/git not installed / not authenticated / non-GitHub remote / network
     // error / etc. All resolve to "no PR info available" for display.
     return [];
   }

--- a/src/lib/ticketSource.ts
+++ b/src/lib/ticketSource.ts
@@ -115,6 +115,8 @@ export type MarkInReviewResult =
   | { outcome: "applied" }
   | { outcome: "unsupported"; reason: string };
 
+export type MarkDoneResult = { outcome: "applied" } | { outcome: "unsupported"; reason: string };
+
 export interface TicketSource {
   /** Stable identifier used as the id prefix and in log lines. Equal to the source's config `name`. */
   readonly name: string;
@@ -135,6 +137,17 @@ export interface TicketSource {
    * rather than pretending the transition happened.
    */
   markInReview(issue: Issue): Promise<MarkInReviewResult>;
+
+  /**
+   * Optional writeback: advance a ticket to done once its PR has merged.
+   * Sources without a native/configured done transition omit this method; the
+   * Board treats an absent method as `{ outcome: "unsupported" }` so the
+   * reviewer can log the skip without claiming a transition that never
+   * happened. Linear omits it on purpose: on merge, Linear's own GitHub
+   * integration moves the issue to Done, which groundcrew then observes via
+   * `fetch()` and the cleaner tears down.
+   */
+  markDone?(issue: Issue): Promise<MarkDoneResult>;
 
   /**
    * Optional: return parent tickets that were excluded from `fetch()` because

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -1,5 +1,5 @@
 import type { Board } from "../lib/board.ts";
-import type { BoardState, MarkInReviewResult } from "../lib/ticketSource.ts";
+import type { BoardState, MarkDoneResult, MarkInReviewResult } from "../lib/ticketSource.ts";
 
 export function makeBoard(overrides: Partial<Board> = {}): Board {
   return {
@@ -13,6 +13,7 @@ export function makeBoard(overrides: Partial<Board> = {}): Board {
     markInReview: vi
       .fn<() => Promise<MarkInReviewResult>>()
       .mockResolvedValue({ outcome: "applied" }),
+    markDone: vi.fn<() => Promise<MarkDoneResult>>().mockResolvedValue({ outcome: "applied" }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

When a shell-source ticket's PR is merged, groundcrew now advances it to `done` via a configured `commands.markDone` script instead of moving it to `in-review`.

The reviewer still treats merged PRs as terminal for the current worktree, but PR lookup now requests GitHub's `headRefOid` and compares it with the local worktree `HEAD` before returning PRs. That prevents an older merged PR from a reused branch name from causing a newer worktree to be marked done and cleaned up.

Linear remains intentionally untouched: on merge, Linear's own GitHub integration moves the issue to Done, which groundcrew observes via `fetch()`.

## Validation

- `node --run verify` - passed: typecheck, lint, markdown-lint, syncpack, and the full Vitest suite (1218 tests) with 100% statements/branches/functions/lines.
- `npx vitest run src/lib/pullRequests.test.ts src/commands/reviewer.test.ts src/commands/status.test.ts src/commands/orchestrator.test.ts --coverage=false` - passed: 151 tests.

## Notes

- `markDone` is optional on `TicketSource`; sources without a configured/native done transition return `unsupported`.
- Shell sources now support `commands.markDone` and `timeouts.markDone`.
- Existing continuation: `tmux attach -t groundcrew:plan-35280541886347`

Agent session: `codex resume 019e9e2d-336d-7490-9b8f-433aba2407f8`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
