### PR TITLE
feat: load the initial prompt from a file (prompts.promptFile)

### DIFF
--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -120,6 +120,9 @@ export default {
   //   // `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/initial-prompt.md`.
   //   // If you uncomment this, also uncomment the readFileSync import above.
   //   initial: readFileSync(new URL("./initial-prompt.md", import.meta.url), "utf8"),
+  //   // Or, instead of `initial`, point at a file (also works in crew.config.json).
+  //   // Resolved relative to this config's directory; `~` and absolute paths work.
+  //   // promptFile: "initial-prompt.md",
   // },
   //
   // // Terminal session manager. "auto" picks cmux when on PATH, else tmux.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,22 @@ export default {
 
 This keeps package defaults portable while letting your private config reference team-specific statuses, tools, plugins, or review loops.
 
+### Loading the prompt from a file (`prompts.promptFile`)
+
+`readFileSync` works for `.ts` configs but not for `crew.config.json`, which has no way to reference an external file. Set `prompts.promptFile` instead and groundcrew reads the file's contents into the initial prompt at load time:
+
+```json
+{
+  "prompts": {
+    "promptFile": "prompt-initial.md"
+  }
+}
+```
+
+- The path is resolved **relative to the config file's directory** (matching the `.ts` `import.meta.url` behavior); a leading `~` is expanded and absolute paths are used as-is.
+- `prompts.initial` and `prompts.promptFile` are **mutually exclusive** — setting both is a hard error. Set neither to keep the built-in default.
+- Placeholder validation runs on the loaded file contents, so an unknown `{{placeholder}}` in the file fails the same way it would inline.
+
 ## Default Hooks
 
 Repo-local `.groundcrew/config.json` is the preferred place for
@@ -199,7 +215,8 @@ and hook contract.
 | `models.definitions.<name>.sandbox`      | optional             | Docker Sandboxes binding for the model. Required at launch when `local.runner` resolves to `sdx`. Field: `agent` (required sbx agent name). Groundcrew assumes the `groundcrew-<agent>` sandbox already exists.                                                                                                                                                                                                                                                                                                             |
 | `models.definitions.<name>.preLaunch`    | optional             | Host-only shell snippet run before the agent exec and outside Safehouse/sdx. Exports survive into the launch shell; under the default `safehouse` runner they are only forwarded to the agent when listed via `preLaunchEnv` or when `cmd` includes its own `safehouse --env-pass=NAMES`. `{{worktree}}` is substituted. A non-zero exit aborts launch. Not supported when `local.runner` resolves to `sdx` in v1.                                                                                                          |
 | `models.definitions.<name>.preLaunchEnv` | optional             | Companion to `preLaunch`: list of env var names to append to groundcrew's `safehouse-clearance` `--env-pass=` flag, so `preLaunch` exports reach the agent without overriding `cmd` and losing the project's egress allowlist. Each entry must match `[A-Za-z_][A-Za-z0-9_]*`. Under `runner: "none"` exports already inherit and `preLaunchEnv` is a no-op. An empty array is a uniform no-op in every runner; a non-empty list is rejected when `cmd` already starts with `safehouse` or when `runner` resolves to `sdx`. |
-| `prompts.initial`                        | unattended template  | First message sent to the agent: the execution wrapper around each task. The task description is the task-specific prompt. Placeholders: `{{task}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override only to change the execution contract for every task, such as team-wide review rules or tool conventions.                                                                                                                                                                                                     |
+| `prompts.initial`                        | unattended template  | First message sent to the agent: the execution wrapper around each task. The task description is the task-specific prompt. Placeholders: `{{task}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override only to change the execution contract for every task, such as team-wide review rules or tool conventions. Mutually exclusive with `prompts.promptFile`.                                                                                                                                                       |
+| `prompts.promptFile`                     | optional             | Path to a UTF-8 file whose contents become `prompts.initial`, read at load time. Resolved relative to the config file's directory; `~` is expanded and absolute paths are used as-is. The JSON-friendly alternative to inlining a large prompt or `readFileSync`. Mutually exclusive with `prompts.initial`.                                                                                                                                                                                                                |
 | `workspaceKind`                          | `"auto"`             | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"`, `"tmux"`, or `"zellij"` to fail loudly when the chosen backend is missing.                                                                                                                                                                                                                                                                                                                                                      |
 | `local.runner`                           | `"auto"`             | Local isolation backend. `"auto"` uses `safehouse` on macOS and `sdx` on Linux/WSL. Explicit: `"safehouse"`, `"sdx"`, `"none"`. `"none"` is never picked implicitly.                                                                                                                                                                                                                                                                                                                                                        |
 | `logging.file`                           | XDG state path       | Append-mode log file. `log()` / `logEvent()` tee here in addition to stdout. Defaults to `${XDG_STATE_HOME:-$HOME/.local/state}/groundcrew/groundcrew.log`.                                                                                                                                                                                                                                                                                                                                                                 |

--- a/src/lib/config.promptFile.test.ts
+++ b/src/lib/config.promptFile.test.ts
@@ -1,0 +1,266 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  deleteEnvironmentVariable,
+  setEnvironmentVariable,
+  snapshotEnvironmentVariables,
+} from "../testHelpers/env.ts";
+import type { Config, LoadedConfig, ResolvedConfig } from "./config.ts";
+
+interface ConfigModule {
+  loadConfig: () => Promise<Readonly<ResolvedConfig>>;
+  loadConfigWithSource: () => Promise<Readonly<LoadedConfig>>;
+}
+
+async function loadFreshConfig(): Promise<ConfigModule> {
+  vi.resetModules();
+  return await import("./config.ts");
+}
+
+const VALID_WORKSPACE = (projectDir: string) => ({
+  projectDir,
+  knownRepositories: ["repo-a"],
+});
+
+function writeConfigFile(dir: string, body: string): string {
+  const configPath = path.join(dir, `config-${Math.random().toString(36).slice(2)}.ts`);
+  writeFileSync(configPath, body);
+  return configPath;
+}
+
+function configSource(config: Config): string {
+  return `export default ${JSON.stringify(config, undefined, 2)};\n`;
+}
+
+function validConfigSource(config: Config): string {
+  return configSource({
+    ...config,
+    agents: {
+      definitions: { claude: {} },
+      ...config.agents,
+    },
+  });
+}
+
+describe("loadConfig prompts.promptFile", () => {
+  const originalEnvironment = snapshotEnvironmentVariables();
+  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME"] as const;
+  let temporary: string;
+
+  beforeEach(() => {
+    temporary = mkdtempSync(path.join(tmpdir(), "groundcrew-config-"));
+    for (const key of ENV_KEYS) {
+      deleteEnvironmentVariable(key);
+    }
+    setEnvironmentVariable("XDG_CONFIG_HOME", path.join(temporary, "xdg-config"));
+    setEnvironmentVariable("XDG_STATE_HOME", path.join(temporary, "xdg-state"));
+    vi.spyOn(process, "cwd").mockReturnValue(temporary);
+  });
+
+  afterEach(() => {
+    rmSync(temporary, { recursive: true, force: true });
+    for (const key of ENV_KEYS) {
+      const original = originalEnvironment[key];
+      if (original === undefined) {
+        deleteEnvironmentVariable(key);
+      } else {
+        setEnvironmentVariable(key, original);
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("uses an explicit inline prompts.initial when no promptFile is set", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { initial: "Just do {{task}} now." },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe("Just do {{task}} now.");
+  });
+
+  it("loads prompts.promptFile contents into prompts.initial", async () => {
+    const promptBody = "Custom prompt for {{task}} in {{worktree}}.";
+    writeFileSync(path.join(temporary, "prompt-initial.md"), promptBody);
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "prompt-initial.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe(promptBody);
+  });
+
+  it("accepts a promptFile whose contents have no placeholders", async () => {
+    const promptBody = "Plain prompt with no placeholders.";
+    writeFileSync(path.join(temporary, "prompt-initial.md"), promptBody);
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "prompt-initial.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe(promptBody);
+  });
+
+  it("resolves a relative prompts.promptFile against the config dir, not cwd", async () => {
+    const nested = path.join(temporary, "nested");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, "prompt-initial.md"), "Prompt from nested config dir.");
+    // Decoy in cwd (mocked to `temporary`) that must NOT be picked up.
+    writeFileSync(path.join(temporary, "prompt-initial.md"), "Prompt from cwd — wrong.");
+    const configPath = writeConfigFile(
+      nested,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "prompt-initial.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe("Prompt from nested config dir.");
+  });
+
+  it("expands a leading ~ in prompts.promptFile", async () => {
+    const fakeHome = path.join(temporary, "home");
+    mkdirSync(fakeHome, { recursive: true });
+    setEnvironmentVariable("HOME", fakeHome);
+    writeFileSync(path.join(fakeHome, "my-prompt.md"), "Prompt from home dir.");
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "~/my-prompt.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe("Prompt from home dir.");
+  });
+
+  it("reads an absolute prompts.promptFile as-is", async () => {
+    const absolutePrompt = path.join(temporary, "abs-prompt.md");
+    writeFileSync(absolutePrompt, "Absolute prompt body.");
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: absolutePrompt },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.prompts.initial).toBe("Absolute prompt body.");
+  });
+
+  it("rejects setting both prompts.initial and prompts.promptFile", async () => {
+    writeFileSync(path.join(temporary, "prompt-initial.md"), "File prompt.");
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { initial: "Inline prompt {{task}}", promptFile: "prompt-initial.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/set either `initial` or `promptFile`, not both/);
+  });
+
+  it("fails with the resolved path when prompts.promptFile cannot be read", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "does-not-exist.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /prompts\.promptFile could not be read at .*does-not-exist\.md/,
+    );
+  });
+
+  it("rejects an empty prompts.promptFile", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/prompts\.promptFile must be a non-empty string/);
+  });
+
+  it("rejects a non-string prompts.promptFile", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      `export default { workspace: ${JSON.stringify(
+        VALID_WORKSPACE(temporary),
+      )}, agents: { definitions: { claude: {} } }, prompts: { promptFile: 123 } };\n`,
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/prompts\.promptFile must be a non-empty string/);
+  });
+
+  it("validates placeholders in the loaded prompts.promptFile contents", async () => {
+    writeFileSync(
+      path.join(temporary, "prompt-initial.md"),
+      "Work on {{task}} but also {{unknownPlaceholder}}.",
+    );
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        prompts: { promptFile: "prompt-initial.md" },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/unknown placeholder "\{\{unknownPlaceholder\}\}"/);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -224,7 +224,14 @@ export interface Config {
     definitions?: Record<string, UserAgentDefinition>;
   };
   prompts?: {
+    /** Inline initial prompt. Mutually exclusive with `promptFile`. */
     initial?: string;
+    /**
+     * Path to a UTF-8 file whose contents become the initial prompt. Resolved
+     * relative to the config file's directory; `~` is expanded; absolute paths
+     * are used as-is. Mutually exclusive with `initial`.
+     */
+    promptFile?: string;
   };
   /**
    * Terminal session manager that hosts agent processes. Defaults to
@@ -917,7 +924,35 @@ function normalizeWorkspace(workspace: Config["workspace"]): ResolvedConfig["wor
   };
 }
 
-function applyDefaults(user: Config): ResolvedConfig {
+/**
+ * Resolve the initial prompt from the user's `prompts` block. `promptFile` and
+ * `initial` are mutually exclusive; when neither is set the built-in default is
+ * used. A `promptFile` is resolved relative to the config file's directory
+ * (matching the `.ts` `import.meta.url` behavior), with `~` expanded and
+ * absolute paths used as-is, then read at load time.
+ */
+function resolveInitialPrompt(prompts: Config["prompts"], configDir: string): string {
+  const { initial, promptFile } = prompts ?? {};
+  if (initial !== undefined && promptFile !== undefined) {
+    fail("prompts: set either `initial` or `promptFile`, not both");
+  }
+
+  if (promptFile !== undefined) {
+    requireString(promptFile, "prompts.promptFile");
+
+    const expanded = expandHome(promptFile);
+    const resolved = path.isAbsolute(expanded) ? expanded : path.resolve(configDir, expanded);
+    try {
+      return readFileSync(resolved, "utf8");
+    } catch (error) {
+      fail(`prompts.promptFile could not be read at ${resolved}: ${String(error)}`);
+    }
+  }
+
+  return initial ?? DEFAULT_PROMPT_INITIAL;
+}
+
+function applyDefaults(user: Config, configDir: string): ResolvedConfig {
   // Guard the top-level shape before reading nested fields, so a
   // malformed runtime config produces a `groundcrew config: ...` error
   // instead of a raw `TypeError: Cannot read properties of undefined`.
@@ -963,7 +998,7 @@ function applyDefaults(user: Config): ResolvedConfig {
       definitions: mergeDefinitions(user.agents?.definitions),
     },
     prompts: {
-      initial: user.prompts?.initial ?? DEFAULT_PROMPT_INITIAL,
+      initial: resolveInitialPrompt(user.prompts, configDir),
     },
     workspaceKind: normalizeWorkspaceKind(user.workspaceKind, "workspaceKind") ?? "auto",
     local: {
@@ -978,7 +1013,6 @@ function applyDefaults(user: Config): ResolvedConfig {
 }
 
 function validatePromptPlaceholders(template: string): void {
-  /* v8 ignore next @preserve -- a no-placeholder prompt is unusual but tests with placeholders consistently match at least once */
   const placeholders = template.match(PROMPT_PLACEHOLDER_RE) ?? [];
   const unknown = placeholders.find((placeholder) => !ALLOWED_PROMPT_PLACEHOLDERS.has(placeholder));
   if (unknown !== undefined) {
@@ -1211,7 +1245,7 @@ export async function loadConfigWithSource(): Promise<Readonly<LoadedConfig>> {
   debug(`Loaded config from ${filepath}`);
 
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- runtime fields are validated by applyDefaults/validate
-  const resolved = applyDefaults(userConfig as unknown as Config);
+  const resolved = applyDefaults(userConfig as unknown as Config, path.dirname(filepath));
 
   validate(resolved);
 


### PR DESCRIPTION
## Why

Storing a large agent prompt inline is poor ergonomics. The `.ts` config solved it by `readFileSync`-ing a sibling `prompt-initial.md` into `prompts.initial` at module load — but the groundcrew-config TUI always saves `crew.config.json`, which inlines the entire prompt (7KB+) as one JSON string and loses the separate-file workflow. JSON cannot reference an external file, so this adds a native loader feature.

## What

Add `prompts.promptFile` to groundcrew's config: a path to a UTF-8 file whose contents become the initial prompt (`prompts.initial` in the resolved config).

- **Resolution:** relative to the config file's directory (matching the `.ts` `import.meta.url` behavior); `~` is expanded; absolute paths are used as-is.
- **Mutual exclusion:** `prompts.initial` and `prompts.promptFile` are mutually exclusive — a hard error if both are set. Neither → the built-in `DEFAULT_PROMPT_INITIAL`.
- **Read at load time;** existing placeholder validation runs on the loaded contents (an unknown `{{placeholder}}` in the file fails exactly as it would inline).
- **Zero blast radius:** `ResolvedConfig.prompts.initial` stays a resolved `string`, so the orchestrator, launch, and rendering are all unchanged. This is a pure loader feature.
- **Backward compatible:** existing inline `prompts.initial` configs keep working.

All changes are in `src/lib/config.ts`: a `resolveInitialPrompt()` helper, threading a `configDir` into `applyDefaults`, and passing `path.dirname(filepath)` at the single call site in `loadConfigWithSource`.

## Tests

New focused suite `src/lib/config.promptFile.test.ts` (split out to stay under the 2000-line `max-lines` cap on `config.test.ts`):

- loads file contents into `prompts.initial`
- relative path resolves against the config dir, **not** cwd (decoy file in cwd proves it)
- `~` expansion and absolute paths
- both `initial` + `promptFile` set → rejected
- unreadable file → error includes the resolved path
- empty / non-string `promptFile` → rejected
- placeholder validation runs on file contents
- zero-placeholder file loads cleanly
- inline `prompts.initial` regression

`node --run verify` passes: all tests green, **100% coverage** (statements/branches/functions/lines), lint/format/cpd/spell/architecture all clean.

## Docs

- `docs/configuration.md`: new "Loading the prompt from a file" section + Full Reference row.
- `crew.config.example.ts`: commented `promptFile` example.

## Decisions

- **No manual version bump.** The repo's semantic-release automation handles the minor publish from this `feat:` commit on merge, so `package.json` is left untouched.
- **Reverted an unrelated `package-lock.json` version-field sync** (pre-existing 4.24.1→4.26.1 drift that `npm install` surfaced) to keep this PR scoped to the feature.
- **Error message wording** keeps the existing `prompts.initial …` text from the shared placeholder validator (the file's contents *become* `prompts.initial`), rather than introducing a `promptFile`-specific variant.

## Scope

This is **Phase 1** (groundcrew engine) of a 3-phase plan. Phase 2 (groundcrew-config TUI wiring) and Phase 3 (migrating an existing config) live in other repos and are explicitly blocked on a published Phase 1.