### PR TITLE
fix: accept simple todo-txt task ids

### DIFF
--- a/src/lib/taskId.test.ts
+++ b/src/lib/taskId.test.ts
@@ -1,26 +1,30 @@
 import { assertPlainTaskId, isPlainTaskId, normalizePlainTaskId } from "./taskId.ts";
 
 describe("plain task ids", () => {
-  it("accepts source-neutral lowercase ids with a numeric suffix", () => {
+  it("accepts source-neutral lowercase slug ids", () => {
+    expect(isPlainTaskId("rrr")).toBe(true);
+    expect(isPlainTaskId("team-abc")).toBe(true);
     expect(isPlainTaskId("team-123")).toBe(true);
     expect(isPlainTaskId("gc-20260608-001")).toBe(true);
     expect(() => {
-      assertPlainTaskId("gc-20260608-001");
+      assertPlainTaskId("rrr");
     }).not.toThrow();
   });
 
   it("rejects ids that are not plain task ids", () => {
-    expect(isPlainTaskId("team-abc")).toBe(false);
+    expect(isPlainTaskId("-rrr")).toBe(false);
+    expect(isPlainTaskId("rrr-")).toBe(false);
     expect(() => {
       assertPlainTaskId("../team-1");
     }).toThrow(/plain task id/);
   });
 
   it("normalizes uppercase ids before validating", () => {
+    expect(normalizePlainTaskId("RRR")).toBe("rrr");
     expect(normalizePlainTaskId("TEAM-123")).toBe("team-123");
   });
 
   it("throws with the original id when normalized input is still invalid", () => {
-    expect(() => normalizePlainTaskId("TEAM-ABC")).toThrow('Invalid task "TEAM-ABC"');
+    expect(() => normalizePlainTaskId("TEAM/ABC")).toThrow('Invalid task "TEAM/ABC"');
   });
 });

--- a/src/lib/taskId.ts
+++ b/src/lib/taskId.ts
@@ -1,4 +1,4 @@
-const PLAIN_TASK_ID_RE = /^[a-z][\da-z]*(?:-[\da-z]+)*-\d+$/;
+const PLAIN_TASK_ID_RE = /^[\da-z]+(?:-[\da-z]+)*$/;
 
 function invalidPlainTaskIdError(task: string): Error {
   return new Error(`Invalid task "${task}": must be a plain task id`);

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -181,6 +181,22 @@ describe(list, () => {
     ]);
   });
 
+  it("finds host sibling worktrees with single-segment todo-txt task ids", () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    mkdirSync(path.join(projectDir, "repo-a-rrr"));
+    const config = makeConfig({ projectDir });
+
+    expect(list(config)).toStrictEqual([
+      {
+        repository: "repo-a",
+        task: "rrr",
+        branchName: "dev-rrr",
+        dir: path.join(projectDir, "repo-a-rrr"),
+        kind: "host",
+      },
+    ]);
+  });
+
   it("prefers the longest configured repository basename when names overlap", () => {
     mkdirSync(path.join(projectDir, "repo-a-admin-gc-20260608-001"));
     const config = makeConfig({
@@ -207,7 +223,7 @@ describe(list, () => {
   });
 
   it("ignores configured repository directories whose task segment is invalid", () => {
-    mkdirSync(path.join(projectDir, "repo-a-not-a-task"));
+    mkdirSync(path.join(projectDir, "repo-a-rrr-"));
     const config = makeConfig({ projectDir });
 
     expect(list(config)).toStrictEqual([]);
@@ -390,6 +406,45 @@ describe(create, () => {
     });
   });
 
+  it("creates worktrees for single-segment todo-txt task ids", async () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    const config = makeConfig({ projectDir });
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator picks out the symbolic-ref probe so it returns origin/<branch>
+      if (hasArguments(arguments_, "symbolic-ref", "refs/remotes/origin/HEAD")) {
+        return "origin/main\n";
+      }
+      return "";
+    });
+
+    const actual = await create(config, {
+      repository: "repo-a",
+      task: "rrr",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      [
+        "-C",
+        path.join(projectDir, "repo-a"),
+        "worktree",
+        "add",
+        "-b",
+        "dev-rrr",
+        path.join(projectDir, "repo-a-rrr"),
+        "origin/main",
+      ],
+      { stdio: "captured", timeoutMs: 0 },
+    );
+    expect(actual).toMatchObject({
+      repository: "repo-a",
+      task: "rrr",
+      branchName: "dev-rrr",
+      dir: path.join(projectDir, "repo-a-rrr"),
+      kind: "host",
+    });
+  });
+
   it("streams git output (stdio inherit) under verbose", async () => {
     mkdirSync(path.join(projectDir, "repo-a"));
     const config = makeConfig({ projectDir });
@@ -544,10 +599,10 @@ describe(create, () => {
     ["backslash", String.raw`team\123`],
     ["embedded ..", "team-..-123"],
     ["traversal segment", `..${path.sep}evil`],
-    ["wrong shape — no digits", "team-abc"],
     ["wrong shape — uppercase", "TEAM-123"],
     ["wrong shape — trailing whitespace", "team-123 "],
-    ["wrong shape — plain word", "foo"],
+    ["wrong shape — leading hyphen", "-rrr"],
+    ["wrong shape — trailing hyphen", "rrr-"],
   ])("rejects invalid task %s", async (_label, task) => {
     mkdirSync(path.join(projectDir, "repo-a"));
     const config = makeConfig({ projectDir });


### PR DESCRIPTION
## Summary

Todo-txt tasks can use simple filename-safe IDs such as `rrr`. The previous worktree task-id validator only accepted IDs ending with a numeric suffix, so an otherwise valid todo-txt task like `Say goodbye repo:groundcrew id:rrr agent:any status:todo` verified but failed at startup with `Invalid task "rrr": must be a plain task id`.

This broadens the plain task-id rule to lowercase alphanumeric slugs with optional hyphen-separated segments, preserving rejection of traversal, path separators, whitespace, uppercase IDs at the worktree boundary, and leading/trailing hyphens.

## Validation

- `npx vitest run src/lib/taskId.test.ts src/lib/worktrees.test.ts`
- `node --run verify`

Agent session: `codex resume 019eaa53-e9b9-7b60-8aa8-ab51669d8818`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>