### PR TITLE
fix: expand ~ in todo-txt todoPath and tasksDir

### DIFF
--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -90,10 +90,11 @@ export function createTodoTxtTaskSource(
   _context: AdapterContext,
 ): TaskSource {
   const sourceName = config.name;
+  const { todoPath, tasksDir } = config;
 
   function buildIssueList(): Issue[] {
-    const updatedAt = fileUpdatedAt(config.todoPath);
-    const { parsedAll } = readAndParseTodo(config.todoPath);
+    const updatedAt = fileUpdatedAt(todoPath);
+    const { parsedAll } = readAndParseTodo(todoPath);
     const issues: Issue[] = [];
 
     for (let i = 0; i < parsedAll.length; i++) {
@@ -109,8 +110,8 @@ export function createTodoTxtTaskSource(
         parsedIndex: i,
         parsedAll,
         sourceName,
-        todoPath: config.todoPath,
-        tasksDir: config.tasksDir,
+        todoPath,
+        tasksDir,
         defaultRepository: config.defaultRepository,
         updatedAt,
       });
@@ -126,7 +127,7 @@ export function createTodoTxtTaskSource(
     name: sourceName,
 
     async verify(): Promise<void> {
-      const errors = validateTodoFile(config.todoPath, config.tasksDir);
+      const errors = validateTodoFile(todoPath, tasksDir);
       if (errors.length > 0) {
         throw new Error(
           `todo-txt source "${sourceName}" verification failed:\n${errors.map((e) => `  - ${e}`).join("\n")}`,
@@ -140,8 +141,8 @@ export function createTodoTxtTaskSource(
 
     async resolveOne(naturalId: string): Promise<Issue | undefined> {
       const canonicalId = toCanonicalId(sourceName, naturalId);
-      const updatedAt = fileUpdatedAt(config.todoPath);
-      const { parsedAll } = readAndParseTodo(config.todoPath);
+      const updatedAt = fileUpdatedAt(todoPath);
+      const { parsedAll } = readAndParseTodo(todoPath);
 
       const index = parsedAll.findIndex(
         (p) =>
@@ -155,8 +156,8 @@ export function createTodoTxtTaskSource(
         parsedIndex: index,
         parsedAll,
         sourceName,
-        todoPath: config.todoPath,
-        tasksDir: config.tasksDir,
+        todoPath,
+        tasksDir,
         defaultRepository: config.defaultRepository,
         updatedAt,
       });
@@ -165,20 +166,20 @@ export function createTodoTxtTaskSource(
     async markInProgress(issue: Issue): Promise<void> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
       const ref = issue.sourceRef as TodoTxtSourceRef;
-      await updateTaskStatus({ todoPath: config.todoPath, ref }, "in-progress");
+      await updateTaskStatus({ todoPath, ref }, "in-progress");
     },
 
     async markInReview(issue: Issue): Promise<MarkInReviewResult> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
       const ref = issue.sourceRef as TodoTxtSourceRef;
-      await updateTaskStatus({ todoPath: config.todoPath, ref }, "in-review");
+      await updateTaskStatus({ todoPath, ref }, "in-review");
       return { outcome: "applied" };
     },
 
     async markDone(issue: Issue): Promise<MarkDoneResult> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
       const ref = issue.sourceRef as TodoTxtSourceRef;
-      const recurResult = await updateTaskStatus({ todoPath: config.todoPath, ref }, "done");
+      const recurResult = await updateTaskStatus({ todoPath, ref }, "done");
       if (recurResult !== undefined) {
         copyPromptFile(recurResult.oldPromptPath, recurResult.newPromptPath);
       }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1691,6 +1691,27 @@ describe("loadConfig", () => {
     expect(actual.sources).toStrictEqual([{ kind: "shell", name: "jira" }]);
   });
 
+  it("expands ~ in todo-txt todoPath and tasksDir", async () => {
+    setEnvironmentVariable("HOME", "/fake-home");
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        `  models: { definitions: { claude: {} } },`,
+        `  sources: [{ kind: "todo-txt", name: "todo", todoPath: "~/todo.md", tasksDir: "~/.tasks", idPrefix: "GC", timezone: "UTC" }],`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.sources[0]).toMatchObject({
+      todoPath: "/fake-home/todo.md",
+      tasksDir: "/fake-home/.tasks",
+    });
+  });
+
   it("preserves the Linear disabled sentinel through resolution", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,4 @@
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -8,6 +7,7 @@ import { cosmiconfig, type CosmiconfigResult, type Loader } from "cosmiconfig";
 import type { LinearAdapterConfig } from "./adapters/linear/schema.ts";
 import type { ShellAdapterConfig } from "./adapters/shell/schema.ts";
 import type { TodoTxtAdapterConfig } from "./adapters/todo-txt/schema.ts";
+import { expandHome } from "./paths.ts";
 import { debug, log, readEnvironmentVariable, setLogFile } from "./util.ts";
 import { xdgConfigPath, xdgStatePath } from "./xdg.ts";
 
@@ -421,16 +421,6 @@ function defaultLogFile(): string {
   return xdgStatePath("groundcrew", "groundcrew.log");
 }
 
-function expandHome(p: string): string {
-  if (p === "~") {
-    return homedir();
-  }
-  if (p.startsWith("~/")) {
-    return path.resolve(homedir(), p.slice(2));
-  }
-  return p;
-}
-
 function fail(message: string): never {
   throw new Error(`groundcrew config: ${message}`);
 }
@@ -802,6 +792,12 @@ function normalizeSources(raw: unknown): SourceConfig[] {
     fail("sources must be an array");
   }
   const names = new Map<string, number>();
+  // Expand ~ in path-typed fields for adapters that accept filesystem paths.
+  // All other path values in ResolvedConfig are expanded at this layer so
+  // downstream adapters receive absolute paths without each having to call
+  // expandHome defensively. isPlainObject() above narrows entry to
+  // Record<string, unknown> so no extra assertion is needed here.
+  const expanded: unknown[] = [];
   for (const [index, entry] of raw.entries()) {
     const configPath = `sources[${index}]`;
     if (!isPlainObject(entry)) {
@@ -828,9 +824,24 @@ function normalizeSources(raw: unknown): SourceConfig[] {
       );
     }
     names.set(effectiveName, index);
+    if (kind === "todo-txt") {
+      expanded.push({
+        ...entry,
+        /* v8 ignore next @preserve -- Zod schema guarantees todoPath/tasksDir are strings; else branch only reachable with a non-string raw value rejected downstream by Zod */
+        ...(typeof entry["todoPath"] === "string"
+          ? { todoPath: expandHome(entry["todoPath"]) }
+          : {}),
+        /* v8 ignore next @preserve -- same as above */
+        ...(typeof entry["tasksDir"] === "string"
+          ? { tasksDir: expandHome(entry["tasksDir"]) }
+          : {}),
+      });
+    } else {
+      expanded.push(entry);
+    }
   }
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- structural validation above guarantees array of {kind: string} entries; per-source Zod validation lives in buildSources
-  return raw as SourceConfig[];
+  return expanded as SourceConfig[];
 }
 
 /**

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,0 +1,22 @@
+import { homedir } from "node:os";
+import path from "node:path";
+
+import { expandHome } from "./paths.ts";
+
+describe("tilde expansion", () => {
+  it("expands bare ~", () => {
+    expect(expandHome("~")).toBe(homedir());
+  });
+
+  it("expands ~/path to absolute path", () => {
+    expect(expandHome("~/foo/bar")).toBe(path.resolve(homedir(), "foo/bar"));
+  });
+
+  it("leaves absolute path unchanged", () => {
+    expect(expandHome("/absolute/path")).toBe("/absolute/path");
+  });
+
+  it("leaves relative path unchanged", () => {
+    expect(expandHome("relative/path")).toBe("relative/path");
+  });
+});

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,12 @@
+import { homedir } from "node:os";
+import path from "node:path";
+
+export function expandHome(p: string): string {
+  if (p === "~") {
+    return homedir();
+  }
+  if (p.startsWith("~/")) {
+    return path.resolve(homedir(), p.slice(2));
+  }
+  return p;
+}


### PR DESCRIPTION
## Summary

`~/...` paths in `todoPath` and `tasksDir` were passed raw to `readFileSync` without tilde expansion, causing the todo-txt source to fail verification when the user's config used `~` shorthand. All other path values in `ResolvedConfig` (workspace dirs, log file) are expanded at config-load time via `expandHome`; this change makes `todo-txt` source paths consistent with that convention.

The fix extracts `expandHome` from `config.ts` into a new `src/lib/paths.ts` module and applies it inside `normalizeSources` for `kind: "todo-txt"` entries — the same layer where all other path normalization happens — rather than in the adapter factory.

## Validation

- `node --run verify` passes (1356 tests, 100% coverage)
- `node --run crew -- source verify t` passes against `~/v/todo.md`

Agent session: `claude --resume cc9d8fcc-7ca8-414a-b358-98a90acabcdc`

<sub>🤖 `commit-push-pr:created v1 core@3.6.0`</sub>