### PR TITLE
feat(status): surface remote ticket status and slot usage per worktree

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1046,6 +1046,25 @@ describe(status, () => {
     expect(consoleLog.output()).not.toContain("  ticket:");
   });
 
+  it("omits the ticket field when multiple sources return the same natural ticket id", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-906", repository: "repo-a", dir: "/work/repo-a-team-906" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-906"]) });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-906", source: "linear", status: "in-progress" })]),
+      fakeSource([sourceIssue({ id: "shell:team-906", source: "shell", status: "done" })], {
+        name: "shell",
+      }),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("team-906\n  state:");
+    expect(output).not.toContain("  ticket:");
+  });
+
   it("omits the ticket field on worktree rows when the board fetch fails", async () => {
     listWorktreesMock.mockReturnValue([
       worktree({ ticket: "team-904", repository: "repo-a", dir: "/work/repo-a-team-904" }),

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -970,7 +970,10 @@ describe(status, () => {
     expect(output).toContain("unavailable: linear down");
   });
 
-  it("prints local inventory before source fetch completes", async () => {
+  it("waits for the ticket source before rendering the inventory so each row can show its status", async () => {
+    // The inventory intentionally blocks on the board fetch: every Worktrees
+    // row carries the remote ticket status, which isn't known until the source
+    // resolves. So nothing renders while the fetch is pending.
     listWorktreesMock.mockReturnValue([worktree({ ticket: "team-1", repository: "repo-a" })]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
     let resolveFetch: ((issues: SourceIssue[]) => void) | undefined;
@@ -986,14 +989,103 @@ describe(status, () => {
     const statusPromise = status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
     await flushMicrotasks();
 
+    expect(consoleLog.output()).not.toContain("Worktrees");
+
+    const completeFetch = resolveFetch;
+    expect(completeFetch).toBeTypeOf("function");
+    completeFetch?.([sourceIssue({ id: "linear:team-1", status: "in-progress" })]);
+    await statusPromise;
+
     const output = consoleLog.output();
     expect(output).toContain("Worktrees");
     expect(output).toContain("team-1\n  state:");
-    expect(output).not.toContain("Queue");
-    const completeFetch = resolveFetch;
-    expect(completeFetch).toBeTypeOf("function");
-    completeFetch?.([]);
-    await statusPromise;
+    expect(output).toContain("  ticket:    in-progress (slot held)");
+  });
+
+  it("annotates an in-progress worktree row with the slot-held ticket status", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-901", repository: "repo-a", dir: "/work/repo-a-team-901" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-901"]) });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-901", status: "in-progress" })]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    expect(consoleLog.output()).toContain("  ticket:    in-progress (slot held)");
+  });
+
+  it("shows the bare canonical status for a worktree whose ticket holds no slot", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-902", repository: "repo-a", dir: "/work/repo-a-team-902" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-902"]) });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-902", status: "in-review" })]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("  ticket:    in-review");
+    expect(output).not.toContain("slot held");
+  });
+
+  it("omits the ticket field for a worktree whose ticket is absent from the board", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-903", repository: "repo-a", dir: "/work/repo-a-team-903" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-903"]) });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([sourceIssue({ id: "linear:team-700", status: "todo" })]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    expect(consoleLog.output()).not.toContain("  ticket:");
+  });
+
+  it("omits the ticket field on worktree rows when the board fetch fails", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ ticket: "team-904", repository: "repo-a", dir: "/work/repo-a-team-904" }),
+    ]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-904"]) });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([], {
+        fetch: async () => {
+          throw new Error("linear down");
+        },
+      }),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("Worktrees");
+    expect(output).not.toContain("  ticket:");
+  });
+
+  it("annotates in-progress rows with no local worktree as slot holders", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({
+          id: "linear:team-905",
+          status: "in-progress",
+          title: "Type the boundary",
+          repository: "repo-b",
+          url: "https://linear.app/example/issue/TEAM-905",
+        }),
+      ]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    expect(output).toContain("In progress (no local worktree)");
+    expect(output).toContain("  ticket:    in-progress (slot held)");
   });
 
   it("hides the Queue section entirely when the source has no eligible Todos", async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -6,6 +6,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
+  type CanonicalStatus,
   type GroundcrewIssue,
   isGroundcrewIssue,
   type Issue as SourceIssue,
@@ -379,9 +380,20 @@ function formatPullRequests(prs: readonly PullRequestSummary[]): string {
   return prs.map((pr) => `${pr.url} (${pr.state})`).join(", ");
 }
 
+/**
+ * Inventory `ticket:` value: the worktree's remote canonical status. Slots are
+ * consumed solely by `in-progress` issues (see `inProgressCount`), so that one
+ * status is spelled out as `slot held` to make the otherwise-implicit rule
+ * legible on the row; every other status renders bare.
+ */
+function formatTicketStatus(canonicalStatus: CanonicalStatus): string {
+  return canonicalStatus === "in-progress" ? "in-progress (slot held)" : canonicalStatus;
+}
+
 async function writeInventoryWorktrees(
   config: ResolvedConfig,
   probe: WorkspaceProbe,
+  statusByTicket: ReadonlyMap<string, CanonicalStatus> | undefined,
 ): Promise<void> {
   writeSection("Worktrees");
   const entries = worktrees
@@ -413,6 +425,14 @@ async function writeInventoryWorktrees(
       writeOutput(inventoryField("title", runState.title));
     }
     writeOutput(inventoryField("state", inventoryStateText(runState, probe, entry.ticket, now)));
+    // `state:` is the local run lifecycle; `ticket:` is the remote status that
+    // actually drives the slot count. They're sourced independently and can
+    // legitimately disagree, so they sit adjacent. Omitted when the board fetch
+    // failed (no map) or the ticket isn't in the fetched board.
+    const ticketStatus = statusByTicket?.get(entry.ticket);
+    if (ticketStatus !== undefined) {
+      writeOutput(inventoryField("ticket", formatTicketStatus(ticketStatus)));
+    }
     writeOutput(inventoryField("repo", entry.repository));
     writeOutput(inventoryField("worktree", entry.dir));
     if (accessHint !== undefined) {
@@ -533,6 +553,27 @@ async function fetchBoardForStatus(config: ResolvedConfig): Promise<BoardFetchRe
   }
 }
 
+/**
+ * Maps each fetched issue's lowercased natural id to its canonical status, so
+ * the Worktrees section can show a `ticket:` field per row. The key matches the
+ * lowercased `WorktreeEntry.ticket` (same join as `inProgressWithoutWorktree`).
+ * `undefined` when the board fetch failed — callers then omit the field rather
+ * than guess.
+ */
+function statusByWorktreeTicket(
+  boardResult: BoardFetchResult,
+): ReadonlyMap<string, CanonicalStatus> | undefined {
+  if (boardResult.kind !== "ok") {
+    return undefined;
+  }
+  return new Map(
+    boardResult.issues.map((issue) => [
+      naturalIdFromCanonical(issue.id).toLowerCase(),
+      issue.status,
+    ]),
+  );
+}
+
 function writeQueueSections(boardResult: BoardFetchResult): void {
   if (boardResult.kind === "error") {
     writeSection("Queue");
@@ -593,6 +634,9 @@ function writeInProgressIssue(issue: SourceIssue): void {
   const naturalId = naturalIdFromCanonical(issue.id);
   writeOutput(issue.url === undefined ? naturalId : `${naturalId}  ${issue.url}`);
   writeOutput(inventoryField("title", issue.title));
+  // These are all in-progress by definition, but spell out the slot-held
+  // status so every holder row reads the same whether or not it has a worktree.
+  writeOutput(inventoryField("ticket", formatTicketStatus(issue.status)));
   if (issue.repository !== undefined) {
     writeOutput(inventoryField("repo", issue.repository));
   }
@@ -622,13 +666,17 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
   // Banner ("groundcrew status\n=================") dropped: the command
   // you just ran already tells you what report you're looking at, and the
   // section headers (`Worktrees`, `Queue`, etc.) carry the visual anchors.
+  // The board fetch runs concurrently with the probe, but we await it before
+  // rendering: each Worktrees row carries the remote ticket status, so the
+  // inventory can't print until the source resolves. A failed fetch returns
+  // quickly and still renders rows (without the `ticket:` field).
   const boardResultPromise = fetchBoardForStatus(config);
   const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-  await writeInventoryWorktrees(config, probe);
+  const boardResult = await boardResultPromise;
+  await writeInventoryWorktrees(config, probe, statusByWorktreeTicket(boardResult));
   const worktreeTickets = new Set(worktrees.list(config).map((entry) => entry.ticket));
   writeStraySessions(probe, worktreeTickets);
 
-  const boardResult = await boardResultPromise;
   writeInProgressWithoutWorktree(boardResult, worktreeTickets);
   if (boardResult.kind === "ok") {
     const used = inProgressCount(boardResult.issues);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -554,11 +554,12 @@ async function fetchBoardForStatus(config: ResolvedConfig): Promise<BoardFetchRe
 }
 
 /**
- * Maps each fetched issue's lowercased natural id to its canonical status, so
- * the Worktrees section can show a `ticket:` field per row. The key matches the
- * lowercased `WorktreeEntry.ticket` (same join as `inProgressWithoutWorktree`).
- * `undefined` when the board fetch failed — callers then omit the field rather
- * than guess.
+ * Maps each fetched issue's lowercased natural id to its canonical status when
+ * exactly one fetched issue has that natural id, so the Worktrees section can
+ * show a `ticket:` field per row without guessing across sources. The key
+ * matches the lowercased `WorktreeEntry.ticket` (same join as
+ * `inProgressWithoutWorktree`). `undefined` when the board fetch failed —
+ * callers then omit the field rather than guess.
  */
 function statusByWorktreeTicket(
   boardResult: BoardFetchResult,
@@ -566,12 +567,19 @@ function statusByWorktreeTicket(
   if (boardResult.kind !== "ok") {
     return undefined;
   }
-  return new Map(
-    boardResult.issues.map((issue) => [
-      naturalIdFromCanonical(issue.id).toLowerCase(),
-      issue.status,
-    ]),
-  );
+  const statuses = new Map<string, CanonicalStatus>();
+  const matchCounts = new Map<string, number>();
+  for (const issue of boardResult.issues) {
+    const ticket = naturalIdFromCanonical(issue.id).toLowerCase();
+    matchCounts.set(ticket, (matchCounts.get(ticket) ?? 0) + 1);
+    statuses.set(ticket, issue.status);
+  }
+  for (const [ticket, matchCount] of matchCounts) {
+    if (matchCount > 1) {
+      statuses.delete(ticket);
+    }
+  }
+  return statuses;
 }
 
 function writeQueueSections(boardResult: BoardFetchResult): void {


### PR DESCRIPTION
## Why

`crew status` made you know groundcrew's internal rule — that a slot is held only while the source ticket is `in-progress` — to tell which worktree was consuming a slot. Two worktrees can both show `running` locally while only one holds a slot, and nothing in the output exposed the remote status that actually drives the count:

```
plan-244692718977688
  state:     running (2h 40m)
  pr:        .../pull/179 (open)
plan-35280541886347
  state:     running (5m)
slots: 1/4 used        <- which one is the 1?
```

## What

Each inventory worktree row gains a `ticket:` line showing the worktree's **remote canonical status**, placed right under `state:` (local run lifecycle) so the local-vs-remote distinction is adjacent:

```
plan-244692718977688
  state:     running (2h 40m)
  ticket:    in-review
plan-35280541886347
  state:     running (5m)
  ticket:    in-progress (slot held)
slots: 1/4 used
```

- Only `in-progress` is spelled out as `(slot held)`, matching `inProgressCount`'s rule exactly. Other statuses render bare (`in-review`, `todo`, `done`, `other`).
- The field is **omitted** when the board fetch fails, the worktree's ticket isn't in the fetched board, or multiple sources return the same natural ticket id — no guessing.
- The "In progress (no local worktree)" rows get the same annotation.

## Behavior change (intentional)

Rendering each row with its status requires the board in hand, so the inventory now **waits for the ticket source** instead of rendering local rows eagerly. The `prints local inventory before source fetch completes` test is rewritten to encode the new contract. A failed fetch still returns fast and renders rows (without the field).

A follow-up (saved as a local design plan) will restore instant local rendering via a TTY live-update, with the plain path here as its non-TTY fallback.

## Validation

`node --run verify` green — 1211 tests, 100% coverage, lint/format/typecheck/architecture/cpd/knip all pass. Added 6 focused cases (holder annotation, bare non-holder status, omit-when-off-board, omit-when-ambiguous-across-sources, omit-when-fetch-fails, no-worktree holder annotation).

## Notes

No Linear ticket — this is a local DX improvement to `crew status`.

Agent session: `codex resume 019e9e2d-4086-7761-b1ef-89553c75a5a0`

<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>
