### PR TITLE
fix: dispatch todo-txt tasks with generated IDs

### DIFF
--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -1,5 +1,5 @@
 import type { ResolvedConfig } from "../lib/config.ts";
-import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import { canonicalLinearIssue, canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { makeBoard } from "../testHelpers/boardFixtures.ts";
 import type { BoardState, Issue } from "../lib/taskSource.ts";
 import { EXHAUSTED_USAGE } from "../lib/usage.ts";
@@ -302,7 +302,65 @@ describe(createDispatcher, () => {
 
       expect(setupMock).not.toHaveBeenCalled();
       expect(board.markInProgress).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("No Todo tasks");
+      expect(consoleLog.output()).toContain(
+        "No eligible Todo tasks after agent/repository filtering",
+      );
+    });
+
+    it("warns and skips Todo tasks with an agent but no repository", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+      const usageProbe = vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({});
+
+      await dispatcher.runOnce({
+        state: boardOf([
+          canonicalShellIssue({
+            naturalId: "GC-1",
+            sourceName: "t",
+            model: "any",
+            repository: undefined,
+          }),
+        ]),
+        worktreeEntries: [],
+        usage: usageProbe,
+        dryRun: false,
+      });
+
+      expect(setupMock).not.toHaveBeenCalled();
+      expect(board.markInProgress).not.toHaveBeenCalled();
+      expect(usageProbe).not.toHaveBeenCalled();
+      const out = consoleLog.output();
+      expect(out).toContain('WARNING: t:gc-1 has agent "any" but no repository');
+      expect(out).toContain('set defaultRepository on source "t"');
+      expect(out).toContain("Known repositories: repo-a, repo-b");
+      expect(out).toContain(
+        "event=dispatch outcome=skipped reason=missing_repository task=gc-1 source=t model=any",
+      );
+      expect(out).toContain("No eligible Todo tasks after agent/repository filtering");
+    });
+
+    it("renders empty known repositories in the missing repository warning", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({
+        config: makeConfig({ workspace: { projectDir: "/work", knownRepositories: [] } }),
+        board,
+      });
+
+      await dispatcher.runOnce({
+        state: boardOf([
+          canonicalShellIssue({
+            naturalId: "GC-1",
+            sourceName: "t",
+            model: "any",
+            repository: undefined,
+          }),
+        ]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(consoleLog.output()).toContain("Known repositories: (none)");
     });
 
     it("stops scanning Todo issues once eligible count reaches the slot cap", async () => {

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -9,7 +9,7 @@
 
 import type { Board } from "../lib/board.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
-import { dispatchableRepository } from "../lib/repositoryValidation.ts";
+import { dispatchableRepository, formatKnownRepositories } from "../lib/repositoryValidation.ts";
 import {
   type BoardState,
   type GroundcrewIssue,
@@ -18,7 +18,7 @@ import {
   naturalIdFromCanonical,
 } from "../lib/taskSource.ts";
 import type { UsageByModel } from "../lib/usage.ts";
-import { errorMessage, failMark, log, logEvent } from "../lib/util.ts";
+import { errorMessage, failMark, log, logEvent, styleWarning } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import {
@@ -61,6 +61,26 @@ function logSkip(verdict: SkipVerdict): void {
     task: naturalIdFromCanonical(verdict.issue.id),
     blockers: verdict.blockers,
     model: verdict.model,
+  });
+}
+
+function logMissingRepositorySkip(
+  issue: Issue,
+  model: string,
+  knownRepositories: readonly string[],
+): void {
+  const task = naturalIdFromCanonical(issue.id);
+  log(
+    styleWarning(
+      `WARNING: ${issue.id} has agent "${model}" but no repository; skipping dispatch. Add --repo <repo> when creating the task, add repo:<repo> to the task line, or set defaultRepository on source "${issue.source}". Known repositories: ${formatKnownRepositories(knownRepositories)}`,
+    ),
+  );
+  logEvent("dispatch", {
+    outcome: "skipped",
+    reason: "missing_repository",
+    task,
+    source: issue.source,
+    model,
   });
 }
 
@@ -170,10 +190,18 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       .toSorted((a, b) => a.id.localeCompare(b.id));
     const activeCount = active.length;
     const slots = config.orchestrator.maximumInProgress - activeCount;
-    // Narrow Todo to tasks that opted in via an `agent-*` label.
-    // Unlabeled tasks are not groundcrew's concern even when in Todo.
+    const rawTodo = state.issues.filter((issue) => issue.status === "todo");
+    for (const issue of rawTodo) {
+      const { model, repository } = issue;
+      if (model !== undefined && repository === undefined) {
+        logMissingRepositorySkip(issue, model, config.workspace.knownRepositories);
+      }
+    }
+
+    // Narrow queued work to tasks that opted in with an agent and resolved a
+    // repository. Unlabeled tasks are not groundcrew's concern.
     // Sort by priority so higher-priority tasks fill slots first.
-    const todo: readonly GroundcrewIssue[] = state.issues
+    const todo: readonly GroundcrewIssue[] = rawTodo
       .filter(
         (issue): issue is GroundcrewIssue => issue.status === "todo" && isGroundcrewIssue(issue),
       )
@@ -186,8 +214,12 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       return;
     }
 
-    if (todo.length === 0) {
+    if (rawTodo.length === 0) {
       log(`No Todo tasks to pick up${idleSuffix}`);
+      return;
+    }
+    if (todo.length === 0) {
+      log(`No eligible Todo tasks after agent/repository filtering${idleSuffix}`);
       return;
     }
 

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -202,9 +202,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     // repository. Unlabeled tasks are not groundcrew's concern.
     // Sort by priority so higher-priority tasks fill slots first.
     const todo: readonly GroundcrewIssue[] = rawTodo
-      .filter(
-        (issue): issue is GroundcrewIssue => issue.status === "todo" && isGroundcrewIssue(issue),
-      )
+      .filter((issue): issue is GroundcrewIssue => isGroundcrewIssue(issue))
       .toSorted((a, b) => prioritySortKey(a.priority) - prioritySortKey(b.priority));
 
     if (slots <= 0) {

--- a/src/lib/repositoryValidation.ts
+++ b/src/lib/repositoryValidation.ts
@@ -11,6 +11,10 @@
 
 import type { Issue } from "./taskSource.ts";
 
+export function formatKnownRepositories(knownRepositories: readonly string[]): string {
+  return knownRepositories.join(", ") || "(none)";
+}
+
 export function dispatchableRepository(
   issue: Issue,
   knownRepositories: readonly string[],
@@ -21,7 +25,7 @@ export function dispatchableRepository(
   }
   if (!knownRepositories.includes(issue.repository)) {
     log(
-      `issue ${issue.id} references unknown repository ${issue.repository}; configured workspace.knownRepositories: ${knownRepositories.join(", ") || "(none)"}`,
+      `issue ${issue.id} references unknown repository ${issue.repository}; configured workspace.knownRepositories: ${formatKnownRepositories(knownRepositories)}`,
     );
     return undefined;
   }

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -311,7 +311,13 @@ describe("run state store", () => {
     expect(readRunState(config, "team-1")).toBeUndefined();
   });
 
-  it("rejects task ids that are not plain Linear-style ids", () => {
+  it("accepts multi-segment source task ids", () => {
+    expect(runStatePath(config, "gc-20260608-001")).toBe(
+      path.join(stateRoot, "runs", "gc-20260608-001.json"),
+    );
+  });
+
+  it("rejects task ids that are not plain source task ids", () => {
     expect(() => runStatePath(config, "../team-1")).toThrow(/plain task id/);
   });
 

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node
 import path from "node:path";
 
 import type { ResolvedConfig } from "./config.ts";
+import { normalizePlainTaskId } from "./taskId.ts";
 
 export type RunLifecycleState = "running" | "interrupted" | "resumed" | "failed-to-launch";
 
@@ -61,15 +62,10 @@ export interface UpdateRunStateInput {
   };
 }
 
-const TASK_RE = /^[a-z][\da-z]*-\d+$/;
 const RUN_STATE_DIRECTORY_NAME = "runs";
 
 function taskKey(task: string): string {
-  const normalized = task.toLowerCase();
-  if (!TASK_RE.test(normalized)) {
-    throw new Error(`Invalid task "${task}": must be a plain task id`);
-  }
-  return normalized;
+  return normalizePlainTaskId(task);
 }
 
 export function runStateDirectory(config: Pick<ResolvedConfig, "logging">): string {

--- a/src/lib/taskId.test.ts
+++ b/src/lib/taskId.test.ts
@@ -1,0 +1,26 @@
+import { assertPlainTaskId, isPlainTaskId, normalizePlainTaskId } from "./taskId.ts";
+
+describe("plain task ids", () => {
+  it("accepts source-neutral lowercase ids with a numeric suffix", () => {
+    expect(isPlainTaskId("team-123")).toBe(true);
+    expect(isPlainTaskId("gc-20260608-001")).toBe(true);
+    expect(() => {
+      assertPlainTaskId("gc-20260608-001");
+    }).not.toThrow();
+  });
+
+  it("rejects ids that are not plain task ids", () => {
+    expect(isPlainTaskId("team-abc")).toBe(false);
+    expect(() => {
+      assertPlainTaskId("../team-1");
+    }).toThrow(/plain task id/);
+  });
+
+  it("normalizes uppercase ids before validating", () => {
+    expect(normalizePlainTaskId("TEAM-123")).toBe("team-123");
+  });
+
+  it("throws with the original id when normalized input is still invalid", () => {
+    expect(() => normalizePlainTaskId("TEAM-ABC")).toThrow('Invalid task "TEAM-ABC"');
+  });
+});

--- a/src/lib/taskId.ts
+++ b/src/lib/taskId.ts
@@ -1,0 +1,23 @@
+const PLAIN_TASK_ID_RE = /^[a-z][\da-z]*(?:-[\da-z]+)*-\d+$/;
+
+function invalidPlainTaskIdError(task: string): Error {
+  return new Error(`Invalid task "${task}": must be a plain task id`);
+}
+
+export function isPlainTaskId(task: string): boolean {
+  return PLAIN_TASK_ID_RE.test(task);
+}
+
+export function assertPlainTaskId(task: string): void {
+  if (!isPlainTaskId(task)) {
+    throw invalidPlainTaskIdError(task);
+  }
+}
+
+export function normalizePlainTaskId(task: string): string {
+  const normalized = task.toLowerCase();
+  if (!isPlainTaskId(normalized)) {
+    throw invalidPlainTaskIdError(task);
+  }
+  return normalized;
+}

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -165,8 +165,49 @@ describe(list, () => {
     ]);
   });
 
+  it("finds host sibling worktrees with multi-segment source task ids", () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    mkdirSync(path.join(projectDir, "repo-a-gc-20260608-001"));
+    const config = makeConfig({ projectDir });
+
+    expect(list(config)).toStrictEqual([
+      {
+        repository: "repo-a",
+        task: "gc-20260608-001",
+        branchName: "dev-gc-20260608-001",
+        dir: path.join(projectDir, "repo-a-gc-20260608-001"),
+        kind: "host",
+      },
+    ]);
+  });
+
+  it("prefers the longest configured repository basename when names overlap", () => {
+    mkdirSync(path.join(projectDir, "repo-a-admin-gc-20260608-001"));
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["repo-a", "repo-a-admin"],
+    });
+
+    expect(list(config)).toStrictEqual([
+      {
+        repository: "repo-a-admin",
+        task: "gc-20260608-001",
+        branchName: "dev-gc-20260608-001",
+        dir: path.join(projectDir, "repo-a-admin-gc-20260608-001"),
+        kind: "host",
+      },
+    ]);
+  });
+
   it("ignores host directories whose <repo> segment is not configured", () => {
     mkdirSync(path.join(projectDir, "ghost-team-1"));
+    const config = makeConfig({ projectDir });
+
+    expect(list(config)).toStrictEqual([]);
+  });
+
+  it("ignores configured repository directories whose task segment is invalid", () => {
+    mkdirSync(path.join(projectDir, "repo-a-not-a-task"));
     const config = makeConfig({ projectDir });
 
     expect(list(config)).toStrictEqual([]);
@@ -308,6 +349,45 @@ describe(create, () => {
     );
     expect(actual.kind).toBe("host");
     expect(actual.dir).toBe(path.join(projectDir, "repo-a-team-1"));
+  });
+
+  it("creates worktrees for multi-segment source task ids", async () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    const config = makeConfig({ projectDir });
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator picks out the symbolic-ref probe so it returns origin/<branch>
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        return "origin/main\n";
+      }
+      return "";
+    });
+
+    const actual = await create(config, {
+      repository: "repo-a",
+      task: "gc-20260608-001",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      [
+        "-C",
+        path.join(projectDir, "repo-a"),
+        "worktree",
+        "add",
+        "-b",
+        "dev-gc-20260608-001",
+        path.join(projectDir, "repo-a-gc-20260608-001"),
+        "origin/main",
+      ],
+      { stdio: "captured", timeoutMs: 0 },
+    );
+    expect(actual).toMatchObject({
+      repository: "repo-a",
+      task: "gc-20260608-001",
+      branchName: "dev-gc-20260608-001",
+      dir: path.join(projectDir, "repo-a-gc-20260608-001"),
+      kind: "host",
+    });
   });
 
   it("streams git output (stdio inherit) under verbose", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { runCommandAsync } from "./commandRunner.ts";
 import { type ResolvedConfig, repositoryBaseDir, worktreeBaseDir } from "./config.ts";
 import { resolveDefaultBranch } from "./defaultBranch.ts";
+import { assertPlainTaskId, isPlainTaskId } from "./taskId.ts";
 import { debug, errorMessage, isVerbose } from "./util.ts";
 import { type WorkspaceProbe, workspaces } from "./workspaces.ts";
 
@@ -39,7 +40,7 @@ export function isWorktreeAlreadyExistsError(error: unknown): error is WorktreeA
 
 export interface WorktreeEntry {
   repository: string;
-  /** Linear task id, lowercased — e.g. "team-220". */
+  /** Source task id, lowercased — e.g. "team-220" or "gc-20260608-001". */
   task: string;
   /** Slash-free `<prefix>-<task>`. */
   branchName: string;
@@ -51,9 +52,6 @@ export interface WorktreeSpec {
   repository: string;
   task: string;
 }
-
-const TASK_RE = /^[a-z][\da-z]*-\d+$/;
-const TASK_DIR_RE = /^(?<repoBasename>.+)-(?<task>[a-z][\da-z]*-\d+)$/;
 
 function branchPrefix(config: ResolvedConfig): string {
   const fromConfig = config.git.branchPrefix;
@@ -97,9 +95,7 @@ function basePaths(config: ResolvedConfig, repository: string, task: string): Ba
   // Tasks must match the same shape the worktree discovery regexes use,
   // so create()/list()/findByTask() agree on what's a valid worktree.
   // This also rejects traversal tokens before they reach path.resolve().
-  if (!TASK_RE.test(task)) {
-    throw new Error(`Invalid task "${task}": must be a plain task id`);
-  }
+  assertPlainTaskId(task);
 
   const repoDir = repoDirFor(config, repository);
   const hostWorktreeName = `${repository}-${task}`;
@@ -116,6 +112,24 @@ function basePaths(config: ResolvedConfig, repository: string, task: string): Ba
 
 function signalProperty(signal?: AbortSignal): { signal: AbortSignal } | Record<never, never> {
   return signal === undefined ? {} : { signal };
+}
+
+function parseWorktreeDirectoryName(
+  directoryName: string,
+  repositoryEntriesByLongestName: readonly (readonly [string, string])[],
+): { repository: string; task: string } | undefined {
+  for (const [repositoryBaseName, repository] of repositoryEntriesByLongestName) {
+    const worktreePrefix = `${repositoryBaseName}-`;
+    if (!directoryName.startsWith(worktreePrefix)) {
+      continue;
+    }
+    const task = directoryName.slice(worktreePrefix.length);
+    if (!isPlainTaskId(task)) {
+      continue;
+    }
+    return { repository, task };
+  }
+  return undefined;
 }
 
 /**
@@ -212,6 +226,9 @@ function listWorktrees(config: ResolvedConfig): WorktreeEntry[] {
   }
 
   for (const [parentDir, repoByBasename] of reposByParent) {
+    const repositoryEntriesByLongestName = [...repoByBasename.entries()].toSorted(
+      ([nameA], [nameB]) => nameB.length - nameA.length,
+    );
     let children: Dirent[];
     try {
       children = readdirSync(parentDir, { withFileTypes: true });
@@ -222,23 +239,14 @@ function listWorktrees(config: ResolvedConfig): WorktreeEntry[] {
       if (!entry.isDirectory()) {
         continue;
       }
-      const match = TASK_DIR_RE.exec(entry.name);
-      if (!match) {
-        continue;
-      }
-      const [, repoBasename, task] = match;
-      /* v8 ignore next 3 @preserve -- TASK_DIR_RE always captures both groups when it matches */
-      if (repoBasename === undefined || task === undefined) {
-        continue;
-      }
-      const repository = repoByBasename.get(repoBasename);
-      if (repository === undefined) {
+      const parsed = parseWorktreeDirectoryName(entry.name, repositoryEntriesByLongestName);
+      if (parsed === undefined) {
         continue;
       }
       entries.push({
-        repository,
-        task,
-        branchName: branchNameForTask(config, task),
+        repository: parsed.repository,
+        task: parsed.task,
+        branchName: branchNameForTask(config, parsed.task),
         dir: path.resolve(parentDir, entry.name),
         kind: "host",
       });

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -118,6 +118,8 @@ function parseWorktreeDirectoryName(
   directoryName: string,
   repositoryEntriesByLongestName: readonly (readonly [string, string])[],
 ): { repository: string; task: string } | undefined {
+  // Match the longest repository basename first so overlapping names like
+  // "repo-a" and "repo-a-admin" parse to the intended repository.
   for (const [repositoryBaseName, repository] of repositoryEntriesByLongestName) {
     const worktreePrefix = `${repositoryBaseName}-`;
     if (!directoryName.startsWith(worktreePrefix)) {


### PR DESCRIPTION
## Summary

Fixes todo-txt dispatch for tasks created with generated IDs such as `GC-20260608-001`. Groundcrew now accepts multi-segment source task IDs across worktree setup and run-state persistence, keeps task-id validation shared, and logs an actionable warning when a todo task has an agent but no repository.

## Validation

- `GROUNDCREW_VERBOSE=1 GROUNDCREW_CONFIG=/private/tmp/groundcrew-todo-only.config.ts node --run crew -- run` with a temporary todo-only config; created and launched `groundcrew-gc-20260608-001`
- `./node_modules/.bin/vitest run src/lib/taskId.test.ts src/lib/worktrees.test.ts src/lib/runState.test.ts src/lib/repositoryValidation.test.ts src/commands/dispatcher.test.ts --coverage.enabled=false`
- `node --run verify`
- Pre-push hook: `node --run verify`

Agent session: `codex resume 019ea8cd-2421-7940-88d8-1910a74b52ee`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>