### PR TITLE
fix: rename stale models references to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install -g @clipboard-health/groundcrew@latest
 
 # 2. Scaffold a global config. Agents are sandboxed by default
 #    (Safehouse/Docker Sandboxes); add --runner none to run unsandboxed on the host.
-crew init --global --project-dir ~/dev --repo OWNER/REPO --model claude
+crew init --global --project-dir ~/dev --repo OWNER/REPO --agent claude
 
 # 3. Run the clone commands printed by `crew init`.
 
@@ -64,7 +64,7 @@ crew doctor
 crew run --watch
 ```
 
-`crew init --global` writes config to `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/`. Pass `--repo` more than once for multiple repos. `--model claude` or `--model codex` chooses the single built-in model preset to enable in the generated config.
+`crew init --global` writes config to `${XDG_CONFIG_HOME:-$HOME/.config}/groundcrew/`. Pass `--repo` more than once for multiple repos. `--agent claude` or `--agent codex` chooses the single built-in agent preset to enable in the generated config.
 
 ## Task Pickup
 
@@ -72,8 +72,8 @@ crew run --watch
 
 Linear works out of the box: assign tasks to yourself and add an `agent-*` label.
 
-- `agent-claude`, `agent-codex`, or `agent-<name>` routes to that model.
-- `agent-any` routes to the enabled model with the most session headroom, after skipping models over their session limit or weekly paced budget.
+- `agent-claude`, `agent-codex`, or `agent-<name>` routes to that agent.
+- `agent-any` routes to the enabled agent with the most session headroom, after skipping agents over their session limit or weekly paced budget.
 - Tasks without an `agent-*` label are ignored by `crew run`; dispatch one manually with `crew start <TASK>`.
 
 Groundcrew scans `workspace.knownRepositories` to infer which repo a task belongs to.
@@ -91,17 +91,19 @@ Write tasks as complete agent instructions: the goal, the context and constraint
 ```bash
 crew init [--global | --local] [--force] [--dry-run]     # create a crew.config.ts
           [--project-dir <dir>] [--repo <repo>]...
-          [--runner <auto|safehouse|sdx|none>] [--model <claude|codex>]
+          [--runner <auto|safehouse|sdx|none>] [--agent <claude|codex>]
 crew doctor                                              # check setup
+crew source list|verify [<source>]                       # inspect configured task sources
 crew task list [--source <name>]                         # list tasks across sources
 crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or its prompt
 crew task create "Title" --source <name> [--agent <name>] # create a source task
+crew task validate [<source>]                            # validate task content
 crew status [<TASK>]                                   # inspect current state or one task
 crew run [--watch]                                       # one-shot or --watch forever
 crew start <TASK>                                      # provision + launch one task now
 crew stop <TASK> [--reason <text>]                     # stop workspace, keep worktree
 crew resume <TASK>                                     # reopen a paused task
-crew cleanup <TASK>                                    # tear down every worktree for a task
+crew cleanup [--force] <TASK>                          # tear down every worktree for a task
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 ```
 
@@ -109,7 +111,7 @@ See [command details](./docs/commands.md) for status output, doctor behavior, an
 
 ## Configuration
 
-Workspace settings and at least one enabled model are required; everything else has a default.
+Workspace settings and at least one enabled agent are required; everything else has a default.
 
 ```ts
 import type { Config } from "@clipboard-health/groundcrew";
@@ -122,7 +124,7 @@ export default {
     // Strings live under projectDir; use { name, projectDirOverride } to override per repo.
     knownRepositories: ["OWNER/REPO"],
   },
-  models: {
+  agents: {
     default: "claude",
     definitions: {
       claude: {},

--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -27,9 +27,9 @@ export default {
     //   { name: "other-org/other-repo", projectDirOverride: "~/work" }
     knownRepositories: ["your-org/your-repo"],
   },
-  models: {
+  agents: {
     default: "claude",
-    // `definitions` is the enabled model set. Built-in keys can use `{}` to
+    // `definitions` is the enabled agent set. Built-in keys can use `{}` to
     // opt into the shipped command/color/usage preset. Add `codex: {}` if you
     // want both shipped agents, or add a custom entry and tag tasks with
     // `agent-<name>`.
@@ -99,7 +99,7 @@ export default {
   //   // it into the agent. Chain with `&&` so a failed mint aborts launch.
   //   preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
   //   preLaunchEnv: ["SESSION_TOKEN"],
-  //   // Required for this model when `local.runner` resolves to `sdx`.
+  //   // Required for this agent when `local.runner` resolves to `sdx`.
   //   sandbox: { agent: "claude" },
   // },
   //
@@ -110,7 +110,7 @@ export default {
   // local: { runner: "auto" },
   //
   // // Groundcrew does not create or authenticate sdx sandboxes. For an sdx
-  // // model, create the matching sandbox yourself before first launch:
+  // // agent, create the matching sandbox yourself before first launch:
   // //   sbx create --name groundcrew-claude claude ~/dev/groundcrew
   // //   sbx exec -it groundcrew-claude claude auth login
   // //   sbx exec -it groundcrew-claude gh auth login

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -159,6 +159,14 @@ describe("crew init", () => {
       expect(actual).not.toContain("disabled: true");
     });
 
+    it("generates a config that uses the `agents` key, not the rejected `models` key", () => {
+      const result = initConfig({ cwd });
+
+      const actual = readFileSync(result.destination, "utf8");
+      expect(actual).toContain("agents: {");
+      expect(actual).not.toMatch(/^\s*models:/m);
+    });
+
     it("fails loudly when a quickstart template anchor is missing", () => {
       const template = path.join(cwd, "crew.config.example.ts");
       writeFileSync(

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -159,14 +159,6 @@ describe("crew init", () => {
       expect(actual).not.toContain("disabled: true");
     });
 
-    it("generates a config that uses the `agents` key, not the rejected `models` key", () => {
-      const result = initConfig({ cwd });
-
-      const actual = readFileSync(result.destination, "utf8");
-      expect(actual).toContain("agents: {");
-      expect(actual).not.toMatch(/^\s*models:/m);
-    });
-
     it("fails loudly when a quickstart template anchor is missing", () => {
       const template = path.join(cwd, "crew.config.example.ts");
       writeFileSync(


### PR DESCRIPTION
## Summary

The `--model` → `--agent` flag rename left stale references behind. The README quickstart and commands block still showed `--model`, and the config examples in both `README.md` and `crew.config.example.ts` still used the `models` key — which `loadConfig` now rejects with a migration error. Because `crew init` copies `crew.config.example.ts` verbatim, every freshly scaffolded config failed to load until the user hand-renamed the key.

This renames `models` → `agents` in both files and aligns the README commands block with the actual `crew --help` output (adds `crew source list|verify`, `crew task validate`, and `cleanup --force`).

Note: the `docs/` directory (e.g. `docs/configuration.md`) still references `models` throughout and likely needs the same treatment — left out of scope here.

## Validation

- `node --run verify` passes (build, lint, tests with 100% coverage, format, spell, knip, cpd).
- `crew init` output verified to produce a config `loadConfig` accepts (`agents` key).
- `crew --help` output cross-checked against every command line in the README commands block.

<sub>🤖 <code>commit-push-pr:created v1 core@3.8.0</code></sub>