### PR TITLE
feat: add crew task validate command with todo-txt agent validation

### DIFF
--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -153,8 +153,8 @@ describe("crew source list", () => {
 
     const lines = log.output().split("\n");
     const [, dataRow] = lines;
-    // verify=yes, writeback=yes (has markInProgress, markInReview, markDone)
-    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+no\s+yes/);
+    // verify=yes, validate=no, writeback=yes (has markInProgress, markInReview, markDone)
+    expect(dataRow).toMatch(/yes\s+yes\s+yes\s+no\s+no\s+yes/);
   });
 
   it("outputs JSON with --json flag", async () => {
@@ -173,6 +173,7 @@ describe("crew source list", () => {
     expect(output).toContain('"listTasks": true');
     expect(output).toContain('"createTask": false');
     expect(output).toContain('"markDone": false');
+    expect(output).toContain('"validate": false');
   });
 
   it("shows todo-txt source with full capabilities", async () => {

--- a/src/commands/source.ts
+++ b/src/commands/source.ts
@@ -1,7 +1,7 @@
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig } from "../lib/config.ts";
 import { summarizeSource, type SourceSummary } from "../lib/sourceCapabilities.ts";
-import { errorMessage, writeOutput } from "../lib/util.ts";
+import { errorMessage, parseSourceFilterArgs, writeOutput } from "../lib/util.ts";
 
 const SOURCE_USAGE = `Usage: crew source <subcommand>
 
@@ -51,6 +51,7 @@ function printSourceTable(summaries: SourceSummary[]): void {
     "LIST TASKS".padEnd(10),
     "GET TASK".padEnd(8),
     "CREATE".padEnd(6),
+    "VALIDATE".padEnd(8),
     "WRITEBACK",
   ].join("  ");
   writeOutput(header);
@@ -65,6 +66,7 @@ function printSourceTable(summaries: SourceSummary[]): void {
       yesNo(cap.listTasks).padEnd(10),
       yesNo(cap.getTask).padEnd(8),
       yesNo(cap.createTask).padEnd(6),
+      yesNo(cap.validate).padEnd(8),
       yesNo(writeback),
     ].join("  ");
     writeOutput(row);
@@ -78,26 +80,11 @@ interface VerifyResult {
 }
 
 async function sourceVerifyCli(argv: string[]): Promise<void> {
-  let jsonOutput = false;
-  let targetSource: string | undefined;
-
-  for (const arg of argv) {
-    if (arg === "--json") {
-      jsonOutput = true;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      throw new Error(
-        `crew source verify: unknown option: ${arg}\nUsage: crew source verify [source] [--json]`,
-      );
-    }
-    if (targetSource !== undefined) {
-      throw new Error(
-        "crew source verify: too many arguments\nUsage: crew source verify [source] [--json]",
-      );
-    }
-    targetSource = arg;
-  }
+  const { targetSource, jsonOutput } = parseSourceFilterArgs(
+    argv,
+    "crew source verify",
+    "Usage: crew source verify [source] [--json]",
+  );
 
   const config = await loadConfig();
   const rawSources = sourcesFromConfig(config);

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -589,7 +589,7 @@ describe("crew task validate", () => {
     expect(process.exitCode).not.toBe(1);
   });
 
-  it("outputs JSON with --json flag when no errors", async () => {
+  it("outputs JSON with supported:true and empty errors when validate passes", async () => {
     const validate = vi.fn<NonNullable<TaskSource["validate"]>>().mockResolvedValue([]);
     buildSourcesMock.mockResolvedValue([stubSource("todo", [], { validate })]);
 
@@ -602,6 +602,24 @@ describe("crew task validate", () => {
 
     const output = log.output();
     expect(output).toContain('"source": "todo"');
+    expect(output).toContain('"supported": true');
+    expect(output).toContain('"errors": []');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("outputs JSON with supported:false for sources without validate()", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"source": "todo"');
+    expect(output).toContain('"supported": false');
     expect(output).toContain('"errors": []');
     expect(process.exitCode).not.toBe(1);
   });
@@ -621,6 +639,7 @@ describe("crew task validate", () => {
 
     const output = log.output();
     expect(output).toContain('"source": "todo"');
+    expect(output).toContain('"supported": true');
     expect(output).toContain("duplicate id");
     expect(process.exitCode).toBe(1);
   });

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -529,3 +529,133 @@ describe("crew task dispatch", () => {
     await expect(taskCli(["ready"])).rejects.toThrow("Usage: crew task");
   });
 });
+
+describe("crew task validate", () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "todo-txt", name: "todo" }]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows ok when validate returns no errors", async () => {
+    const validate = vi.fn<NonNullable<TaskSource["validate"]>>().mockResolvedValue([]);
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [], { validate })]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("ok");
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("shows errors and sets exit code 1 when validate returns errors", async () => {
+    const validate = vi
+      .fn<NonNullable<TaskSource["validate"]>>()
+      .mockResolvedValue(['line 1: duplicate id "GC-1"', 'line 5: malformed due: date "bad"']);
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [], { validate })]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("2 error(s)");
+    expect(log.output()).toContain('duplicate id "GC-1"');
+    expect(log.output()).toContain('malformed due: date "bad"');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("shows not supported for sources without validate()", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(log.output()).toContain("not supported");
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("outputs JSON with --json flag when no errors", async () => {
+    const validate = vi.fn<NonNullable<TaskSource["validate"]>>().mockResolvedValue([]);
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [], { validate })]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"source": "todo"');
+    expect(output).toContain('"errors": []');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it("outputs JSON with --json flag and sets exit code 1 when errors present", async () => {
+    const validate = vi
+      .fn<NonNullable<TaskSource["validate"]>>()
+      .mockResolvedValue(['line 1: duplicate id "X"']);
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [], { validate })]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"source": "todo"');
+    expect(output).toContain("duplicate id");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("filters to the named source only", async () => {
+    const validateTodo = vi.fn<NonNullable<TaskSource["validate"]>>().mockResolvedValue([]);
+    const validateLinear = vi.fn<NonNullable<TaskSource["validate"]>>().mockResolvedValue([]);
+    buildSourcesMock.mockResolvedValue([
+      stubSource("todo", [], { validate: validateTodo }),
+      stubSource("linear", [], { validate: validateLinear }),
+    ]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["validate", "todo"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(validateTodo).toHaveBeenCalledTimes(1);
+    expect(validateLinear).not.toHaveBeenCalled();
+    expect(log.output()).toContain("todo");
+    expect(log.output()).not.toContain("linear");
+  });
+
+  it("throws when the named source is not found", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["validate", "missing"])).rejects.toThrow('no source named "missing"');
+  });
+
+  it.each([
+    { argv: ["validate", "--bogus"], message: "unknown option: --bogus" },
+    { argv: ["validate", "a", "b"], message: "too many arguments" },
+  ])("rejects invalid validate arguments: $argv", async ({ argv, message }) => {
+    await expect(taskCli(argv)).rejects.toThrow(message);
+  });
+});

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -7,14 +7,15 @@ import {
   type Task,
   type TaskSource,
 } from "../lib/taskSource.ts";
-import { writeOutput } from "../lib/util.ts";
+import { parseSourceFilterArgs, writeOutput } from "../lib/util.ts";
 
 const TASK_USAGE = `Usage: crew task <subcommand>
 
 Subcommands:
   list [options]                  List tasks across configured sources
   get <task-id> [options]         Get one task
-  create "Short title" [options]  Create one task`;
+  create "Short title" [options]  Create one task
+  validate [source] [options]     Validate task content`;
 
 const LIST_USAGE = `Usage: crew task list [options]
 
@@ -610,6 +611,84 @@ async function taskCreateCli(argv: readonly string[]): Promise<void> {
   writeOutput(created.id);
 }
 
+const VALIDATE_USAGE = `Usage: crew task validate [source]
+
+Options:
+  --json  Print results as JSON.`;
+
+interface ValidateResult {
+  source: string;
+  supported: boolean;
+  errors: string[];
+}
+
+async function taskValidateCli(argv: string[]): Promise<void> {
+  const { targetSource, jsonOutput } = parseSourceFilterArgs(
+    argv,
+    "crew task validate",
+    VALIDATE_USAGE,
+  );
+
+  // jscpd:ignore-start -- shared source-loading boilerplate; extracting to a helper would break vi.mock
+  const config = await loadConfig();
+  const rawSources = sourcesFromConfig(config);
+  const allSources = await buildSources(rawSources, { globalConfig: config });
+
+  let sources = allSources;
+  if (targetSource !== undefined) {
+    sources = allSources.filter((s) => s.name === targetSource);
+    if (sources.length === 0) {
+      throw new Error(`crew task validate: no source named "${targetSource}"`);
+    }
+  }
+  // jscpd:ignore-end
+
+  const results: ValidateResult[] = await Promise.all(
+    sources.map(async (source): Promise<ValidateResult> => {
+      if (source.validate === undefined) {
+        return { source: source.name, supported: false, errors: [] };
+      }
+      const errors = await source.validate();
+      return { source: source.name, supported: true, errors };
+    }),
+  );
+
+  const hasErrors = results.some((r) => r.errors.length > 0);
+
+  if (jsonOutput) {
+    writeOutput(
+      JSON.stringify(
+        results.map(({ source, errors }) => ({ source, errors })),
+        null,
+        2,
+      ),
+    );
+    if (hasErrors) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  const nameWidth = Math.max(...results.map((r) => r.source.length));
+  for (const result of results) {
+    if (!result.supported) {
+      writeOutput(`${result.source.padEnd(nameWidth)}  not supported`);
+      continue;
+    }
+    if (result.errors.length === 0) {
+      writeOutput(`${result.source.padEnd(nameWidth)}  ok`);
+    } else {
+      writeOutput(
+        `${result.source.padEnd(nameWidth)}  ${result.errors.length} error(s)\n${result.errors.map((e) => `  - ${e}`).join("\n")}`,
+      );
+    }
+  }
+
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}
+
 export async function taskCli(argv: string[]): Promise<void> {
   const [verb, ...rest] = argv;
   if (verb === "list") {
@@ -622,6 +701,10 @@ export async function taskCli(argv: string[]): Promise<void> {
   }
   if (verb === "create") {
     await taskCreateCli(rest);
+    return;
+  }
+  if (verb === "validate") {
+    await taskValidateCli(rest);
     return;
   }
   throw new Error(TASK_USAGE);

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -658,7 +658,7 @@ async function taskValidateCli(argv: string[]): Promise<void> {
   if (jsonOutput) {
     writeOutput(
       JSON.stringify(
-        results.map(({ source, errors }) => ({ source, errors })),
+        results.map(({ source, supported, errors }) => ({ source, supported, errors })),
         null,
         2,
       ),

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -11,6 +11,30 @@ import type { TodoTxtSourceRef } from "./normalizer.ts";
 // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests don't need the full config shape
 const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
 
+const contextWithModels: AdapterContext = {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- partial config sufficient for agent validation tests
+  globalConfig: {
+    models: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+  } as unknown as ResolvedConfig,
+};
+
+function makeSourceWithModels(tmp: TempDir): ReturnType<typeof createTodoTxtTaskSource> {
+  return createTodoTxtTaskSource(
+    {
+      kind: "todo-txt",
+      name: "todo",
+      todoPath: tmp.todoPath,
+      tasksDir: tmp.tasksDir,
+      idPrefix: "GC",
+      timezone: "UTC",
+    },
+    contextWithModels,
+  );
+}
+
 interface TempDir {
   dir: string;
   todoPath: string;
@@ -899,6 +923,54 @@ describe("TodoTxtTaskSource", () => {
     tmp.writeTodo("id:GC-IS agent:codex status:wip Task\n");
     const source = makeSource(tmp);
     await expect(source.verify()).rejects.toThrow(/invalid status/);
+  });
+
+  it("validate() returns empty array for a valid file", async () => {
+    tmp.writeTodo("(A) Good task id:GC-V1 agent:any status:todo\n");
+    tmp.writeTask("GC-V1", "Prompt.");
+    const source = makeSource(tmp);
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
+  });
+
+  it("validate() returns errors as an array without throwing", async () => {
+    tmp.writeTodo(
+      "Task A id:DUP agent:any status:in-progress\nTask B id:DUP agent:any status:in-progress\n",
+    );
+    const source = makeSource(tmp);
+    const errors = await source.validate?.();
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0]).toMatch(/duplicate id/);
+  });
+
+  it("validate() flags unknown agent when knownAgents are derived from config", async () => {
+    tmp.writeTodo("Task id:GC-AG1 agent:unknown-bot status:in-progress\n");
+    const source = makeSourceWithModels(tmp);
+    const errors = await source.validate?.();
+    expect(errors).toContainEqual(expect.stringContaining('unknown agent "unknown-bot"'));
+  });
+
+  it("validate() does not flag agent matching a configured model", async () => {
+    tmp.writeTodo("Task id:GC-AG2 agent:claude status:in-progress\n");
+    const source = makeSourceWithModels(tmp);
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
+  });
+
+  it("validate() does not flag agent:any", async () => {
+    tmp.writeTodo("Task id:GC-AG3 agent:any status:in-progress\n");
+    const source = makeSourceWithModels(tmp);
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
+  });
+
+  it("verify() catches unknown agent when knownAgents are derived from config", async () => {
+    tmp.writeTodo("Task id:GC-AV agent:unknown-bot status:in-progress\n");
+    const source = makeSourceWithModels(tmp);
+    await expect(source.verify()).rejects.toThrow(/unknown agent "unknown-bot"/);
+  });
+
+  it("validate() skips agent check when no models config is present", async () => {
+    tmp.writeTodo("Task id:GC-AG4 agent:anything-goes status:in-progress\n");
+    const source = makeSource(tmp); // fakeContext has no models
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
   });
 
   it("markInProgress throws when task status is already in-progress", async () => {

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from
 import path from "node:path";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
+import { AGENT_ANY_MODEL } from "../../config.ts";
 import {
   type CreateTaskInput,
   type Issue,
@@ -298,11 +299,19 @@ function openPromptEditor(promptPath: string): void {
 
 export function createTodoTxtTaskSource(
   config: TodoTxtAdapterConfig,
-  _context: AdapterContext,
+  context: AdapterContext,
 ): TaskSource {
   const sourceName = config.name;
   /* v8 ignore next @preserve -- Covered in source tests; full-suite V8 coverage remaps this line inconsistently. */
   const { todoPath, tasksDir } = config;
+
+  const knownAgents =
+    context.globalConfig.models === undefined
+      ? undefined
+      : new Set([
+          AGENT_ANY_MODEL,
+          ...Object.keys(context.globalConfig.models.definitions).map((k) => k.toLowerCase()),
+        ]);
 
   function listTasks(): Issue[] {
     const updatedAt = fileUpdatedAt(todoPath);
@@ -366,12 +375,16 @@ export function createTodoTxtTaskSource(
     name: sourceName,
 
     async verify(): Promise<void> {
-      const errors = validateTodoFile(todoPath, tasksDir);
+      const errors = validateTodoFile(todoPath, tasksDir, knownAgents);
       if (errors.length > 0) {
         throw new Error(
           `todo-txt source "${sourceName}" verification failed:\n${errors.map((e) => `  - ${e}`).join("\n")}`,
         );
       }
+    },
+
+    async validate(): Promise<string[]> {
+      return validateTodoFile(todoPath, tasksDir, knownAgents);
     },
 
     async listTasks(): Promise<Issue[]> {

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -423,11 +423,15 @@ function validateActiveTaskLine(
   id: string,
   prefix: string,
   errors: string[],
+  knownAgents?: ReadonlySet<string>,
 ): void {
   const agent = parsed.metadata["agent"]?.[0];
   /* v8 ignore next @preserve -- parser KEY_VALUE_RE requires \S+, so empty agent values can't be parsed */
   if (agent !== undefined && agent.trim().length === 0) {
     errors.push(`${prefix}: empty agent: value for task "${id}"`);
+  }
+  if (knownAgents !== undefined && agent !== undefined && !knownAgents.has(agent.toLowerCase())) {
+    errors.push(`${prefix}: unknown agent "${agent}" for task "${id}"`);
   }
 
   const statusValue = parsed.metadata["status"]?.[0];
@@ -449,7 +453,11 @@ function validateActiveTaskLine(
   validateDepsAndDates(parsed, parsedAll, id, prefix, errors);
 }
 
-export function validateTodoFile(todoPath: string, tasksDir: string): string[] {
+export function validateTodoFile(
+  todoPath: string,
+  tasksDir: string,
+  knownAgents?: ReadonlySet<string>,
+): string[] {
   const errors: string[] = [];
   let content: string;
   try {
@@ -487,7 +495,7 @@ export function validateTodoFile(todoPath: string, tasksDir: string): string[] {
       continue;
     }
 
-    validateActiveTaskLine(parsed, parsedAll, tasksDir, id, prefix, errors);
+    validateActiveTaskLine(parsed, parsedAll, tasksDir, id, prefix, errors, knownAgents);
   }
 
   return errors;

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -11,6 +11,7 @@ interface SourceCapabilities {
   markInProgress: boolean;
   markInReview: boolean;
   markDone: boolean;
+  validate: boolean;
 }
 
 export interface SourceSummary {
@@ -29,6 +30,7 @@ const LINEAR_CAPABILITIES: SourceCapabilities = {
   markInProgress: true,
   markInReview: true,
   markDone: false,
+  validate: false,
 };
 
 const UNKNOWN_KIND_CAPABILITIES: SourceCapabilities = {
@@ -39,6 +41,7 @@ const UNKNOWN_KIND_CAPABILITIES: SourceCapabilities = {
   markInProgress: false,
   markInReview: false,
   markDone: false,
+  validate: false,
 };
 
 function shellCapabilities(raw: unknown): SourceCapabilities {
@@ -52,6 +55,7 @@ function shellCapabilities(raw: unknown): SourceCapabilities {
     markInProgress: commands.markInProgress !== undefined,
     markInReview: commands.markInReview !== undefined,
     markDone: commands.markDone !== undefined,
+    validate: false,
   };
 }
 
@@ -63,6 +67,7 @@ const TODO_TXT_CAPABILITIES: SourceCapabilities = {
   markInProgress: true,
   markInReview: true,
   markDone: true,
+  validate: true,
 };
 
 export function summarizeSource(raw: unknown): SourceSummary {

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -202,6 +202,13 @@ export interface TaskSource {
    * don't distinguish parents simply omit this method; Board returns [].
    */
   fetchParentSkips?: () => Promise<readonly ParentSkip[]>;
+
+  /**
+   * Optional: validate task content and return human-readable error strings.
+   * Sources that cannot validate task content omit this method.
+   * Unlike `verify()`, this never throws — errors are returned as an array.
+   */
+  validate?: () => Promise<string[]>;
 }
 
 export class RepositoryResolutionError extends Error {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -247,6 +247,35 @@ export function parseDryRunPositionals(argv: string[], usage: string): DryRunPos
   return { dryRun, positionals };
 }
 
+interface SourceFilterArgs {
+  targetSource: string | undefined;
+  jsonOutput: boolean;
+}
+
+/** Parse the `[source] [--json]` argument pattern shared by source-scoped subcommands. */
+export function parseSourceFilterArgs(
+  argv: string[],
+  commandName: string,
+  usage: string,
+): SourceFilterArgs {
+  let jsonOutput = false;
+  let targetSource: string | undefined;
+  for (const arg of argv) {
+    if (arg === "--json") {
+      jsonOutput = true;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`${commandName}: unknown option: ${arg}\n${usage}`);
+    }
+    if (targetSource !== undefined) {
+      throw new Error(`${commandName}: too many arguments\n${usage}`);
+    }
+    targetSource = arg;
+  }
+  return { targetSource, jsonOutput };
+}
+
 export function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
## Summary

Adds `crew task validate [source] [--json]` — a new subcommand that runs content validation on task sources that opt in. Sources implement the optional `validate?(): Promise<string[]>` method on `TaskSource` (returns errors as an array rather than throwing, unlike `verify()`).

The todo-txt adapter implements it, using the existing `validateTodoFile()` logic plus a new check: `agent:` values are validated against `config.models.definitions` when a model config is present. This catches the checks the user asked for: duplicate IDs, missing/empty prompt files, invalid `status:` positions, unresolved `dep:` references, malformed dates, invalid recurrence expressions, and unknown agent names.

Also:
- Extracts a shared `parseSourceFilterArgs` helper used by both `crew source verify` and `crew task validate`
- Adds `validate` as a capability in `sourceCapabilities.ts` so `crew source list` shows `VALIDATE yes/no` for each source
- todo-txt shows `validate: yes`; Linear and shell show `validate: no`

## Validation

- `node --run verify` passes: all 1536 tests green, 100% coverage (statements, branches, functions, lines), cpd, lint, format all clean

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>