### PR TITLE
fix: allow title-only todo-txt ready tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.
 crew doctor                                              # check setup
 crew task list [--source <name>]                         # list tasks across sources
 crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or its prompt
-crew task create "Title" --source <name> --agent <name>  # create a source task
+crew task create "Title" --source <name> [--agent <name>] # create a source task
 crew status [<TASK>]                                   # inspect current state or one task
 crew run [--watch]                                       # one-shot or --watch forever
 crew start <TASK>                                      # provision + launch one task now

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ crew task get GC-20260608-001 --source todo
 crew task get todo:GC-20260608-001 --prompt
 ```
 
-`crew task create "Short title" --source <source> --agent <agent>` creates a task in a source that supports creation. Todo.txt creation appends the todo line, defaults to priority `A` unless `--priority` is provided, writes `.tasks/<id>.md`, and leaves `status:todo` as the final meaningful token, so no separate ready command is required.
+`crew task create "Short title" --source <source> [--agent <agent>]` creates a task in a source that supports creation. When `--agent` is omitted, it defaults to `any`. Todo.txt creation appends the todo line, defaults to priority `A` unless `--priority` is provided, writes `.tasks/<id>.md`, and leaves `status:todo` as the final meaningful token, so no separate ready command is required. Hand-written todo-txt lines can omit `.tasks/<id>.md` when the line has a non-empty title; that title becomes the prompt text.
 
 ```bash
 crew task create "Fix cancellation retry race" \

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -78,7 +78,7 @@ export default {
 };
 ```
 
-Creating a todo task appends a line with `status:todo` as the final meaningful token and writes the prompt to `.tasks/<id>.md`. New todo tasks default to priority `A`; pass `--priority <letter>` to override it.
+Creating a todo task appends a line with `status:todo` as the final meaningful token and writes the prompt to `.tasks/<id>.md`. New todo tasks default to priority `A`; pass `--priority <letter>` to override it. If `--agent` is omitted, the task uses `agent:any`.
 
 ```bash
 crew task create "Fix cancellation retry race" \
@@ -92,6 +92,12 @@ crew task create "Fix cancellation retry race" \
 
 ```txt
 (A) Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo
+```
+
+For hand-written todo lines, a non-empty title is enough prompt text when `.tasks/<id>.md` is absent. Omit `agent:` to default to `agent:any`:
+
+```txt
+Say goodbye repo:ClipboardHealth/groundcrew id:GC-20260608-002 status:todo
 ```
 
 ## Linear

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -476,6 +476,30 @@ describe("crew task create", () => {
     expect(log.output()).not.toContain("sourceRef");
   });
 
