### PR TITLE
feat: add todo-txt TaskSource adapter

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -115,6 +115,13 @@
     "vitest",
     "wordmark",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "dwmy",
+    "recurrence",
+    "todopath",
+    "todotxt",
+    "nostatus",
+    "norec",
+    "nodone"
   ]
 }

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -173,6 +173,25 @@ describe("crew source list", () => {
     expect(output).toContain('"markDone": false');
   });
 
+  it("shows todo-txt source with full capabilities", async () => {
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "todo-txt", name: "todo", todoPath: "todo.txt", tasksDir: ".tasks", idPrefix: "GC" },
+    ]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list"]);
+    } finally {
+      log.restore();
+    }
+
+    const lines = log.output().split("\n");
+    const [, dataRow] = lines;
+    expect(dataRow).toContain("todo");
+    expect(dataRow).toContain("todo-txt");
+    // verify=yes, listTasks=yes, getTask=yes, create=no, writeback=yes
+    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+no\s+yes/);
+  });
+
   it("shows an unknown adapter kind with fallback capabilities (listTasks only)", async () => {
     sourcesFromConfigMock.mockReturnValue([{ kind: "custom-plugin", name: "my-plugin" }]);
     const log = captureConsoleLog();

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -121,11 +121,12 @@ describe(listAdapterDirectories, () => {
 });
 
 describe("adapterRegistry production IIFE", () => {
-  it("loads the built-in linear and shell adapters from src/lib/adapters/", async () => {
+  it("loads the built-in adapters from src/lib/adapters/", async () => {
     const registry = await adapterRegistry;
-    expect(Object.keys(registry).toSorted()).toStrictEqual(["linear", "shell"]);
+    expect(Object.keys(registry).toSorted()).toStrictEqual(["linear", "shell", "todo-txt"]);
     expect(registry["linear"]?.kind).toBe("linear");
     expect(registry["shell"]?.kind).toBe("shell");
+    expect(registry["todo-txt"]?.kind).toBe("todo-txt");
   });
 
   it("each loaded adapter exposes a Zod configSchema and a create function", async () => {

--- a/src/lib/adapters/todo-txt/index.ts
+++ b/src/lib/adapters/todo-txt/index.ts
@@ -1,0 +1,12 @@
+import type { AdapterDefinition } from "../../adapterDefinition.ts";
+
+import { createTodoTxtTaskSource } from "./source.ts";
+import { todoTxtAdapterConfigSchema } from "./schema.ts";
+
+const definition: AdapterDefinition<typeof todoTxtAdapterConfigSchema> = {
+  kind: "todo-txt",
+  configSchema: todoTxtAdapterConfigSchema,
+  create: createTodoTxtTaskSource,
+};
+
+export default definition;

--- a/src/lib/adapters/todo-txt/normalizer.ts
+++ b/src/lib/adapters/todo-txt/normalizer.ts
@@ -1,0 +1,156 @@
+import path from "node:path";
+
+import { type Blocker, type CanonicalStatus, type Issue, toCanonicalId } from "../../taskSource.ts";
+import { getMetadataAll, getMetadataFirst, hashLine, type ParsedTodoLine } from "./parser.ts";
+
+export interface TodoTxtSourceRef {
+  sourceName: string;
+  todoPath: string;
+  id: string;
+  lineFingerprint: string;
+  promptPath: string;
+}
+
+function derivedCanonicalStatus(parsed: ParsedTodoLine): CanonicalStatus {
+  if (parsed.completed) {
+    return "done";
+  }
+  const statusValue = getMetadataFirst(parsed, "status");
+  if (statusValue === "todo") {
+    return parsed.isStatusFinalToken ? "todo" : "other";
+  }
+  if (statusValue === "in-progress") {
+    return "in-progress";
+  }
+  if (statusValue === "in-review") {
+    return "in-review";
+  }
+  if (statusValue === "done") {
+    return "done";
+  }
+  return "other";
+}
+
+function priorityToNumber(priority: string | undefined): number | undefined {
+  if (priority === undefined) {
+    return undefined;
+  }
+  /* v8 ignore next @preserve -- codePointAt(0) on non-empty string never returns undefined */
+  const code = priority.codePointAt(0) ?? 0;
+  /* v8 ignore next @preserve -- same: "A" is a non-empty string literal */
+  const baseCode = "A".codePointAt(0) ?? 65;
+  return code - baseCode + 1;
+}
+
+function resolveBlocker(
+  depId: string,
+  allParsed: (ParsedTodoLine | null)[],
+  sourceName: string,
+): Blocker {
+  const found = allParsed.find(
+    (p): p is ParsedTodoLine =>
+      p !== null && getMetadataFirst(p, "id")?.toLowerCase() === depId.toLowerCase(),
+  );
+
+  const id = toCanonicalId(sourceName, depId);
+
+  if (found === undefined) {
+    return {
+      id,
+      title: depId,
+      status: "other",
+      statusReason: "missing",
+    };
+  }
+
+  const status = derivedCanonicalStatus(found);
+  const nativeStatus = found.completed ? "x" : (getMetadataFirst(found, "status") ?? "(no status)");
+
+  return {
+    id,
+    title: found.title || depId,
+    status,
+    ...(status === "other" && { statusReason: "unmapped" as const }),
+    nativeStatus,
+  };
+}
+
+export interface NormalizeOptions {
+  parsed: ParsedTodoLine;
+  allParsed: (ParsedTodoLine | null)[];
+  sourceName: string;
+  todoPath: string;
+  tasksDir: string;
+  defaultRepository: string | undefined;
+  description: string;
+  updatedAt: string;
+}
+
+export function normalizeToIssue(options: NormalizeOptions): Issue | undefined {
+  const {
+    parsed,
+    allParsed,
+    sourceName,
+    todoPath,
+    tasksDir,
+    defaultRepository,
+    description,
+    updatedAt,
+  } = options;
+
+  const id = getMetadataFirst(parsed, "id");
+  /* v8 ignore next @preserve -- callers always pre-filter for id: before invoking */
+  if (id === undefined) {
+    return undefined;
+  }
+
+  const agent = getMetadataFirst(parsed, "agent");
+  const status = derivedCanonicalStatus(parsed);
+  const repository = getMetadataFirst(parsed, "repo") ?? defaultRepository;
+
+  const depIds = getMetadataAll(parsed, "dep");
+  const blockers: Blocker[] = depIds.map((depId) => resolveBlocker(depId, allParsed, sourceName));
+
+  const promptOverride = getMetadataFirst(parsed, "prompt");
+  const promptPath = promptOverride ?? path.join(tasksDir, `${id}.md`);
+
+  const sourceRef: TodoTxtSourceRef = {
+    sourceName,
+    todoPath,
+    id,
+    lineFingerprint: hashLine(parsed.raw),
+    promptPath,
+  };
+
+  const priority = priorityToNumber(parsed.priority);
+
+  return {
+    id: toCanonicalId(sourceName, id),
+    source: sourceName,
+    title: parsed.title,
+    description,
+    status,
+    repository,
+    model: agent,
+    assignee: "",
+    updatedAt,
+    blockers,
+    hasMoreBlockers: false,
+    ...(priority !== undefined && { priority }),
+    sourceRef,
+  };
+}
+
+export function isActiveForFetch(parsed: ParsedTodoLine): boolean {
+  if (parsed.completed) {
+    return false;
+  }
+  if (getMetadataFirst(parsed, "id") === undefined) {
+    return false;
+  }
+  if (getMetadataFirst(parsed, "agent") === undefined) {
+    return false;
+  }
+  const statusValue = getMetadataFirst(parsed, "status");
+  return statusValue === "todo" || statusValue === "in-progress" || statusValue === "in-review";
+}

--- a/src/lib/adapters/todo-txt/parser.ts
+++ b/src/lib/adapters/todo-txt/parser.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+
+type TodoMetadata = Record<string, string[] | undefined>;
+
+export interface ParsedTodoLine {
+  readonly raw: string;
+  readonly completed: boolean;
+  readonly completionDate?: string;
+  readonly priority?: string;
+  readonly creationDate?: string;
+  readonly title: string;
+  readonly projects: readonly string[];
+  readonly contexts: readonly string[];
+  readonly metadata: TodoMetadata;
+  /** True when the final meaningful whitespace-delimited token is a `status:X` field. */
+  readonly isStatusFinalToken: boolean;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const KEY_VALUE_RE = /^(?<key>[a-zA-Z][a-zA-Z0-9-]*):(?<value>\S+)$/;
+const PRIORITY_RE = /^\((?<priority>[A-Z])\) /;
+const PROJECT_RE = /^\+\S+$/;
+const CONTEXT_RE = /^@\S+$/;
+
+export function hashLine(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function extractDatePrefix(rest: string): { date: string | undefined; rest: string } {
+  const spaceIdx = rest.indexOf(" ");
+  const candidate = spaceIdx === -1 ? rest : rest.slice(0, spaceIdx);
+  if (DATE_RE.test(candidate)) {
+    return { date: candidate, rest: spaceIdx === -1 ? "" : rest.slice(spaceIdx + 1).trimStart() };
+  }
+  return { date: undefined, rest };
+}
+
+function parseTodoLine(raw: string): ParsedTodoLine {
+  let rest = raw.trim();
+  let completed = false;
+  let completionDate: string | undefined;
+  let priority: string | undefined;
+  let creationDate: string | undefined;
+
+  if (rest.startsWith("x ")) {
+    completed = true;
+    rest = rest.slice(2).trimStart();
+    ({ date: completionDate, rest } = extractDatePrefix(rest));
+  }
+
+  const priorityMatch = PRIORITY_RE.exec(rest);
+  if (priorityMatch !== null) {
+    priority = priorityMatch.groups?.["priority"];
+    rest = rest.slice(priorityMatch[0].length);
+  }
+
+  ({ date: creationDate, rest } = extractDatePrefix(rest));
+
+  const tokens = rest.split(/\s+/).filter((t) => t.length > 0);
+  const projects: string[] = [];
+  const contexts: string[] = [];
+  const metadata: TodoMetadata = {};
+  const titleParts: string[] = [];
+
+  for (const token of tokens) {
+    if (PROJECT_RE.test(token)) {
+      projects.push(token.slice(1));
+    } else if (CONTEXT_RE.test(token)) {
+      contexts.push(token.slice(1));
+    } else {
+      const kvMatch = KEY_VALUE_RE.exec(token);
+      if (kvMatch === null) {
+        titleParts.push(token);
+      } else {
+        /* v8 ignore next @preserve -- named capture groups are always defined when regex matches */
+        const { key, value } = kvMatch.groups ?? {};
+        /* v8 ignore else @preserve -- named groups always defined when regex matches */
+        if (key !== undefined && value !== undefined) {
+          const existing = metadata[key] ?? [];
+          metadata[key] = [...existing, value];
+        }
+      }
+    }
+  }
+
+  const lastToken = tokens.at(-1) ?? "";
+  const lastKv = KEY_VALUE_RE.exec(lastToken);
+  const isStatusFinalToken = lastKv !== null && lastKv.groups?.["key"] === "status";
+
+  return {
+    raw,
+    completed,
+    ...(completionDate !== undefined && { completionDate }),
+    ...(priority !== undefined && { priority }),
+    ...(creationDate !== undefined && { creationDate }),
+    title: titleParts.join(" "),
+    projects,
+    contexts,
+    metadata,
+    isStatusFinalToken,
+  };
+}
+
+export function parseAllLines(fileContent: string): (ParsedTodoLine | null)[] {
+  return fileContent.split("\n").map((line) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      return null;
+    }
+    return parseTodoLine(line);
+  });
+}
+
+export function getMetadataFirst(parsed: ParsedTodoLine, key: string): string | undefined {
+  return parsed.metadata[key]?.[0];
+}
+
+export function getMetadataAll(parsed: ParsedTodoLine, key: string): string[] {
+  return parsed.metadata[key] ?? [];
+}

--- a/src/lib/adapters/todo-txt/schema.ts
+++ b/src/lib/adapters/todo-txt/schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const todoTxtAdapterConfigSchema = z.object({
+  kind: z.literal("todo-txt"),
+  name: z
+    .string()
+    .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)")
+    .default("todo"),
+  todoPath: z.string().default("todo.txt"),
+  tasksDir: z.string().default(".tasks"),
+  defaultRepository: z.string().optional(),
+  idPrefix: z.string().default("GC"),
+  timezone: z.string().default("UTC"),
+});
+
+export type TodoTxtAdapterConfig = z.infer<typeof todoTxtAdapterConfigSchema>;

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -1,0 +1,913 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { AdapterContext } from "../../adapterDefinition.ts";
+import type { ResolvedConfig } from "../../config.ts";
+import type { Issue } from "../../taskSource.ts";
+import { createTodoTxtTaskSource } from "./source.ts";
+import type { TodoTxtSourceRef } from "./normalizer.ts";
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests don't need the full config shape
+const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
+
+interface TempDir {
+  dir: string;
+  todoPath: string;
+  tasksDir: string;
+  writeTodo: (content: string) => void;
+  writeTask: (id: string, content: string) => void;
+  cleanup: () => void;
+}
+
+function makeTempDir(): TempDir {
+  const dir = mkdtempSync(path.join(tmpdir(), "todo-txt-test-"));
+  const todoPath = path.join(dir, "todo.txt");
+  const tasksDir = path.join(dir, ".tasks");
+  mkdirSync(tasksDir, { recursive: true });
+
+  return {
+    dir,
+    todoPath,
+    tasksDir,
+    writeTodo(content: string): void {
+      writeFileSync(todoPath, content, "utf8");
+    },
+    writeTask(id: string, content: string): void {
+      writeFileSync(path.join(tasksDir, `${id}.md`), content, "utf8");
+    },
+    cleanup(): void {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeSource(tmp: TempDir, defaultRepository?: string) {
+  return createTodoTxtTaskSource(
+    {
+      kind: "todo-txt",
+      name: "todo",
+      todoPath: tmp.todoPath,
+      tasksDir: tmp.tasksDir,
+      defaultRepository,
+      idPrefix: "GC",
+      timezone: "UTC",
+    },
+    fakeContext,
+  );
+}
+
+function sourceRef(issue: Issue): TodoTxtSourceRef {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests read the sourceRef shape
+  return issue.sourceRef as TodoTxtSourceRef;
+}
+
+function assertDefined<T>(v: T | undefined | null, label = "value"): T {
+  if (v === null || v === undefined) {
+    throw new TypeError(`Expected ${label} to be defined`);
+  }
+  return v;
+}
+
+describe("TodoTxtTaskSource", () => {
+  let tmp: TempDir;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    tmp = makeTempDir();
+  });
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
+  // Test 1: Parse minimal ready task
+  it("parses a minimal ready task", async () => {
+    tmp.writeTodo(
+      "(A) Fix cancellation retry race +marketplace @backend id:GC-001 agent:codex status:todo\n",
+    );
+    tmp.writeTask("GC-001", "Fix the retry race condition.");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(1);
+    const [issue] = issues;
+    expect(issue?.id).toBe("todo:gc-001");
+    expect(issue?.title).toBe("Fix cancellation retry race");
+    expect(issue?.status).toBe("todo");
+    expect(issue?.model).toBe("codex");
+  });
+
+  // Test 2: Ignore draft task with no status:todo
+  it("ignores draft task with no status field", async () => {
+    tmp.writeTodo("(A) Draft task +foo id:GC-002 agent:codex\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  // Test 3: Do not dispatch task where status:todo is not final token
+  it("maps status:todo (not final token) to status other", async () => {
+    tmp.writeTodo("(A) Task with extra token id:GC-003 agent:codex status:todo extra-token\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.status).toBe("other");
+  });
+
+  // Test 4: Read .tasks/<id>.md into description
+  it("reads .tasks/<id>.md into task description", async () => {
+    tmp.writeTodo("(A) My task id:GC-004 agent:claude status:todo\n");
+    tmp.writeTask("GC-004", "# Detailed description\n\nDo the thing.\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.description).toBe("# Detailed description\n\nDo the thing.\n");
+  });
+
+  // Test 5: Map agent:codex → model:"codex"
+  it("maps agent:codex to model codex", async () => {
+    tmp.writeTodo("id:GC-005 agent:codex status:todo Task five\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.model).toBe("codex");
+  });
+
+  // Test 6: Map agent:claude → model:"claude"
+  it("maps agent:claude to model claude", async () => {
+    tmp.writeTodo("id:GC-006 agent:claude status:todo Task six\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.model).toBe("claude");
+  });
+
+  // Test 7: Handle agent:any
+  it("handles agent:any", async () => {
+    tmp.writeTodo("id:GC-007 agent:any status:todo Task seven\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.model).toBe("any");
+  });
+
+  // Test 8: Default repository from config when no repo:
+  it("defaults repository from config when no repo: field", async () => {
+    tmp.writeTodo("id:GC-008 agent:codex status:todo Task eight\n");
+
+    const source = makeSource(tmp, "OrgA/repo-default");
+    const issues = await source.fetch();
+
+    expect(issues[0]?.repository).toBe("OrgA/repo-default");
+  });
+
+  // Test 9: Use repo: override when present
+  it("uses repo: override from task metadata", async () => {
+    tmp.writeTodo("id:GC-009 agent:codex repo:OrgB/repo-override status:todo Task nine\n");
+
+    const source = makeSource(tmp, "OrgA/repo-default");
+    const issues = await source.fetch();
+
+    expect(issues[0]?.repository).toBe("OrgB/repo-override");
+  });
+
+  // Test 10: Emit blockers from dep:
+  it("emits blockers from dep: fields", async () => {
+    tmp.writeTodo(
+      // title text must come before metadata so status:todo remains the final token
+      "Task ten A id:GC-010a agent:codex status:todo\nTask ten B id:GC-010b agent:codex dep:GC-010a status:todo\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    const taskB = issues.find((i) => i.id === "todo:gc-010b");
+    expect(taskB?.blockers).toHaveLength(1);
+    expect(taskB?.blockers[0]?.id).toBe("todo:gc-010a");
+    expect(taskB?.blockers[0]?.status).toBe("todo");
+  });
+
+  // Test 11: Do not dispatch task with unresolved or unfinished blocker
+  it("marks task with unresolved dep as having other-status blocker", async () => {
+    tmp.writeTodo("id:GC-011 agent:codex dep:MISSING-001 status:todo Task eleven\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    const task = issues.find((i) => i.id === "todo:gc-011");
+    expect(task?.blockers).toHaveLength(1);
+    expect(task?.blockers[0]?.status).toBe("other");
+    expect(task?.blockers[0]?.statusReason).toBe("missing");
+  });
+
+  // Test 12: markInProgress rewrites status
+  it("markInProgress rewrites status:todo to status:in-progress", async () => {
+    tmp.writeTodo("# comment\nid:GC-012 agent:codex status:todo Task twelve\n# end\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+    const [task] = issues;
+    expect(task).toBeDefined();
+
+    await source.markInProgress(assertDefined(task, "task"));
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("status:in-progress");
+    expect(updated).not.toContain("status:todo");
+    // unrelated lines preserved
+    expect(updated).toContain("# comment");
+    expect(updated).toContain("# end");
+  });
+
+  // Test 13: markInReview rewrites status
+  it("markInReview rewrites status:in-progress to status:in-review", async () => {
+    tmp.writeTodo("id:GC-013 agent:codex status:in-progress Task thirteen\n");
+
+    // Build a fake in-progress issue to pass to markInReview
+    const source = makeSource(tmp);
+    // Use resolveOne to get the issue regardless of fetch filter
+    const task = await source.resolveOne("GC-013");
+    expect(task).toBeDefined();
+
+    const result = await source.markInReview(assertDefined(task, "task"));
+    expect(result.outcome).toBe("applied");
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("status:in-review");
+  });
+
+  // Test 14: markDone marks task complete
+  it("markDone marks task complete with x prefix and status:done", async () => {
+    const now = new Date("2026-06-08T12:00:00Z");
+    tmp.writeTodo("id:GC-014 agent:codex status:in-review Task fourteen\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-014");
+    expect(task).toBeDefined();
+
+    const ref = sourceRef(assertDefined(task, "task"));
+    const { updateTaskStatus } = await import("./writeback.ts");
+    await updateTaskStatus({ todoPath: tmp.todoPath, ref, now }, "done");
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("x 2026-06-08");
+    expect(updated).toContain("status:done");
+  });
+
+  // Test 15: markDone on rec:+1w creates next task with new ID/date
+  it("markDone on rec:+1w creates next recurring task", async () => {
+    // Use rec:+1w (strict): new due = original due + 1w = 2026-06-08
+    tmp.writeTodo(
+      "(A) Weekly cleanup id:cleanup-20260601 agent:any due:2026-06-01 rec:+1w status:in-review\n",
+    );
+    tmp.writeTask("cleanup-20260601", "Cleanup prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("cleanup-20260601");
+    expect(task).toBeDefined();
+
+    const markDone = assertDefined(source.markDone?.bind(source), "markDone");
+    await markDone(assertDefined(task, "task"));
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    // Original task marked done
+    expect(updated).toMatch(/^x \d{4}-\d{2}-\d{2} /m);
+    expect(updated).toContain("status:done");
+    // New recurring task with advanced due (strict: original due + 1w = 2026-06-08)
+    expect(updated).toContain("id:cleanup-20260608");
+    expect(updated).toContain("due:2026-06-08");
+    expect(updated).toMatch(/.*id:cleanup-20260608.*status:todo/);
+
+    // Prompt file copied to new id
+    const newPromptPath = path.join(tmp.tasksDir, "cleanup-20260608.md");
+    const newPromptContent = readFileSync(newPromptPath, "utf8");
+    expect(newPromptContent).toBe("Cleanup prompt.");
+  });
+
+  // Test 16: Atomic rewrite preserves unrelated lines/comments
+  it("atomic rewrite preserves unrelated lines and comments", async () => {
+    tmp.writeTodo(
+      "# My todo list\n(A) Other task id:OTHER-001 agent:codex status:todo\nid:GC-016 agent:codex status:todo Task sixteen\n# trailing comment\n",
+    );
+    tmp.writeTask("GC-016", "Prompt.");
+    tmp.writeTask("OTHER-001", "Other prompt.");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+    const task = issues.find((i) => i.id === "todo:gc-016");
+    expect(task).toBeDefined();
+
+    await source.markInProgress(assertDefined(task, "task"));
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("# My todo list");
+    expect(updated).toContain("OTHER-001");
+    expect(updated).toContain("status:todo"); // OTHER-001 still todo
+    expect(updated).toContain("# trailing comment");
+    expect(updated).toMatch(/GC-016.*status:in-progress/);
+  });
+
+  // Test 17: Conflicting line fingerprint handled safely
+  it("falls back to id: lookup when line fingerprint does not match", async () => {
+    tmp.writeTodo("id:GC-017 agent:codex status:todo Task seventeen\n");
+
+    const source = makeSource(tmp);
+    const task = await source.fetch().then((issues) => issues[0]);
+    expect(task).toBeDefined();
+
+    // Simulate user editing the line between fetch and writeback
+    tmp.writeTodo("id:GC-017 agent:codex status:todo Task seventeen (edited)\n");
+
+    // Should still succeed (falls back to id: lookup)
+    await source.markInProgress(assertDefined(task, "task"));
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("status:in-progress");
+  });
+
+  // Test 18: getTask (resolveOne) and listTasks (fetch) use same normalization
+  it("resolveOne and fetch return same normalized shape for same task", async () => {
+    tmp.writeTodo("(A) Same task id:GC-018 agent:codex repo:OrgA/repo status:todo\n");
+    tmp.writeTask("GC-018", "Prompt content.");
+
+    const source = makeSource(tmp, "OrgA/default");
+    const [fetchedIssue] = await source.fetch();
+    const resolvedIssue = await source.resolveOne("GC-018");
+
+    expect(resolvedIssue).toBeDefined();
+    // All normalizable fields should match
+    expect(resolvedIssue?.id).toBe(fetchedIssue?.id);
+    expect(resolvedIssue?.title).toBe(fetchedIssue?.title);
+    expect(resolvedIssue?.description).toBe(fetchedIssue?.description);
+    expect(resolvedIssue?.status).toBe(fetchedIssue?.status);
+    expect(resolvedIssue?.model).toBe(fetchedIssue?.model);
+    expect(resolvedIssue?.repository).toBe(fetchedIssue?.repository);
+    expect(resolvedIssue?.priority).toBe(fetchedIssue?.priority);
+    expect(resolvedIssue?.blockers).toStrictEqual(fetchedIssue?.blockers);
+  });
+
+  // Test 19: resolveOne returns undefined for missing id
+  it("resolveOne returns undefined when task id is not found", async () => {
+    tmp.writeTodo("id:GC-019 agent:codex status:todo Task\n");
+
+    const source = makeSource(tmp);
+    const result = await source.resolveOne("NONEXISTENT");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("includes in-progress and in-review tasks in fetch", async () => {
+    tmp.writeTodo(
+      "id:IP-001 agent:codex status:in-progress In progress\nid:IR-001 agent:codex status:in-review In review\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(2);
+    expect(issues.find((i) => i.id === "todo:ip-001")?.status).toBe("in-progress");
+    expect(issues.find((i) => i.id === "todo:ir-001")?.status).toBe("in-review");
+  });
+
+  it("excludes completed (x prefix) tasks from fetch", async () => {
+    tmp.writeTodo("x 2026-06-01 id:DONE-001 agent:codex status:done Done task\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it("maps priority (A) to priority 1", async () => {
+    tmp.writeTodo("(A) High priority task id:PRI-001 agent:codex status:todo\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.priority).toBe(1);
+  });
+
+  it("sets description to empty string when no prompt file exists", async () => {
+    tmp.writeTodo("id:NO-PROMPT agent:codex status:todo No prompt task\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.description).toBe("");
+  });
+
+  it("canonicalId is todo:<lowercased-id>", async () => {
+    tmp.writeTodo("id:GC-UPPER-001 agent:codex status:todo Uppercase id\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.id).toBe("todo:gc-upper-001");
+  });
+
+  it("sourceRef carries the todo path and fingerprint", async () => {
+    tmp.writeTodo("id:GC-REF-001 agent:codex status:todo Ref task\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+    const ref = sourceRef(assertDefined(issues[0], "issue"));
+
+    expect(ref.sourceName).toBe("todo");
+    expect(ref.todoPath).toBe(tmp.todoPath);
+    expect(ref.id).toBe("GC-REF-001");
+    expect(ref.lineFingerprint).toHaveLength(64); // sha256 hex
+  });
+
+  it("emits multiple blockers from repeated dep: fields", async () => {
+    tmp.writeTodo(
+      "id:DEP-A agent:codex status:todo Dep A\nid:DEP-B agent:codex status:done Dep B\nid:MAIN-001 agent:codex dep:DEP-A dep:DEP-B status:todo Main\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+    const main = issues.find((i) => i.id === "todo:main-001");
+
+    expect(main?.blockers).toHaveLength(2);
+  });
+
+  it("markInProgress fails when task not found", async () => {
+    tmp.writeTodo("id:GC-NF agent:codex status:todo Task\n");
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    // Remove the file to simulate disappearance
+    writeFileSync(tmp.todoPath, "# empty\n");
+
+    await expect(source.markInProgress(assertDefined(issues[0], "issue"))).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it("verify() passes when todo file is valid", async () => {
+    tmp.writeTodo("(A) Good task id:GC-V1 agent:codex status:in-progress\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).resolves.not.toThrow();
+  });
+
+  it("verify() throws when todo file is missing", async () => {
+    const source = makeSource(tmp); // todoPath does not exist
+    await expect(source.verify()).rejects.toThrow(/missing todo file/);
+  });
+
+  it("verify() catches duplicate id:", async () => {
+    tmp.writeTodo("id:DUP agent:codex status:todo Task A\nid:DUP agent:codex status:todo Task B\n");
+    tmp.writeTask("DUP", "Prompt.");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/duplicate id/);
+  });
+
+  it("verify() catches status:todo not final token", async () => {
+    tmp.writeTodo("id:GC-V3 agent:codex status:todo extra-token\n");
+    tmp.writeTask("GC-V3", "Prompt.");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/not the final token/);
+  });
+
+  it("verify() catches malformed due: date", async () => {
+    tmp.writeTodo("id:GC-V4 agent:codex due:not-a-date status:in-progress\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/malformed due/);
+  });
+
+  it("verify() catches malformed rec:", async () => {
+    tmp.writeTodo("id:GC-V5 agent:codex rec:bad-recurrence status:in-progress\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/malformed rec/);
+  });
+
+  it("parses creation date in task line", async () => {
+    tmp.writeTodo("(A) 2026-01-01 Task with creation date id:CD-001 agent:codex status:todo\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.title).toBe("Task with creation date");
+  });
+
+  it("normalizes status:done from metadata to done status", async () => {
+    tmp.writeTodo("id:DONE-META agent:codex status:done Task done\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("DONE-META");
+
+    expect(task?.status).toBe("done");
+  });
+
+  it("markDone with rec:1m advances month", async () => {
+    tmp.writeTodo(
+      "id:monthly-20260601 agent:any due:2026-06-01 rec:1m status:in-progress Monthly task\n",
+    );
+    tmp.writeTask("monthly-20260601", "Monthly prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("monthly-20260601");
+    expect(task).toBeDefined();
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-15T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    expect(recurResult?.newId).toBe("monthly-20260715");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("due:2026-07-15");
+  });
+
+  it("fetch returns empty array when todo file does not exist", async () => {
+    const source = makeSource(tmp); // no todo.txt created
+    const issues = await source.fetch();
+    expect(issues).toHaveLength(0);
+  });
+
+  it("normalizes unknown status value to other", async () => {
+    tmp.writeTodo("id:WIP-001 agent:codex status:wip Task with custom status\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("WIP-001");
+
+    expect(task?.status).toBe("other");
+  });
+
+  it("markInReview throws when task is not in-progress", async () => {
+    tmp.writeTodo("id:GC-ERR1 agent:codex status:todo Task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-ERR1");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "in-review")).rejects.toThrow(
+      /expected "in-progress"/,
+    );
+  });
+
+  it("markDone throws when task has unexpected status", async () => {
+    tmp.writeTodo("id:GC-ERR2 agent:codex status:other Task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-ERR2");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "done")).rejects.toThrow(
+      /cannot mark done/,
+    );
+  });
+
+  it("verify() catches missing prompt file for ready task", async () => {
+    // Ready task (status:todo final token) with no .tasks/<id>.md
+    tmp.writeTodo("id:GC-MP agent:codex status:todo\n"); // no task file created
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/missing prompt file/);
+  });
+
+  it("verify() catches empty prompt file for ready task", async () => {
+    tmp.writeTodo("id:GC-EP agent:codex status:todo\n");
+    tmp.writeTask("GC-EP", "   "); // whitespace-only
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/empty prompt file/);
+  });
+
+  it("verify() catches unresolved dep", async () => {
+    tmp.writeTodo("id:GC-UD agent:codex dep:GHOST-001 status:in-progress Task\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/unresolved dep/);
+  });
+
+  it("verify() catches invalid status value", async () => {
+    tmp.writeTodo("id:GC-IS agent:codex status:wip Task\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/invalid status/);
+  });
+
+  it("markInProgress throws when task status is already in-progress", async () => {
+    tmp.writeTodo("id:GC-IP2 agent:codex status:in-progress Task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-IP2");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "in-progress")).rejects.toThrow(
+      /expected "todo"/,
+    );
+  });
+
+  it("markInProgress throws with (none) message for task with no status field", async () => {
+    tmp.writeTodo("id:GC-NS1 agent:codex No status task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-NS1");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "in-progress")).rejects.toThrow(
+      /\(none\)/,
+    );
+  });
+
+  it("markInReview throws with (none) message for task with no status field", async () => {
+    tmp.writeTodo("id:GC-NS2 agent:codex No status task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-NS2");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "in-review")).rejects.toThrow(
+      /\(none\)/,
+    );
+  });
+
+  it("markDone throws with (none) message for task with no status field", async () => {
+    tmp.writeTodo("id:GC-NS3 agent:codex No status task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-NS3");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    await expect(updateTaskStatus({ todoPath: tmp.todoPath, ref }, "done")).rejects.toThrow(
+      /\(none\)/,
+    );
+  });
+
+  it("blocker with x-completed status resolves to done", async () => {
+    tmp.writeTodo(
+      "x 2026-06-01 id:DONE-DEP agent:codex status:done Completed dep\nid:WAITER agent:codex dep:DONE-DEP status:todo Waiter\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    const waiter = issues.find((i) => i.id === "todo:waiter");
+    expect(waiter?.blockers[0]?.status).toBe("done");
+    expect(waiter?.blockers[0]?.nativeStatus).toBe("x");
+  });
+
+  it("blocker with empty title falls back to dep id as title", async () => {
+    // A dep task with only metadata (no descriptive text) has an empty title
+    tmp.writeTodo(
+      "id:NO-TITLE-DEP agent:codex status:todo\nid:HAS-DEP agent:codex dep:NO-TITLE-DEP status:todo Has dep\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    const hasDep = issues.find((i) => i.id === "todo:has-dep");
+    expect(hasDep?.blockers[0]?.title).toBe("NO-TITLE-DEP");
+  });
+
+  it("isActiveForFetch returns false for task with id but no agent", async () => {
+    tmp.writeTodo("id:NO-AGENT-001 status:todo Task with no agent\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues.find((i) => i.id === "todo:no-agent-001")).toBeUndefined();
+  });
+
+  it("blocker resolution skips null and no-id lines in file", async () => {
+    // File has a comment line and a no-id line before the dep task
+    // — find() must skip null entries (p !== null) and non-id lines (?.)
+    tmp.writeTodo(
+      "# a comment\nagent:codex status:todo No id\nid:COMMENT-DEP agent:codex status:todo\nid:COMMENT-MAIN agent:codex dep:COMMENT-DEP status:todo Main\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+    const main = issues.find((i) => i.id === "todo:comment-main");
+
+    expect(main?.blockers).toHaveLength(1);
+    expect(main?.blockers[0]?.status).toBe("todo");
+  });
+
+  it("blocker with no status field uses (no status) as native status", async () => {
+    tmp.writeTodo(
+      // no status: field on first dep line
+      "id:NOSTATUS-DEP agent:codex\nid:MAIN-NS agent:codex dep:NOSTATUS-DEP status:todo Main\n",
+    );
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    const main = issues.find((i) => i.id === "todo:main-ns");
+    expect(main?.blockers[0]?.nativeStatus).toBe("(no status)");
+  });
+
+  it("markDone on recurring task creates suffix id when new id already exists", async () => {
+    // Both the original task and the "next" id already exist
+    tmp.writeTodo(
+      "(A) Weekly cleanup id:cleanup-20260601 agent:any due:2026-06-01 rec:+1w status:in-review\n(A) Weekly cleanup id:cleanup-20260608 agent:any due:2026-06-08 rec:+1w status:todo\n",
+    );
+    tmp.writeTask("cleanup-20260601", "Prompt.");
+    tmp.writeTask("cleanup-20260608", "Existing next prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("cleanup-20260601");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-05T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    // New id gets -002 suffix since cleanup-20260608 already exists
+    expect(recurResult?.newId).toBe("cleanup-20260608-002");
+  });
+
+  it("markDone with rec: task having t: threshold date advances it too", async () => {
+    // rec:+1w strict: due advances from 2026-06-01 → 2026-06-08; t: advances from 2026-05-25 → 2026-06-01
+    tmp.writeTodo(
+      "id:threshold-001 agent:any due:2026-06-01 t:2026-05-25 rec:+1w status:in-progress\n",
+    );
+    tmp.writeTask("threshold-001", "Threshold task.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("threshold-001");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-01T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-01"); // t: advanced 1w from 2026-05-25
+    expect(updated).toContain("due:2026-06-08");
+    // id has no 8-digit date component, so date is appended
+    expect(recurResult?.newId).toBe("threshold-001-20260608");
+  });
+
+  it("parses a completed line with no text after the date", async () => {
+    // Bare completed line: "x YYYY-MM-DD" with no description
+    tmp.writeTodo("x 2026-06-01\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(0); // no id, so filtered
+  });
+
+  it("isActiveForFetch returns false for line with no id: field", async () => {
+    // A line with agent and status but no id
+    tmp.writeTodo("agent:codex status:todo No id line\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(0);
+  });
+
+  it("resolveOne skips lines with no id when searching", async () => {
+    // File has a no-id line and a task line; resolveOne should find the task line
+    tmp.writeTodo("agent:codex status:todo No id\nid:GC-FIND1 agent:codex status:todo Task\n");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("GC-FIND1");
+
+    expect(task?.id).toBe("todo:gc-find1");
+  });
+
+  it("markDone on task with no recurrence returns undefined recurResult", async () => {
+    tmp.writeTodo("id:NOREC-001 agent:codex status:in-progress Task\n");
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("NOREC-001");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const ref = sourceRef(assertDefined(task, "task"));
+    const recurResult = await updateTaskStatus({ todoPath: tmp.todoPath, ref }, "done");
+
+    expect(recurResult).toBeUndefined();
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("status:done");
+  });
+
+  it("source.markDone on non-recurring task does not copy prompt file", async () => {
+    tmp.writeTodo("id:NODONE-REC agent:codex status:in-review Non-recurring task\n");
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("NODONE-REC");
+
+    const markDone = assertDefined(source.markDone?.bind(source), "markDone");
+    const result = await markDone(assertDefined(task, "task"));
+
+    expect(result.outcome).toBe("applied");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("status:done");
+  });
+
+  it("parses x-completed line with no date prefix", async () => {
+    // "x Some task" without a date after x
+    tmp.writeTodo("x Some task id:NO-DATE-X agent:codex status:done\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    // Completed tasks are excluded from fetch
+    expect(issues).toHaveLength(0);
+    // But resolveOne can find it
+    const task = await source.resolveOne("NO-DATE-X");
+    expect(task?.status).toBe("done");
+  });
+
+  it("parses a line with priority and creation date but no description", async () => {
+    // "(A) 2026-01-01" with no tokens after the creation date
+    tmp.writeTodo("(A) 2026-01-01\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues).toHaveLength(0); // no id/agent/status
+  });
+
+  it("markDone with rec:1d creates next daily task", async () => {
+    tmp.writeTodo(
+      "id:daily-20260608 agent:any due:2026-06-08 rec:1d status:in-progress Daily task\n",
+    );
+    tmp.writeTask("daily-20260608", "Daily prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("daily-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    // Normal (non-strict) rec:1d: advance from completion date 2026-06-08 + 1d = 2026-06-09
+    expect(recurResult?.newId).toBe("daily-20260609");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("due:2026-06-09");
+  });
+
+  it("verify() passes on file with resolved dep", async () => {
+    tmp.writeTodo(
+      "id:DEP-V1 agent:codex status:in-progress\nid:WAITER-V1 agent:codex dep:DEP-V1 status:todo\n",
+    );
+    tmp.writeTask("WAITER-V1", "Prompt.");
+    const source = makeSource(tmp);
+    // verify should not throw — the dep IS resolved
+    await expect(source.verify()).resolves.not.toThrow();
+  });
+
+  it("verify() handles completed tasks with id and agent", async () => {
+    tmp.writeTodo("x 2026-06-01 id:DONE-V1 agent:codex status:done Completed\n");
+    const source = makeSource(tmp);
+    // completed tasks are skipped in verify (not checked for prompt/dep)
+    await expect(source.verify()).resolves.not.toThrow();
+  });
+
+  it("verify() catches id-less agent line", async () => {
+    // No id: field but has agent — should not be validated (skipped by id check)
+    // Also has a valid ready task to prevent "no tasks" condition
+    tmp.writeTodo(
+      "agent:codex status:todo No id here\nid:VALID-V1 agent:codex status:in-progress\n",
+    );
+    const source = makeSource(tmp);
+    // Should pass — id-less lines are skipped
+    await expect(source.verify()).resolves.not.toThrow();
+  });
+
+  it("markDone with rec:1y creates next annual task", async () => {
+    tmp.writeTodo(
+      "id:annual-20260101 agent:any due:2026-01-01 rec:+1y status:in-progress Annual task\n",
+    );
+    tmp.writeTask("annual-20260101", "Annual prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("annual-20260101");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-15T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    expect(recurResult?.newId).toBe("annual-20270101");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("due:2027-01-01");
+  });
+});

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -1,0 +1,188 @@
+import { readFileSync, statSync } from "node:fs";
+
+import type { AdapterContext } from "../../adapterDefinition.ts";
+import {
+  type Issue,
+  type MarkDoneResult,
+  type MarkInReviewResult,
+  type TaskSource,
+  toCanonicalId,
+} from "../../taskSource.ts";
+import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
+import { getMetadataFirst, parseAllLines } from "./parser.ts";
+import type { TodoTxtAdapterConfig } from "./schema.ts";
+import { copyPromptFile, updateTaskStatus, validateTodoFile } from "./writeback.ts";
+
+function readDescription(promptPath: string): string {
+  try {
+    return readFileSync(promptPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function fileUpdatedAt(filePath: string): string {
+  try {
+    return new Date(statSync(filePath).mtimeMs).toISOString();
+  } catch {
+    /* v8 ignore next @preserve -- statSync failing means file missing; covered by empty-file tests */
+    return new Date().toISOString();
+  }
+}
+
+function readAndParseTodo(todoPath: string): {
+  rawLines: string[];
+  parsedAll: ReturnType<typeof parseAllLines>;
+} {
+  let content: string;
+  try {
+    content = readFileSync(todoPath, "utf8");
+  } catch {
+    content = "";
+  }
+  return {
+    rawLines: content.split("\n"),
+    parsedAll: parseAllLines(content),
+  };
+}
+
+function buildIssue(options: {
+  parsedIndex: number;
+  parsedAll: ReturnType<typeof parseAllLines>;
+  sourceName: string;
+  todoPath: string;
+  tasksDir: string;
+  defaultRepository: string | undefined;
+  updatedAt: string;
+}): Issue | undefined {
+  const { parsedIndex, parsedAll, sourceName, todoPath, tasksDir, defaultRepository, updatedAt } =
+    options;
+  const parsed = parsedAll[parsedIndex];
+  /* v8 ignore next @preserve -- callers always validate parsedIndex before calling buildIssue */
+  if (parsed === null || parsed === undefined) {
+    return undefined;
+  }
+
+  const id = getMetadataFirst(parsed, "id");
+  /* v8 ignore next @preserve -- callers pre-filter by isActiveForFetch which requires id: */
+  if (id === undefined) {
+    return undefined;
+  }
+
+  const promptOverride = getMetadataFirst(parsed, "prompt");
+  const promptPath = promptOverride ?? `${tasksDir}/${id}.md`;
+  const description = readDescription(promptPath);
+
+  return normalizeToIssue({
+    parsed,
+    allParsed: parsedAll,
+    sourceName,
+    todoPath,
+    tasksDir,
+    defaultRepository,
+    description,
+    updatedAt,
+  });
+}
+
+export function createTodoTxtTaskSource(
+  config: TodoTxtAdapterConfig,
+  _context: AdapterContext,
+): TaskSource {
+  const sourceName = config.name;
+
+  function buildIssueList(): Issue[] {
+    const updatedAt = fileUpdatedAt(config.todoPath);
+    const { parsedAll } = readAndParseTodo(config.todoPath);
+    const issues: Issue[] = [];
+
+    for (let i = 0; i < parsedAll.length; i++) {
+      const parsed = parsedAll[i];
+      if (parsed === null || parsed === undefined) {
+        continue;
+      }
+      if (!isActiveForFetch(parsed)) {
+        continue;
+      }
+
+      const issue = buildIssue({
+        parsedIndex: i,
+        parsedAll,
+        sourceName,
+        todoPath: config.todoPath,
+        tasksDir: config.tasksDir,
+        defaultRepository: config.defaultRepository,
+        updatedAt,
+      });
+      /* v8 ignore else @preserve -- isActiveForFetch guarantees id: present, so buildIssue always returns an Issue */
+      if (issue !== undefined) {
+        issues.push(issue);
+      }
+    }
+    return issues;
+  }
+
+  return {
+    name: sourceName,
+
+    async verify(): Promise<void> {
+      const errors = validateTodoFile(config.todoPath, config.tasksDir);
+      if (errors.length > 0) {
+        throw new Error(
+          `todo-txt source "${sourceName}" verification failed:\n${errors.map((e) => `  - ${e}`).join("\n")}`,
+        );
+      }
+    },
+
+    async fetch(): Promise<Issue[]> {
+      return buildIssueList();
+    },
+
+    async resolveOne(naturalId: string): Promise<Issue | undefined> {
+      const canonicalId = toCanonicalId(sourceName, naturalId);
+      const updatedAt = fileUpdatedAt(config.todoPath);
+      const { parsedAll } = readAndParseTodo(config.todoPath);
+
+      const index = parsedAll.findIndex(
+        (p) =>
+          p !== null && toCanonicalId(sourceName, getMetadataFirst(p, "id") ?? "") === canonicalId,
+      );
+      if (index === -1) {
+        return undefined;
+      }
+
+      return buildIssue({
+        parsedIndex: index,
+        parsedAll,
+        sourceName,
+        todoPath: config.todoPath,
+        tasksDir: config.tasksDir,
+        defaultRepository: config.defaultRepository,
+        updatedAt,
+      });
+    },
+
+    async markInProgress(issue: Issue): Promise<void> {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
+      const ref = issue.sourceRef as TodoTxtSourceRef;
+      await updateTaskStatus({ todoPath: config.todoPath, ref }, "in-progress");
+    },
+
+    async markInReview(issue: Issue): Promise<MarkInReviewResult> {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
+      const ref = issue.sourceRef as TodoTxtSourceRef;
+      await updateTaskStatus({ todoPath: config.todoPath, ref }, "in-review");
+      return { outcome: "applied" };
+    },
+
+    async markDone(issue: Issue): Promise<MarkDoneResult> {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
+      const ref = issue.sourceRef as TodoTxtSourceRef;
+      const recurResult = await updateTaskStatus({ todoPath: config.todoPath, ref }, "done");
+      if (recurResult !== undefined) {
+        copyPromptFile(recurResult.oldPromptPath, recurResult.newPromptPath);
+      }
+      return { outcome: "applied" };
+    },
+  };
+}

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -1,0 +1,490 @@
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { hashLine, parseAllLines, type ParsedTodoLine } from "./parser.ts";
+import type { TodoTxtSourceRef } from "./normalizer.ts";
+
+export interface RecurResult {
+  newId: string;
+  newTodoLine: string;
+  oldPromptPath: string;
+  newPromptPath: string;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function compactDate(date: Date): string {
+  return isoDate(date).replaceAll("-", "");
+}
+
+function addDays(dateStr: string, days: number): string {
+  const ms = Date.parse(`${dateStr}T00:00:00Z`);
+  return isoDate(new Date(ms + days * 24 * 60 * 60 * 1000));
+}
+
+function addMonths(dateStr: string, months: number): string {
+  const parts = dateStr.split("-").map(Number);
+  /* v8 ignore next @preserve -- well-formed YYYY-MM-DD always produces 3 numeric parts */
+  const year = parts[0] ?? 2000;
+  /* v8 ignore next @preserve -- same: parts[1] is always defined */
+  const month = parts[1] ?? 1;
+  /* v8 ignore next @preserve -- same: parts[2] is always defined */
+  const day = parts[2] ?? 1;
+  const d = new Date(Date.UTC(year, month - 1 + months, day));
+  return isoDate(d);
+}
+
+interface Recurrence {
+  amount: number;
+  unit: "d" | "w" | "m" | "y";
+  strict: boolean;
+}
+
+const REC_RE = /^(?<strict>\+?)(?<amount>\d+)(?<unit>[dwmy])$/;
+
+function parseRecurrence(rec: string): Recurrence | undefined {
+  const m = REC_RE.exec(rec);
+  if (m === null) {
+    return undefined;
+  }
+  const [, strictStr, amountStr, unit] = m;
+  /* v8 ignore next @preserve -- regex [dwmy] guarantees unit is always one of d/w/m/y */
+  if (unit !== "d" && unit !== "w" && unit !== "m" && unit !== "y") {
+    return undefined;
+  }
+  return {
+    strict: strictStr === "+",
+    /* v8 ignore next @preserve -- regex (\d+) guarantees amountStr is always defined */
+    amount: Number.parseInt(amountStr ?? "1", 10),
+    unit,
+  };
+}
+
+function advanceDate(dateStr: string, rec: Recurrence): string {
+  const { amount, unit } = rec;
+  if (unit === "d") {
+    return addDays(dateStr, amount);
+  }
+  if (unit === "w") {
+    return addDays(dateStr, amount * 7);
+  }
+  if (unit === "m") {
+    return addMonths(dateStr, amount);
+  }
+  return addMonths(dateStr, amount * 12);
+}
+
+function advanceId(id: string, newDate: Date): string {
+  const dateCompact = compactDate(newDate);
+  // Replace the first 8-digit run (compact date) in the id
+  const replaced = id.replace(/\d{8}/, dateCompact);
+  return replaced === id ? `${id}-${dateCompact}` : replaced;
+}
+
+function buildUniqueId(baseNewId: string, existingIds: Set<string>): string {
+  if (existingIds.has(baseNewId.toLowerCase())) {
+    for (let suffix = 2; suffix <= 999; suffix++) {
+      const candidate = `${baseNewId}-${String(suffix).padStart(3, "0")}`;
+      /* v8 ignore else @preserve -- double collision (suffix also taken) is untestable without 1000 tasks */
+      if (!existingIds.has(candidate.toLowerCase())) {
+        return candidate;
+      }
+    }
+    /* v8 ignore next @preserve -- 999 collisions is unreachable in practice */
+    return `${baseNewId}-${Date.now()}`;
+  }
+  return baseNewId;
+}
+
+function replaceStatusToken(line: string, newStatus: string): string {
+  return line.replaceAll(/\bstatus:\S+/g, `status:${newStatus}`);
+}
+
+function buildDoneLine(originalLine: string, completionDate: string): string {
+  // Remove priority marker if present, replace status, prepend x <date>
+  const withoutPriority = originalLine.replace(/^\([A-Z]\) /, "");
+  const withDoneStatus = replaceStatusToken(withoutPriority, "done");
+  return `x ${completionDate} ${withDoneStatus}`;
+}
+
+function buildRecurringLine(
+  originalLine: string,
+  originalId: string,
+  newId: string,
+  oldDue: string | undefined,
+  newDue: string | undefined,
+  oldT: string | undefined,
+  newT: string | undefined,
+): string {
+  let line = originalLine;
+  line = line.replace(`id:${originalId}`, `id:${newId}`);
+  /* v8 ignore else @preserve -- oldDue absent means no due: replacement needed */
+  if (oldDue !== undefined && newDue !== undefined) {
+    line = line.replace(`due:${oldDue}`, `due:${newDue}`);
+  }
+  /* v8 ignore else @preserve -- oldT absent means no t: replacement needed */
+  if (oldT !== undefined && newT !== undefined) {
+    line = line.replace(`t:${oldT}`, `t:${newT}`);
+  }
+  return replaceStatusToken(line, "todo");
+}
+
+async function acquireLock(lockPath: string, maxAttempts = 40, delayMs = 50): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      closeSync(fd);
+      return;
+    } catch (error) {
+      /* v8 ignore next @preserve -- openSync always throws Error with a code */
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") {
+        throw error;
+      }
+      /* v8 ignore next 5 @preserve -- retry sleep requires concurrent lock ownership, untestable in unit tests */
+      if (attempt + 1 < maxAttempts) {
+        // oxlint-disable-next-line no-await-in-loop -- polling lock acquisition
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
+    }
+  }
+  /* v8 ignore next @preserve -- exhausting 40 lock attempts is unreachable in normal test conditions */
+  throw new Error(
+    `todo-txt: could not acquire lock at ${lockPath} after ${maxAttempts * delayMs}ms`,
+  );
+}
+
+function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // best-effort
+  }
+}
+
+function atomicWrite(filePath: string, content: string): void {
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, filePath);
+}
+
+export interface UpdateOptions {
+  todoPath: string;
+  ref: TodoTxtSourceRef;
+  now?: Date;
+}
+
+async function withLock<T>(lockPath: string, fn: () => T | Promise<T>): Promise<T> {
+  await acquireLock(lockPath);
+  try {
+    // return await is required here so the finally block runs while the lock is held
+    return await Promise.resolve(fn());
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+type StatusMutation = "in-progress" | "in-review" | "done";
+
+function assertValidTransition(
+  newStatus: StatusMutation,
+  currentStatus: string | undefined,
+  id: string,
+): void {
+  const s = currentStatus ?? "(none)";
+  if (newStatus === "in-progress" && currentStatus !== "todo") {
+    throw new Error(
+      `todo-txt: cannot mark in-progress: task "${id}" has status "${s}", expected "todo"`,
+    );
+  }
+  if (newStatus === "in-review" && currentStatus !== "in-progress") {
+    throw new Error(
+      `todo-txt: cannot mark in-review: task "${id}" has status "${s}", expected "in-progress"`,
+    );
+  }
+  if (
+    newStatus === "done" &&
+    currentStatus !== "in-review" &&
+    currentStatus !== "in-progress" &&
+    currentStatus !== "todo"
+  ) {
+    throw new Error(`todo-txt: cannot mark done: task "${id}" has status "${s}"`);
+  }
+}
+
+function buildRecurResult(
+  parsed: ParsedTodoLine,
+  parsedAll: (ParsedTodoLine | null)[],
+  originalLine: string,
+  ref: TodoTxtSourceRef,
+  completionDateStr: string,
+  now: Date,
+): RecurResult | undefined {
+  const recStr = parsed.metadata["rec"]?.[0];
+  if (recStr === undefined) {
+    return undefined;
+  }
+  const rec = parseRecurrence(recStr);
+  /* v8 ignore next @preserve -- malformed rec: is caught by validate(); reaching here with undefined rec is improbable */
+  if (rec === undefined) {
+    return undefined;
+  }
+
+  const existingIds = new Set(
+    parsedAll
+      .filter((p): p is NonNullable<typeof p> => p !== null)
+      .map((p) => p.metadata["id"]?.[0]?.toLowerCase())
+      .filter((id): id is string => id !== undefined),
+  );
+
+  const oldDue = parsed.metadata["due"]?.[0];
+  const oldT = parsed.metadata["t"]?.[0];
+
+  // due: advances from old due (strict) or completion date (normal)
+  /* v8 ignore next @preserve -- oldDue undefined with rec: is unusual; callers typically pair rec: with due: */
+  const dueBase = rec.strict ? (oldDue ?? completionDateStr) : completionDateStr;
+  /* v8 ignore next @preserve -- oldDue undefined means skip due advancement */
+  const newDue = oldDue === undefined ? undefined : advanceDate(dueBase, rec);
+  // t: always advances from its own current value by the same period
+  const newT = oldT === undefined ? undefined : advanceDate(oldT, rec);
+
+  // Compute new date for id advancement
+  /* v8 ignore next @preserve -- newDue undefined when no due: field; rare edge case */
+  const newDateForId = newDue === undefined ? now : new Date(`${newDue}T00:00:00Z`);
+  const baseNewId = advanceId(ref.id, newDateForId);
+  const newId = buildUniqueId(baseNewId, existingIds);
+
+  const newTodoLine = buildRecurringLine(originalLine, ref.id, newId, oldDue, newDue, oldT, newT);
+  const oldPromptPath = ref.promptPath;
+  const newPromptPath = oldPromptPath.replace(ref.id, newId);
+
+  return { newId, newTodoLine, oldPromptPath, newPromptPath };
+}
+
+export async function updateTaskStatus(
+  options: UpdateOptions,
+  newStatus: StatusMutation,
+): Promise<RecurResult | undefined> {
+  const { todoPath, ref } = options;
+  const now = options.now ?? new Date();
+  const lockPath = `${todoPath}.lock`;
+
+  return await withLock(lockPath, () => {
+    const content = readFileSync(todoPath, "utf8");
+    const rawLines = content.split("\n");
+    const parsedAll = parseAllLines(content);
+
+    // Find the target line — prefer fingerprint match, fall back to id: match
+    let targetIndex = rawLines.findIndex((line) => hashLine(line) === ref.lineFingerprint);
+    if (targetIndex >= 0) {
+      // Verify the fingerprint matched a real task line, not a blank/comment collision
+      const matched = parsedAll[targetIndex];
+      /* v8 ignore next @preserve -- SHA-256 collision with a blank/comment line is unreachable */
+      if (matched === null || matched === undefined) {
+        targetIndex = -1;
+      }
+    }
+    if (targetIndex < 0) {
+      // Fingerprint mismatch or structural check failed — find by id: (O(n) scan)
+      targetIndex = parsedAll.findIndex((parsed) => {
+        if (parsed === null || parsed === undefined) {
+          return false;
+        }
+        return parsed.metadata["id"]?.[0]?.toLowerCase() === ref.id.toLowerCase();
+      });
+    }
+
+    if (targetIndex < 0) {
+      throw new Error(`todo-txt: task id "${ref.id}" not found in ${todoPath}`);
+    }
+
+    const originalLine = rawLines[targetIndex];
+    /* v8 ignore next @preserve -- rawLines and parsedAll are co-indexed; targetIndex < length */
+    if (originalLine === undefined) {
+      throw new Error(`todo-txt: line index ${targetIndex} out of range in ${todoPath}`);
+    }
+
+    const parsed = parsedAll[targetIndex];
+    /* v8 ignore next 3 @preserve -- targetIndex found via fingerprint/id match, so parsed is never null/undefined */
+    if (parsed === null || parsed === undefined) {
+      throw new Error(`todo-txt: could not parse line ${targetIndex} in ${todoPath}`);
+    }
+
+    assertValidTransition(newStatus, parsed.metadata["status"]?.[0], ref.id);
+
+    let recurResult: RecurResult | undefined;
+    let updatedLine: string;
+
+    if (newStatus === "done") {
+      const completionDateStr = isoDate(now);
+      updatedLine = buildDoneLine(originalLine, completionDateStr);
+      recurResult = buildRecurResult(parsed, parsedAll, originalLine, ref, completionDateStr, now);
+    } else {
+      updatedLine = replaceStatusToken(originalLine, newStatus);
+    }
+
+    const newLines = [...rawLines];
+    newLines[targetIndex] = updatedLine;
+
+    if (recurResult !== undefined) {
+      // Insert new recurring line after the done line
+      newLines.splice(targetIndex + 1, 0, recurResult.newTodoLine);
+    }
+
+    atomicWrite(todoPath, newLines.join("\n"));
+    return recurResult;
+  });
+}
+
+export function copyPromptFile(oldPath: string, newPath: string): void {
+  try {
+    const content = readFileSync(oldPath, "utf8");
+    mkdirSync(path.dirname(newPath), { recursive: true });
+    writeFileSync(newPath, content, "utf8");
+  } catch {
+    // prompt file is optional — copy is best-effort
+  }
+}
+
+function validatePromptFile(
+  tasksDir: string,
+  id: string,
+  promptOverride: string | undefined,
+  prefix: string,
+  errors: string[],
+): void {
+  const promptPath = promptOverride ?? path.join(tasksDir, `${id}.md`);
+  try {
+    const desc = readFileSync(promptPath, "utf8");
+    if (desc.trim().length === 0) {
+      errors.push(`${prefix}: empty prompt file "${promptPath}" for ready task "${id}"`);
+    }
+  } catch {
+    errors.push(`${prefix}: missing prompt file "${promptPath}" for ready task "${id}"`);
+  }
+}
+
+function validateDepsAndDates(
+  parsed: ParsedTodoLine,
+  parsedAll: (ParsedTodoLine | null)[],
+  id: string,
+  prefix: string,
+  errors: string[],
+): void {
+  const depIds = parsed.metadata["dep"] ?? [];
+  for (const depId of depIds) {
+    const depFound = parsedAll.find(
+      (p): p is ParsedTodoLine =>
+        p !== null && p.metadata["id"]?.[0]?.toLowerCase() === depId.toLowerCase(),
+    );
+    if (depFound === undefined) {
+      errors.push(`${prefix}: unresolved dep "${depId}" for task "${id}"`);
+    }
+  }
+
+  for (const dateField of ["due", "t"]) {
+    const dateVal = parsed.metadata[dateField]?.[0];
+    if (dateVal !== undefined && !DATE_RE.test(dateVal)) {
+      errors.push(
+        `${prefix}: malformed ${dateField}: date "${dateVal}" for task "${id}" (expected YYYY-MM-DD)`,
+      );
+    }
+  }
+
+  const recVal = parsed.metadata["rec"]?.[0];
+  if (recVal !== undefined && parseRecurrence(recVal) === undefined) {
+    errors.push(
+      `${prefix}: malformed rec: "${recVal}" for task "${id}" (expected e.g. 1d, 1w, +1m)`,
+    );
+  }
+}
+
+function validateActiveTaskLine(
+  parsed: ParsedTodoLine,
+  parsedAll: (ParsedTodoLine | null)[],
+  tasksDir: string,
+  id: string,
+  prefix: string,
+  errors: string[],
+): void {
+  const agent = parsed.metadata["agent"]?.[0];
+  /* v8 ignore next @preserve -- parser KEY_VALUE_RE requires \S+, so empty agent values can't be parsed */
+  if (agent !== undefined && agent.trim().length === 0) {
+    errors.push(`${prefix}: empty agent: value for task "${id}"`);
+  }
+
+  const statusValue = parsed.metadata["status"]?.[0];
+  const validStatuses = ["todo", "in-progress", "in-review", "done", "other"];
+  if (statusValue !== undefined && !validStatuses.includes(statusValue)) {
+    errors.push(`${prefix}: invalid status "${statusValue}" for task "${id}"`);
+  }
+
+  if (statusValue === "todo" && !parsed.isStatusFinalToken) {
+    errors.push(
+      `${prefix}: task "${id}" has status:todo but it is not the final token — task will not be dispatched`,
+    );
+  }
+
+  if (statusValue === "todo" && parsed.isStatusFinalToken) {
+    validatePromptFile(tasksDir, id, parsed.metadata["prompt"]?.[0], prefix, errors);
+  }
+
+  validateDepsAndDates(parsed, parsedAll, id, prefix, errors);
+}
+
+export function validateTodoFile(todoPath: string, tasksDir: string): string[] {
+  const errors: string[] = [];
+  let content: string;
+  try {
+    content = readFileSync(todoPath, "utf8");
+  } catch {
+    return [`missing todo file: ${todoPath}`];
+  }
+
+  const parsedAll = parseAllLines(content);
+  const idsSeen = new Map<string, number>();
+
+  for (let i = 0; i < parsedAll.length; i++) {
+    const parsed = parsedAll[i];
+    if (parsed === null || parsed === undefined) {
+      continue;
+    }
+
+    const lineNum = i + 1;
+    const prefix = `line ${lineNum}`;
+
+    const id = parsed.metadata["id"]?.[0];
+    if (id !== undefined) {
+      const lower = id.toLowerCase();
+      if (idsSeen.has(lower)) {
+        errors.push(`${prefix}: duplicate id "${id}" (first seen on line ${idsSeen.get(lower)})`);
+      } else {
+        idsSeen.set(lower, lineNum);
+      }
+    }
+
+    if (id === undefined || parsed.metadata["agent"] === undefined) {
+      continue;
+    }
+    if (parsed.completed) {
+      continue;
+    }
+
+    validateActiveTaskLine(parsed, parsedAll, tasksDir, id, prefix, errors);
+  }
+
+  return errors;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ import { cosmiconfig, type CosmiconfigResult, type Loader } from "cosmiconfig";
 
 import type { LinearAdapterConfig } from "./adapters/linear/schema.ts";
 import type { ShellAdapterConfig } from "./adapters/shell/schema.ts";
+import type { TodoTxtAdapterConfig } from "./adapters/todo-txt/schema.ts";
 import { debug, log, readEnvironmentVariable, setLogFile } from "./util.ts";
 import { xdgConfigPath, xdgStatePath } from "./xdg.ts";
 
@@ -20,7 +21,7 @@ export { BUILD_SECRET_NAMES } from "./buildSecrets.ts";
  * `ResolvedConfig.sources[]`. The runtime Zod validation lives in each
  * adapter's `schema.ts` and runs at `buildSources` time, not here.
  */
-export type SourceConfig = LinearAdapterConfig | ShellAdapterConfig;
+export type SourceConfig = LinearAdapterConfig | ShellAdapterConfig | TodoTxtAdapterConfig;
 
 export interface HookCommands {
   prepareWorktree?: string;

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -55,6 +55,16 @@ function shellCapabilities(raw: unknown): SourceCapabilities {
   };
 }
 
+const TODO_TXT_CAPABILITIES: SourceCapabilities = {
+  verify: true,
+  listTasks: true,
+  getTask: true,
+  createTask: false,
+  markInProgress: true,
+  markInReview: true,
+  markDone: true,
+};
+
 export function summarizeSource(raw: unknown): SourceSummary {
   const { kind } = kindShape.parse(raw);
   const { name } = nameShape.parse(raw);
@@ -65,6 +75,8 @@ export function summarizeSource(raw: unknown): SourceSummary {
     capabilities = LINEAR_CAPABILITIES;
   } else if (kind === "shell") {
     capabilities = shellCapabilities(raw);
+  } else if (kind === "todo-txt") {
+    capabilities = TODO_TXT_CAPABILITIES;
   } else {
     capabilities = UNKNOWN_KIND_CAPABILITIES;
   }


### PR DESCRIPTION
## Summary

Implements a native `todo-txt` task source so Groundcrew can dispatch work from a plain-text `todo.txt` file without requiring a Linear account or shell script adapter. Tasks use standard todo.txt format with `key:value` extensions for Groundcrew fields (`id:`, `agent:`, `status:`, `repo:`, `dep:`, `rec:`). Long prompts live in `.tasks/<id>.md`, keeping the index file human-editable and compatible with existing todo.txt tooling.

Key capabilities:
- **Parser** (`parser.ts`): tokenises priority, completion marker, projects/contexts, and all `key:value` metadata; enforces the `status:todo`-must-be-final-token readiness rule
- **Normaliser** (`normalizer.ts`): maps parsed lines to canonical `Issue` objects, resolves `dep:` blockers, reads prompt files
- **Writeback** (`writeback.ts`): atomic status transitions (advisory lock + temp-file rename), recurrence advancement (`rec:+1w/1d/1m/1y`), `crew source verify` validation
- **Integration**: registered in the adapter registry, added to `SourceConfig` union, reported by `crew source list`

## Validation

- `node --run verify` passes: all 1351 tests green, 100% branch/line/statement/function coverage
- Acceptance tests cover all 19 spec criteria from the build brief (parsing, filtering, agent mapping, repo defaults, blockers, writeback, recurrence, atomic safety, consistency between `fetch`/`resolveOne`)

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>