### PR TITLE
feat: require explicit sources config, exit with guidance when none configured

### DIFF
--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -2,16 +2,17 @@ import type { Config } from "@clipboard-health/groundcrew";
 // import { readFileSync } from "node:fs";
 
 export default {
-  // Groundcrew's built-in Linear adapter is implicit and needs no config:
-  // it picks up every Linear issue assigned to your API key's viewer that
-  // carries an `agent-*` label. There is no project / view block. The default
-  // Linear status names `In Progress` and `In Review` disambiguate Linear's
-  // `started` workflow states; other statuses fall back to workflow
-  // `state.type` (`unstarted` → todo, `started` → in progress,
-  // `completed`/`canceled`/`duplicate` → terminal).
+  // Task sources — at least one is required; add a `sources` array to get
+  // started. Two built-in options:
   //
-  // Opt a task in: assign it to yourself and add an `agent-<model>`
-  // label (e.g. `agent-claude`, `agent-any`).
+  //   Zero credentials: use a local todo.txt file. No API key needed.
+  //   sources: [{ kind: "todo-txt" }]
+  //
+  //   Linear: picks up issues assigned to your API key's viewer that carry
+  //   an `agent-*` label. Requires GROUNDCREW_LINEAR_API_KEY.
+  //   sources: [{ kind: "linear" }]
+  //
+  // Running `crew run` without a sources array will print this guidance and exit.
   workspace: {
     // Parent directory under which groundcrew clones repositories and (by
     // default) creates per-task worktrees.

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -227,7 +227,7 @@ describe("crew init", () => {
       expect(output).toContain('PROJECT_DIR="$HOME/dev"');
       expect(output).toContain('mkdir -p "$PROJECT_DIR/OWNER"');
       expect(output).toContain('git clone git@github.com:OWNER/REPO.git "$PROJECT_DIR/OWNER/REPO"');
-      expect(output).toContain('export GROUNDCREW_LINEAR_API_KEY="lin_api_..."');
+      expect(output).toContain('sources: [{ kind: "linear" }]');
       expect(output).toContain("crew doctor");
       expect(output).toContain("crew run --watch");
     });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -296,9 +296,11 @@ function writeInitGuidance(destination: string, options: InitConfigOptions): voi
     writeOutput("  - Set workspace.projectDir and workspace.knownRepositories");
   }
   writeCloneGuidance(options);
-  writeOutput("  - If using Linear, export your API key:");
-  writeOutput('      export GROUNDCREW_LINEAR_API_KEY="lin_api_..."');
-  writeOutput("  - In Linear, assign tasks to yourself and add an agent-* label to opt them in");
+  writeOutput("  - Add a task source to your config (required):");
+  writeOutput("      # Zero credentials — uses a local todo.txt file:");
+  writeOutput('      sources: [{ kind: "todo-txt" }]');
+  writeOutput("      # Or use Linear (requires GROUNDCREW_LINEAR_API_KEY):");
+  writeOutput('      sources: [{ kind: "linear" }]');
   writeOutput("  - Validate and start:");
   writeOutput("      crew doctor");
   writeOutput("      crew run --watch");

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import type { LinearClient } from "@linear/sdk";
 
 import type * as configModule from "../lib/config.ts";
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { loadConfigWithSource, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { getUsageByModel } from "../lib/usage.ts";
 import type * as utilModule from "../lib/util.ts";
@@ -20,7 +20,7 @@ import { setupWorkspace } from "./setupWorkspace.ts";
 
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof configModule>();
-  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+  return { ...actual, loadConfigWithSource: vi.fn<typeof loadConfigWithSource>() };
 });
 vi.mock(import("../lib/adapters/linear/client.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -79,7 +79,7 @@ type RawRequestMock = ReturnType<
   typeof vi.fn<(query: string, variables?: Record<string, unknown>) => Promise<unknown>>
 >;
 
-const loadConfigMock = vi.mocked(loadConfig);
+const loadConfigMock = vi.mocked(loadConfigWithSource);
 const linearClientMock = vi.mocked(getLinearClient);
 const sleepMock = vi.mocked(sleep);
 const listMock = vi.mocked(worktrees.list);
@@ -92,7 +92,7 @@ const findPullRequestsMock = vi.mocked(findPullRequestsForBranch);
 
 function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
   return {
-    sources: overrides.sources ?? [],
+    sources: overrides.sources ?? [{ kind: "linear" }],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main", ...overrides.git },
     workspace: {
@@ -119,6 +119,13 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     local: { runner: "auto", ...overrides.local },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
+}
+
+function makeLoadedConfig(config: ResolvedConfig = makeConfig()): {
+  config: ResolvedConfig;
+  source: { kind: "xdg"; filepath: string };
+} {
+  return { config, source: { kind: "xdg", filepath: "/tmp/crew.config.ts" } };
 }
 
 interface IssueNodeStub {
@@ -332,7 +339,7 @@ describe(orchestrate, () => {
 
   beforeEach(() => {
     consoleLog = captureConsoleLog();
-    loadConfigMock.mockResolvedValue(makeConfig());
+    loadConfigMock.mockResolvedValue(makeLoadedConfig());
     listMock.mockReturnValue([]);
     teardownMock.mockResolvedValue(emptyTeardownResult());
     sleepMock.mockResolvedValue();
@@ -575,15 +582,17 @@ describe(orchestrate, () => {
     // default to codex. With no usage data both score 0; the tiebreak
     // should hand the slot to codex (the default), not claude.
     loadConfigMock.mockResolvedValue(
-      makeConfig({
-        models: {
-          default: "codex",
-          definitions: {
-            claude: { cmd: "claude", color: "#fff" },
-            codex: { cmd: "codex", color: "#000" },
+      makeLoadedConfig(
+        makeConfig({
+          models: {
+            default: "codex",
+            definitions: {
+              claude: { cmd: "claude", color: "#fff" },
+              codex: { cmd: "codex", color: "#000" },
+            },
           },
-        },
-      }),
+        }),
+      ),
     );
     const client = makeClient({
       pages: [
@@ -744,13 +753,15 @@ describe(orchestrate, () => {
 
   it("respects maximumInProgress and reports capacity", async () => {
     loadConfigMock.mockResolvedValue(
-      makeConfig({
-        orchestrator: {
-          maximumInProgress: 1,
-          pollIntervalMilliseconds: 1,
-          sessionLimitPercentage: 85,
-        },
-      }),
+      makeLoadedConfig(
+        makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1,
+            sessionLimitPercentage: 85,
+          },
+        }),
+      ),
     );
     const client = makeClient({
       pages: [
@@ -983,13 +994,15 @@ describe(orchestrate, () => {
 
   it("does not let blocked Todo tasks consume available slots", async () => {
     loadConfigMock.mockResolvedValue(
-      makeConfig({
-        orchestrator: {
-          maximumInProgress: 1,
-          pollIntervalMilliseconds: 1,
-          sessionLimitPercentage: 85,
-        },
-      }),
+      makeLoadedConfig(
+        makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1,
+            sessionLimitPercentage: 85,
+          },
+        }),
+      ),
     );
     const client = makeClient({
       pages: [
@@ -1273,15 +1286,17 @@ JSON
       chmodSync(fetchScript, 0o755);
       chmodSync(reviewScript, 0o755);
       loadConfigMock.mockResolvedValue(
-        makeConfig({
-          sources: [
-            {
-              kind: "shell",
-              name: "test-source",
-              commands: { fetch: fetchScript, markInReview: reviewScript },
-            },
-          ],
-        }),
+        makeLoadedConfig(
+          makeConfig({
+            sources: [
+              {
+                kind: "shell",
+                name: "test-source",
+                commands: { fetch: fetchScript, markInReview: reviewScript },
+              },
+            ],
+          }),
+        ),
       );
       listMock.mockReturnValue([hostEntryFor("repo-a", "x-1")]);
       workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["x-1"]) });
@@ -1608,13 +1623,15 @@ JSON
 
   it("stops scanning Todo issues once eligible count reaches the slot cap", async () => {
     loadConfigMock.mockResolvedValue(
-      makeConfig({
-        orchestrator: {
-          maximumInProgress: 1,
-          pollIntervalMilliseconds: 1,
-          sessionLimitPercentage: 85,
-        },
-      }),
+      makeLoadedConfig(
+        makeConfig({
+          orchestrator: {
+            maximumInProgress: 1,
+            pollIntervalMilliseconds: 1,
+            sessionLimitPercentage: 85,
+          },
+        }),
+      ),
     );
     const client = makeClient({
       pages: [
@@ -1839,15 +1856,17 @@ JSON
       chmodSync(verifyScript, 0o755);
 
       loadConfigMock.mockResolvedValue(
-        makeConfig({
-          sources: [
-            {
-              kind: "shell",
-              name: "test-source",
-              commands: { verify: verifyScript, fetch: "echo '[]'" },
-            },
-          ],
-        }),
+        makeLoadedConfig(
+          makeConfig({
+            sources: [
+              {
+                kind: "shell",
+                name: "test-source",
+                commands: { verify: verifyScript, fetch: "echo '[]'" },
+              },
+            ],
+          }),
+        ),
       );
       const client = makeClient({ pages: [[]] });
       mockLinearClient(client);

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -359,6 +359,18 @@ describe(orchestrate, () => {
     vi.clearAllMocks();
   });
 
+  it("exits with code 1 and prints guidance when no sources are configured", async () => {
+    loadConfigMock.mockResolvedValue(makeLoadedConfig(makeConfig({ sources: [] })));
+
+    await orchestrate({ watch: false, dryRun: false });
+
+    expect(process.exitCode).toBe(1);
+    expect(consoleLog.output()).toContain("No task sources configured");
+    expect(consoleLog.output()).toContain("/tmp/crew.config.ts");
+    expect(consoleLog.output()).toContain('sources: [{ kind: "todo-txt" }]');
+    expect(consoleLog.output()).toContain('sources: [{ kind: "linear" }]');
+  });
+
   it("rejects when the Linear API key resolves to no viewer", async () => {
     const client = makeClient({ viewerFound: false });
     mockLinearClient(client);

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -7,11 +7,11 @@
 
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { loadConfigWithSource, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { type BoardState, RepositoryResolutionError } from "../lib/taskSource.ts";
 import { getUsageByModel, type UsageByModel } from "../lib/usage.ts";
-import { errorMessage, log, sleep } from "../lib/util.ts";
+import { errorMessage, log, sleep, writeOutput } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
 import { type Cleaner, createCleaner } from "./cleaner.ts";
 import { createDispatcher, type Dispatcher } from "./dispatcher.ts";
@@ -83,12 +83,28 @@ async function fetchUsageOrEmpty(
 }
 
 export async function orchestrate(options: OrchestratorOptions): Promise<void> {
-  const config = await loadConfig();
+  const { config, source: configSource } = await loadConfigWithSource();
 
-  // Build all sources (Linear implicit + any user-declared shell adapters).
-  // sourcesFromConfig synthesizes the implicit linear source from the config;
-  // this ensures the Linear adapter's markInProgress is reachable via board.
-  const allSources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  const rawSources = sourcesFromConfig(config);
+  if (rawSources.length === 0) {
+    writeOutput(
+      [
+        "No task sources configured. Add a sources array to your config:",
+        "",
+        `  Path: ${configSource.filepath}`,
+        "",
+        "  # Zero credentials — uses a local todo.txt file:",
+        "  sources: [{ kind: \"todo-txt\" }]",
+        "",
+        "  # Or use Linear (requires GROUNDCREW_LINEAR_API_KEY):",
+        "  sources: [{ kind: \"linear\" }]",
+      ].join("\n"),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const allSources = await buildSources(rawSources, { globalConfig: config });
   const board: Board = createBoard(allSources);
   await board.verify();
 

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -94,10 +94,10 @@ export async function orchestrate(options: OrchestratorOptions): Promise<void> {
         `  Path: ${configSource.filepath}`,
         "",
         "  # Zero credentials — uses a local todo.txt file:",
-        "  sources: [{ kind: \"todo-txt\" }]",
+        '  sources: [{ kind: "todo-txt" }]',
         "",
         "  # Or use Linear (requires GROUNDCREW_LINEAR_API_KEY):",
-        "  sources: [{ kind: \"linear\" }]",
+        '  sources: [{ kind: "linear" }]',
       ].join("\n"),
     );
     process.exitCode = 1;

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -145,7 +145,7 @@ function host(overrides: Partial<HostCapabilities> = {}): HostCapabilities {
 
 function makeConfig(): ResolvedConfig {
   return {
-    sources: [],
+    sources: [{ kind: "linear" }],
     defaults: { hooks: {} },
     git: { remote: "origin", defaultBranch: "main" },
     workspace: { projectDir: "/work", knownRepositories: ["repo-a"] },

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -538,10 +538,8 @@ type BoardFetchResult =
 
 /**
  * Single board fetch used by both the slot count header and the
- * Queue/Blocked sections. `sourcesFromConfig` prepends an implicit Linear
- * source when none are configured, so we always attempt; failures
- * (e.g., missing API key) are captured and rendered later as
- * `unavailable: ...` in the Queue section.
+ * Queue/Blocked sections. Failures (e.g., missing API key) are captured
+ * and rendered later as `unavailable: ...` in the Queue section.
  */
 async function fetchBoardForStatus(config: ResolvedConfig): Promise<BoardFetchResult> {
   try {

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -115,12 +115,11 @@ describe(buildSources, () => {
 // ─────────────────────────────────────────────────────────────────────────
 
 function makeMixedConfig(): ResolvedConfig {
-  // Minimal ResolvedConfig with an explicit shell source. The Linear adapter
-  // is synthesized implicitly by sourcesFromConfig under the post-#110 model
-  // (Linear is always-on, filtered server-side by viewer + agent-* label).
+  // Minimal ResolvedConfig with explicit Linear and shell sources.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test fixture; the linear adapter only reads workspace.knownRepositories
   return {
     sources: [
+      { kind: "linear" },
       {
         kind: "shell",
         name: "shell-test",

--- a/src/lib/buildSources.test.ts
+++ b/src/lib/buildSources.test.ts
@@ -203,7 +203,7 @@ describe(`${buildSources.name} — cross-source independence with no Linear API 
 });
 
 describe(sourcesFromConfig, () => {
-  it("prepends an implicit linear source by default", () => {
+  it("returns only the explicit sources when no Linear entry is present", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "shell", command: ["./fetch.sh"] }],
@@ -211,19 +211,19 @@ describe(sourcesFromConfig, () => {
 
     const result = sourcesFromConfig(config);
 
-    expect(result).toStrictEqual([{ kind: "linear" }, { kind: "shell", command: ["./fetch.sh"] }]);
+    expect(result).toStrictEqual([{ kind: "shell", command: ["./fetch.sh"] }]);
   });
 
-  it("returns just the implicit linear source when config.sources is empty", () => {
+  it("returns empty when config.sources is empty", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = { sources: [] } as unknown as ResolvedConfig;
 
     const result = sourcesFromConfig(config);
 
-    expect(result).toStrictEqual([{ kind: "linear" }]);
+    expect(result).toStrictEqual([]);
   });
 
-  it("omits the implicit linear source when the user already declared one with kind 'linear'", () => {
+  it("returns the explicit linear source as-is", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "linear", name: "linear" }],
@@ -232,10 +232,7 @@ describe(sourcesFromConfig, () => {
     expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", name: "linear" }]);
   });
 
-  it("omits the implicit linear source when a Linear source is declared with a custom name", () => {
-    // A Linear source with a custom `name` is still Linear; prepending the
-    // implicit `{ kind: "linear" }` would spawn a duplicate adapter pointed at
-    // the same viewer (distinct names, so createBoard wouldn't catch it).
+  it("returns a linear source declared with a custom name as-is", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "linear", name: "custom-linear" }],
@@ -244,9 +241,7 @@ describe(sourcesFromConfig, () => {
     expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear", name: "custom-linear" }]);
   });
 
-  it("omits the implicit linear source when the user declared one with name 'linear'", () => {
-    // A user-declared shell source with name "linear" would otherwise collide
-    // with the implicit Linear source; omit the implicit one.
+  it("returns a shell source named 'linear' as-is", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "shell", name: "linear", command: ["./fetch.sh"] }],
@@ -257,14 +252,13 @@ describe(sourcesFromConfig, () => {
     ]);
   });
 
-  it("keeps the implicit linear source when explicit sources use distinct names", () => {
+  it("returns only the shell source when no Linear entry is present", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "shell", name: "jira", command: ["./fetch.sh"] }],
     } as unknown as ResolvedConfig;
 
     expect(sourcesFromConfig(config)).toStrictEqual([
-      { kind: "linear" },
       { kind: "shell", name: "jira", command: ["./fetch.sh"] },
     ]);
   });
@@ -296,8 +290,6 @@ describe(sourcesFromConfig, () => {
   });
 
   it("drops a disabled linear entry even when it is the only source, leaving no sources", () => {
-    // No implicit linear is synthesized (the disabled entry is explicit
-    // linear), and the entry itself is filtered out — zero sources remain.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "linear", enabled: false }],
@@ -306,10 +298,7 @@ describe(sourcesFromConfig, () => {
     expect(sourcesFromConfig(config)).toStrictEqual([]);
   });
 
-  it("drops any disabled non-linear source while still synthesizing implicit linear", () => {
-    // The `enabled: false` opt-out is generic: a disabled shell source is
-    // filtered out, and because no Linear entry is present the implicit Linear
-    // source is still synthesized.
+  it("drops a disabled non-linear source and returns only the remaining enabled ones", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [
@@ -319,31 +308,26 @@ describe(sourcesFromConfig, () => {
     } as unknown as ResolvedConfig;
 
     expect(sourcesFromConfig(config)).toStrictEqual([
-      { kind: "linear" },
       { kind: "shell", name: "jira", command: ["./fetch.sh"] },
     ]);
   });
 
-  it("keeps implicit Linear when a disabled non-linear source is merely named 'linear'", () => {
-    // A source that is Linear only by *name* (e.g. a shell source named
-    // "linear") takes over the Linear slot only while it's enabled. Disabling
-    // it must not suppress the implicit Linear source and leave the queue empty
-    // — only a real `{ kind: "linear" }` sentinel does that.
+  it("returns empty when a shell source named 'linear' is disabled and no other sources exist", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sourcesFromConfig only reads sources; unused fields are irrelevant
     const config = {
       sources: [{ kind: "shell", name: "linear", enabled: false, command: ["./fetch.sh"] }],
     } as unknown as ResolvedConfig;
 
-    expect(sourcesFromConfig(config)).toStrictEqual([{ kind: "linear" }]);
+    expect(sourcesFromConfig(config)).toStrictEqual([]);
   });
 });
 
 describe(isLinearEnabled, () => {
-  it("is true for the implicit Linear source when no sources are declared", () => {
+  it("is false when no sources are declared", () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- isLinearEnabled only reads sources; unused fields are irrelevant
     const config = { sources: [] } as unknown as ResolvedConfig;
 
-    expect(isLinearEnabled(config)).toBe(true);
+    expect(isLinearEnabled(config)).toBe(false);
   });
 
   it("is false when Linear is opted out via { kind: 'linear', enabled: false }", () => {

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -84,8 +84,7 @@ function isSourceDisabled(raw: unknown): boolean {
 
 /**
  * True when `raw` declares `kind: "linear"`, regardless of `name` or `enabled`.
- * This is what lets the `{ kind: "linear", enabled: false }` opt-out suppress
- * the implicit Linear source even though the entry itself is filtered out.
+ * Used by `isLinearEnabled` to detect explicitly configured Linear sources.
  */
 function isLinearKindSource(raw: unknown): boolean {
   return sourceFields(raw).kind === "linear";
@@ -102,11 +101,9 @@ export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
 }
 
 /**
- * True when the resolved config keeps Linear active — i.e. the user has not
- * opted out with `{ kind: "linear", enabled: false }`. Callers use this to skip
- * Linear API calls (and the missing-API-key error they raise) when Linear is
- * off. Derived from `sourcesFromConfig` so it honors both the explicit opt-out
- * sentinel and the implicit-source synthesis.
+ * True when an enabled source explicitly declares `kind: "linear"`. Callers
+ * use this to skip Linear API calls (and the missing-API-key error they raise)
+ * when Linear is not configured.
  */
 export function isLinearEnabled(config: ResolvedConfig): boolean {
   return sourcesFromConfig(config).some(isLinearKindSource);

--- a/src/lib/buildSources.ts
+++ b/src/lib/buildSources.ts
@@ -92,51 +92,13 @@ function isLinearKindSource(raw: unknown): boolean {
 }
 
 /**
- * True when `raw` is an explicitly-declared Linear source. Matches either a
- * `kind: "linear"` entry — regardless of any `name` override — or any entry
- * whose resolved runtime name (explicit `name`, else `kind`) is "linear".
- * The latter catches a non-Linear adapter the user named "linear", which
- * would otherwise collide with the implicit Linear source.
- *
- * Used to suppress the synthesized implicit Linear source so a renamed Linear
- * entry like `{ kind: "linear", name: "custom" }` doesn't spawn a duplicate
- * adapter pointed at the same viewer. Returns false for malformed entries
- * (no `kind`/`name`) — those get rejected by the per-adapter Zod schema
- * downstream.
- */
-function isExplicitLinearSource(raw: unknown): boolean {
-  const { kind, name } = sourceFields(raw);
-  return kind === "linear" || (name ?? kind) === "linear";
-}
-
-/**
- * Build the runtime source list from a ResolvedConfig: synthesizes the
- * implicit Linear source (Linear is always active under the post-#110
- * model — viewer + agent-* label filtering happens at the GraphQL layer)
- * and appends any user-declared `sources`. The implicit source is omitted
- * when the user already declared a Linear source — by `kind: "linear"`, or by
- * a surviving (non-disabled) source whose runtime name is "linear" — so they
- * can override its `name` / construction without spawning a duplicate adapter.
- *
- * Users opt out of Linear entirely with the sentinel
- * `{ kind: "linear", enabled: false }`: it still counts as an explicit Linear
- * declaration (so the implicit source is suppressed) and is itself filtered
- * out (so no Linear adapter is constructed and no API key is required). Any
- * other source with `enabled: false` is likewise dropped from the result.
+ * Build the runtime source list from a ResolvedConfig: returns the enabled
+ * entries from `config.sources`. Any source with `enabled: false` is dropped.
+ * Returns an empty array when no sources are configured — callers are
+ * responsible for detecting that state and guiding the user.
  */
 export function sourcesFromConfig(config: ResolvedConfig): readonly unknown[] {
-  const kept = config.sources.filter((source) => !isSourceDisabled(source));
-  // A `kind: "linear"` entry suppresses the implicit source even when it is the
-  // disabled opt-out sentinel — it's removed from `kept` above, leaving Linear
-  // off entirely. A source that's Linear only by *name* (e.g. a shell source
-  // named "linear") suppresses the implicit source only while it survives the
-  // filter, so disabling such an entry doesn't silently drop Linear.
-  const hasExplicitLinear =
-    config.sources.some(isLinearKindSource) || kept.some(isExplicitLinearSource);
-  if (hasExplicitLinear) {
-    return kept;
-  }
-  return [{ kind: "linear" }, ...kept];
+  return config.sources.filter((source) => !isSourceDisabled(source));
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the implicit Linear synthesis that silently made Linear the default task source for all new users. Previously, anyone without a Linear API key would get a confusing auth error on startup rather than actionable guidance.

Now:
- `sourcesFromConfig()` simply returns the user's configured sources (filtering disabled ones) — no implicit Linear prepended
- `crew run` with no sources configured prints the config file path and two ready-to-copy snippets (todo-txt for zero credentials, Linear for API-key users), then exits 1
- `crew init` guidance and `crew.config.example.ts` lead with todo-txt as the zero-credential option
- `isLinearEnabled()` correctly returns false when sources is empty (was true before due to implicit synthesis)

Users who relied on implicit Linear must add `sources: [{ kind: "linear" }]` to their config.

## Validation

- `node --run verify` passes (all checks green; pre-existing knip failure unrelated)
- `node --run test -- buildSources` all tests pass with updated expectations

## Notes

Breaking change for users relying on implicit Linear — they need one line added to their config. Fails fast and self-explains rather than silently misbehaving.

<sub>🤖 `commit-push-pr:created v1 core@3.6.0`</sub>