+  it("defaults omitted create agent to any", async () => {
+    const created = makeIssue({ id: "todo:any-1" });
+    const createTask = vi.fn<NonNullable<TaskSource["createTask"]>>().mockResolvedValue(created);
+    const todo = stubSource("todo", [], { createTask });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["create", "Default agent", "--source", "todo"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(createTask).toHaveBeenCalledWith({
+      title: "Default agent",
+      agent: "any",
+      projects: [],
+      contexts: [],
+      dependencies: [],
+      edit: false,
+    });
+    expect(log.output()).toBe("todo:any-1");
+  });
+
   it("fails when the source does not support creation", async () => {
     buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
 
@@ -487,7 +511,6 @@ describe("crew task create", () => {
   it.each([
     { argv: ["create"], message: "Quote multi-word titles" },
     { argv: ["create", "Missing source", "--agent", "codex"], message: "--source is required" },
-    { argv: ["create", "Missing agent", "--source", "todo"], message: "--agent is required" },
     {
       argv: ["create", "Unknown option", "--source", "todo", "--agent", "codex", "--bogus"],
       message: "unknown option",

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,5 +1,5 @@
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { AGENT_ANY_MODEL, loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import {
   type CanonicalStatus,
   type CreateTaskInput,
@@ -35,7 +35,7 @@ Options:
   --json           Print normalized task JSON.
   --prompt         Print only the task description/prompt.`;
 
-const CREATE_USAGE = `Usage: crew task create "Short title" --source <source> --agent <agent> [options]`;
+const CREATE_USAGE = `Usage: crew task create "Short title" --source <source> [--agent <agent>] [options]`;
 
 const CANONICAL_STATUSES: readonly CanonicalStatus[] = [
   "todo",
@@ -328,13 +328,9 @@ function parseCreateOptions(argv: readonly string[]): CreateOptions {
   if (state.sourceName === undefined) {
     throw new Error("crew task create: --source is required");
   }
-  if (state.agent === undefined) {
-    throw new Error("crew task create: --agent is required");
-  }
-
   const input: CreateTaskInput = {
     title,
-    agent: state.agent,
+    agent: state.agent ?? AGENT_ANY_MODEL,
     projects: state.projects,
     contexts: state.contexts,
     dependencies: state.dependencies,

--- a/src/lib/adapters/todo-txt/normalizer.test.ts
+++ b/src/lib/adapters/todo-txt/normalizer.test.ts
@@ -54,6 +54,10 @@ describe(normalizeToIssue, () => {
   it("leaves repository undefined when neither task nor source provides one", () => {
     expect(normalize("No repo id:NO-REPO-1 agent:codex status:todo")?.repository).toBeUndefined();
   });
+
+  it("defaults missing agent metadata to agent-any", () => {
+    expect(normalize("No agent id:NO-AGENT-1 status:todo")?.model).toBe("any");
+  });
 });
 
 describe(isActiveForFetch, () => {
@@ -63,7 +67,7 @@ describe(isActiveForFetch, () => {
     { line: "Active review id:ACTIVE-3 agent:codex status:in-review", active: true },
     { line: "x 2026-06-08 Done id:DONE-1 agent:codex status:done", active: false },
     { line: "No id agent:codex status:todo", active: false },
-    { line: "No agent id:NO-AGENT-1 status:todo", active: false },
+    { line: "No agent id:NO-AGENT-1 status:todo", active: true },
     { line: "Unknown status id:UNKNOWN-1 agent:codex status:waiting", active: false },
   ])("returns $active for $line", ({ line, active }) => {
     expect(isActiveForFetch(parseOne(line))).toBe(active);

--- a/src/lib/adapters/todo-txt/normalizer.ts
+++ b/src/lib/adapters/todo-txt/normalizer.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { AGENT_ANY_MODEL } from "../../config.ts";
 import { type Blocker, type CanonicalStatus, type Issue, toCanonicalId } from "../../taskSource.ts";
 import { getMetadataAll, getMetadataFirst, hashLine, type ParsedTodoLine } from "./parser.ts";
 
@@ -104,7 +105,7 @@ export function normalizeToIssue(options: NormalizeOptions): Issue | undefined {
     return undefined;
   }
 
-  const agent = getMetadataFirst(parsed, "agent");
+  const agent = getMetadataFirst(parsed, "agent") ?? AGENT_ANY_MODEL;
   const status = derivedCanonicalStatus(parsed);
   const repository = getMetadataFirst(parsed, "repo") ?? defaultRepository;
 
@@ -146,9 +147,6 @@ export function isActiveForFetch(parsed: ParsedTodoLine): boolean {
     return false;
   }
   if (getMetadataFirst(parsed, "id") === undefined) {
-    return false;
-  }
-  if (getMetadataFirst(parsed, "agent") === undefined) {
     return false;
   }
   const statusValue = getMetadataFirst(parsed, "status");

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -450,6 +450,15 @@ describe("TodoTxtTaskSource", () => {
     expect(issues[0]?.model).toBe("any");
   });
 
+  it("defaults missing agent metadata to agent-any", async () => {
+    tmp.writeTodo("Task seven id:GC-007 status:todo\n");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues[0]?.model).toBe("any");
+  });
+
   // Test 8: Default repository from config when no repo:
   it("defaults repository from config when no repo: field", async () => {
     tmp.writeTodo("id:GC-008 agent:codex status:todo Task eight\n");
@@ -686,13 +695,13 @@ describe("TodoTxtTaskSource", () => {
     expect(issues[0]?.priority).toBe(1);
   });
 
-  it("sets description to empty string when no prompt file exists", async () => {
-    tmp.writeTodo("id:NO-PROMPT agent:codex status:todo No prompt task\n");
+  it("uses title as description when no prompt file exists", async () => {
+    tmp.writeTodo("No prompt task id:NO-PROMPT agent:codex status:todo\n");
 
     const source = makeSource(tmp);
     const issues = await source.fetch();
 
-    expect(issues[0]?.description).toBe("");
+    expect(issues[0]?.description).toBe("No prompt task\n");
   });
 
   it("canonicalId is todo:<lowercased-id>", async () => {
@@ -861,8 +870,13 @@ describe("TodoTxtTaskSource", () => {
     );
   });
 
-  it("verify() catches missing prompt file for ready task", async () => {
-    // Ready task (status:todo final token) with no .tasks/<id>.md
+  it("verify() allows a title-only ready task without a prompt file", async () => {
+    tmp.writeTodo("Say goodbye repo:groundcrew id:rrr agent:any status:todo\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).resolves.toBeUndefined();
+  });
+
+  it("verify() catches missing prompt file for ready task without a title", async () => {
     tmp.writeTodo("id:GC-MP agent:codex status:todo\n"); // no task file created
     const source = makeSource(tmp);
     await expect(source.verify()).rejects.toThrow(/missing prompt file/);
@@ -965,13 +979,13 @@ describe("TodoTxtTaskSource", () => {
     expect(hasDep?.blockers[0]?.title).toBe("NO-TITLE-DEP");
   });
 
-  it("isActiveForFetch returns false for task with id but no agent", async () => {
-    tmp.writeTodo("id:NO-AGENT-001 status:todo Task with no agent\n");
+  it("fetch defaults a task with id but no agent to agent-any", async () => {
+    tmp.writeTodo("Task with no agent id:NO-AGENT-001 status:todo\n");
 
     const source = makeSource(tmp);
     const issues = await source.fetch();
 
-    expect(issues.find((i) => i.id === "todo:no-agent-001")).toBeUndefined();
+    expect(issues.find((i) => i.id === "todo:no-agent-001")?.model).toBe("any");
   });
 
   it("blocker resolution skips null and no-id lines in file", async () => {

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -13,19 +13,30 @@ import {
 } from "../../taskSource.ts";
 import { readEnvironmentVariable } from "../../util.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
-import { getMetadataFirst, parseAllLines } from "./parser.ts";
+import { getMetadataFirst, parseAllLines, type ParsedTodoLine } from "./parser.ts";
 import type { TodoTxtAdapterConfig } from "./schema.ts";
 import { copyPromptFile, updateTaskStatus, validateTodoFile, withLock } from "./writeback.ts";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const RECURRENCE_RE = /^\+?\d+[dwmy]$/;
 
-function readDescription(promptPath: string): string {
+function readPromptFile(promptPath: string): string | undefined {
   try {
     return readFileSync(promptPath, "utf8");
   } catch {
-    return "";
+    return undefined;
   }
+}
+
+function descriptionFor(parsed: ParsedTodoLine, promptPath: string): string {
+  const promptContent = readPromptFile(promptPath);
+  if (promptContent !== undefined && promptContent.trim().length > 0) {
+    return promptContent;
+  }
+  if (parsed.title.trim().length > 0) {
+    return `${parsed.title}\n`;
+  }
+  return promptContent ?? "";
 }
 
 function fileUpdatedAt(filePath: string): string {
@@ -76,7 +87,7 @@ function buildIssue(options: {
 
   const promptOverride = getMetadataFirst(parsed, "prompt");
   const promptPath = promptOverride ?? `${tasksDir}/${id}.md`;
-  const description = readDescription(promptPath);
+  const description = descriptionFor(parsed, promptPath);
 
   return normalizeToIssue({
     parsed,

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -363,17 +363,21 @@ function validatePromptFile(
   tasksDir: string,
   id: string,
   promptOverride: string | undefined,
+  title: string,
   prefix: string,
   errors: string[],
 ): void {
   const promptPath = promptOverride ?? path.join(tasksDir, `${id}.md`);
+  const shouldRequirePrompt = promptOverride !== undefined || title.trim().length === 0;
   try {
     const desc = readFileSync(promptPath, "utf8");
-    if (desc.trim().length === 0) {
+    if (desc.trim().length === 0 && shouldRequirePrompt) {
       errors.push(`${prefix}: empty prompt file "${promptPath}" for ready task "${id}"`);
     }
   } catch {
-    errors.push(`${prefix}: missing prompt file "${promptPath}" for ready task "${id}"`);
+    if (shouldRequirePrompt) {
+      errors.push(`${prefix}: missing prompt file "${promptPath}" for ready task "${id}"`);
+    }
   }
 }
 
@@ -439,7 +443,7 @@ function validateActiveTaskLine(
   }
 
   if (statusValue === "todo" && parsed.isStatusFinalToken) {
-    validatePromptFile(tasksDir, id, parsed.metadata["prompt"]?.[0], prefix, errors);
+    validatePromptFile(tasksDir, id, parsed.metadata["prompt"]?.[0], parsed.title, prefix, errors);
   }
 
   validateDepsAndDates(parsed, parsedAll, id, prefix, errors);
@@ -476,7 +480,7 @@ export function validateTodoFile(todoPath: string, tasksDir: string): string[] {
       }
     }
 
-    if (id === undefined || parsed.metadata["agent"] === undefined) {
+    if (id === undefined) {
       continue;
     }
     if (parsed.completed) {


### PR DESCRIPTION
## Summary

Todo-txt ready tasks can now rely on their line title as prompt text when `.tasks/<id>.md` is absent, so a line like `Say goodbye repo:groundcrew id:rrr agent:any status:todo` verifies and dispatches. Todo-txt tasks without `agent:` now default to `agent:any`, and `crew task create` defaults omitted `--agent` to `any`.

## Validation

- `npx vitest run src/lib/adapters/todo-txt/source.test.ts src/lib/adapters/todo-txt/normalizer.test.ts src/commands/task.test.ts`
- `node --run verify`

Agent session: `codex resume 019eaa53-e9b9-7b60-8aa8-ab51669d8818`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>