### PR TITLE
feat: add task commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vitest.config.*.timestamp*
 .nx/self-healing
 .claude/settings.local.json
 docs/superpowers/
+static/logo-concept.html

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.
           [--project-dir <dir>] [--repo <repo>]...
           [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]
 crew doctor                                              # check setup
+crew task list [--source <name>]                         # list tasks across sources
+crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or its prompt
+crew task create "Title" --source <name> --agent <name>  # create a source task
 crew status [<TASK>]                                   # inspect current state or one task
 crew run [--watch]                                       # one-shot or --watch forever
 crew start <TASK>                                      # provision + launch one task now

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,35 @@
 # Commands
 
+## Task
+
+`crew task list` lists normalized tasks across all configured sources. Use `--source <name>` to call only one source's `listTasks()` method. Filters include repeatable `--status <status>`, `--agent <name>`, `--repo <owner/repo>`, `--blocked`, `--unblocked`, and `--limit <n>`. Add `--json` for normalized task JSON.
+
+```bash
+crew task list
+crew task list --source todo --status todo --unblocked
+crew task list --agent codex --repo ClipboardHealth/api --json
+```
+
+`crew task get <task-id>` prints one normalized task. Canonical IDs such as `todo:GC-20260608-001` route directly to the named source. Natural IDs can be resolved with `--source <name>` or, when unique, by searching all configured sources. If more than one source matches, the command fails and asks for a canonical ID or `--source`.
+
+```bash
+crew task get todo:GC-20260608-001
+crew task get GC-20260608-001 --source todo
+crew task get todo:GC-20260608-001 --prompt
+```
+
+`crew task create "Short title" --source <source> --agent <agent>` creates a task in a source that supports creation. Todo.txt creation appends the todo line, defaults to priority `A` unless `--priority` is provided, writes `.tasks/<id>.md`, and leaves `status:todo` as the final meaningful token, so no separate ready command is required.
+
+```bash
+crew task create "Fix cancellation retry race" \
+  --source todo \
+  --agent codex \
+  --repo ClipboardHealth/api \
+  --project marketplace \
+  --context backend \
+  --edit
+```
+
 ## Status
 
 `crew status <TASK>` prints a read-only snapshot for one task: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the task status from the configured task source.

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -12,21 +12,23 @@ export default {
       name: "jira",
       commands: {
         verify: "jira me",
-        fetch: "~/.config/groundcrew/jira-fetch.sh",
-        resolveOne: "~/.config/groundcrew/jira-resolve.sh ${id}",
+        listTasks: "~/.config/groundcrew/jira-list.sh",
+        getTask: "~/.config/groundcrew/jira-get.sh ${id}",
         markInProgress: "jira issue move ${id} 'In Progress'",
         markInReview: "jira issue move ${id} 'In Review'",
         markDone: "jira issue move ${id} 'Done'",
       },
-      timeouts: { fetch: 60_000, markInReview: 15_000, markDone: 15_000 },
+      timeouts: { listTasks: 60_000, markInReview: 15_000, markDone: 15_000 },
     },
   ],
 };
 ```
 
-`commands.fetch` must print a JSON array of issues. `commands.resolveOne`, when
+`commands.listTasks` must print a JSON array of issues. `commands.getTask`, when
 set, must print one issue, print nothing for "not found", or exit `3` for "not
-found". `commands.markInProgress`, when set, receives the issue's `sourceRef` as
+found". The legacy aliases `commands.fetch` and `commands.resolveOne` still work
+for existing configs, but new configs should use `listTasks` and `getTask`.
+`commands.markInProgress`, when set, receives the issue's `sourceRef` as
 JSON on stdin. `commands.markInReview`, when set, receives the same `sourceRef` and is run
 after groundcrew sees an **open** PR on the task's worktree branch (in-progress
 tasks only). If omitted, groundcrew treats in-review advancement as unsupported
@@ -56,6 +58,41 @@ leaves the task for the source's own integration to close out. `${id}`,
 ```
 
 Allowed `status` values are `todo`, `in-progress`, `in-review`, `done`, and `other`. Use `null` for `repository` or `model` when a task should not be groundcrew-eligible. `hasMoreBlockers` is optional and defaults to `false`; `sourceRef` is opaque data that groundcrew passes back to your writeback command.
