### PR TITLE
feat: add crew source list and crew source verify commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
+import { sourceCli } from "./commands/source.ts";
 import { statusCli } from "./commands/status.ts";
 import { createDefaultUpgradeCliOptions, upgradeCli } from "./commands/upgrade.ts";
 import {
@@ -173,6 +174,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Verify host prerequisites (PATH tools, config validity, Linear reachability)",
     usage: "",
     invoke: doctorCli,
+  },
+  source: {
+    summary: "Inspect configured task sources",
+    usage: "<list|verify> [...]",
+    invoke: sourceCli,
   },
   status: {
     summary: "Print read-only groundcrew state, or one task's local/Linear status",

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -1,0 +1,316 @@
+/* eslint-disable no-template-curly-in-string -- ${id}-style placeholders are intentional shell substitution literals, not JS template expressions */
+
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { TaskSource } from "../lib/taskSource.ts";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+
+import { sourceCli } from "./source.ts";
+
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    loadConfig: vi.fn<typeof loadConfig>(),
+  };
+});
+
+vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    buildSources: vi.fn<typeof buildSources>(),
+    sourcesFromConfig: vi.fn<typeof sourcesFromConfig>(),
+  };
+});
+
+const loadConfigMock = vi.mocked(loadConfig);
+const buildSourcesMock = vi.mocked(buildSources);
+const sourcesFromConfigMock = vi.mocked(sourcesFromConfig);
+
+function makeConfig(): ResolvedConfig {
+  return {
+    sources: [],
+    defaults: { hooks: {} },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: {
+        claude: { cmd: "safehouse claude --permission-mode auto", color: "#fff" },
+      },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function stubSource(name: string): TaskSource {
+  return {
+    name,
+    verify: vi.fn<TaskSource["verify"]>(),
+    fetch: vi.fn<TaskSource["fetch"]>(),
+    resolveOne: vi.fn<TaskSource["resolveOne"]>(),
+    markInProgress: vi.fn<TaskSource["markInProgress"]>(),
+    markInReview: vi.fn<TaskSource["markInReview"]>(),
+  };
+}
+
+const LINEAR_RAW = { kind: "linear" };
+const SHELL_RAW_MINIMAL = { kind: "shell", name: "jira", commands: { fetch: "./fetch.sh" } };
+const SHELL_RAW_FULL = {
+  kind: "shell",
+  name: "jira",
+  commands: {
+    verify: "jira me",
+    fetch: "./fetch.sh",
+    resolveOne: "./resolve.sh ${id}",
+    markInProgress: "jira move ${id} 'In Progress'",
+    markInReview: "jira move ${id} 'In Review'",
+    markDone: "jira move ${id} 'Done'",
+  },
+};
+
+describe("sourceCli dispatch", () => {
+  it("throws with usage for an unknown subcommand", async () => {
+    await expect(sourceCli(["unknown"])).rejects.toThrow("crew source");
+  });
+
+  it("throws with usage when no subcommand given", async () => {
+    await expect(sourceCli([])).rejects.toThrow("crew source");
+  });
+});
+
+describe("crew source list", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+  });
+
+  it("prints table with a linear source", async () => {
+    sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain("NAME");
+    expect(output).toContain("KIND");
+    expect(output).toContain("WRITEBACK");
+    expect(output).toContain("linear");
+  });
+
+  it("shows linear capabilities correctly", async () => {
+    sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const lines = log.output().split("\n");
+    // first line is the header, second is the data row
+    const [, linearRow] = lines;
+    expect(linearRow).toContain("yes");
+    expect(linearRow).toContain("no"); // createTask = false
+  });
+
+  it("shows minimal shell source with no verify, writeback = no", async () => {
+    sourcesFromConfigMock.mockReturnValue([SHELL_RAW_MINIMAL]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const lines = log.output().split("\n");
+    const [, dataRow] = lines;
+    // no verify, no writeback commands
+    expect(dataRow).toMatch(/no\s+yes\s+yes\s+no\s+no/);
+  });
+
+  it("shows full shell source with verify and all writeback commands", async () => {
+    sourcesFromConfigMock.mockReturnValue([SHELL_RAW_FULL]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const lines = log.output().split("\n");
+    const [, dataRow] = lines;
+    // verify=yes, writeback=yes (has markInProgress, markInReview, markDone)
+    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+no\s+yes/);
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"name": "linear"');
+    expect(output).toContain('"kind": "linear"');
+    expect(output).toContain('"verify": true');
+    expect(output).toContain('"listTasks": true');
+    expect(output).toContain('"createTask": false');
+    expect(output).toContain('"markDone": false');
+  });
+
+  it("shows an unknown adapter kind with fallback capabilities (listTasks only)", async () => {
+    sourcesFromConfigMock.mockReturnValue([{ kind: "custom-plugin", name: "my-plugin" }]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const lines = log.output().split("\n");
+    const [, dataRow] = lines;
+    expect(dataRow).toContain("my-plugin");
+    // unknown kind: verify=no, listTasks=yes, getTask=no, create=no, writeback=no
+    expect(dataRow).toMatch(/no\s+yes\s+no\s+no\s+no/);
+  });
+
+  it("shows (no sources configured) when sourcesFromConfig returns empty array", async () => {
+    sourcesFromConfigMock.mockReturnValue([]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("no sources");
+  });
+
+  it("throws on unknown argument", async () => {
+    sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
+    await expect(sourceCli(["list", "--foo"])).rejects.toThrow("unknown argument: --foo");
+  });
+});
+
+describe("crew source verify", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
+  });
+
+  it("verifies all sources and shows ok", async () => {
+    const source = stubSource("linear");
+    buildSourcesMock.mockResolvedValue([source]);
+
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["verify"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("linear");
+    expect(log.output()).toContain("ok");
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("shows failed and sets exit code 1 when verify throws", async () => {
+    const source = stubSource("linear");
+    vi.mocked(source.verify).mockRejectedValue(new Error("Missing LINEAR_API_KEY"));
+    buildSourcesMock.mockResolvedValue([source]);
+
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["verify"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("failed");
+    expect(log.output()).toContain("Missing LINEAR_API_KEY");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("verifies a specific source by name", async () => {
+    const linear = stubSource("linear");
+    const jira = stubSource("jira");
+    buildSourcesMock.mockResolvedValue([linear, jira]);
+
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["verify", "jira"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("jira");
+    expect(log.output()).not.toContain("linear");
+    expect(vi.mocked(linear.verify)).not.toHaveBeenCalledWith();
+    expect(vi.mocked(jira.verify)).toHaveBeenCalledWith();
+  });
+
+  it("throws when the named source is not found", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("linear")]);
+    await expect(sourceCli(["verify", "nonexistent"])).rejects.toThrow(
+      'no source named "nonexistent"',
+    );
+  });
+
+  it("outputs JSON with --json flag", async () => {
+    const source = stubSource("linear");
+    buildSourcesMock.mockResolvedValue([source]);
+
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["verify", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"source": "linear"');
+    expect(output).toContain('"ok": true');
+  });
+
+  it("outputs JSON with ok:false and message on failure", async () => {
+    const source = stubSource("linear");
+    vi.mocked(source.verify).mockRejectedValue(new Error("bad token"));
+    buildSourcesMock.mockResolvedValue([source]);
+
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["verify", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"ok": false');
+    expect(output).toContain('"message": "bad token"');
+  });
+
+  it("throws on unknown option", async () => {
+    buildSourcesMock.mockResolvedValue([]);
+    await expect(sourceCli(["verify", "--foo"])).rejects.toThrow("unknown option: --foo");
+  });
+
+  it("throws on too many arguments", async () => {
+    buildSourcesMock.mockResolvedValue([]);
+    await expect(sourceCli(["verify", "linear", "extra"])).rejects.toThrow("too many arguments");
+  });
+});

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -209,6 +209,7 @@ describe("crew source list", () => {
 
 describe("crew source verify", () => {
   beforeEach(() => {
+    process.exitCode = undefined;
     loadConfigMock.mockResolvedValue(makeConfig());
     sourcesFromConfigMock.mockReturnValue([LINEAR_RAW]);
   });

--- a/src/commands/source.ts
+++ b/src/commands/source.ts
@@ -1,0 +1,154 @@
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
+import { loadConfig } from "../lib/config.ts";
+import { summarizeSource, type SourceSummary } from "../lib/sourceCapabilities.ts";
+import { errorMessage, writeOutput } from "../lib/util.ts";
+
+const SOURCE_USAGE = `Usage: crew source <subcommand>
+
+Subcommands:
+  list [--json]              List configured sources and their capabilities
+  verify [source] [--json]   Verify one or all configured sources`;
+
+async function sourceListCli(argv: string[]): Promise<void> {
+  let jsonOutput = false;
+  for (const arg of argv) {
+    if (arg === "--json") {
+      jsonOutput = true;
+      continue;
+    }
+    throw new Error(`crew source list: unknown argument: ${arg}\nUsage: crew source list [--json]`);
+  }
+
+  const config = await loadConfig();
+  const rawSources = sourcesFromConfig(config);
+  const summaries = rawSources.map(summarizeSource);
+
+  if (jsonOutput) {
+    writeOutput(JSON.stringify(summaries, null, 2));
+    return;
+  }
+
+  printSourceTable(summaries);
+}
+
+function yesNo(value: boolean): string {
+  return value ? "yes" : "no";
+}
+
+function printSourceTable(summaries: SourceSummary[]): void {
+  if (summaries.length === 0) {
+    writeOutput("(no sources configured)");
+    return;
+  }
+
+  const nameWidth = Math.max(4, ...summaries.map((s) => s.name.length));
+  const kindWidth = Math.max(4, ...summaries.map((s) => s.kind.length));
+
+  const header = [
+    "NAME".padEnd(nameWidth),
+    "KIND".padEnd(kindWidth),
+    "VERIFY".padEnd(6),
+    "LIST TASKS".padEnd(10),
+    "GET TASK".padEnd(8),
+    "CREATE".padEnd(6),
+    "WRITEBACK",
+  ].join("  ");
+  writeOutput(header);
+
+  for (const summary of summaries) {
+    const { capabilities: cap } = summary;
+    const writeback = cap.markInProgress || cap.markInReview || cap.markDone;
+    const row = [
+      summary.name.padEnd(nameWidth),
+      summary.kind.padEnd(kindWidth),
+      yesNo(cap.verify).padEnd(6),
+      yesNo(cap.listTasks).padEnd(10),
+      yesNo(cap.getTask).padEnd(8),
+      yesNo(cap.createTask).padEnd(6),
+      yesNo(writeback),
+    ].join("  ");
+    writeOutput(row);
+  }
+}
+
+interface VerifyResult {
+  source: string;
+  ok: boolean;
+  message?: string;
+}
+
+async function sourceVerifyCli(argv: string[]): Promise<void> {
+  let jsonOutput = false;
+  let targetSource: string | undefined;
+
+  for (const arg of argv) {
+    if (arg === "--json") {
+      jsonOutput = true;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(
+        `crew source verify: unknown option: ${arg}\nUsage: crew source verify [source] [--json]`,
+      );
+    }
+    if (targetSource !== undefined) {
+      throw new Error(
+        "crew source verify: too many arguments\nUsage: crew source verify [source] [--json]",
+      );
+    }
+    targetSource = arg;
+  }
+
+  const config = await loadConfig();
+  const rawSources = sourcesFromConfig(config);
+  const allSources = await buildSources(rawSources, { globalConfig: config });
+
+  let sources = allSources;
+  if (targetSource !== undefined) {
+    sources = allSources.filter((s) => s.name === targetSource);
+    if (sources.length === 0) {
+      throw new Error(`crew source verify: no source named "${targetSource}"`);
+    }
+  }
+
+  const results: VerifyResult[] = await Promise.all(
+    sources.map(async (source) => {
+      try {
+        await source.verify();
+        return { source: source.name, ok: true };
+      } catch (error) {
+        return { source: source.name, ok: false, message: errorMessage(error) };
+      }
+    }),
+  );
+
+  if (jsonOutput) {
+    writeOutput(JSON.stringify(results, null, 2));
+  } else {
+    const nameWidth = Math.max(...results.map((r) => r.source.length));
+    for (const result of results) {
+      const parts = [result.source.padEnd(nameWidth), result.ok ? "ok" : "failed"];
+      if (!result.ok && result.message !== undefined) {
+        parts.push(result.message);
+      }
+      writeOutput(parts.join("  "));
+    }
+  }
+
+  if (results.some((r) => !r.ok)) {
+    process.exitCode = 1;
+  }
+}
+
+export async function sourceCli(argv: string[]): Promise<void> {
+  const [verb, ...rest] = argv;
+  if (verb === "list") {
+    await sourceListCli(rest);
+    return;
+  }
+  if (verb === "verify") {
+    await sourceVerifyCli(rest);
+    return;
+  }
+  throw new Error(SOURCE_USAGE);
+}

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -4,6 +4,8 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import { captureConsoleError } from "../../../testHelpers/consoleCapture.ts";
+
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import type { ResolvedConfig } from "../../config.ts";
 import type { Issue as CanonicalIssue } from "../../taskSource.ts";
@@ -530,5 +532,70 @@ describe(createShellTaskSource, () => {
     };
     await expect(source.markDone?.(issue)).resolves.toStrictEqual({ outcome: "applied" });
     expect(readFileSync(stdinCapture, "utf8")).toBe(JSON.stringify(sourceRef));
+  });
+
+  it("fetch() works when commands.listTasks is used instead of commands.fetch", async () => {
+    const script = dir.writeScript(
+      "list.sh",
+      `cat <<'JSON'\n${payload(shellIssue({ id: "X-2" }))}\nJSON`,
+    );
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { listTasks: script } },
+      fakeContext,
+    );
+    const issues = await source.fetch();
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.id).toBe("test:x-2");
+  });
+
+  it("resolveOne() uses commands.getTask when set instead of commands.resolveOne", async () => {
+    const getTaskScript = dir.writeScript(
+      "get.sh",
+      `echo "{\\"id\\":\\"$1\\",\\"title\\":\\"t\\",\\"description\\":\\"\\",\\"status\\":\\"todo\\",\\"repository\\":null,\\"model\\":null,\\"assignee\\":\\"u\\",\\"updatedAt\\":\\"2026-01-01T00:00:00Z\\",\\"blockers\\":[],\\"sourceRef\\":null}"`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", getTask: `${getTaskScript} \${id}` },
+      },
+      fakeContext,
+    );
+    const issue = await source.resolveOne("X-2");
+    expect(issue?.id).toBe("test:x-2");
+  });
+
+  it("warns to stderr when both commands.listTasks and commands.fetch are set", () => {
+    const err = captureConsoleError();
+    try {
+      createShellTaskSource(
+        { kind: "shell", name: "test", commands: { listTasks: "echo '[]'", fetch: "echo '[]'" } },
+        fakeContext,
+      );
+    } finally {
+      err.restore();
+    }
+    expect(err.output()).toContain("commands.fetch is ignored");
+  });
+
+  it("warns to stderr when both commands.getTask and commands.resolveOne are set", () => {
+    const err = captureConsoleError();
+    try {
+      createShellTaskSource(
+        {
+          kind: "shell",
+          name: "test",
+          commands: {
+            fetch: "echo '[]'",
+            getTask: "./get.sh",
+            resolveOne: "./resolve.sh",
+          },
+        },
+        fakeContext,
+      );
+    } finally {
+      err.restore();
+    }
+    expect(err.output()).toContain("commands.resolveOne is ignored");
   });
 });

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -25,6 +25,7 @@ import {
   type MarkInReviewResult,
   type TaskSource,
 } from "../../taskSource.ts";
+import { writeError } from "../../util.ts";
 
 import { invokeShellCommand } from "./invoke.ts";
 import {
@@ -36,8 +37,8 @@ import {
 
 interface ResolvedShellTimeouts {
   verify: number;
-  fetch: number;
-  resolveOne: number;
+  listTasks: number;
+  getTask: number;
   markInProgress: number;
   markInReview: number;
   markDone: number;
@@ -45,8 +46,8 @@ interface ResolvedShellTimeouts {
 
 const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
   verify: 10_000,
-  fetch: 30_000,
-  resolveOne: 10_000,
+  listTasks: 30_000,
+  getTask: 10_000,
   markInProgress: 10_000,
   markInReview: 10_000,
   markDone: 10_000,
@@ -55,12 +56,47 @@ const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
 function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShellTimeouts {
   return {
     verify: overrides?.verify ?? DEFAULT_TIMEOUTS.verify,
-    fetch: overrides?.fetch ?? DEFAULT_TIMEOUTS.fetch,
-    resolveOne: overrides?.resolveOne ?? DEFAULT_TIMEOUTS.resolveOne,
+    listTasks: overrides?.listTasks ?? overrides?.fetch ?? DEFAULT_TIMEOUTS.listTasks,
+    getTask: overrides?.getTask ?? overrides?.resolveOne ?? DEFAULT_TIMEOUTS.getTask,
     markInProgress: overrides?.markInProgress ?? DEFAULT_TIMEOUTS.markInProgress,
     markInReview: overrides?.markInReview ?? DEFAULT_TIMEOUTS.markInReview,
     markDone: overrides?.markDone ?? DEFAULT_TIMEOUTS.markDone,
   };
+}
+
+function warnDuplicate(sourceName: string, preferred: string, legacy: string): void {
+  writeError(
+    `shell source "${sourceName}": commands.${preferred} and commands.${legacy} are both set; commands.${legacy} is ignored (use commands.${preferred})`,
+  );
+}
+
+/** Preferred name preferred over legacy alias. Throws if neither is set (Zod schema invariant). */
+function resolveListTasksCommand(
+  commands: ShellAdapterConfig["commands"],
+  sourceName: string,
+): string {
+  const { listTasks, fetch } = commands;
+  if (listTasks !== undefined && fetch !== undefined) {
+    warnDuplicate(sourceName, "listTasks", "fetch");
+  }
+  const resolved = listTasks ?? fetch;
+  /* v8 ignore next @preserve -- Zod superRefine guarantees at least one is set */
+  if (resolved === undefined) {
+    throw new Error(`shell source "${sourceName}": commands.listTasks is required`);
+  }
+  return resolved;
+}
+
+/** Preferred name preferred over legacy alias. Returns undefined when neither is set. */
+function resolveGetTaskCommand(
+  commands: ShellAdapterConfig["commands"],
+  sourceName: string,
+): string | undefined {
+  const { getTask, resolveOne } = commands;
+  if (getTask !== undefined && resolveOne !== undefined) {
+    warnDuplicate(sourceName, "getTask", "resolveOne");
+  }
+  return getTask ?? resolveOne;
 }
 
 export function toCanonicalIssue(shellIssue: ShellIssue, sourceName: string): CanonicalIssue {
@@ -94,11 +130,13 @@ export function createShellTaskSource(
 ): TaskSource {
   const sourceName = config.name;
   const timeouts = mergeTimeouts(config.timeouts);
+  const listTasksCommand = resolveListTasksCommand(config.commands, sourceName);
+  const getTaskCommand = resolveGetTaskCommand(config.commands, sourceName);
 
   async function runFetch(): Promise<CanonicalIssue[]> {
     const { stdout } = await invokeShellCommand({
-      command: config.commands.fetch,
-      timeoutMs: timeouts.fetch,
+      command: listTasksCommand,
+      timeoutMs: timeouts.listTasks,
       cwd: config.cwd,
       env: config.env,
       sourceName,
@@ -154,14 +192,13 @@ export function createShellTaskSource(
     fetch: runFetch,
     async resolveOne(naturalId: string): Promise<CanonicalIssue | undefined> {
       const canonicalId = toCanonicalId(sourceName, naturalId);
-      const resolveCommand = config.commands.resolveOne;
-      if (resolveCommand === undefined) {
+      if (getTaskCommand === undefined) {
         const all = await runFetch();
         return all.find((i) => i.id === canonicalId);
       }
       const result = await invokeShellCommand({
-        command: resolveCommand,
-        timeoutMs: timeouts.resolveOne,
+        command: getTaskCommand,
+        timeoutMs: timeouts.getTask,
         cwd: config.cwd,
         env: config.env,
         substitutions: {

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -169,6 +169,43 @@ describe("shell adapter config schema", () => {
     expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
   });
 
+  it("accepts commands.listTasks as the preferred name for fetch", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { listTasks: "echo '[]'" },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it("accepts commands.getTask as the preferred name for resolveOne", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "echo '[]'", getTask: "./get.sh ${id}" },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it("rejects config with neither fetch nor listTasks", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { verify: "echo ok" },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/listTasks.*required/i);
+  });
+
+  it("accepts timeouts.listTasks and timeouts.getTask", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { listTasks: "echo '[]'" },
+      timeouts: { listTasks: 60_000, getTask: 15_000 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
   it("requires kebab-case names", () => {
     const config = {
       kind: "shell",

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -49,14 +49,29 @@ export const shellAdapterConfigSchema = z.object({
   name: z
     .string()
     .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)"),
-  commands: z.object({
-    verify: z.string().optional(),
-    fetch: z.string(),
-    resolveOne: z.string().optional(),
-    markInProgress: z.string().optional(),
-    markInReview: z.string().optional(),
-    markDone: z.string().optional(),
-  }),
+  commands: z
+    .object({
+      verify: z.string().optional(),
+      /** Preferred name. Alias: `fetch`. */
+      listTasks: z.string().optional(),
+      /** Legacy alias for `listTasks`. Prefer `listTasks` in new configs. */
+      fetch: z.string().optional(),
+      /** Preferred name. Alias: `resolveOne`. */
+      getTask: z.string().optional(),
+      /** Legacy alias for `getTask`. Prefer `getTask` in new configs. */
+      resolveOne: z.string().optional(),
+      markInProgress: z.string().optional(),
+      markInReview: z.string().optional(),
+      markDone: z.string().optional(),
+    })
+    .superRefine((commands, ctx) => {
+      if (commands.listTasks === undefined && commands.fetch === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: "commands.listTasks (or the legacy alias commands.fetch) is required",
+        });
+      }
+    }),
   cwd: z.string().optional(),
   timeouts: z
     .object({
@@ -64,7 +79,13 @@ export const shellAdapterConfigSchema = z.object({
       // zero, negative, and fractional values would either deadlock or
       // misbehave inside setTimeout.
       verify: z.number().int().positive().optional(),
+      /** Timeout for the listTasks command (preferred). */
+      listTasks: z.number().int().positive().optional(),
+      /** Legacy timeout alias for listTasks. Prefer `listTasks` in new configs. */
       fetch: z.number().int().positive().optional(),
+      /** Timeout for the getTask command (preferred). */
+      getTask: z.number().int().positive().optional(),
+      /** Legacy timeout alias for getTask. Prefer `getTask` in new configs. */
       resolveOne: z.number().int().positive().optional(),
       markInProgress: z.number().int().positive().optional(),
       markInReview: z.number().int().positive().optional(),

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -13,7 +13,7 @@ import { adapterRegistry } from "./adapters/registry.ts";
 import type { ResolvedConfig } from "./config.ts";
 import type { TaskSource } from "./taskSource.ts";
 
-const kindShape = z.object({ kind: z.string() });
+export const kindShape = z.object({ kind: z.string() });
 
 /**
  * Production entry point. Awaits the directory-scanned registry, then dispatches.

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+import { shellAdapterConfigSchema } from "./adapters/shell/schema.ts";
+import { kindShape } from "./buildSources.ts";
+
+interface SourceCapabilities {
+  verify: boolean;
+  listTasks: boolean;
+  getTask: boolean;
+  createTask: boolean;
+  markInProgress: boolean;
+  markInReview: boolean;
+  markDone: boolean;
+}
+
+export interface SourceSummary {
+  name: string;
+  kind: string;
+  capabilities: SourceCapabilities;
+}
+
+const nameShape = z.looseObject({ name: z.string().optional() });
+
+const LINEAR_CAPABILITIES: SourceCapabilities = {
+  verify: true,
+  listTasks: true,
+  getTask: true,
+  createTask: false,
+  markInProgress: true,
+  markInReview: true,
+  markDone: false,
+};
+
+const UNKNOWN_KIND_CAPABILITIES: SourceCapabilities = {
+  verify: false,
+  listTasks: true,
+  getTask: false,
+  createTask: false,
+  markInProgress: false,
+  markInReview: false,
+  markDone: false,
+};
+
+function shellCapabilities(raw: unknown): SourceCapabilities {
+  const config = shellAdapterConfigSchema.parse(raw);
+  const { commands } = config;
+  return {
+    verify: commands.verify !== undefined,
+    listTasks: true,
+    getTask: true,
+    createTask: false,
+    markInProgress: commands.markInProgress !== undefined,
+    markInReview: commands.markInReview !== undefined,
+    markDone: commands.markDone !== undefined,
+  };
+}
+
+export function summarizeSource(raw: unknown): SourceSummary {
+  const { kind } = kindShape.parse(raw);
+  const { name } = nameShape.parse(raw);
+  const sourceName = name ?? kind;
+
+  let capabilities: SourceCapabilities;
+  if (kind === "linear") {
+    capabilities = LINEAR_CAPABILITIES;
+  } else if (kind === "shell") {
+    capabilities = shellCapabilities(raw);
+  } else {
+    capabilities = UNKNOWN_KIND_CAPABILITIES;
+  }
+
+  return { name: sourceName, kind, capabilities };
+}


### PR DESCRIPTION
## Summary

Adds a minimal source admin CLI under `crew source` for discovering and verifying configured `TaskSource`s — without touching task retrieval, which remains under `crew task`.

- `crew source list [--json]` prints a capability table (VERIFY, LIST TASKS, GET TASK, CREATE, WRITEBACK) for every configured source, with `--json` emitting the full per-capability breakdown.
- `crew source verify [source] [--json]` runs per-source verification in parallel, reports `ok`/`failed` for each, and exits non-zero if any fail.

Also renames the shell adapter's `commands.fetch` → `commands.listTasks` and `commands.resolveOne` → `commands.getTask` as the preferred names, with the old names kept as backward-compatible aliases that warn on use when both are set simultaneously.

## Validation

- `node --run verify` passes: 1283 tests, 100% coverage, lint/format/knip clean.

Agent session: `claude --resume 39a1a71e-2529-4661-b096-1ae98d1ab27b`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>