### PR TITLE
fix: skip Linear lookup on resume when Linear is disabled

### DIFF
--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -276,6 +276,21 @@ describe(resumeWorkspace, () => {
     );
   });
 
+  it("skips the Linear lookup during state resume when Linear is disabled", async () => {
+    const noLinearConfig: ResolvedConfig = {
+      ...makeConfig(),
+      sources: [{ kind: "linear", enabled: false }],
+    };
+
+    await resumeWorkspace(noLinearConfig, { task: "team-1" });
+
+    expect(getLinearClientMock).not.toHaveBeenCalled();
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("task team-1 (TEAM-1)"),
+    );
+  });
+
   it("renders empty task details and no previous reason when state has neither", async () => {
     readRunStateMock.mockReturnValue(makeRunStateWithoutReason());
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
@@ -316,6 +331,19 @@ describe(resumeWorkspace, () => {
       config,
       expect.objectContaining({ name: "team-1" }),
     );
+  });
+
+  it("rejects with a clear error when state is missing and Linear is disabled", async () => {
+    readRunStateMock.mockReset();
+    const noLinearConfig: ResolvedConfig = {
+      ...makeConfig(),
+      sources: [{ kind: "linear", enabled: false }],
+    };
+
+    await expect(resumeWorkspace(noLinearConfig, { task: "team-1" })).rejects.toThrow(
+      /no run state recorded and Linear is disabled/,
+    );
+    expect(getLinearClientMock).not.toHaveBeenCalled();
   });
 
   it("stages neutral prepare + agent srt settings and wraps the resumed agent under srt", async () => {

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,5 +1,6 @@
 import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
+import { isLinearEnabled } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { buildLaunchCommand } from "../lib/launchCommand.ts";
@@ -74,11 +75,15 @@ async function contextFromLinear(
 }
 
 async function contextFromState(
+  config: ResolvedConfig,
   task: string,
   state: RunState,
   worktree: WorktreeEntry,
 ): Promise<ResumeContext> {
-  const details = await fetchTaskDetails(task);
+  // Skip the Linear lookup when Linear is disabled — otherwise the
+  // missing-API-key error logs noisily even though resume only needs it to
+  // enrich the prompt title/description (which falls back to the task id).
+  const details = isLinearEnabled(config) ? await fetchTaskDetails(task) : undefined;
   return {
     task,
     repository: state.repository,
@@ -102,7 +107,13 @@ async function buildResumeContext(config: ResolvedConfig, task: string): Promise
     throw new Error(`No worktree found for ${task}; cannot resume.`);
   }
   if (state !== undefined) {
-    return await contextFromState(task, state, worktree);
+    return await contextFromState(config, task, state, worktree);
+  }
+  // The cold-resume path resolves repository + model from Linear alone, so it
+  // can't proceed when Linear is disabled. Fail with a clear reason instead of
+  // the cryptic missing-API-key error getLinearClient() would otherwise raise.
+  if (!isLinearEnabled(config)) {
+    throw new Error(`Cannot resume ${task}: no run state recorded and Linear is disabled.`);
   }
   return await contextFromLinear(config, task, worktree);
 }

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import type { AdapterContext, AdapterDefinition } from "./adapterDefinition.ts";
-import { buildSources, buildSourcesWith, sourcesFromConfig } from "./buildSources.ts";
+import {
+  buildSources,
+  buildSourcesWith,
+  isLinearEnabled,
+  sourcesFromConfig,
+} from "./buildSources.ts";
 import type { ResolvedConfig } from "./config.ts";
 import type { MarkInReviewResult, TaskSource } from "./taskSource.ts";
 import { readEnvironmentVariable } from "./util.ts";
@@ -330,5 +335,46 @@ describe(sourcesFromConfig, () => {
     } as unknown as ResolvedConfig;
 
     expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear" }]);
+  });
+});
+
+describe(isLinearEnabled, () => {
+  it("is true for the implicit Linear source when no sources are declared", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- isLinearEnabled only reads sources; unused fields are irrelevant
+    const config = { sources: [] } as unknown as ResolvedConfig;
+
+    expect(isLinearEnabled(config)).toBe(true);
+  });
+
+  it("is false when Linear is opted out via { kind: 'linear', enabled: false }", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- isLinearEnabled only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [
+        { kind: "linear", enabled: false },
+        { kind: "shell", name: "plans", command: ["./fetch.sh"] },
+      ],
+    } as unknown as ResolvedConfig;
+
+    expect(isLinearEnabled(config)).toBe(false);
+  });
+
+  it("is true for an explicitly declared, enabled Linear source", () => {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- isLinearEnabled only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "linear", name: "custom-linear" }],
+    } as unknown as ResolvedConfig;
+
+    expect(isLinearEnabled(config)).toBe(true);
+  });
+
+  it("is false when a shell source merely named 'linear' is the only source", () => {
+    // A source that is Linear only by *name* is not a real Linear adapter, so
+    // Linear is not enabled even though it occupies the Linear slot.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- isLinearEnabled only reads sources; unused fields are irrelevant
+    const config = {
+      sources: [{ kind: "shell", name: "linear", command: ["./fetch.sh"] }],
+    } as unknown as ResolvedConfig;
+
+    expect(isLinearEnabled(config)).toBe(false);
   });
 });

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -138,3 +138,14 @@ export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
   }
   return [{ kind: "linear" }, ...kept];
 }
+
+/**
+ * True when the resolved config keeps Linear active — i.e. the user has not
+ * opted out with `{ kind: "linear", enabled: false }`. Callers use this to skip
+ * Linear API calls (and the missing-API-key error they raise) when Linear is
+ * off. Derived from `sourcesFromConfig` so it honors both the explicit opt-out
+ * sentinel and the implicit-source synthesis.
+ */
+export function isLinearEnabled(config: ResolvedConfig): boolean {
+  return sourcesFromConfig(config).some(isLinearKindSource);
+}


### PR DESCRIPTION
## Summary

When the Linear integration is opted out via `{ kind: "linear", enabled: false }`, `crew resume` still called the Linear API to enrich the prompt title/description. With no API key set, every resume logged a noisy `Resume Linear detail lookup failed: Linear API key not set` error even though the resume succeeded — the lookup is non-essential and already falls back to the task id.

This adds an `isLinearEnabled(config)` helper (derived from `sourcesFromConfig`, so it honors the opt-out sentinel and implicit-source synthesis) and gates both resume paths on it:

- **State resume** (the reported case): skips the Linear lookup entirely, silencing the spurious error while still falling back to the task id for the prompt title.
- **Cold resume** (no run state recorded): this path can only resolve repository + model from Linear, so it now fails with a clear `Cannot resume <task>: no run state recorded and Linear is disabled.` instead of the cryptic missing-API-key error.

All other Linear consumers (`orchestrator`, `status`, `doctor`, `setupWorkspace`) already route through `buildSources(sourcesFromConfig(...))`, which respects the opt-out, so no changes were needed there.

## Validation

- `node --run verify` — passing (1263 tests, 100% statement/branch/function/line coverage).
- Added unit tests for `isLinearEnabled` and both gated resume paths (state-resume skip + cold-resume clear error).

Agent session: `claude --resume 4cf6208b-e352-43c3-a017-f0d6796f315b`
<sub>🤖 <code>commit-push-pr:created v1 core@3.5.0</code></sub>