+
+## Todo.txt
+
+The built-in `todo-txt` source supports listing, getting, writeback, and task creation through `crew task create`.
+
+```ts
+export default {
+  sources: [
+    {
+      kind: "todo-txt",
+      name: "todo",
+      todoPath: "todo.txt",
+      tasksDir: ".tasks",
+      idPrefix: "GC",
+      timezone: "UTC",
+    },
+  ],
+};
+```
+
+Creating a todo task appends a line with `status:todo` as the final meaningful token and writes the prompt to `.tasks/<id>.md`. New todo tasks default to priority `A`; pass `--priority <letter>` to override it.
+
+```bash
+crew task create "Fix cancellation retry race" \
+  --source todo \
+  --agent codex \
+  --repo ClipboardHealth/api \
+  --project marketplace \
+  --context backend \
+  --edit
+```
+
+```txt
+(A) Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo
+```
 
 ## The `description` is the agent's prompt
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -11,6 +11,7 @@ import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { statusCli } from "./commands/status.ts";
+import { taskCli } from "./commands/task.ts";
 import {
   createDefaultUpgradeCliOptions,
   upgradeCli,
@@ -45,6 +46,9 @@ vi.mock(import("./commands/setupWorkspace.ts"), () => ({
 vi.mock(import("./commands/status.ts"), () => ({
   statusCli: vi.fn<typeof statusCli>(),
 }));
+vi.mock(import("./commands/task.ts"), () => ({
+  taskCli: vi.fn<typeof taskCli>(),
+}));
 vi.mock(import("./commands/upgrade.ts"), () => ({
   upgradeCli: vi.fn<typeof upgradeCli>(),
   createDefaultUpgradeCliOptions: vi.fn<typeof createDefaultUpgradeCliOptions>(),
@@ -57,6 +61,7 @@ const resumeMock = vi.mocked(resumeWorkspaceCli);
 const setupMock = vi.mocked(setupWorkspaceCli);
 const cleanupMock = vi.mocked(cleanupWorkspaceCli);
 const statusMock = vi.mocked(statusCli);
+const taskMock = vi.mocked(taskCli);
 const upgradeCliMock = vi.mocked(upgradeCli);
 const createDefaultUpgradeCliOptionsMock = vi.mocked(createDefaultUpgradeCliOptions);
 const requireFromTest = createRequire(import.meta.url);
@@ -117,6 +122,7 @@ describe(run, () => {
     setupMock.mockResolvedValue();
     cleanupMock.mockResolvedValue();
     statusMock.mockResolvedValue();
+    taskMock.mockResolvedValue();
     upgradeCliMock.mockResolvedValue();
     createDefaultUpgradeCliOptionsMock.mockResolvedValue(makeFakeUpgradeOptions());
   });
@@ -142,8 +148,8 @@ describe(run, () => {
     expect(helpOutput).toContain("[--repo <repo>]...");
     expect(helpOutput).toContain("--runner <runner>");
     expect(helpOutput).toContain("--model <model>");
+    expect(helpOutput).toContain("crew task <list|get|create>");
     expect(helpOutput).not.toContain("sandbox");
-    expect(helpOutput).not.toContain("crew task");
     expect(process.exitCode).toBe(1);
   });
 
@@ -384,6 +390,13 @@ describe(run, () => {
     await run(["status"]);
 
     expect(statusMock).toHaveBeenCalledWith([]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("dispatches task namespace arguments to taskCli", async () => {
+    await run(["task", "list", "--source", "todo"]);
+
+    expect(taskMock).toHaveBeenCalledWith(["list", "--source", "todo"]);
     expect(process.exitCode).toBeUndefined();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { sourceCli } from "./commands/source.ts";
 import { statusCli } from "./commands/status.ts";
+import { taskCli } from "./commands/task.ts";
 import { createDefaultUpgradeCliOptions, upgradeCli } from "./commands/upgrade.ts";
 import {
   errorMessage,
@@ -179,6 +180,11 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "Inspect configured task sources",
     usage: "<list|verify> [...]",
     invoke: sourceCli,
+  },
+  task: {
+    summary: "List, get, and create tasks across configured sources",
+    usage: "<list|get|create> [...]",
+    invoke: taskCli,
   },
   status: {
     summary: "Print read-only groundcrew state, or one task's local/Linear status",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -94,6 +94,8 @@ function stubSource(name: string): TaskSource {
   return {
     name,
     verify: vi.fn<TaskSource["verify"]>(),
+    listTasks: vi.fn<TaskSource["listTasks"]>(),
+    getTask: vi.fn<TaskSource["getTask"]>(),
     fetch: vi.fn<TaskSource["fetch"]>(),
     resolveOne: vi.fn<TaskSource["resolveOne"]>(),
     markInProgress: vi.fn<TaskSource["markInProgress"]>(),

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -318,7 +318,12 @@ describe(resumeWorkspace, () => {
       stateType: "unstarted",
       status: "Todo",
       statusId: "state-todo",
+      assignee: "Alice",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [],
+      hasMoreBlockers: false,
       url: "https://linear.app/example/issue/TEAM-1",
+      priority: 0,
     });
 
     await resumeWorkspace(config, { task: "team-1" });

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -56,6 +56,8 @@ function stubSource(name: string): TaskSource {
   return {
     name,
     verify: vi.fn<TaskSource["verify"]>(),
+    listTasks: vi.fn<TaskSource["listTasks"]>(),
+    getTask: vi.fn<TaskSource["getTask"]>(),
     fetch: vi.fn<TaskSource["fetch"]>(),
     resolveOne: vi.fn<TaskSource["resolveOne"]>(),
     markInProgress: vi.fn<TaskSource["markInProgress"]>(),
@@ -188,8 +190,8 @@ describe("crew source list", () => {
     const [, dataRow] = lines;
     expect(dataRow).toContain("todo");
     expect(dataRow).toContain("todo-txt");
-    // verify=yes, listTasks=yes, getTask=yes, create=no, writeback=yes
-    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+no\s+yes/);
+    // verify=yes, listTasks=yes, getTask=yes, create=yes, writeback=yes
+    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+yes\s+yes/);
   });
 
   it("shows an unknown adapter kind with fallback capabilities (listTasks only)", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -102,18 +102,28 @@ function fakeSource(
   issues: readonly SourceIssue[],
   overrides: {
     name?: string;
+    listTasks?: TaskSource["listTasks"];
+    getTask?: TaskSource["getTask"];
     fetch?: TaskSource["fetch"];
     resolveOne?: TaskSource["resolveOne"];
   } = {},
 ): TaskSource {
-  const fetch: TaskSource["fetch"] = overrides.fetch ?? (async () => [...issues]);
+  const listTasks: TaskSource["listTasks"] =
+    overrides.listTasks ?? overrides.fetch ?? (async () => [...issues]);
+  const getTask: TaskSource["getTask"] =
+    overrides.getTask ??
+    (overrides.resolveOne === undefined
+      ? async (naturalId) =>
+          issues.find((issue) => issue.id === `${issue.source}:${naturalId.toLowerCase()}`) ?? null
+      : async (naturalId) => (await overrides.resolveOne?.(naturalId)) ?? null);
+  const fetch: TaskSource["fetch"] = overrides.fetch ?? listTasks;
   const resolveOne: TaskSource["resolveOne"] =
-    overrides.resolveOne ??
-    (async (naturalId) =>
-      issues.find((issue) => issue.id === `${issue.source}:${naturalId.toLowerCase()}`));
+    overrides.resolveOne ?? (async (naturalId) => (await getTask(naturalId)) ?? undefined);
   return {
     name: overrides.name ?? "linear",
     verify: noop,
+    listTasks,
+    getTask,
     fetch,
     resolveOne,
     markInProgress: noop,

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -1,0 +1,505 @@
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { naturalIdFromCanonical, type TaskSource, type Issue } from "../lib/taskSource.ts";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+
+import { taskCli } from "./task.ts";
+
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    loadConfig: vi.fn<typeof loadConfig>(),
+  };
+});
+
+vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    buildSources: vi.fn<typeof buildSources>(),
+    sourcesFromConfig: vi.fn<typeof sourcesFromConfig>(),
+  };
+});
+
+const loadConfigMock = vi.mocked(loadConfig);
+const buildSourcesMock = vi.mocked(buildSources);
+const sourcesFromConfigMock = vi.mocked(sourcesFromConfig);
+
+function makeConfig(): ResolvedConfig {
+  return {
+    sources: [],
+    defaults: { hooks: {} },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    models: {
+      default: "claude",
+      definitions: {
+        claude: { cmd: "safehouse claude --permission-mode auto", color: "#fff" },
+      },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "todo:gc-1",
+    source: "todo",
+    title: "Fix retry race",
+    description: "Investigate cancellation retries.",
+    status: "todo",
+    repository: "ClipboardHealth/api",
+    model: "codex",
+    assignee: "",
+    updatedAt: "2026-06-08T12:00:00.000Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: {},
+    ...overrides,
+  };
+}
+
+function stubSource(
+  name: string,
+  issues: readonly Issue[],
+  overrides: Partial<TaskSource> = {},
+): TaskSource {
+  const getTask = vi.fn<TaskSource["getTask"]>().mockImplementation(async (id) => {
+    const match = issues.find(
+      (issue) => naturalIdFromCanonical(issue.id).toLowerCase() === id.toLowerCase(),
+    );
+    return match ?? null;
+  });
+  return {
+    name,
+    verify: vi.fn<TaskSource["verify"]>(),
+    listTasks: vi.fn<TaskSource["listTasks"]>().mockResolvedValue([...issues]),
+    getTask,
+    fetch: vi.fn<TaskSource["fetch"]>(),
+    resolveOne: vi.fn<TaskSource["resolveOne"]>(),
+    markInProgress: vi.fn<TaskSource["markInProgress"]>(),
+    markInReview: vi.fn<TaskSource["markInReview"]>(),
+    ...overrides,
+  };
+}
+
+describe("crew task list", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "todo-txt", name: "todo" }]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists tasks from only the named source when --source is provided", async () => {
+    const todo = stubSource("todo", [makeIssue()]);
+    const linear = stubSource("linear", [makeIssue({ id: "linear:eng-1", source: "linear" })]);
+    buildSourcesMock.mockResolvedValue([todo, linear]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["list", "--source", "todo"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.listTasks).toHaveBeenCalledTimes(1);
+    expect(linear.listTasks).not.toHaveBeenCalled();
+    expect(log.output()).toContain("todo:gc-1");
+    expect(log.output()).toContain("Fix retry race");
+    expect(log.output()).not.toContain("linear:eng-1");
+  });
+
+  it("applies list filters and prints normalized JSON without sourceRef", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({ id: "todo:gc-1" }),
+      makeIssue({
+        id: "todo:gc-2",
+        blockers: [{ id: "todo:dep-1", title: "Dependency", status: "todo" }],
+      }),
+      makeIssue({ id: "todo:gc-3", status: "in-progress" }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli([
+        "list",
+        "--status",
+        "todo",
+        "--agent",
+        "codex",
+        "--repo",
+        "ClipboardHealth/api",
+        "--unblocked",
+        "--limit",
+        "1",
+        "--json",
+      ]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain('"id": "todo:gc-1"');
+    expect(log.output()).not.toContain("todo:gc-2");
+    expect(log.output()).not.toContain("sourceRef");
+  });
+
+  it("filters blocked tasks and renders table fallbacks for missing agent and repository", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({
+        id: "todo:gc-2",
+        model: undefined,
+        repository: undefined,
+        blockers: [{ id: "todo:dep-1", title: "Dependency", status: "todo" }],
+      }),
+      makeIssue({ id: "todo:gc-3" }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["list", "--blocked"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("todo:gc-2");
+    expect(log.output()).toContain("yes");
+    expect(log.output()).toContain("-");
+    expect(log.output()).not.toContain("todo:gc-3");
+  });
+
+  it("prints no tasks when filters remove every task", async () => {
+    const todo = stubSource("todo", [makeIssue()]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["list", "--status", "done"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toBe("(no tasks)");
+  });
+
+  it("fails when a named list source is not configured", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["list", "--source", "missing"])).rejects.toThrow(/no source named/);
+  });
+
+  it.each([
+    { argv: ["list", "--limit", "0"], message: "--limit must be a positive integer" },
+    { argv: ["list", "--status", "bogus"], message: "unknown status" },
+    { argv: ["list", "--blocked", "--unblocked"], message: "mutually exclusive" },
+    { argv: ["list", "--source"], message: "requires a value" },
+    { argv: ["list", "--bogus"], message: "unknown argument" },
+  ])("rejects invalid list arguments: $argv", async ({ argv, message }) => {
+    await expect(taskCli(argv)).rejects.toThrow(message);
+  });
+});
+
+describe("crew task get", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "todo-txt", name: "todo" }]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a canonical id directly to its source and prints only the prompt with --prompt", async () => {
+    const todo = stubSource("todo", [makeIssue({ description: "Prompt body\n" })]);
+    const linear = stubSource("linear", [makeIssue({ id: "linear:gc-1", source: "linear" })]);
+    buildSourcesMock.mockResolvedValue([todo, linear]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "todo:GC-1", "--prompt"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.getTask).toHaveBeenCalledWith("GC-1");
+    expect(linear.getTask).not.toHaveBeenCalled();
+    expect(log.output()).toBe("Prompt body\n");
+  });
+
+  it("resolves a source-native id with --source and prints task details by default", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({
+        url: "https://example.test/task/gc-1",
+        blockers: [{ id: "todo:dep-1", title: "Dependency", status: "todo" }],
+      }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "GC-1", "--source", "todo"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("todo:gc-1");
+    expect(log.output()).toContain("repo: ClipboardHealth/api");
+    expect(log.output()).toContain("agent: codex");
+    expect(log.output()).toContain("url: https://example.test/task/gc-1");
+    expect(log.output()).toContain("blockers: dep-1(todo)");
+    expect(log.output()).toContain("Investigate cancellation retries.");
+  });
+
+  it("omits optional task details when the source does not provide them", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({
+        repository: undefined,
+        model: undefined,
+        description: "",
+      }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "GC-1", "--source", "todo"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("todo:gc-1");
+    expect(log.output()).not.toContain("repo:");
+    expect(log.output()).not.toContain("agent:");
+    expect(log.output()).not.toContain("url:");
+    expect(log.output()).not.toContain("blockers:");
+    expect(log.output()).not.toContain("Investigate cancellation retries.");
+  });
+
+  it("prints one task as normalized JSON", async () => {
+    const todo = stubSource("todo", [makeIssue({ priority: 1 })]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "GC-1", "--source", "todo", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain('"priority": 1');
+    expect(log.output()).not.toContain("sourceRef");
+  });
+
+  it("resolves a natural id when exactly one source matches", async () => {
+    const todo = stubSource("todo", []);
+    const linear = stubSource("linear", [makeIssue({ id: "linear:gc-1", source: "linear" })]);
+    buildSourcesMock.mockResolvedValue([todo, linear]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "GC-1", "--prompt"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.getTask).toHaveBeenCalledWith("GC-1");
+    expect(linear.getTask).toHaveBeenCalledWith("GC-1");
+    expect(log.output()).toBe("Investigate cancellation retries.");
+  });
+
+  it("fails natural id lookup when multiple sources match", async () => {
+    const todo = stubSource("todo", [makeIssue()]);
+    const linear = stubSource("linear", [makeIssue({ id: "linear:gc-1", source: "linear" })]);
+    buildSourcesMock.mockResolvedValue([todo, linear]);
+
+    await expect(taskCli(["get", "GC-1"])).rejects.toThrow(/matched multiple sources/);
+  });
+
+  it("fails natural id lookup when no source matches", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["get", "GC-404"])).rejects.toThrow(/not found across configured sources/);
+  });
+
+  it("surfaces source lookup errors when no source matches", async () => {
+    const todo = stubSource("todo", [], {
+      getTask: vi.fn<TaskSource["getTask"]>().mockRejectedValue(new Error("source offline")),
+    });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    await expect(taskCli(["get", "GC-1"])).rejects.toThrow("source offline");
+  });
+
+  it.each([
+    { argv: ["get"], message: "Usage: crew task get" },
+    { argv: ["get", "GC-1", "--json", "--prompt"], message: "mutually exclusive" },
+    { argv: ["get", "GC-1", "--bogus"], message: "unknown option" },
+    { argv: ["get", "todo:"], message: "invalid canonical" },
+    { argv: ["get", "todo:GC-1", "--source", "linear"], message: "already names source" },
+  ])("rejects invalid get arguments: $argv", async ({ argv, message }) => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [makeIssue()])]);
+
+    await expect(taskCli(argv)).rejects.toThrow(message);
+  });
+
+  it("fails source-specific lookup when the source does not have the task", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["get", "GC-1", "--source", "todo"])).rejects.toThrow(
+      /not found in source/,
+    );
+  });
+
+  it("fails canonical lookup when the source does not have the task", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["get", "todo:GC-1"])).rejects.toThrow(/not found in source/);
+  });
+});
+
+describe("crew task create", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "todo-txt", name: "todo" }]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates in the named source and prints the canonical id", async () => {
+    const created = makeIssue({ id: "todo:gc-20260608-001" });
+    const createTask = vi.fn<NonNullable<TaskSource["createTask"]>>().mockResolvedValue(created);
+    const todo = stubSource("todo", [], { createTask });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli([
+        "create",
+        "Fix cancellation retry race",
+        "--source",
+        "todo",
+        "--agent",
+        "codex",
+        "--repo",
+        "ClipboardHealth/api",
+        "--project",
+        "marketplace",
+        "--context",
+        "backend",
+        "--description",
+        "Prompt body",
+      ]);
+    } finally {
+      log.restore();
+    }
+
+    expect(createTask).toHaveBeenCalledWith({
+      title: "Fix cancellation retry race",
+      agent: "codex",
+      repository: "ClipboardHealth/api",
+      projects: ["marketplace"],
+      contexts: ["backend"],
+      dependencies: [],
+      description: "Prompt body",
+      edit: false,
+    });
+    expect(log.output()).toBe("todo:gc-20260608-001");
+  });
+
+  it("forwards every create option and prints created task JSON", async () => {
+    const created = makeIssue({ id: "todo:custom-1", priority: 2, url: "https://example.test/t" });
+    const createTask = vi.fn<NonNullable<TaskSource["createTask"]>>().mockResolvedValue(created);
+    const todo = stubSource("todo", [], { createTask });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli([
+        "create",
+        "Full option task",
+        "--source",
+        "todo",
+        "--agent",
+        "claude",
+        "--id",
+        "CUSTOM-1",
+        "--priority",
+        "B",
+        "--dep",
+        "DEP-1",
+        "--due",
+        "2026-06-09",
+        "--rec",
+        "+1w",
+        "--prompt-file",
+        "/tmp/prompt.md",
+        "--edit",
+        "--json",
+      ]);
+    } finally {
+      log.restore();
+    }
+
+    expect(createTask).toHaveBeenCalledWith({
+      title: "Full option task",
+      agent: "claude",
+      id: "CUSTOM-1",
+      priority: "B",
+      projects: [],
+      contexts: [],
+      dependencies: ["DEP-1"],
+      due: "2026-06-09",
+      recurrence: "+1w",
+      promptFile: "/tmp/prompt.md",
+      edit: true,
+    });
+    expect(log.output()).toContain('"id": "todo:custom-1"');
+    expect(log.output()).toContain('"url": "https://example.test/t"');
+    expect(log.output()).not.toContain("sourceRef");
+  });
+
+  it("fails when the source does not support creation", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(
+      taskCli(["create", "No support", "--source", "todo", "--agent", "codex"]),
+    ).rejects.toThrow(/does not support task creation/);
+  });
+
+  it.each([
+    { argv: ["create"], message: "Quote multi-word titles" },
+    { argv: ["create", "Missing source", "--agent", "codex"], message: "--source is required" },
+    { argv: ["create", "Missing agent", "--source", "todo"], message: "--agent is required" },
+    {
+      argv: ["create", "Unknown option", "--source", "todo", "--agent", "codex", "--bogus"],
+      message: "unknown option",
+    },
+    {
+      argv: ["create", "Missing value", "--source", "todo", "--agent"],
+      message: "requires a value",
+    },
+  ])("rejects invalid create arguments: $argv", async ({ argv, message }) => {
+    await expect(taskCli(argv)).rejects.toThrow(message);
+  });
+});
+
+describe("crew task dispatch", () => {
+  it("throws usage for unknown task subcommands", async () => {
+    await expect(taskCli(["ready"])).rejects.toThrow("Usage: crew task");
+  });
+});

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,0 +1,627 @@
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import {
+  type CanonicalStatus,
+  type CreateTaskInput,
+  naturalIdFromCanonical,
+  type Task,
+  type TaskSource,
+} from "../lib/taskSource.ts";
+import { writeOutput } from "../lib/util.ts";
+
+const TASK_USAGE = `Usage: crew task <subcommand>
+
+Subcommands:
+  list [options]                  List tasks across configured sources
+  get <task-id> [options]         Get one task
+  create "Short title" [options]  Create one task`;
+
+const LIST_USAGE = `Usage: crew task list [options]
+
+Options:
+  --source <name>      Limit to one source.
+  --status <status>    Filter by status. Repeatable.
+  --agent <name>       Filter by agent/model.
+  --repo <owner/repo>  Filter by repository.
+  --blocked            Show only blocked tasks.
+  --unblocked          Show only unblocked tasks.
+  --json               Print normalized task JSON.
+  --limit <n>          Limit output.`;
+
+const GET_USAGE = `Usage: crew task get <task-id> [options]
+
+Options:
+  --source <name>  Resolve a source-native ID against a specific source.
+  --json           Print normalized task JSON.
+  --prompt         Print only the task description/prompt.`;
+
+const CREATE_USAGE = `Usage: crew task create "Short title" --source <source> --agent <agent> [options]`;
+
+const CANONICAL_STATUSES: readonly CanonicalStatus[] = [
+  "todo",
+  "in-progress",
+  "in-review",
+  "done",
+  "other",
+] as const;
+
+const CANONICAL_STATUS_SET: ReadonlySet<string> = new Set(CANONICAL_STATUSES);
+
+interface ListOptions {
+  sourceName?: string;
+  statuses: CanonicalStatus[];
+  agent?: string;
+  repository?: string;
+  blocked: boolean;
+  unblocked: boolean;
+  json: boolean;
+  limit?: number;
+}
+
+interface GetOptions {
+  taskId: string;
+  sourceName?: string;
+  json: boolean;
+  prompt: boolean;
+}
+
+interface CreateOptions {
+  title: string;
+  sourceName: string;
+  input: CreateTaskInput;
+  json: boolean;
+}
+
+interface CreateParseState {
+  positionals: string[];
+  sourceName?: string;
+  agent?: string;
+  repository?: string;
+  id?: string;
+  priority?: string;
+  projects: string[];
+  contexts: string[];
+  dependencies: string[];
+  due?: string;
+  recurrence?: string;
+  promptFile?: string;
+  description?: string;
+  edit: boolean;
+  json: boolean;
+}
+
+interface PrintableTask {
+  id: string;
+  source: string;
+  title: string;
+  description: string;
+  status: CanonicalStatus;
+  repository: string | undefined;
+  model: string | undefined;
+  assignee: string;
+  updatedAt: string;
+  blockers: Task["blockers"];
+  hasMoreBlockers: boolean;
+  url?: string;
+  priority?: number;
+}
+
+function isCanonicalStatus(value: string): value is CanonicalStatus {
+  return CANONICAL_STATUS_SET.has(value);
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  index: number,
+  option: string,
+  usage: string,
+): string {
+  const value = argv[index + 1];
+  if (value === undefined) {
+    throw new Error(`crew task: ${option} requires a value\n${usage}`);
+  }
+  return value;
+}
+
+type CreateValueHandler = (state: CreateParseState, value: string) => void;
+
+const CREATE_VALUE_HANDLERS: Readonly<Record<string, CreateValueHandler | undefined>> = {
+  "--source": (state, value) => {
+    state.sourceName = value;
+  },
+  "--agent": (state, value) => {
+    state.agent = value;
+  },
+  "--repo": (state, value) => {
+    state.repository = value;
+  },
+  "--id": (state, value) => {
+    state.id = value;
+  },
+  "--priority": (state, value) => {
+    state.priority = value;
+  },
+  "--project": (state, value) => {
+    state.projects.push(value);
+  },
+  "--context": (state, value) => {
+    state.contexts.push(value);
+  },
+  "--dep": (state, value) => {
+    state.dependencies.push(value);
+  },
+  "--due": (state, value) => {
+    state.due = value;
+  },
+  "--rec": (state, value) => {
+    state.recurrence = value;
+  },
+  "--prompt-file": (state, value) => {
+    state.promptFile = value;
+  },
+  "--description": (state, value) => {
+    state.description = value;
+  },
+};
+
+function parseLimit(raw: string): number {
+  const limit = Number.parseInt(raw, 10);
+  if (!Number.isInteger(limit) || limit < 1 || String(limit) !== raw) {
+    throw new Error("crew task list: --limit must be a positive integer");
+  }
+  return limit;
+}
+
+function parseListOptions(argv: readonly string[]): ListOptions {
+  const options: ListOptions = {
+    statuses: [],
+    blocked: false,
+    unblocked: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    /* v8 ignore next 3 @preserve -- index is bounded by argv.length; guard exists for noUncheckedIndexedAccess */
+    if (argument === undefined) {
+      continue;
+    }
+    if (argument === "--source") {
+      options.sourceName = readOptionValue(argv, index, argument, LIST_USAGE);
+      index += 1;
+      continue;
+    }
+    if (argument === "--status") {
+      const status = readOptionValue(argv, index, argument, LIST_USAGE);
+      if (!isCanonicalStatus(status)) {
+        throw new Error(
+          `crew task list: unknown status "${status}" (expected ${CANONICAL_STATUSES.join(", ")})`,
+        );
+      }
+      options.statuses.push(status);
+      index += 1;
+      continue;
+    }
+    if (argument === "--agent") {
+      options.agent = readOptionValue(argv, index, argument, LIST_USAGE);
+      index += 1;
+      continue;
+    }
+    if (argument === "--repo") {
+      options.repository = readOptionValue(argv, index, argument, LIST_USAGE);
+      index += 1;
+      continue;
+    }
+    if (argument === "--blocked") {
+      options.blocked = true;
+      continue;
+    }
+    if (argument === "--unblocked") {
+      options.unblocked = true;
+      continue;
+    }
+    if (argument === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (argument === "--limit") {
+      options.limit = parseLimit(readOptionValue(argv, index, argument, LIST_USAGE));
+      index += 1;
+      continue;
+    }
+    throw new Error(`crew task list: unknown argument: ${argument}\n${LIST_USAGE}`);
+  }
+
+  if (options.blocked && options.unblocked) {
+    throw new Error("crew task list: --blocked and --unblocked are mutually exclusive");
+  }
+
+  return options;
+}
+
+function parseGetOptions(argv: readonly string[]): GetOptions {
+  const positionals: string[] = [];
+  let sourceName: string | undefined;
+  let json = false;
+  let prompt = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    /* v8 ignore next 3 @preserve -- index is bounded by argv.length; guard exists for noUncheckedIndexedAccess */
+    if (argument === undefined) {
+      continue;
+    }
+    if (argument === "--source") {
+      sourceName = readOptionValue(argv, index, argument, GET_USAGE);
+      index += 1;
+      continue;
+    }
+    if (argument === "--json") {
+      json = true;
+      continue;
+    }
+    if (argument === "--prompt") {
+      prompt = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(`crew task get: unknown option: ${argument}\n${GET_USAGE}`);
+    }
+    positionals.push(argument);
+  }
+
+  const [taskId, ...extras] = positionals;
+  if (taskId === undefined || extras.length > 0) {
+    throw new Error(GET_USAGE);
+  }
+  if (json && prompt) {
+    throw new Error("crew task get: --json and --prompt are mutually exclusive");
+  }
+
+  return { taskId, ...(sourceName === undefined ? {} : { sourceName }), json, prompt };
+}
+
+function parseCreateOptions(argv: readonly string[]): CreateOptions {
+  const state: CreateParseState = {
+    positionals: [],
+    projects: [],
+    contexts: [],
+    dependencies: [],
+    edit: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    /* v8 ignore next 3 @preserve -- index is bounded by argv.length; guard exists for noUncheckedIndexedAccess */
+    if (argument === undefined) {
+      continue;
+    }
+    const valueHandler = CREATE_VALUE_HANDLERS[argument];
+    if (valueHandler !== undefined) {
+      valueHandler(state, readOptionValue(argv, index, argument, CREATE_USAGE));
+      index += 1;
+      continue;
+    }
+    if (argument === "--edit") {
+      state.edit = true;
+      continue;
+    }
+    if (argument === "--json") {
+      state.json = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(`crew task create: unknown option: ${argument}\n${CREATE_USAGE}`);
+    }
+    state.positionals.push(argument);
+  }
+
+  const [title, ...extras] = state.positionals;
+  if (title === undefined || extras.length > 0) {
+    throw new Error(`${CREATE_USAGE}\nQuote multi-word titles as one argument.`);
+  }
+  if (state.sourceName === undefined) {
+    throw new Error("crew task create: --source is required");
+  }
+  if (state.agent === undefined) {
+    throw new Error("crew task create: --agent is required");
+  }
+
+  const input: CreateTaskInput = {
+    title,
+    agent: state.agent,
+    projects: state.projects,
+    contexts: state.contexts,
+    dependencies: state.dependencies,
+    edit: state.edit,
+    ...(state.repository === undefined ? {} : { repository: state.repository }),
+    ...(state.id === undefined ? {} : { id: state.id }),
+    ...(state.priority === undefined ? {} : { priority: state.priority }),
+    ...(state.due === undefined ? {} : { due: state.due }),
+    ...(state.recurrence === undefined ? {} : { recurrence: state.recurrence }),
+    ...(state.promptFile === undefined ? {} : { promptFile: state.promptFile }),
+    ...(state.description === undefined ? {} : { description: state.description }),
+  };
+
+  return { title, sourceName: state.sourceName, input, json: state.json };
+}
+
+async function loadTaskSources(): Promise<TaskSource[]> {
+  const config: ResolvedConfig = await loadConfig();
+  return await buildSources(sourcesFromConfig(config), { globalConfig: config });
+}
+
+function findSource(sources: readonly TaskSource[], sourceName: string): TaskSource {
+  const source = sources.find((candidate) => candidate.name === sourceName);
+  if (source === undefined) {
+    throw new Error(`crew task: no source named "${sourceName}"`);
+  }
+  return source;
+}
+
+function taskIsBlocked(task: Task): boolean {
+  return task.hasMoreBlockers || task.blockers.some((blocker) => blocker.status !== "done");
+}
+
+function filterTasks(tasks: readonly Task[], options: ListOptions): Task[] {
+  let filtered = [...tasks];
+  if (options.statuses.length > 0) {
+    filtered = filtered.filter((task) => options.statuses.includes(task.status));
+  }
+  if (options.agent !== undefined) {
+    filtered = filtered.filter((task) => task.model === options.agent);
+  }
+  if (options.repository !== undefined) {
+    filtered = filtered.filter((task) => task.repository === options.repository);
+  }
+  if (options.blocked) {
+    filtered = filtered.filter(taskIsBlocked);
+  }
+  if (options.unblocked) {
+    filtered = filtered.filter((task) => !taskIsBlocked(task));
+  }
+  if (options.limit !== undefined) {
+    filtered = filtered.slice(0, options.limit);
+  }
+  return filtered;
+}
+
+function printableTask(task: Task): PrintableTask {
+  return {
+    id: task.id,
+    source: task.source,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    repository: task.repository,
+    model: task.model,
+    assignee: task.assignee,
+    updatedAt: task.updatedAt,
+    blockers: task.blockers,
+    hasMoreBlockers: task.hasMoreBlockers,
+    ...(task.url === undefined ? {} : { url: task.url }),
+    ...(task.priority === undefined ? {} : { priority: task.priority }),
+  };
+}
+
+function writeJson(tasks: readonly Task[]): void {
+  writeOutput(JSON.stringify(tasks.map(printableTask), null, 2));
+}
+
+function writeTaskJson(task: Task): void {
+  writeOutput(JSON.stringify(printableTask(task), null, 2));
+}
+
+function writeTaskTable(tasks: readonly Task[]): void {
+  if (tasks.length === 0) {
+    writeOutput("(no tasks)");
+    return;
+  }
+
+  const rows = tasks.map((task) => ({
+    id: task.id,
+    status: task.status,
+    agent: task.model ?? "-",
+    repository: task.repository ?? "-",
+    blocked: taskIsBlocked(task) ? "yes" : "no",
+    title: task.title,
+  }));
+  const idWidth = Math.max(2, ...rows.map((row) => row.id.length));
+  const statusWidth = Math.max(6, ...rows.map((row) => row.status.length));
+  const agentWidth = Math.max(5, ...rows.map((row) => row.agent.length));
+  const repositoryWidth = Math.max(4, ...rows.map((row) => row.repository.length));
+
+  writeOutput(
+    [
+      "ID".padEnd(idWidth),
+      "STATUS".padEnd(statusWidth),
+      "AGENT".padEnd(agentWidth),
+      "REPO".padEnd(repositoryWidth),
+      "BLOCKED",
+      "TITLE",
+    ].join("  "),
+  );
+  for (const row of rows) {
+    writeOutput(
+      [
+        row.id.padEnd(idWidth),
+        row.status.padEnd(statusWidth),
+        row.agent.padEnd(agentWidth),
+        row.repository.padEnd(repositoryWidth),
+        row.blocked.padEnd(7),
+        row.title,
+      ].join("  "),
+    );
+  }
+}
+
+function canonicalParts(taskId: string): { sourceName: string; naturalId: string } | undefined {
+  const colonIndex = taskId.indexOf(":");
+  if (colonIndex === -1) {
+    return undefined;
+  }
+  const sourceName = taskId.slice(0, colonIndex);
+  const naturalId = taskId.slice(colonIndex + 1);
+  if (sourceName.length === 0 || naturalId.length === 0) {
+    throw new Error(`crew task get: invalid canonical task id "${taskId}"`);
+  }
+  return { sourceName, naturalId };
+}
+
+async function taskFromSource(source: TaskSource, naturalId: string): Promise<Task | null> {
+  return await source.getTask(naturalId);
+}
+
+async function resolveTask(
+  sources: readonly TaskSource[],
+  taskId: string,
+  sourceName: string | undefined,
+): Promise<Task> {
+  const canonical = canonicalParts(taskId);
+  if (canonical !== undefined) {
+    if (sourceName !== undefined && sourceName !== canonical.sourceName) {
+      throw new Error(
+        `crew task get: canonical id "${taskId}" already names source "${canonical.sourceName}"`,
+      );
+    }
+    const source = findSource(sources, canonical.sourceName);
+    const task = await taskFromSource(source, canonical.naturalId);
+    if (task === null) {
+      throw new Error(`Task ${taskId} not found in source "${source.name}".`);
+    }
+    return task;
+  }
+
+  if (sourceName !== undefined) {
+    const source = findSource(sources, sourceName);
+    const task = await taskFromSource(source, taskId);
+    if (task === null) {
+      throw new Error(`Task ${taskId} not found in source "${source.name}".`);
+    }
+    return task;
+  }
+
+  const results = await Promise.allSettled(
+    sources.map(async (source) => await taskFromSource(source, taskId)),
+  );
+  const matches: Task[] = [];
+  const rejections: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value !== null) {
+        matches.push(result.value);
+      }
+      continue;
+    }
+    rejections.push(result.reason);
+  }
+  if (matches.length === 0) {
+    if (rejections.length > 0) {
+      throw rejections[0];
+    }
+    throw new Error(`Task ${taskId} not found across configured sources.`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Task id "${taskId}" matched multiple sources: ${matches.map((task) => task.id).join(", ")}. Re-run with a canonical id or --source <name>.`,
+    );
+  }
+  const [match] = matches;
+  /* v8 ignore next 3 @preserve -- matches.length was checked above; guard exists for noUncheckedIndexedAccess */
+  if (match === undefined) {
+    throw new Error(`Task ${taskId} not found across configured sources.`);
+  }
+  return match;
+}
+
+function writeTaskDetails(task: Task): void {
+  writeOutput(task.id);
+  writeOutput(`title: ${task.title}`);
+  writeOutput(`status: ${task.status}`);
+  writeOutput(`source: ${task.source}`);
+  if (task.repository !== undefined) {
+    writeOutput(`repo: ${task.repository}`);
+  }
+  if (task.model !== undefined) {
+    writeOutput(`agent: ${task.model}`);
+  }
+  if (task.url !== undefined) {
+    writeOutput(`url: ${task.url}`);
+  }
+  if (task.blockers.length > 0) {
+    writeOutput(
+      `blockers: ${task.blockers.map((blocker) => `${naturalIdFromCanonical(blocker.id)}(${blocker.status})`).join(", ")}`,
+    );
+  }
+  if (task.description.trim().length > 0) {
+    writeOutput("");
+    writeOutput(task.description);
+  }
+}
+
+async function taskListCli(argv: readonly string[]): Promise<void> {
+  const options = parseListOptions(argv);
+  const sources = await loadTaskSources();
+  const selectedSources =
+    options.sourceName === undefined ? sources : [findSource(sources, options.sourceName)];
+  const sourceTasks = await Promise.all(
+    selectedSources.map(async (source) => await source.listTasks()),
+  );
+  const tasks = filterTasks(sourceTasks.flat(), options);
+
+  if (options.json) {
+    writeJson(tasks);
+    return;
+  }
+  writeTaskTable(tasks);
+}
+
+async function taskGetCli(argv: readonly string[]): Promise<void> {
+  const options = parseGetOptions(argv);
+  const sources = await loadTaskSources();
+  const task = await resolveTask(sources, options.taskId, options.sourceName);
+
+  if (options.prompt) {
+    writeOutput(task.description);
+    return;
+  }
+  if (options.json) {
+    writeTaskJson(task);
+    return;
+  }
+  writeTaskDetails(task);
+}
+
+async function taskCreateCli(argv: readonly string[]): Promise<void> {
+  const options = parseCreateOptions(argv);
+  const sources = await loadTaskSources();
+  const source = findSource(sources, options.sourceName);
+  if (source.createTask === undefined) {
+    throw new Error(`crew task create: source "${source.name}" does not support task creation`);
+  }
+  const created = await source.createTask(options.input);
+
+  if (options.json) {
+    writeTaskJson(created);
+    return;
+  }
+  writeOutput(created.id);
+}
+
+export async function taskCli(argv: string[]): Promise<void> {
+  const [verb, ...rest] = argv;
+  if (verb === "list") {
+    await taskListCli(rest);
+    return;
+  }
+  if (verb === "get") {
+    await taskGetCli(rest);
+    return;
+  }
+  if (verb === "create") {
+    await taskCreateCli(rest);
+    return;
+  }
+  throw new Error(TASK_USAGE);
+}

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -376,7 +376,12 @@ describe(createLinearTaskSource, () => {
       stateType: "unstarted",
       status: "Todo",
       statusId: "state-todo",
+      assignee: "Alice",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [],
+      hasMoreBlockers: false,
       url: "https://linear.app/example/issue/TEAM-1",
+      priority: 0,
     });
     const source = createLinearTaskSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -401,7 +406,12 @@ describe(createLinearTaskSource, () => {
       stateType: "unstarted",
       status: "Todo",
       statusId: "state-todo",
+      assignee: "Alice",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [{ id: "team-2", title: "Blocking task", status: "Todo", stateType: "unstarted" }],
+      hasMoreBlockers: true,
       url: "https://linear.app/example/issue/TEAM-1",
+      priority: 2,
     });
     const source = createLinearTaskSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -411,6 +421,18 @@ describe(createLinearTaskSource, () => {
 
     expect(issue?.id).toBe("linear:team-1");
     expect(issue?.description).toBe("Resolved description");
+    expect(issue?.assignee).toBe("Alice");
+    expect(issue?.updatedAt).toBe("2026-01-01T00:00:00Z");
+    expect(issue?.blockers).toStrictEqual([
+      {
+        id: "linear:team-2",
+        title: "Blocking task",
+        status: "todo",
+        nativeStatus: "Todo",
+      },
+    ]);
+    expect(issue?.hasMoreBlockers).toBe(true);
+    expect(issue?.priority).toBe(2);
   });
 
   it("returns null for missing Linear tasks through getTask() and undefined through resolveOne()", async () => {
@@ -432,6 +454,17 @@ describe(createLinearTaskSource, () => {
     } satisfies AdapterContext);
 
     await expect(source.getTask("team-1")).rejects.toThrow("Linear API: timeout");
+  });
+
+  it("does not treat every task-prefixed Linear lookup failure as missing", async () => {
+    vi.spyOn(boardSource, "fetchResolvedIssue").mockRejectedValue(
+      new Error("Task TEAM-1 lookup failed in Linear"),
+    );
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.getTask("team-1")).rejects.toThrow("lookup failed");
   });
 
   it("markInProgress() forwards uuid/teamId from sourceRef", async () => {

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -284,6 +284,25 @@ describe(createLinearTaskSource, () => {
     expect(issues[1]?.status).toBe("in-progress");
   });
 
+  it("listTasks() converts each LinearIssue into a canonical Issue", async () => {
+    const innerFetch = vi.fn<() => Promise<boardSource.BoardState>>().mockResolvedValue({
+      timestamp: "2026-01-01T00:00:00Z",
+      issues: [linearIssue({ id: "team-1" })],
+      parentSkips: [],
+    });
+    vi.spyOn(boardSource, "createBoardSource").mockReturnValue({
+      verify: vi.fn<() => Promise<void>>(),
+      fetch: innerFetch,
+    });
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    const issues = await source.listTasks();
+
+    expect(issues.map((issue) => issue.id)).toStrictEqual(["linear:team-1"]);
+  });
+
   it("uses configured Linear status names before falling back to state.type", async () => {
     const innerFetch = vi.fn<() => Promise<boardSource.BoardState>>().mockResolvedValue({
       timestamp: "2026-01-01T00:00:00Z",
@@ -369,6 +388,50 @@ describe(createLinearTaskSource, () => {
     expect(issue?.repository).toBe("repo-a");
     expect(issue?.model).toBe("claude");
     expect(issue?.status).toBe("todo");
+  });
+
+  it("getTask() returns a canonical Issue with description populated from fetchResolvedIssue", async () => {
+    vi.spyOn(boardSource, "fetchResolvedIssue").mockResolvedValue({
+      uuid: "uuid-abc",
+      title: "Resolved title",
+      description: "Resolved description",
+      repository: "repo-a",
+      model: "claude",
+      teamId: "team-xyz",
+      stateType: "unstarted",
+      status: "Todo",
+      statusId: "state-todo",
+      url: "https://linear.app/example/issue/TEAM-1",
+    });
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    const issue = await source.getTask("team-1");
+
+    expect(issue?.id).toBe("linear:team-1");
+    expect(issue?.description).toBe("Resolved description");
+  });
+
+  it("returns null for missing Linear tasks through getTask() and undefined through resolveOne()", async () => {
+    vi.spyOn(boardSource, "fetchResolvedIssue")
+      .mockRejectedValueOnce(new Error("Task TEAM-404 not found in Linear"))
+      .mockRejectedValueOnce(new Error("Task TEAM-404 not found in Linear"));
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.getTask("team-404")).resolves.toBeNull();
+    await expect(source.resolveOne("team-404")).resolves.toBeUndefined();
+  });
+
+  it("preserves non-missing Linear lookup failures", async () => {
+    vi.spyOn(boardSource, "fetchResolvedIssue").mockRejectedValue(new Error("Linear API: timeout"));
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.getTask("team-1")).rejects.toThrow("Linear API: timeout");
   });
 
   it("markInProgress() forwards uuid/teamId from sourceRef", async () => {

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -105,7 +105,8 @@ function toCanonicalParentSkip(skip: LinearParentSkip, sourceName: string): Cano
 function isLinearNotFoundError(error: unknown, naturalId: string): boolean {
   return (
     error instanceof Error &&
-    error.message === `Task ${naturalId.toUpperCase()} not found in Linear`
+    error.message.startsWith(`Task ${naturalId.toUpperCase()} `) &&
+    error.message.includes("not found")
   );
 }
 
@@ -217,11 +218,12 @@ export function createLinearTaskSource(
       }),
       repository: resolved.repository,
       model: resolved.model,
-      assignee: "Unassigned",
-      updatedAt: new Date().toISOString(),
-      blockers: [],
-      hasMoreBlockers: false,
+      assignee: resolved.assignee,
+      updatedAt: resolved.updatedAt,
+      blockers: resolved.blockers.map((b) => toCanonicalBlocker(b, sourceName, statusNames)),
+      hasMoreBlockers: resolved.hasMoreBlockers,
       url: resolved.url,
+      ...(resolved.priority === 0 ? {} : { priority: resolved.priority }),
       sourceRef,
     };
   }

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -102,6 +102,13 @@ function toCanonicalParentSkip(skip: LinearParentSkip, sourceName: string): Cano
   };
 }
 
+function isLinearNotFoundError(error: unknown, naturalId: string): boolean {
+  return (
+    error instanceof Error &&
+    error.message === `Task ${naturalId.toUpperCase()} not found in Linear`
+  );
+}
+
 export function toCanonicalIssue(
   linearIssue: LinearIssue,
   sourceName: string,
@@ -169,53 +176,75 @@ export function createLinearTaskSource(
 
   let lastParentSkips: readonly CanonicalParentSkip[] = [];
 
+  async function listTasks(): Promise<CanonicalIssue[]> {
+    const state = await getBoardSource().fetch();
+    lastParentSkips = state.parentSkips.map((skip) => toCanonicalParentSkip(skip, sourceName));
+    return state.issues.map((linearIssue) =>
+      toCanonicalIssue(linearIssue, sourceName, statusNames),
+    );
+  }
+
+  async function getTask(naturalId: string): Promise<CanonicalIssue | null> {
+    let resolved: Awaited<ReturnType<typeof fetchResolvedIssue>>;
+    try {
+      resolved = await fetchResolvedIssue({
+        client: getClient(),
+        config: globalConfig,
+        task: naturalId,
+      });
+    } catch (error: unknown) {
+      if (isLinearNotFoundError(error, naturalId)) {
+        return null;
+      }
+      throw error;
+    }
+    const sourceRef: LinearSourceRef = {
+      uuid: resolved.uuid,
+      statusId: resolved.statusId,
+      teamId: resolved.teamId,
+      stateType: resolved.stateType,
+      nativeStatus: resolved.status,
+    };
+    return {
+      id: toCanonicalId(sourceName, naturalId),
+      source: sourceName,
+      title: resolved.title,
+      description: resolved.description,
+      status: canonicalStatusFromLinearState({
+        nativeStatus: resolved.status,
+        stateType: resolved.stateType,
+        statusNames,
+      }),
+      repository: resolved.repository,
+      model: resolved.model,
+      assignee: "Unassigned",
+      updatedAt: new Date().toISOString(),
+      blockers: [],
+      hasMoreBlockers: false,
+      url: resolved.url,
+      sourceRef,
+    };
+  }
+
   return {
     name: sourceName,
     async verify(): Promise<void> {
       await getBoardSource().verify();
     },
+    async listTasks(): Promise<CanonicalIssue[]> {
+      return await listTasks();
+    },
+    async getTask(naturalId: string): Promise<CanonicalIssue | null> {
+      return await getTask(naturalId);
+    },
     async fetch(): Promise<CanonicalIssue[]> {
-      const state = await getBoardSource().fetch();
-      lastParentSkips = state.parentSkips.map((skip) => toCanonicalParentSkip(skip, sourceName));
-      return state.issues.map((linearIssue) =>
-        toCanonicalIssue(linearIssue, sourceName, statusNames),
-      );
+      return await listTasks();
     },
     async fetchParentSkips(): Promise<readonly CanonicalParentSkip[]> {
       return lastParentSkips;
     },
     async resolveOne(naturalId: string): Promise<CanonicalIssue | undefined> {
-      const resolved = await fetchResolvedIssue({
-        client: getClient(),
-        config: globalConfig,
-        task: naturalId,
-      });
-      const sourceRef: LinearSourceRef = {
-        uuid: resolved.uuid,
-        statusId: resolved.statusId,
-        teamId: resolved.teamId,
-        stateType: resolved.stateType,
-        nativeStatus: resolved.status,
-      };
-      return {
-        id: toCanonicalId(sourceName, naturalId),
-        source: sourceName,
-        title: resolved.title,
-        description: resolved.description,
-        status: canonicalStatusFromLinearState({
-          nativeStatus: resolved.status,
-          stateType: resolved.stateType,
-          statusNames,
-        }),
-        repository: resolved.repository,
-        model: resolved.model,
-        assignee: "Unassigned",
-        updatedAt: new Date().toISOString(),
-        blockers: [],
-        hasMoreBlockers: false,
-        url: resolved.url,
-        sourceRef,
-      };
+      return (await getTask(naturalId)) ?? undefined;
     },
     async markInProgress(issue: CanonicalIssue): Promise<void> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- by the Linear adapter's contract, every Issue it produces carries a LinearSourceRef in sourceRef

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -20,8 +20,9 @@ interface IssueNodeStub {
   id: string;
   identifier: string;
   title: string;
-  description?: string | undefined;
+  description?: string | null | undefined;
   updatedAt: string;
+  url: string;
   priority?: number;
   state?: { id: string; name: string; type: string } | null;
   team?: { id: string; key: string } | null;
@@ -79,6 +80,7 @@ function issueNode(overrides: Partial<IssueNodeStub>): IssueNodeStub {
     title: overrides.title ?? "Title",
     description: "description" in overrides ? overrides.description : "Touches repo-a.",
     updatedAt: overrides.updatedAt ?? "2025-01-01T00:00:00.000Z",
+    url: overrides.url ?? "https://linear.app/example/issue/TEAM-1",
     priority: overrides.priority ?? 0,
     state:
       overrides.state === undefined
@@ -197,14 +199,7 @@ function makeClient(options: ClientStubOptions = {}): ClientStub {
     if (query.includes("ResolveIssue")) {
       return {
         data: {
-          issue: {
-            id: "uuid-1",
-            title: "Title",
-            description: "Touches repo-a.",
-            team: { id: "team-default" },
-            labels: { nodes: [] },
-            state: { name: "Todo", type: "unstarted" },
-          },
+          issue: issueNode({ labels: { nodes: [] } }),
         },
       };
     }
@@ -403,6 +398,11 @@ describe(fetchResolvedIssue, () => {
     expect(resolved.repository).toBe("repo-a");
     expect(resolved.model).toBe("claude");
     expect(resolved.teamId).toBe("team-default");
+    expect(resolved.assignee).toBe("Alice");
+    expect(resolved.updatedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(resolved.blockers).toStrictEqual([]);
+    expect(resolved.hasMoreBlockers).toBe(false);
+    expect(resolved.priority).toBe(0);
   });
 
   it("resolves a matched non-default model from an enabled agent-* label", async () => {
@@ -410,14 +410,7 @@ describe(fetchResolvedIssue, () => {
       client: {
         rawRequest: vi.fn<RawRequest>(async () => ({
           data: {
-            issue: {
-              id: "uuid-1",
-              title: "Title",
-              description: "Touches repo-a.",
-              team: { id: "team-default" },
-              labels: { nodes: [{ name: "agent-codex" }] },
-              state: { name: "Todo", type: "unstarted" },
-            },
+            issue: issueNode({ labels: { nodes: [{ name: "agent-codex" }] } }),
           },
         })),
       },
@@ -436,14 +429,7 @@ describe(fetchResolvedIssue, () => {
       client: {
         rawRequest: vi.fn<RawRequest>(async () => ({
           data: {
-            issue: {
-              id: "uuid-1",
-              title: "Title",
-              description: "Touches repo-a.",
-              team: { id: "team-default" },
-              labels: { nodes: [{ name: "agent-codex" }] },
-              state: { name: "Todo", type: "unstarted" },
-            },
+            issue: issueNode({ labels: { nodes: [{ name: "agent-codex" }] } }),
           },
         })),
       },
@@ -473,14 +459,10 @@ describe(fetchResolvedIssue, () => {
       client: {
         rawRequest: vi.fn<RawRequest>(async () => ({
           data: {
-            issue: {
-              id: "uuid-1",
-              title: "Title",
+            issue: issueNode({
               description: "No matching repository.",
-              team: { id: "team-default" },
               labels: { nodes: [{ name: "agent-claude" }] },
-              state: { name: "Todo", type: "unstarted" },
-            },
+            }),
           },
         })),
       },
@@ -566,6 +548,9 @@ describe(fetchRawLinearIssue, () => {
     expect(raw.stateType).toBe("unstarted");
     expect(raw.teamId).toBe("team-default");
     expect(raw.hasChildren).toBe(false);
+    expect(raw.assignee).toBe("Alice");
+    expect(raw.updatedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(raw.priority).toBe(0);
   });
 
   it("coerces a null description to an empty string", async () => {
@@ -573,14 +558,7 @@ describe(fetchRawLinearIssue, () => {
       client: {
         rawRequest: vi.fn<RawRequest>(async () => ({
           data: {
-            issue: {
-              id: "uuid-1",
-              title: "Title",
-              description: null,
-              team: { id: "team-default" },
-              labels: { nodes: [] },
-              state: { name: "Todo", type: "unstarted" },
-            },
+            issue: issueNode({ description: null, labels: { nodes: [] } }),
           },
         })),
       },
@@ -591,6 +569,62 @@ describe(fetchRawLinearIssue, () => {
       task: "team-1",
     });
     expect(raw.description).toBe("");
+  });
+
+  it("defaults missing assignee and children fields in raw lookup", async () => {
+    const { children: _children, ...issueWithoutChildren } = issueNode({
+      assignee: null,
+      labels: { nodes: [] },
+    });
+    const client = {
+      client: {
+        rawRequest: vi.fn<RawRequest>(async () => ({
+          data: {
+            issue: issueWithoutChildren,
+          },
+        })),
+      },
+    };
+
+    const raw = await fetchRawLinearIssue({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests hit the LinearClient surface consumed by boardSource
+      client: client as unknown as LinearClient,
+      task: "team-1",
+    });
+
+    expect(raw.assignee).toBe("Unassigned");
+    expect(raw.hasChildren).toBe(false);
+  });
+
+  it("returns raw blockers and child presence from single issue lookup", async () => {
+    const client = {
+      client: {
+        rawRequest: vi.fn<RawRequest>(async () => ({
+          data: {
+            issue: issueNode({
+              children: { nodes: [{ id: "child-1" }] },
+              labels: { nodes: [] },
+              inverseRelations: {
+                nodes: [blockingRelation("TEAM-9", "Todo", "unstarted")],
+                pageInfo: { hasNextPage: true },
+              },
+            }),
+          },
+        })),
+      },
+    };
+
+    const raw = await fetchRawLinearIssue({
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests hit the LinearClient surface consumed by boardSource
+      client: client as unknown as LinearClient,
+      task: "team-1",
+    });
+
+    expect(raw.blockers).toStrictEqual([
+      { id: "team-9", title: "Blocker", status: "Todo", stateType: "unstarted" },
+    ]);
+    expect(raw.hasMoreBlockers).toBe(true);
+    expect(raw.hasChildren).toBe(true);
   });
 
   it("throws a not-found error when the issue is null", async () => {

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -403,7 +403,12 @@ interface ResolvedIssue {
   stateType: string;
   status: string;
   statusId: string;
+  assignee: string;
+  updatedAt: string;
+  blockers: Blocker[];
+  hasMoreBlockers: boolean;
   url: string;
+  priority: number;
 }
 
 const ISSUE_LABEL_PAGE_SIZE = 50;
@@ -419,6 +424,8 @@ export interface RawLinearIssue {
   stateName: string;
   stateType: string;
   stateId: string;
+  assignee: string;
+  updatedAt: string;
   blockers: Blocker[];
   hasMoreBlockers: boolean;
   /**
@@ -430,6 +437,8 @@ export interface RawLinearIssue {
   hasChildren: boolean;
   /** Linear `Issue.url` — direct web link to the task. */
   url: string;
+  /** Linear priority: 1=Urgent, 2=High, 3=Medium, 4=Low, 0=No priority. */
+  priority: number;
 }
 
 export async function fetchBlockersForTask(arguments_: {
@@ -495,9 +504,12 @@ export async function fetchRawLinearIssue(arguments_: {
         id
         title
         description
+        updatedAt
         url
+        priority
         team { id }
         state { id name type }
+        assignee { name }
         children { nodes { id } }
         labels(first: ${ISSUE_LABEL_PAGE_SIZE}) {
           nodes { name }
@@ -523,9 +535,12 @@ export async function fetchRawLinearIssue(arguments_: {
       id: string;
       title: string;
       description?: string | null;
+      updatedAt: string;
       url: string;
+      priority: number;
       team?: { id: string } | null;
       state?: { id: string; name: string; type: string } | null;
+      assignee?: { name: string } | null;
       children?: { nodes: { id: string }[] } | null;
       labels: { nodes: { name: string }[] };
       inverseRelations?: {
@@ -550,10 +565,13 @@ export async function fetchRawLinearIssue(arguments_: {
     stateType: issue.state?.type ?? "",
     /* v8 ignore next @preserve -- ResolveIssue query selects state; null only if Linear genuinely returns a stateless task */
     stateId: issue.state?.id ?? "",
+    assignee: issue.assignee?.name ?? "Unassigned",
+    updatedAt: issue.updatedAt,
     blockers: blockersFromRelations(issue.inverseRelations?.nodes ?? []),
     hasMoreBlockers: issue.inverseRelations?.pageInfo.hasNextPage ?? false,
     hasChildren: (issue.children?.nodes.length ?? 0) > 0,
     url: issue.url,
+    priority: issue.priority,
   };
 }
 
@@ -648,7 +666,12 @@ export async function fetchResolvedIssue(arguments_: {
     stateType: raw.stateType,
     status: raw.stateName,
     statusId: raw.stateId,
+    assignee: raw.assignee,
+    updatedAt: raw.updatedAt,
+    blockers: raw.blockers,
+    hasMoreBlockers: raw.hasMoreBlockers,
     url: raw.url,
+    priority: raw.priority,
   };
 }
 

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -18,6 +18,8 @@ function emptySource(name: string): TaskSource {
   return {
     name,
     verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    listTasks: vi.fn<() => Promise<never[]>>().mockResolvedValue([]),
+    getTask: vi.fn<() => Promise<null>>().mockResolvedValue(null),
     fetch: vi.fn<() => Promise<never[]>>().mockResolvedValue([]),
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -205,6 +205,21 @@ describe(createShellTaskSource, () => {
     expect(issues[0]?.source).toBe("test");
   });
 
+  it("listTasks() parses well-formed JSON and prefixes ids with the source name", async () => {
+    const script = dir.writeScript(
+      "list.sh",
+      `cat <<'JSON'\n${payload(shellIssue({ id: "X-1" }))}\nJSON`,
+    );
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { listTasks: script } },
+      fakeContext,
+    );
+
+    const issues = await source.listTasks();
+
+    expect(issues[0]?.id).toBe("test:x-1");
+  });
+
   it("fetch() throws when the script emits malformed JSON", async () => {
     const script = dir.writeScript("bad.sh", 'echo "not json"');
     const source = createShellTaskSource(
@@ -312,6 +327,25 @@ describe(createShellTaskSource, () => {
       fakeContext,
     );
     const issue = await source.resolveOne("X-1");
+    expect(issue?.id).toBe("test:x-1");
+  });
+
+  it("getTask() runs the configured command and applies ${id} substitution", async () => {
+    const getTaskScript = dir.writeScript(
+      "get.sh",
+      `echo "{\\"id\\":\\"$1\\",\\"title\\":\\"t\\",\\"description\\":\\"\\",\\"status\\":\\"todo\\",\\"repository\\":null,\\"model\\":null,\\"assignee\\":\\"u\\",\\"updatedAt\\":\\"2026-01-01T00:00:00Z\\",\\"blockers\\":[],\\"sourceRef\\":null}"`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", getTask: `${getTaskScript} \${id}` },
+      },
+      fakeContext,
+    );
+
+    const issue = await source.getTask("X-1");
+
     expect(issue?.id).toBe("test:x-1");
   });
 

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -145,6 +145,31 @@ export function createShellTaskSource(
     return parsed.map((si) => toCanonicalIssue(si, sourceName));
   }
 
+  async function getTask(naturalId: string): Promise<CanonicalIssue | null> {
+    const canonicalId = toCanonicalId(sourceName, naturalId);
+    if (getTaskCommand === undefined) {
+      const all = await runFetch();
+      return all.find((i) => i.id === canonicalId) ?? null;
+    }
+    const result = await invokeShellCommand({
+      command: getTaskCommand,
+      timeoutMs: timeouts.getTask,
+      cwd: config.cwd,
+      env: config.env,
+      substitutions: {
+        id: naturalId,
+        canonicalId,
+        name: sourceName,
+      },
+      sourceName,
+    });
+    if (result.exitCode === 3 || result.stdout.trim().length === 0) {
+      return null;
+    }
+    const parsed = shellIssueSchema.parse(JSON.parse(result.stdout));
+    return toCanonicalIssue(parsed, sourceName);
+  }
+
   // Shared by markInProgress / markInReview: both pipe the canonical issue's
   // opaque sourceRef to a status-transition script on stdin, with the natural
   // and canonical ids substituted into the command.
@@ -189,30 +214,15 @@ export function createShellTaskSource(
         sourceName,
       });
     },
+    async listTasks(): Promise<CanonicalIssue[]> {
+      return await runFetch();
+    },
+    async getTask(naturalId: string): Promise<CanonicalIssue | null> {
+      return await getTask(naturalId);
+    },
     fetch: runFetch,
     async resolveOne(naturalId: string): Promise<CanonicalIssue | undefined> {
-      const canonicalId = toCanonicalId(sourceName, naturalId);
-      if (getTaskCommand === undefined) {
-        const all = await runFetch();
-        return all.find((i) => i.id === canonicalId);
-      }
-      const result = await invokeShellCommand({
-        command: getTaskCommand,
-        timeoutMs: timeouts.getTask,
-        cwd: config.cwd,
-        env: config.env,
-        substitutions: {
-          id: naturalId,
-          canonicalId,
-          name: sourceName,
-        },
-        sourceName,
-      });
-      if (result.exitCode === 3 || result.stdout.trim().length === 0) {
-        return undefined;
-      }
-      const parsed = shellIssueSchema.parse(JSON.parse(result.stdout));
-      return toCanonicalIssue(parsed, sourceName);
+      return (await getTask(naturalId)) ?? undefined;
     },
     async markInProgress(issue: CanonicalIssue): Promise<void> {
       await invokeWriteback(config.commands.markInProgress, timeouts.markInProgress, issue);

--- a/src/lib/adapters/todo-txt/normalizer.test.ts
+++ b/src/lib/adapters/todo-txt/normalizer.test.ts
@@ -1,0 +1,71 @@
+import { parseAllLines, type ParsedTodoLine } from "./parser.ts";
+import { isActiveForFetch, normalizeToIssue } from "./normalizer.ts";
+
+function parseOne(line: string): ParsedTodoLine {
+  const [parsed] = parseAllLines(`${line}\n`);
+  if (parsed === null || parsed === undefined) {
+    throw new Error("expected parsed todo line");
+  }
+  return parsed;
+}
+
+function normalize(line: string, defaultRepository?: string) {
+  const parsed = parseOne(line);
+  return normalizeToIssue({
+    parsed,
+    allParsed: [parsed],
+    sourceName: "todo",
+    todoPath: "todo.txt",
+    tasksDir: ".tasks",
+    defaultRepository,
+    description: "Prompt",
+    updatedAt: "2026-06-08T00:00:00.000Z",
+  });
+}
+
+describe(normalizeToIssue, () => {
+  it.each([
+    { line: "Todo final id:TODO-1 agent:codex status:todo", status: "todo" },
+    { line: "Todo draft id:TODO-2 agent:codex status:todo extra", status: "other" },
+    { line: "Doing id:DOING-1 agent:codex status:in-progress", status: "in-progress" },
+    { line: "Review id:REVIEW-1 agent:codex status:in-review", status: "in-review" },
+    { line: "Done metadata id:DONE-1 agent:codex status:done", status: "done" },
+    { line: "Unknown id:UNKNOWN-1 agent:codex status:waiting", status: "other" },
+    { line: "x 2026-06-08 Completed id:DONE-2 agent:codex status:done", status: "done" },
+  ])("maps $line to $status", ({ line, status }) => {
+    expect(normalize(line)?.status).toBe(status);
+  });
+
+  it("uses repo metadata and prompt override when present", () => {
+    const issue = normalize(
+      "Prompted id:PROMPT-1 agent:codex repo:Org/repo prompt:custom.md status:todo",
+    );
+
+    expect(issue?.repository).toBe("Org/repo");
+    expect(issue?.sourceRef).toMatchObject({ promptPath: "custom.md" });
+  });
+
+  it("falls back to the default repository when repo metadata is absent", () => {
+    expect(
+      normalize("Default repo id:DEFAULT-1 agent:codex status:todo", "Org/default")?.repository,
+    ).toBe("Org/default");
+  });
+
+  it("leaves repository undefined when neither task nor source provides one", () => {
+    expect(normalize("No repo id:NO-REPO-1 agent:codex status:todo")?.repository).toBeUndefined();
+  });
+});
+
+describe(isActiveForFetch, () => {
+  it.each([
+    { line: "Active todo id:ACTIVE-1 agent:codex status:todo", active: true },
+    { line: "Active progress id:ACTIVE-2 agent:codex status:in-progress", active: true },
+    { line: "Active review id:ACTIVE-3 agent:codex status:in-review", active: true },
+    { line: "x 2026-06-08 Done id:DONE-1 agent:codex status:done", active: false },
+    { line: "No id agent:codex status:todo", active: false },
+    { line: "No agent id:NO-AGENT-1 status:todo", active: false },
+    { line: "Unknown status id:UNKNOWN-1 agent:codex status:waiting", active: false },
+  ])("returns $active for $line", ({ line, active }) => {
+    expect(isActiveForFetch(parseOne(line))).toBe(active);
+  });
+});

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -79,6 +79,8 @@ describe("TodoTxtTaskSource", () => {
 
   afterEach(() => {
     tmp.cleanup();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   // Test 1: Parse minimal ready task
@@ -97,6 +99,293 @@ describe("TodoTxtTaskSource", () => {
     expect(issue?.title).toBe("Fix cancellation retry race");
     expect(issue?.status).toBe("todo");
     expect(issue?.model).toBe("codex");
+  });
+
+  it("creates a ready todo task with a prompt file", async () => {
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    const created = await source.createTask?.({
+      title: "Fix cancellation retry race",
+      agent: "codex",
+      repository: "ClipboardHealth/api",
+      id: "GC-20260608-001",
+      projects: ["marketplace"],
+      contexts: ["backend"],
+      dependencies: [],
+      description: "Investigate retry handling.",
+      edit: false,
+    });
+
+    expect(created?.id).toBe("todo:gc-20260608-001");
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe(
+      "(A) Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo\n",
+    );
+    expect(readFileSync(path.join(tmp.tasksDir, "GC-20260608-001.md"), "utf8")).toBe(
+      "Investigate retry handling.\n",
+    );
+  });
+
+  it("generates the next dated id and separates from an unterminated todo file", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-08T12:00:00.000Z"));
+    tmp.writeTodo(
+      "\nTask outside sequence id:OTHER-1 agent:codex status:todo\nNo id task agent:codex status:todo\nNonnumeric sequence id:GC-20260608-ABC agent:codex status:todo\nExisting task id:GC-20260608-001 agent:codex status:todo\nLower sequence id:GC-20260608-000 agent:codex status:todo",
+    );
+
+    const source = makeSource(tmp);
+    const created = await source.createTask?.({
+      title: "Generated task",
+      agent: "codex",
+      projects: [],
+      contexts: [],
+      dependencies: [],
+      edit: false,
+    });
+
+    expect(created?.id).toBe("todo:gc-20260608-002");
+    expect(readFileSync(tmp.todoPath, "utf8")).toContain(
+      "\n(A) Generated task id:GC-20260608-002 agent:codex status:todo\n",
+    );
+    expect(readFileSync(path.join(tmp.tasksDir, "GC-20260608-002.md"), "utf8")).toBe(
+      "Generated task\n",
+    );
+  });
+
+  it("copies prompt-file content and accepts prefixed project/context names", async () => {
+    const promptFile = path.join(tmp.dir, "prompt.md");
+    writeFileSync(promptFile, "Existing prompt.\n", "utf8");
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await source.createTask?.({
+      title: "Prompt file task",
+      agent: "claude",
+      id: "PROMPT-1",
+      priority: "C",
+      projects: ["+marketplace"],
+      contexts: ["@backend"],
+      dependencies: ["DEP-1"],
+      due: "2026-06-09",
+      recurrence: "+1w",
+      promptFile,
+      edit: false,
+    });
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe(
+      "(C) Prompt file task +marketplace @backend id:PROMPT-1 agent:claude dep:DEP-1 due:2026-06-09 rec:+1w status:todo\n",
+    );
+    expect(readFileSync(path.join(tmp.tasksDir, "PROMPT-1.md"), "utf8")).toBe("Existing prompt.\n");
+  });
+
+  it("creates the todo file when it does not exist", async () => {
+    const source = makeSource(tmp);
+
+    await source.createTask?.({
+      title: "No existing todo",
+      agent: "codex",
+      id: "NO-FILE-1",
+      projects: [],
+      contexts: [],
+      dependencies: [],
+      edit: false,
+    });
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe(
+      "(A) No existing todo id:NO-FILE-1 agent:codex status:todo\n",
+    );
+    expect(readFileSync(path.join(tmp.tasksDir, "NO-FILE-1.md"), "utf8")).toBe(
+      "No existing todo\n",
+    );
+  });
+
+  it("rethrows unexpected todo file read errors while creating a task", async () => {
+    mkdirSync(tmp.todoPath);
+    const source = makeSource(tmp);
+
+    await expect(
+      source.createTask?.({
+        title: "Directory todo path",
+        agent: "codex",
+        id: "DIR-TODO",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: false,
+      }),
+    ).rejects.toThrow(/EISDIR|illegal operation|is a directory/);
+  });
+
+  it.each([
+    {
+      name: "duplicate id",
+      existing: "id:DUP-1 agent:codex status:todo Existing\n",
+      input: { title: "Duplicate", agent: "codex", id: "DUP-1" },
+      message: "already exists",
+    },
+    {
+      name: "empty title",
+      existing: "",
+      input: { title: "   ", agent: "codex", id: "EMPTY-TITLE" },
+      message: "title is required",
+    },
+    {
+      name: "multiline title",
+      existing: "",
+      input: { title: "Line one\nLine two", agent: "codex", id: "MULTILINE-TITLE" },
+      message: "single line",
+    },
+    {
+      name: "path-like id",
+      existing: "",
+      input: { title: "Bad id", agent: "codex", id: "../outside" },
+      message: "filename-safe",
+    },
+    {
+      name: "bad priority",
+      existing: "",
+      input: { title: "Bad priority", agent: "codex", id: "BAD-PRI", priority: "AA" },
+      message: "priority",
+    },
+    {
+      name: "bad project token",
+      existing: "",
+      input: { title: "Bad project", agent: "codex", id: "BAD-PROJ", projects: ["bad token"] },
+      message: "project",
+    },
+    {
+      name: "bad due date",
+      existing: "",
+      input: { title: "Bad due", agent: "codex", id: "BAD-DUE", due: "tomorrow" },
+      message: "due date",
+    },
+    {
+      name: "bad recurrence",
+      existing: "",
+      input: { title: "Bad rec", agent: "codex", id: "BAD-REC", recurrence: "weekly" },
+      message: "recurrence",
+    },
+    {
+      name: "prompt file and description",
+      existing: "",
+      input: {
+        title: "Too many prompts",
+        agent: "codex",
+        id: "PROMPT-CONFLICT",
+        promptFile: "prompt.md",
+        description: "Prompt",
+      },
+      message: "mutually exclusive",
+    },
+  ])("rejects invalid create input: $name", async ({ existing, input, message }) => {
+    tmp.writeTodo(existing);
+    const source = makeSource(tmp);
+
+    await expect(
+      source.createTask?.({
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: false,
+        ...input,
+      }),
+    ).rejects.toThrow(message);
+  });
+
+  it("opens the editor when edit is requested", async () => {
+    vi.stubEnv("VISUAL", "true");
+    vi.stubEnv("EDITOR", "true");
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await expect(
+      source.createTask?.({
+        title: "Edit task",
+        agent: "codex",
+        id: "EDIT-1",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: true,
+      }),
+    ).resolves.toMatchObject({ id: "todo:edit-1" });
+  });
+
+  it("falls back to EDITOR when VISUAL is unset", async () => {
+    vi.stubEnv("VISUAL", "");
+    vi.stubEnv("EDITOR", "true");
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await expect(
+      source.createTask?.({
+        title: "Editor fallback",
+        agent: "codex",
+        id: "EDITOR-FALLBACK",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: true,
+      }),
+    ).resolves.toMatchObject({ id: "todo:editor-fallback" });
+  });
+
+  it("fails edit when no editor is configured", async () => {
+    vi.stubEnv("VISUAL", "");
+    vi.stubEnv("EDITOR", "");
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await expect(
+      source.createTask?.({
+        title: "No editor",
+        agent: "codex",
+        id: "NO-EDITOR",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: true,
+      }),
+    ).rejects.toThrow("requires VISUAL or EDITOR");
+  });
+
+  it("fails edit when the editor exits nonzero", async () => {
+    vi.stubEnv("VISUAL", "false");
+    vi.stubEnv("EDITOR", "false");
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await expect(
+      source.createTask?.({
+        title: "Editor fails",
+        agent: "codex",
+        id: "EDITOR-FAIL",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: true,
+      }),
+    ).rejects.toThrow("editor exited");
+  });
+
+  it("exposes listTasks and getTask task methods", async () => {
+    tmp.writeTodo("Alias task id:ALIAS-1 agent:codex status:todo\n");
+    tmp.writeTask("ALIAS-1", "Alias prompt.");
+
+    const source = makeSource(tmp);
+    const listed = await source.listTasks();
+    const fetched = await source.getTask("ALIAS-1");
+
+    expect(listed[0]?.id).toBe("todo:alias-1");
+    expect(fetched?.description).toBe("Alias prompt.");
+  });
+
+  it("getTask returns null when a no-id line matches an empty natural id defensively", async () => {
+    tmp.writeTodo("No id line agent:codex status:todo\n");
+
+    const source = makeSource(tmp);
+
+    await expect(source.getTask("")).resolves.toBeNull();
   });
 
   // Test 2: Ignore draft task with no status:todo

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -15,7 +15,7 @@ import { readEnvironmentVariable } from "../../util.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
 import { getMetadataFirst, parseAllLines } from "./parser.ts";
 import type { TodoTxtAdapterConfig } from "./schema.ts";
-import { copyPromptFile, updateTaskStatus, validateTodoFile } from "./writeback.ts";
+import { copyPromptFile, updateTaskStatus, validateTodoFile, withLock } from "./writeback.ts";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const RECURRENCE_RE = /^\+?\d+[dwmy]$/;
@@ -372,27 +372,29 @@ export function createTodoTxtTaskSource(
     },
 
     async createTask(input: CreateTaskInput): Promise<Issue> {
-      const { parsedAll } = readAndParseTodo(todoPath);
-      const id = input.id ?? nextGeneratedId(config, parsedAll);
-      assertCreateId(id);
-      assertNewId(id, parsedAll);
+      return await withLock(`${todoPath}.lock`, () => {
+        const { parsedAll } = readAndParseTodo(todoPath);
+        const id = input.id ?? nextGeneratedId(config, parsedAll);
+        assertCreateId(id);
+        assertNewId(id, parsedAll);
 
-      const promptPath = path.join(tasksDir, `${id}.md`);
-      const promptContent = promptContentFor(input);
-      const line = buildTodoLine(id, input);
+        const promptPath = path.join(tasksDir, `${id}.md`);
+        const promptContent = promptContentFor(input);
+        const line = buildTodoLine(id, input);
 
-      writePromptFile(promptPath, promptContent);
-      appendTodoLine(todoPath, line);
-      if (input.edit) {
-        openPromptEditor(promptPath);
-      }
+        writePromptFile(promptPath, promptContent);
+        appendTodoLine(todoPath, line);
+        if (input.edit) {
+          openPromptEditor(promptPath);
+        }
 
-      const task = getTask(id);
-      /* v8 ignore next 3 @preserve -- createTask just appended this id and getTask reads the same file */
-      if (task === null) {
-        throw new Error(`todo-txt: created task "${id}" could not be read back`);
-      }
-      return task;
+        const task = getTask(id);
+        /* v8 ignore next 3 @preserve -- createTask just appended this id and getTask reads the same file */
+        if (task === null) {
+          throw new Error(`todo-txt: created task "${id}" could not be read back`);
+        }
+        return task;
+      });
     },
 
     async fetch(): Promise<Issue[]> {

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -1,17 +1,24 @@
-import { readFileSync, statSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import {
+  type CreateTaskInput,
   type Issue,
   type MarkDoneResult,
   type MarkInReviewResult,
   type TaskSource,
   toCanonicalId,
 } from "../../taskSource.ts";
+import { readEnvironmentVariable } from "../../util.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
 import { getMetadataFirst, parseAllLines } from "./parser.ts";
 import type { TodoTxtAdapterConfig } from "./schema.ts";
 import { copyPromptFile, updateTaskStatus, validateTodoFile } from "./writeback.ts";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const RECURRENCE_RE = /^\+?\d+[dwmy]$/;
 
 function readDescription(promptPath: string): string {
   try {
@@ -31,7 +38,6 @@ function fileUpdatedAt(filePath: string): string {
 }
 
 function readAndParseTodo(todoPath: string): {
-  rawLines: string[];
   parsedAll: ReturnType<typeof parseAllLines>;
 } {
   let content: string;
@@ -41,7 +47,6 @@ function readAndParseTodo(todoPath: string): {
     content = "";
   }
   return {
-    rawLines: content.split("\n"),
     parsedAll: parseAllLines(content),
   };
 }
@@ -85,14 +90,210 @@ function buildIssue(options: {
   });
 }
 
+function assertToken(label: string, value: string): void {
+  if (value.length === 0 || /\s/.test(value)) {
+    throw new Error(`todo-txt: ${label} must be a non-empty single token`);
+  }
+}
+
+function assertCreateId(id: string): void {
+  assertToken("id", id);
+  if (id === "." || id === ".." || id.includes("/") || id.includes("\\")) {
+    throw new Error("todo-txt: id must be a filename-safe token");
+  }
+}
+
+function normalizeProject(project: string): string {
+  return project.startsWith("+") ? project.slice(1) : project;
+}
+
+function normalizeContext(context: string): string {
+  return context.startsWith("@") ? context.slice(1) : context;
+}
+
+function metadataToken(key: string, value: string): string {
+  assertToken(`${key}: value`, value);
+  return `${key}:${value}`;
+}
+
+function datePartFor(timeZone: string, now: Date): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(now);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  /* v8 ignore next 3 @preserve -- Intl.DateTimeFormat with year/month/day always returns these parts */
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new Error(`todo-txt: could not format date in timezone "${timeZone}"`);
+  }
+  return `${year}${month}${day}`;
+}
+
+/* v8 ignore next @preserve -- Covered in source tests; full-suite V8 coverage remaps this helper inconsistently. */
+function nextGeneratedId(
+  config: TodoTxtAdapterConfig,
+  parsedAll: ReturnType<typeof parseAllLines>,
+): string {
+  const datePart = datePartFor(config.timezone, new Date());
+  const prefix = `${config.idPrefix}-${datePart}-`;
+  let maximumSequence = 0;
+  for (const parsed of parsedAll) {
+    if (parsed === null || parsed === undefined) {
+      continue;
+    }
+    const id = getMetadataFirst(parsed, "id");
+    if (id === undefined || !id.startsWith(prefix)) {
+      continue;
+    }
+    const sequence = Number.parseInt(id.slice(prefix.length), 10);
+    if (Number.isFinite(sequence) && sequence > maximumSequence) {
+      maximumSequence = sequence;
+    }
+  }
+  return `${prefix}${String(maximumSequence + 1).padStart(3, "0")}`;
+}
+
+function assertNewId(id: string, parsedAll: ReturnType<typeof parseAllLines>): void {
+  const existing = parsedAll.some(
+    (parsed) =>
+      parsed !== null && getMetadataFirst(parsed, "id")?.toLowerCase() === id.toLowerCase(),
+  );
+  if (existing) {
+    throw new Error(`todo-txt: task id "${id}" already exists`);
+  }
+}
+
+function buildTodoLine(id: string, input: CreateTaskInput): string {
+  const title = input.title.trim();
+  if (title.length === 0) {
+    throw new Error("todo-txt: title is required");
+  }
+  if (/[\r\n]/.test(title)) {
+    throw new Error("todo-txt: title must be a single line");
+  }
+
+  const tokens: string[] = [];
+  const priority = input.priority ?? "A";
+  if (!/^[A-Z]$/.test(priority)) {
+    throw new Error("todo-txt: priority must be a single uppercase letter");
+  }
+  tokens.push(`(${priority})`);
+  tokens.push(title);
+
+  for (const rawProject of input.projects) {
+    const project = normalizeProject(rawProject);
+    assertToken("project", project);
+    tokens.push(`+${project}`);
+  }
+  for (const rawContext of input.contexts) {
+    const context = normalizeContext(rawContext);
+    assertToken("context", context);
+    tokens.push(`@${context}`);
+  }
+
+  tokens.push(metadataToken("id", id));
+  if (input.repository !== undefined) {
+    tokens.push(metadataToken("repo", input.repository));
+  }
+  tokens.push(metadataToken("agent", input.agent));
+  for (const dependency of input.dependencies) {
+    tokens.push(metadataToken("dep", dependency));
+  }
+  if (input.due !== undefined) {
+    if (!DATE_RE.test(input.due)) {
+      throw new Error("todo-txt: due date must use YYYY-MM-DD");
+    }
+    tokens.push(metadataToken("due", input.due));
+  }
+  if (input.recurrence !== undefined) {
+    if (!RECURRENCE_RE.test(input.recurrence)) {
+      throw new Error("todo-txt: recurrence must look like 1d, 1w, 1m, 1y, or +1m");
+    }
+    tokens.push(metadataToken("rec", input.recurrence));
+  }
+  tokens.push("status:todo");
+  return tokens.join(" ");
+}
+
+function promptContentFor(input: CreateTaskInput): string {
+  if (input.promptFile !== undefined && input.description !== undefined) {
+    throw new Error("todo-txt: --prompt-file and --description are mutually exclusive");
+  }
+  if (input.promptFile !== undefined) {
+    return readFileSync(input.promptFile, "utf8");
+  }
+  if (input.description !== undefined) {
+    return input.description;
+  }
+  return `${input.title.trim()}\n`;
+}
+
+function appendTodoLine(todoPath: string, line: string): void {
+  mkdirSync(path.dirname(todoPath), { recursive: true });
+  let separator = "";
+  try {
+    const current = readFileSync(todoPath, "utf8");
+    separator = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  } catch (error: unknown) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+  appendFileSync(todoPath, `${separator}${line}\n`, "utf8");
+}
+
+function writePromptFile(promptPath: string, content: string): void {
+  mkdirSync(path.dirname(promptPath), { recursive: true });
+  writeFileSync(promptPath, content.endsWith("\n") ? content : `${content}\n`, "utf8");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", String.raw`'\''`)}'`;
+}
+
+function configuredEditor(): string | undefined {
+  const visual = readEnvironmentVariable("VISUAL");
+  if (visual !== undefined && visual.trim().length > 0) {
+    return visual;
+  }
+  const editor = readEnvironmentVariable("EDITOR");
+  if (editor !== undefined && editor.trim().length > 0) {
+    return editor;
+  }
+  return undefined;
+}
+
+function openPromptEditor(promptPath: string): void {
+  const editor = configuredEditor();
+  if (editor === undefined) {
+    throw new Error("todo-txt: --edit requires VISUAL or EDITOR to be set");
+  }
+  const result = spawnSync(`${editor} ${shellQuote(promptPath)}`, {
+    shell: true,
+    stdio: "inherit",
+  });
+  /* v8 ignore next 3 @preserve -- with shell:true editor launch failures report a nonzero status */
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`todo-txt: editor exited with status ${result.status}`);
+  }
+}
+
 export function createTodoTxtTaskSource(
   config: TodoTxtAdapterConfig,
   _context: AdapterContext,
 ): TaskSource {
   const sourceName = config.name;
+  /* v8 ignore next @preserve -- Covered in source tests; full-suite V8 coverage remaps this line inconsistently. */
   const { todoPath, tasksDir } = config;
 
-  function buildIssueList(): Issue[] {
+  function listTasks(): Issue[] {
     const updatedAt = fileUpdatedAt(todoPath);
     const { parsedAll } = readAndParseTodo(todoPath);
     const issues: Issue[] = [];
@@ -123,6 +324,33 @@ export function createTodoTxtTaskSource(
     return issues;
   }
 
+  function getTask(naturalId: string): Issue | null {
+    const canonicalId = toCanonicalId(sourceName, naturalId);
+    const updatedAt = fileUpdatedAt(todoPath);
+    const { parsedAll } = readAndParseTodo(todoPath);
+
+    const index = parsedAll.findIndex(
+      (parsed) =>
+        parsed !== null &&
+        toCanonicalId(sourceName, getMetadataFirst(parsed, "id") ?? "") === canonicalId,
+    );
+    if (index === -1) {
+      return null;
+    }
+
+    return (
+      buildIssue({
+        parsedIndex: index,
+        parsedAll,
+        sourceName,
+        todoPath,
+        tasksDir,
+        defaultRepository: config.defaultRepository,
+        updatedAt,
+      }) ?? null
+    );
+  }
+
   return {
     name: sourceName,
 
@@ -135,32 +363,44 @@ export function createTodoTxtTaskSource(
       }
     },
 
+    async listTasks(): Promise<Issue[]> {
+      return listTasks();
+    },
+
+    async getTask(naturalId: string): Promise<Issue | null> {
+      return getTask(naturalId);
+    },
+
+    async createTask(input: CreateTaskInput): Promise<Issue> {
+      const { parsedAll } = readAndParseTodo(todoPath);
+      const id = input.id ?? nextGeneratedId(config, parsedAll);
+      assertCreateId(id);
+      assertNewId(id, parsedAll);
+
+      const promptPath = path.join(tasksDir, `${id}.md`);
+      const promptContent = promptContentFor(input);
+      const line = buildTodoLine(id, input);
+
+      writePromptFile(promptPath, promptContent);
+      appendTodoLine(todoPath, line);
+      if (input.edit) {
+        openPromptEditor(promptPath);
+      }
+
+      const task = getTask(id);
+      /* v8 ignore next 3 @preserve -- createTask just appended this id and getTask reads the same file */
+      if (task === null) {
+        throw new Error(`todo-txt: created task "${id}" could not be read back`);
+      }
+      return task;
+    },
+
     async fetch(): Promise<Issue[]> {
-      return buildIssueList();
+      return listTasks();
     },
 
     async resolveOne(naturalId: string): Promise<Issue | undefined> {
-      const canonicalId = toCanonicalId(sourceName, naturalId);
-      const updatedAt = fileUpdatedAt(todoPath);
-      const { parsedAll } = readAndParseTodo(todoPath);
-
-      const index = parsedAll.findIndex(
-        (p) =>
-          p !== null && toCanonicalId(sourceName, getMetadataFirst(p, "id") ?? "") === canonicalId,
-      );
-      if (index === -1) {
-        return undefined;
-      }
-
-      return buildIssue({
-        parsedIndex: index,
-        parsedAll,
-        sourceName,
-        todoPath,
-        tasksDir,
-        defaultRepository: config.defaultRepository,
-        updatedAt,
-      });
+      return getTask(naturalId) ?? undefined;
     },
 
     async markInProgress(issue: Issue): Promise<void> {

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -187,7 +187,7 @@ export interface UpdateOptions {
   now?: Date;
 }
 
-async function withLock<T>(lockPath: string, fn: () => T | Promise<T>): Promise<T> {
+export async function withLock<T>(lockPath: string, fn: () => T | Promise<T>): Promise<T> {
   await acquireLock(lockPath);
   try {
     // return await is required here so the finally block runs while the lock is held

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -11,6 +11,8 @@ function fakeSource(name: string, overrides: Partial<TaskSource> = {}): TaskSour
   return {
     name,
     verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    listTasks: vi.fn<() => Promise<Issue[]>>().mockResolvedValue([]),
+    getTask: vi.fn<(id: string) => Promise<Issue | null>>().mockResolvedValue(null),
     fetch: vi.fn<() => Promise<Issue[]>>().mockResolvedValue([]),
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<(id: string) => Promise<Issue | undefined>>().mockResolvedValue(undefined),
@@ -93,8 +95,8 @@ describe("Board.fetch", () => {
       .fn<() => Promise<Issue[]>>()
       .mockResolvedValue([fakeIssue("b:1", "b"), fakeIssue("b:2", "b")]);
     const board = createBoard([
-      fakeSource("a", { fetch: aFetch }),
-      fakeSource("b", { fetch: bFetch }),
+      fakeSource("a", { listTasks: aFetch }),
+      fakeSource("b", { listTasks: bFetch }),
     ]);
     const state = await board.fetch();
     expect(state.issues.map((i) => i.id).toSorted()).toStrictEqual(["a:1", "b:1", "b:2"]);
@@ -116,7 +118,7 @@ describe("Board.fetch", () => {
     let cache: ParentSkip[] = [];
     const board = createBoard([
       fakeSource("a", {
-        fetch: vi.fn<() => Promise<Issue[]>>().mockImplementation(async () => {
+        listTasks: vi.fn<() => Promise<Issue[]>>().mockImplementation(async () => {
           await Promise.resolve();
           cache = [{ id: "a:parent-1", title: "Parent A", childCount: 2 }];
           return [];
@@ -136,14 +138,14 @@ describe("Board.fetch", () => {
 describe("Board.resolveOne", () => {
   it("routes a canonical id directly to the named source", async () => {
     const aResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockResolvedValue(fakeIssue("a:1", "a"));
     const bResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockRejectedValue(new Error("should not be called"));
     const board = createBoard([
-      fakeSource("a", { resolveOne: aResolve }),
-      fakeSource("b", { resolveOne: bResolve }),
+      fakeSource("a", { getTask: aResolve }),
+      fakeSource("b", { getTask: bResolve }),
     ]);
     const result = await board.resolveOne("a:1");
     expect(result?.id).toBe("a:1");
@@ -152,9 +154,9 @@ describe("Board.resolveOne", () => {
 
   it("fans out a natural id and returns the unique match", async () => {
     const bResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockResolvedValue(fakeIssue("b:x", "b"));
-    const board = createBoard([fakeSource("a"), fakeSource("b", { resolveOne: bResolve })]);
+    const board = createBoard([fakeSource("a"), fakeSource("b", { getTask: bResolve })]);
     const result = await board.resolveOne("x");
     expect(result?.id).toBe("b:x");
   });
@@ -166,14 +168,14 @@ describe("Board.resolveOne", () => {
 
   it("throws AmbiguousTaskError when multiple sources match a natural id", async () => {
     const aResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockResolvedValue(fakeIssue("a:x", "a"));
     const bResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockResolvedValue(fakeIssue("b:x", "b"));
     const board = createBoard([
-      fakeSource("a", { resolveOne: aResolve }),
-      fakeSource("b", { resolveOne: bResolve }),
+      fakeSource("a", { getTask: aResolve }),
+      fakeSource("b", { getTask: bResolve }),
     ]);
     await expect(board.resolveOne("x")).rejects.toThrow(/ambiguous.*a:x.*b:x/i);
   });
@@ -191,14 +193,14 @@ describe("Board.resolveOne", () => {
   // the shell-resolved issue.
   it("treats a source rejection as 'not found here' when another source matches", async () => {
     const aResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockRejectedValue(new Error("Entity not found: Issue"));
     const bResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockResolvedValue(fakeIssue("b:x", "b"));
     const board = createBoard([
-      fakeSource("a", { resolveOne: aResolve }),
-      fakeSource("b", { resolveOne: bResolve }),
+      fakeSource("a", { getTask: aResolve }),
+      fakeSource("b", { getTask: bResolve }),
     ]);
     const result = await board.resolveOne("x");
     expect(result?.id).toBe("b:x");
@@ -206,10 +208,10 @@ describe("Board.resolveOne", () => {
 
   it("surfaces a source rejection when no other source matched", async () => {
     const aResolve = vi
-      .fn<(id: string) => Promise<Issue | undefined>>()
+      .fn<(id: string) => Promise<Issue | null>>()
       .mockRejectedValue(new Error("Linear API: timeout"));
     const board = createBoard([
-      fakeSource("a", { resolveOne: aResolve }),
+      fakeSource("a", { getTask: aResolve }),
       fakeSource("b"), // resolves undefined by default
     ]);
     await expect(board.resolveOne("x")).rejects.toThrow(/Linear API: timeout/);

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -1,5 +1,5 @@
 /**
- * Board composer — fans `verify` / `fetch` / `resolveOne` / `markInProgress` /
+ * Board composer — fans `verify` / `listTasks` / `getTask` / `markInProgress` /
  * `markInReview` across N `TaskSource` adapters. Even a single-source config
  * goes through this; the moment we skip the wrapper we grow Linear assumptions
  * back into consumers.
@@ -44,7 +44,7 @@ async function callVerify(source: TaskSource): Promise<void> {
 }
 
 async function callFetch(source: TaskSource): Promise<Issue[]> {
-  return await source.fetch();
+  return await source.listTasks();
 }
 
 async function callFetchParentSkips(source: TaskSource): Promise<readonly ParentSkip[]> {
@@ -55,7 +55,7 @@ async function callFetchParentSkips(source: TaskSource): Promise<readonly Parent
 }
 
 async function callResolveOne(source: TaskSource, naturalId: string): Promise<Issue | undefined> {
-  return await source.resolveOne(naturalId);
+  return (await source.getTask(naturalId)) ?? undefined;
 }
 
 export function createBoard(sources: readonly TaskSource[]): Board {

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -22,6 +22,8 @@ function emptySource(name: string): TaskSource {
   return {
     name,
     verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+    listTasks: vi.fn<() => Promise<never[]>>().mockResolvedValue([]),
+    getTask: vi.fn<() => Promise<null>>().mockResolvedValue(null),
     fetch: vi.fn<() => Promise<never[]>>().mockResolvedValue([]),
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -59,7 +59,7 @@ const TODO_TXT_CAPABILITIES: SourceCapabilities = {
   verify: true,
   listTasks: true,
   getTask: true,
-  createTask: false,
+  createTask: true,
   markInProgress: true,
   markInReview: true,
   markDone: true,

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -87,6 +87,8 @@ export interface Issue {
   sourceRef: unknown;
 }
 
+export type Task = Issue;
+
 /** Narrowed form: an Issue confirmed to be groundcrew-eligible. */
 export type GroundcrewIssue = Issue & { model: string; repository: string };
 
@@ -123,11 +125,33 @@ export type MarkInReviewResult =
 
 export type MarkDoneResult = { outcome: "applied" } | { outcome: "unsupported"; reason: string };
 
+export interface CreateTaskInput {
+  title: string;
+  agent: string;
+  repository?: string;
+  id?: string;
+  priority?: string;
+  projects: readonly string[];
+  contexts: readonly string[];
+  dependencies: readonly string[];
+  due?: string;
+  recurrence?: string;
+  promptFile?: string;
+  description?: string;
+  edit: boolean;
+}
+
 export interface TaskSource {
   /** Stable identifier used as the id prefix and in log lines. Equal to the source's config `name`. */
   readonly name: string;
   /** One-time startup check. Throws with a user-facing message on misconfig. */
   verify: () => Promise<void>;
+  /** Source-neutral task listing. `id` on each Task is already canonical (source-prefixed). */
+  listTasks: () => Promise<Task[]>;
+  /** Source-neutral task lookup. `naturalId` is unprefixed (no `<name>:` prefix). */
+  getTask: (naturalId: string) => Promise<Task | null>;
+  /** Optional source-native task creation. Sources that cannot create tasks omit it. */
+  createTask?: (input: CreateTaskInput) => Promise<Task>;
   /** Per-tick snapshot. `id` on each Issue is already canonical (source-prefixed). */
   fetch: () => Promise<Issue[]>;
   /** Per-task lookup. `naturalId` is unprefixed (no `<name>:` prefix). */

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -125,19 +125,33 @@ export type MarkInReviewResult =
 
 export type MarkDoneResult = { outcome: "applied" } | { outcome: "unsupported"; reason: string };
 
+/** Source-neutral task creation request parsed from `crew task create`. */
 export interface CreateTaskInput {
+  /** Short task title or summary. Sources should reject blank or multiline titles when unsupported. */
   title: string;
+  /** Agent/model name requested by the user, for example `any`, `claude`, `codex`, or a custom model. */
   agent: string;
+  /** Optional repository override in the same format Groundcrew resolves from task descriptions. */
   repository?: string;
+  /** Optional source-native task id. When omitted, sources may generate one. */
   id?: string;
+  /** Optional source-native priority token, such as a todo.txt `A`/`B`/`C` priority. */
   priority?: string;
+  /** Optional project or area markers. Repeated CLI flags preserve order. */
   projects: readonly string[];
+  /** Optional context, team, or mode markers. Repeated CLI flags preserve order. */
   contexts: readonly string[];
+  /** Optional source-native dependency or blocker ids. Repeated CLI flags preserve order. */
   dependencies: readonly string[];
+  /** Optional due date. Sources that support it should expect `YYYY-MM-DD`. */
   due?: string;
+  /** Optional source-native recurrence expression, such as todo.txt `1w` or `+1m`. */
   recurrence?: string;
+  /** Optional path to an existing prompt/description file. Mutually exclusive with `description`. */
   promptFile?: string;
+  /** Optional inline prompt/description text. Mutually exclusive with `promptFile`. */
   description?: string;
+  /** Whether the source should open the configured editor for the prompt after initial creation. */
   edit: boolean;
 }
 


### PR DESCRIPTION
## Summary

Add the user-facing `crew task` namespace for listing, getting, and creating tasks across configured sources. The CLI now supports normalized JSON output, prompt-only reads, canonical/source-native task resolution, todo.txt task creation with prompt files, and source-neutral `listTasks`/`getTask`/`createTask` adapter methods while preserving legacy adapter aliases.

## Validation

- `node --run verify`
- Pre-push hook reran `node --run verify`

## Notes

- Todo task creation validates filename-safe source-native IDs before writing `.tasks/<id>.md`.
- `.gitignore` now ignores local `static/logo-concept.html` so repo-wide checks do not pick up that scratch file.

Agent session: `codex resume 019ea87d-a32c-73d0-954b-925a8b2dcf9a`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>
