### PR TITLE
feat: defer todo-txt dispatch until t: threshold date

### DIFF
--- a/src/lib/adapters/todo-txt/normalizer.test.ts
+++ b/src/lib/adapters/todo-txt/normalizer.test.ts
@@ -81,6 +81,16 @@ describe(isActiveForFetch, () => {
     { name: "past threshold", line: "Ready id:T-3 t:2026-06-01 status:todo", active: true },
     { name: "malformed threshold", line: "Ready id:T-4 t:next-week status:todo", active: true },
     {
+      name: "non-calendar threshold matching the date format",
+      line: "Ready id:T-7 t:2026-99-99 status:todo",
+      active: true,
+    },
+    {
+      name: "non-calendar day overflow threshold",
+      line: "Ready id:T-8 t:2026-12-32 status:todo",
+      active: true,
+    },
+    {
       name: "future threshold but already in-progress",
       line: "Started early id:T-5 t:2026-06-09 status:in-progress",
       active: true,

--- a/src/lib/adapters/todo-txt/normalizer.test.ts
+++ b/src/lib/adapters/todo-txt/normalizer.test.ts
@@ -61,6 +61,8 @@ describe(normalizeToIssue, () => {
 });
 
 describe(isActiveForFetch, () => {
+  const today = "2026-06-08";
+
   it.each([
     { line: "Active todo id:ACTIVE-1 agent:codex status:todo", active: true },
     { line: "Active progress id:ACTIVE-2 agent:codex status:in-progress", active: true },
@@ -70,6 +72,25 @@ describe(isActiveForFetch, () => {
     { line: "No agent id:NO-AGENT-1 status:todo", active: true },
     { line: "Unknown status id:UNKNOWN-1 agent:codex status:waiting", active: false },
   ])("returns $active for $line", ({ line, active }) => {
-    expect(isActiveForFetch(parseOne(line))).toBe(active);
+    expect(isActiveForFetch(parseOne(line), today)).toBe(active);
+  });
+
+  it.each([
+    { name: "future threshold", line: "Deferred id:T-1 t:2026-06-09 status:todo", active: false },
+    { name: "threshold today", line: "Ready id:T-2 t:2026-06-08 status:todo", active: true },
+    { name: "past threshold", line: "Ready id:T-3 t:2026-06-01 status:todo", active: true },
+    { name: "malformed threshold", line: "Ready id:T-4 t:next-week status:todo", active: true },
+    {
+      name: "future threshold but already in-progress",
+      line: "Started early id:T-5 t:2026-06-09 status:in-progress",
+      active: true,
+    },
+    {
+      name: "future threshold but already in-review",
+      line: "Reviewed early id:T-6 t:2026-06-09 status:in-review",
+      active: true,
+    },
+  ])("returns $active for $name", ({ line, active }) => {
+    expect(isActiveForFetch(parseOne(line), today)).toBe(active);
   });
 });

--- a/src/lib/adapters/todo-txt/normalizer.ts
+++ b/src/lib/adapters/todo-txt/normalizer.ts
@@ -2,7 +2,13 @@ import path from "node:path";
 
 import { AGENT_ANY } from "../../config.ts";
 import { type Blocker, type CanonicalStatus, type Issue, toCanonicalId } from "../../taskSource.ts";
-import { getMetadataAll, getMetadataFirst, hashLine, type ParsedTodoLine } from "./parser.ts";
+import {
+  DATE_RE,
+  getMetadataAll,
+  getMetadataFirst,
+  hashLine,
+  type ParsedTodoLine,
+} from "./parser.ts";
 
 export interface TodoTxtSourceRef {
   sourceName: string;
@@ -142,7 +148,7 @@ export function normalizeToIssue(options: NormalizeOptions): Issue | undefined {
   };
 }
 
-export function isActiveForFetch(parsed: ParsedTodoLine): boolean {
+export function isActiveForFetch(parsed: ParsedTodoLine, todayIsoDate: string): boolean {
   if (parsed.completed) {
     return false;
   }
@@ -150,5 +156,21 @@ export function isActiveForFetch(parsed: ParsedTodoLine): boolean {
     return false;
   }
   const statusValue = getMetadataFirst(parsed, "status");
-  return statusValue === "todo" || statusValue === "in-progress" || statusValue === "in-review";
+  if (statusValue === "todo") {
+    return !isDeferredByThreshold(parsed, todayIsoDate);
+  }
+  return statusValue === "in-progress" || statusValue === "in-review";
+}
+
+// Per todo.txt convention, t: (threshold) hides a task until that date.
+// Only not-yet-started tasks defer; in-progress/in-review work must stay
+// visible so the orchestrator keeps tracking it. Malformed t: values are
+// surfaced by validate() and do not block dispatch.
+function isDeferredByThreshold(parsed: ParsedTodoLine, todayIsoDate: string): boolean {
+  const threshold = getMetadataFirst(parsed, "t");
+  if (threshold === undefined || !DATE_RE.test(threshold)) {
+    return false;
+  }
+  // ISO YYYY-MM-DD dates order lexicographically
+  return threshold > todayIsoDate;
 }

--- a/src/lib/adapters/todo-txt/normalizer.ts
+++ b/src/lib/adapters/todo-txt/normalizer.ts
@@ -168,9 +168,18 @@ export function isActiveForFetch(parsed: ParsedTodoLine, todayIsoDate: string): 
 // surfaced by validate() and do not block dispatch.
 function isDeferredByThreshold(parsed: ParsedTodoLine, todayIsoDate: string): boolean {
   const threshold = getMetadataFirst(parsed, "t");
-  if (threshold === undefined || !DATE_RE.test(threshold)) {
+  if (threshold === undefined || !DATE_RE.test(threshold) || !isCalendarDate(threshold)) {
     return false;
   }
   // ISO YYYY-MM-DD dates order lexicographically
   return threshold > todayIsoDate;
+}
+
+// DATE_RE is format-only; non-calendar values like 2026-99-99 would compare
+// greater than any real date and defer the task forever.
+function isCalendarDate(value: string): boolean {
+  const monthIndex = Number(value.slice(5, 7)) - 1;
+  const day = Number(value.slice(8, 10));
+  const date = new Date(Date.UTC(Number(value.slice(0, 4)), monthIndex, day));
+  return date.getUTCMonth() === monthIndex && date.getUTCDate() === day;
 }

--- a/src/lib/adapters/todo-txt/parser.ts
+++ b/src/lib/adapters/todo-txt/parser.ts
@@ -16,7 +16,7 @@ export interface ParsedTodoLine {
   readonly isStatusFinalToken: boolean;
 }
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+export const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const KEY_VALUE_RE = /^(?<key>[a-zA-Z][a-zA-Z0-9-]*):(?<value>\S+)$/;
 const PRIORITY_RE = /^\((?<priority>[A-Z])\) /;
 const PROJECT_RE = /^\+\S+$/;

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -1124,6 +1124,68 @@ describe("TodoTxtTaskSource", () => {
     expect(recurResult?.newId).toBe("cleanup-20260608-002");
   });
 
+  it("fetch defers status:todo tasks whose t: threshold is in the future", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-08T12:00:00.000Z"));
+    tmp.writeTodo(
+      "Deferred task id:DEFER-1 agent:codex t:2026-06-09 status:todo\nReady task id:READY-1 agent:codex t:2026-06-08 status:todo\nPast threshold id:READY-2 agent:codex t:2026-06-01 status:todo\n",
+    );
+    tmp.writeTask("DEFER-1", "Deferred prompt.");
+    tmp.writeTask("READY-1", "Ready prompt.");
+    tmp.writeTask("READY-2", "Past prompt.");
+
+    const source = makeSource(tmp);
+    const issues = await source.fetch();
+
+    expect(issues.map((issue) => issue.id)).toStrictEqual(["todo:ready-1", "todo:ready-2"]);
+  });
+
+  it("fetch computes today in the configured timezone when deferring on t:", async () => {
+    // 2026-06-09T03:00Z is still 2026-06-08 in America/Chicago (UTC-5),
+    // so a t:2026-06-09 task is deferred there but ready in UTC.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T03:00:00.000Z"));
+    tmp.writeTodo("Deferred task id:TZ-1 agent:codex t:2026-06-09 status:todo\n");
+    tmp.writeTask("TZ-1", "Timezone prompt.");
+
+    const chicagoSource = createTodoTxtTaskSource(
+      {
+        kind: "todo-txt",
+        name: "todo",
+        todoPath: tmp.todoPath,
+        tasksDir: tmp.tasksDir,
+        idPrefix: "GC",
+        timezone: "America/Chicago",
+      },
+      fakeContext,
+    );
+    const utcSource = makeSource(tmp);
+
+    await expect(chicagoSource.fetch()).resolves.toHaveLength(0);
+    await expect(utcSource.fetch()).resolves.toHaveLength(1);
+  });
+
+  it("markDone with rec:+1w and t: but no due: advances the id using the new t:", async () => {
+    tmp.writeTodo(
+      "Weekly status id:status-20260601 agent:any t:2026-06-01 rec:+1w status:in-progress\n",
+    );
+    tmp.writeTask("status-20260601", "Status prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("status-20260601");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-01T00:00:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08"); // t: advanced 1w from 2026-06-01
+    expect(recurResult?.newId).toBe("status-20260608");
+  });
+
   it("markDone with rec: task having t: threshold date advances it too", async () => {
     // rec:+1w strict: due advances from 2026-06-01 → 2026-06-08; t: advances from 2026-05-25 → 2026-06-01
     tmp.writeTodo(

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -14,11 +14,10 @@ import {
 } from "../../taskSource.ts";
 import { readEnvironmentVariable } from "../../util.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
-import { getMetadataFirst, parseAllLines, type ParsedTodoLine } from "./parser.ts";
+import { DATE_RE, getMetadataFirst, parseAllLines, type ParsedTodoLine } from "./parser.ts";
 import type { TodoTxtAdapterConfig } from "./schema.ts";
 import { copyPromptFile, updateTaskStatus, validateTodoFile, withLock } from "./writeback.ts";
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const RECURRENCE_RE = /^\+?\d+[dwmy]$/;
 
 function readPromptFile(promptPath: string): string | undefined {
@@ -128,7 +127,7 @@ function metadataToken(key: string, value: string): string {
   return `${key}:${value}`;
 }
 
-function datePartFor(timeZone: string, now: Date): string {
+function isoDateFor(timeZone: string, now: Date): string {
   const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone,
     year: "numeric",
@@ -142,7 +141,11 @@ function datePartFor(timeZone: string, now: Date): string {
   if (year === undefined || month === undefined || day === undefined) {
     throw new Error(`todo-txt: could not format date in timezone "${timeZone}"`);
   }
-  return `${year}${month}${day}`;
+  return `${year}-${month}-${day}`;
+}
+
+function datePartFor(timeZone: string, now: Date): string {
+  return isoDateFor(timeZone, now).replaceAll("-", "");
 }
 
 /* v8 ignore next @preserve -- Covered in source tests; full-suite V8 coverage remaps this helper inconsistently. */
@@ -312,6 +315,7 @@ export function createTodoTxtTaskSource(
 
   function listTasks(): Issue[] {
     const updatedAt = fileUpdatedAt(todoPath);
+    const todayIsoDate = isoDateFor(config.timezone, new Date());
     const { parsedAll } = readAndParseTodo(todoPath);
     const issues: Issue[] = [];
 
@@ -320,7 +324,7 @@ export function createTodoTxtTaskSource(
       if (parsed === null || parsed === undefined) {
         continue;
       }
-      if (!isActiveForFetch(parsed)) {
+      if (!isActiveForFetch(parsed, todayIsoDate)) {
         continue;
       }
 

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-import { hashLine, parseAllLines, type ParsedTodoLine } from "./parser.ts";
+import { DATE_RE, hashLine, parseAllLines, type ParsedTodoLine } from "./parser.ts";
 import type { TodoTxtSourceRef } from "./normalizer.ts";
 
 export interface RecurResult {
@@ -18,8 +18,6 @@ export interface RecurResult {
   oldPromptPath: string;
   newPromptPath: string;
 }
-
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function isoDate(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -261,9 +259,12 @@ function buildRecurResult(
   // t: always advances from its own current value by the same period
   const newT = oldT === undefined ? undefined : advanceDate(oldT, rec);
 
-  // Compute new date for id advancement
-  /* v8 ignore next @preserve -- newDue undefined when no due: field; rare edge case */
-  const newDateForId = newDue === undefined ? now : new Date(`${newDue}T00:00:00Z`);
+  // Compute new date for id advancement: prefer due:, then t:, so ids stay
+  // schedule-aligned for t:-only recurring tasks
+  const newScheduleDate = newDue ?? newT;
+  /* v8 ignore next @preserve -- rec: without due: or t: is unusual; id falls back to completion date */
+  const newDateForId =
+    newScheduleDate === undefined ? now : new Date(`${newScheduleDate}T00:00:00Z`);
   const baseNewId = advanceId(ref.id, newDateForId);
   const newId = buildUniqueId(baseNewId, existingIds);
 


### PR DESCRIPTION
## Summary

A recurring todo-txt task (`rec:1w due:2026-06-23`) was dispatched two weeks before its date because nothing gated dispatch on dates — `isActiveForFetch` only checked `status:`. Worse, without a gate a recurring task degenerates into running on every poll cycle: each completion writes a new `status:todo` line that is immediately eligible again.

Per todo.txt convention (sleek, SwiftoDo, topydo), `t:` (threshold) is the deferral mechanism — `due:` is just a deadline. The recurrence writeback already parsed and advanced `t:` on completion but never honored it. Now `fetch()` skips `status:todo` tasks whose `t:` is in the future, computed in the source's configured timezone. In-progress/in-review tasks stay visible so the orchestrator keeps tracking started work, and malformed `t:` values (already flagged by `validate()`) do not block dispatch.

Also: recurring tasks with `t:` but no `due:` advance their id from the new `t:` date instead of the completion date, keeping ids schedule-aligned; the `DATE_RE` regex previously duplicated across three adapter files is now a single export from `parser.ts`.

## Validation

- `node --run verify` passes (lint, format, architecture, 1548 tests, 100% coverage).
- New unit tests cover future/today/past/malformed thresholds, in-progress visibility, timezone boundary behavior (America/Chicago vs UTC), and t:-only recurrence id advancement.
- Note: the coverage gate is flaky locally (V8 remap nondeterminism) — clean `main` also fails it intermittently with identical symptoms.

Agent session: `claude --resume 37870d3d-1166-49c0-bcaf-c5712e0edfd5`

<sub>🤖 <code>commit-push-pr:created v1 core@3.6.0</code></sub>