### PR TITLE
fix: use agents config for todo-txt validation

### DIFF
--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -8,20 +8,33 @@ import type { Issue } from "../../taskSource.ts";
 import { createTodoTxtTaskSource } from "./source.ts";
 import type { TodoTxtSourceRef } from "./normalizer.ts";
 
-// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- tests don't need the full config shape
-const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
+function makeAdapterContext(options: {
+  defaultAgent: string;
+  definitions: ResolvedConfig["agents"]["definitions"];
+}): AdapterContext {
+  const { defaultAgent, definitions } = options;
+  return {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- partial config sufficient for source tests
+    globalConfig: {
+      agents: { default: defaultAgent, definitions },
+    } as unknown as ResolvedConfig,
+  };
+}
 
-const contextWithModels: AdapterContext = {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- partial config sufficient for agent validation tests
-  globalConfig: {
-    models: {
-      default: "claude",
-      definitions: { claude: { cmd: "claude", color: "#fff" } },
-    },
-  } as unknown as ResolvedConfig,
-};
+const fakeContext = makeAdapterContext({
+  defaultAgent: "codex",
+  definitions: {
+    claude: { cmd: "claude", color: "#fff" },
+    codex: { cmd: "codex", color: "#3267e3" },
+  },
+});
 
-function makeSourceWithModels(tmp: TempDir): ReturnType<typeof createTodoTxtTaskSource> {
+const contextWithAgents = makeAdapterContext({
+  defaultAgent: "claude",
+  definitions: { claude: { cmd: "claude", color: "#fff" } },
+});
+
+function makeSourceWithAgents(tmp: TempDir): ReturnType<typeof createTodoTxtTaskSource> {
   return createTodoTxtTaskSource(
     {
       kind: "todo-txt",
@@ -31,7 +44,7 @@ function makeSourceWithModels(tmp: TempDir): ReturnType<typeof createTodoTxtTask
       idPrefix: "GC",
       timezone: "UTC",
     },
-    contextWithModels,
+    contextWithAgents,
   );
 }
 
@@ -944,33 +957,34 @@ describe("TodoTxtTaskSource", () => {
 
   it("validate() flags unknown agent when knownAgents are derived from config", async () => {
     tmp.writeTodo("Task id:GC-AG1 agent:unknown-bot status:in-progress\n");
-    const source = makeSourceWithModels(tmp);
+    const source = makeSourceWithAgents(tmp);
     const errors = await source.validate?.();
     expect(errors).toContainEqual(expect.stringContaining('unknown agent "unknown-bot"'));
   });
 
-  it("validate() does not flag agent matching a configured model", async () => {
+  it("validate() does not flag agent matching a configured agent", async () => {
     tmp.writeTodo("Task id:GC-AG2 agent:claude status:in-progress\n");
-    const source = makeSourceWithModels(tmp);
+    const source = makeSourceWithAgents(tmp);
     await expect(source.validate?.()).resolves.toStrictEqual([]);
   });
 
   it("validate() does not flag agent:any", async () => {
     tmp.writeTodo("Task id:GC-AG3 agent:any status:in-progress\n");
-    const source = makeSourceWithModels(tmp);
+    const source = makeSourceWithAgents(tmp);
     await expect(source.validate?.()).resolves.toStrictEqual([]);
   });
 
   it("verify() catches unknown agent when knownAgents are derived from config", async () => {
     tmp.writeTodo("Task id:GC-AV agent:unknown-bot status:in-progress\n");
-    const source = makeSourceWithModels(tmp);
+    const source = makeSourceWithAgents(tmp);
     await expect(source.verify()).rejects.toThrow(/unknown agent "unknown-bot"/);
   });
 
-  it("validate() skips agent check when no models config is present", async () => {
+  it("validate() flags unknown agent from the default resolved config context", async () => {
     tmp.writeTodo("Task id:GC-AG4 agent:anything-goes status:in-progress\n");
-    const source = makeSource(tmp); // fakeContext has no models
-    await expect(source.validate?.()).resolves.toStrictEqual([]);
+    const source = makeSource(tmp);
+    const errors = await source.validate?.();
+    expect(errors).toContainEqual(expect.stringContaining('unknown agent "anything-goes"'));
   });
 
   it("markInProgress throws when task status is already in-progress", async () => {

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from
 import path from "node:path";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
-import { AGENT_ANY_MODEL } from "../../config.ts";
+import { AGENT_ANY } from "../../config.ts";
 import {
   type CreateTaskInput,
   type Issue,
@@ -305,13 +305,10 @@ export function createTodoTxtTaskSource(
   /* v8 ignore next @preserve -- Covered in source tests; full-suite V8 coverage remaps this line inconsistently. */
   const { todoPath, tasksDir } = config;
 
-  const knownAgents =
-    context.globalConfig.models === undefined
-      ? undefined
-      : new Set([
-          AGENT_ANY_MODEL,
-          ...Object.keys(context.globalConfig.models.definitions).map((k) => k.toLowerCase()),
-        ]);
+  const knownAgents = new Set([
+    AGENT_ANY,
+    ...Object.keys(context.globalConfig.agents.definitions).map((k) => k.toLowerCase()),
+  ]);
 
   function listTasks(): Issue[] {
     const updatedAt = fileUpdatedAt(todoPath);


### PR DESCRIPTION
## Summary

Fixes the main-branch start failure caused by the todo-txt adapter still reading the removed `models` config shape. The adapter now derives known agents from resolved `agents.definitions` and keeps `agent:any` validation aligned with the rest of the config model.

## Validation

- `node --run build:dev`
- `npx vitest run src/lib/adapters/todo-txt/source.test.ts`
- `node --run lint`
- `node --run verify`
- Pre-push hook: `node --run verify`

Agent session: `codex resume 019ead40-b343-75e3-a6b8-03d297228993`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>