### PR TITLE
docs: fix 404 link to blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="./static/demo.tape"><img alt="Groundcrew dispatching tasks into tmux panes with coding agents running in parallel" src="./static/demo.gif" width="800"></a>
 </p>
 
-Groundcrew watches assigned tasks, creates isolated worktrees, launches agent CLIs in dedicated terminals, and leaves each task's work on its own PR-ready branch. For the backstory, read _[Tasks to pull requests while you sleep](https://www.clipboardworks.com/resources/blog/tasks-to-pull-requests-while-you-sleep)_.
+Groundcrew watches assigned tasks, creates isolated worktrees, launches agent CLIs in dedicated terminals, and leaves each task's work on its own PR-ready branch. For the backstory, read _[Tickets to pull requests while you sleep](https://www.clipboardworks.com/resources/blog/tickets-to-pull-requests-while-you-sleep)_.
 
 ## Why
 


### PR DESCRIPTION
## Summary

The README's "backstory" link pointed to `/resources/blog/tasks-to-pull-requests-while-you-sleep`, which now 404s. The blog post moved to `/resources/blog/tickets-to-pull-requests-while-you-sleep`.

This updates both the link target and the link text (Tasks → Tickets) to match. Verified: old URL returns 404, new URL returns 200.

## Changes

- `README.md`: update blog link URL and text from "Tasks" to "Tickets"

🤖 Generated with [Claude Code](https://claude.com/claude-code)