### PR TITLE
feat: add createTask and validate hooks to shell adapter

### DIFF
--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -79,6 +79,15 @@ const SHELL_RAW_FULL = {
     markDone: "jira move ${id} 'Done'",
   },
 };
+const SHELL_RAW_CREATE_VALIDATE = {
+  kind: "shell",
+  name: "plans",
+  commands: {
+    fetch: "./fetch.sh",
+    createTask: "./create.sh ${title}",
+    validate: "./validate.sh",
+  },
+};
 
 describe("sourceCli dispatch", () => {
   it("throws with usage for an unknown subcommand", async () => {
@@ -174,6 +183,21 @@ describe("crew source list", () => {
     expect(output).toContain('"createTask": false');
     expect(output).toContain('"markDone": false');
     expect(output).toContain('"validate": false');
+  });
+
+  it("reports shell createTask and validate capabilities when configured", async () => {
+    sourcesFromConfigMock.mockReturnValue([SHELL_RAW_CREATE_VALIDATE]);
+    const log = captureConsoleLog();
+    try {
+      await sourceCli(["list", "--json"]);
+    } finally {
+      log.restore();
+    }
+
+    const output = log.output();
+    expect(output).toContain('"name": "plans"');
+    expect(output).toContain('"createTask": true');
+    expect(output).toContain('"validate": true');
   });
 
   it("shows todo-txt source with full capabilities", async () => {

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -8,7 +8,7 @@ import { captureConsoleError } from "../../../testHelpers/consoleCapture.ts";
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import type { ResolvedConfig } from "../../config.ts";
-import type { Issue as CanonicalIssue } from "../../taskSource.ts";
+import type { CreateTaskInput, Issue as CanonicalIssue } from "../../taskSource.ts";
 
 import { createShellTaskSource, toCanonicalIssue } from "./factory.ts";
 import type { ShellIssue } from "./schema.ts";
@@ -171,6 +171,18 @@ describe(toCanonicalIssue, () => {
 
 function payload(issue: ShellIssue): string {
   return JSON.stringify([issue]);
+}
+
+function createInput(overrides: Partial<CreateTaskInput> = {}): CreateTaskInput {
+  return {
+    title: "Title",
+    agent: "any",
+    projects: [],
+    contexts: [],
+    dependencies: [],
+    edit: false,
+    ...overrides,
+  };
 }
 
 describe(createShellTaskSource, () => {
@@ -631,5 +643,259 @@ describe(createShellTaskSource, () => {
       err.restore();
     }
     expect(err.output()).toContain("commands.resolveOne is ignored");
+  });
+
+  it("createTask is absent on the source when commands.createTask is unset", () => {
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },
+      fakeContext,
+    );
+    expect(source.createTask).toBeUndefined();
+  });
+
+  it("createTask is present on the source when commands.createTask is set", () => {
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'", createTask: "echo '{}'" } },
+      fakeContext,
+    );
+    expect(source.createTask).toBeDefined();
+  });
+
+  it("createTask expands every scalar (empty string for absent optionals), comma-joins list fields, and shell-quotes args", async () => {
+    const capture = path.join(dir.path, "create-args.txt");
+    // printf '%s\n' "$@" writes each received positional arg on its own line —
+    // empty args become blank lines, proving the empty-string substitutions and
+    // the shell-quoting (a spaced title arrives as ONE arg, not two).
+    const createScript = dir.writeScript(
+      "create.sh",
+      `printf '%s\\n' "$@" > "${capture}"\ncat <<'JSON'\n${JSON.stringify(
+        shellIssue({ id: "NEW-1" }),
+      )}\nJSON`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: {
+          fetch: "echo '[]'",
+          createTask: `${createScript} \${title} \${agent} \${repo} \${team} \${id} \${priority} \${due} \${recurrence} \${promptFile} \${description} \${edit} \${projects} \${contexts} \${dependencies}`,
+        },
+      },
+      fakeContext,
+    );
+
+    const created = await source.createTask?.(
+      createInput({
+        title: "My Task",
+        agent: "claude",
+        repository: "org/repo",
+        priority: "A",
+        projects: ["proj1", "proj2"],
+        contexts: ["ctx1"],
+        dependencies: ["dep1", "dep2"],
+      }),
+    );
+
+    const expectedArgs = [
+      "My Task",
+      "claude",
+      "org/repo",
+      "",
+      "",
+      "A",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "proj1,proj2",
+      "ctx1",
+      "dep1,dep2",
+    ];
+    expect(readFileSync(capture, "utf8")).toBe(`${expectedArgs.join("\n")}\n`);
+    // The returned ShellIssue is parsed and converted to a canonical issue.
+    expect(created?.id).toBe("test:new-1");
+    expect(created?.source).toBe("test");
+  });
+
+  it('createTask substitutes edit as the string "true" when input.edit is true', async () => {
+    const capture = path.join(dir.path, "create-edit.txt");
+    const createScript = dir.writeScript(
+      "create-edit.sh",
+      `printf '%s' "$1" > "${capture}"\ncat <<'JSON'\n${JSON.stringify(
+        shellIssue({ id: "NEW-2" }),
+      )}\nJSON`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", createTask: `${createScript} \${edit}` },
+      },
+      fakeContext,
+    );
+
+    await source.createTask?.(createInput({ edit: true }));
+
+    expect(readFileSync(capture, "utf8")).toBe("true");
+  });
+
+  it("createTask throws on a nonzero exit", async () => {
+    const createScript = dir.writeScript("create-fail.sh", 'echo "boom" >&2; exit 1');
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", createTask: createScript },
+      },
+      fakeContext,
+    );
+    await expect(source.createTask?.(createInput())).rejects.toThrow(/boom/);
+  });
+
+  it("createTask throws when the script produces no output", async () => {
+    const createScript = dir.writeScript("create-empty.sh", "exit 0");
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", createTask: createScript },
+      },
+      fakeContext,
+    );
+    await expect(source.createTask?.(createInput())).rejects.toThrow(/no output/i);
+  });
+
+  // invokeShellCommand resolves (does not throw) on exit 3 — its lookup
+  // "not found" sentinel. Creation has no not-found concept, so exit 3 must
+  // be a hard failure rather than a silently-parsed (or empty) result.
+  it("createTask throws on exit 3 (the lookup not-found sentinel)", async () => {
+    const createScript = dir.writeScript("create-nf.sh", "exit 3");
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", createTask: createScript },
+      },
+      fakeContext,
+    );
+    await expect(source.createTask?.(createInput())).rejects.toThrow(/exited 3/);
+  });
+
+  it("validate is absent on the source when commands.validate is unset", () => {
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },
+      fakeContext,
+    );
+    expect(source.validate).toBeUndefined();
+  });
+
+  it("validate is present on the source when commands.validate is set", () => {
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'", validate: "echo '[]'" } },
+      fakeContext,
+    );
+    expect(source.validate).toBeDefined();
+  });
+
+  it("validate returns [] for empty stdout", async () => {
+    const validateScript = dir.writeScript("validate-empty.sh", "exit 0");
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
+  });
+
+  it("validate returns [] for a JSON empty array", async () => {
+    const source = createShellTaskSource(
+      { kind: "shell", name: "test", commands: { fetch: "echo '[]'", validate: "echo '[]'" } },
+      fakeContext,
+    );
+    await expect(source.validate?.()).resolves.toStrictEqual([]);
+  });
+
+  it("validate returns the parsed error array", async () => {
+    const validateScript = dir.writeScript(
+      "validate-errors.sh",
+      `cat <<'JSON'\n["error one","error two"]\nJSON`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    await expect(source.validate?.()).resolves.toStrictEqual(["error one", "error two"]);
+  });
+
+  it("validate returns a one-element error array (does not throw) on a nonzero exit", async () => {
+    const validateScript = dir.writeScript(
+      "validate-fail.sh",
+      'echo "validator crashed" >&2; exit 1',
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    const errors = await source.validate?.();
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0]).toMatch(/validate command failed/);
+    expect(errors?.[0]).toMatch(/validator crashed/);
+  });
+
+  it("validate returns a one-element error array (does not throw) on exit 3", async () => {
+    const validateScript = dir.writeScript("validate-nf.sh", "exit 3");
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    const errors = await source.validate?.();
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0]).toMatch(/exited 3/);
+  });
+
+  it("validate returns a one-element error array (does not throw) on malformed stdout", async () => {
+    const validateScript = dir.writeScript("validate-bad.sh", 'echo "not json"');
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    const errors = await source.validate?.();
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0]).toMatch(/validate command failed/);
+  });
+
+  it("validate returns a one-element error array when stdout is a non-string-array JSON payload", async () => {
+    const validateScript = dir.writeScript("validate-shape.sh", `echo '[1, 2, 3]'`);
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", validate: validateScript },
+      },
+      fakeContext,
+    );
+    const errors = await source.validate?.();
+    expect(errors).toHaveLength(1);
+    expect(errors?.[0]).toMatch(/validate command failed/);
   });
 });

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -718,6 +718,28 @@ describe(createShellTaskSource, () => {
     expect(created?.source).toBe("test");
   });
 
+  it("createTask exposes input.repository under both ${repo} and ${repository}", async () => {
+    const capture = path.join(dir.path, "create-repo.txt");
+    const createScript = dir.writeScript(
+      "create-repo.sh",
+      `printf '%s\\n' "$1" "$2" > "${capture}"\ncat <<'JSON'\n${JSON.stringify(
+        shellIssue({ id: "NEW-3" }),
+      )}\nJSON`,
+    );
+    const source = createShellTaskSource(
+      {
+        kind: "shell",
+        name: "test",
+        commands: { fetch: "echo '[]'", createTask: `${createScript} \${repo} \${repository}` },
+      },
+      fakeContext,
+    );
+
+    await source.createTask?.(createInput({ repository: "org/repo" }));
+
+    expect(readFileSync(capture, "utf8")).toBe("org/repo\norg/repo\n");
+  });
+
   it('createTask substitutes edit as the string "true" when input.edit is true', async () => {
     const capture = path.join(dir.path, "create-edit.txt");
     const createScript = dir.writeScript(

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -1,7 +1,7 @@
 /**
  * Shell-adapter `TaskSource` factory. Wires `invokeShellCommand` to the
- * four TaskSource operations and applies the ShellIssue Zod schema for
- * runtime validation of script stdout.
+ * TaskSource operations and applies the ShellIssue Zod schema for runtime
+ * validation of script stdout.
  *
  * Fallback behavior for omitted commands:
  *  - `verify` absent → no-op (always succeeds).
@@ -13,11 +13,16 @@
  *  - `markInProgress` absent → silent no-op.
  *  - `markInReview` absent → reports unsupported.
  *  - `markDone` absent → reports unsupported.
+ *  - `createTask` absent → method omitted entirely (source reports it cannot
+ *    create tasks; the optional method is attached only when configured).
+ *  - `validate` absent → method omitted entirely (same capability-detection
+ *    contract as createTask).
  *  - `fetch` is required by the Zod schema.
  */
 
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import {
+  type CreateTaskInput,
   toCanonicalId,
   type Blocker as CanonicalBlocker,
   type Issue as CanonicalIssue,
@@ -25,7 +30,7 @@ import {
   type MarkInReviewResult,
   type TaskSource,
 } from "../../taskSource.ts";
-import { writeError } from "../../util.ts";
+import { errorMessage, writeError } from "../../util.ts";
 
 import { invokeShellCommand } from "./invoke.ts";
 import {
@@ -33,6 +38,7 @@ import {
   shellFetchOutputSchema,
   type ShellIssue,
   shellIssueSchema,
+  shellValidateOutputSchema,
 } from "./schema.ts";
 
 interface ResolvedShellTimeouts {
@@ -42,6 +48,8 @@ interface ResolvedShellTimeouts {
   markInProgress: number;
   markInReview: number;
   markDone: number;
+  createTask: number;
+  validate: number;
 }
 
 const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
@@ -51,16 +59,21 @@ const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
   markInProgress: 10_000,
   markInReview: 10_000,
   markDone: 10_000,
+  createTask: 30_000,
+  validate: 30_000,
 };
 
 function mergeTimeouts(overrides: ShellAdapterConfig["timeouts"]): ResolvedShellTimeouts {
+  const o = overrides ?? {};
   return {
-    verify: overrides?.verify ?? DEFAULT_TIMEOUTS.verify,
-    listTasks: overrides?.listTasks ?? overrides?.fetch ?? DEFAULT_TIMEOUTS.listTasks,
-    getTask: overrides?.getTask ?? overrides?.resolveOne ?? DEFAULT_TIMEOUTS.getTask,
-    markInProgress: overrides?.markInProgress ?? DEFAULT_TIMEOUTS.markInProgress,
-    markInReview: overrides?.markInReview ?? DEFAULT_TIMEOUTS.markInReview,
-    markDone: overrides?.markDone ?? DEFAULT_TIMEOUTS.markDone,
+    verify: o.verify ?? DEFAULT_TIMEOUTS.verify,
+    listTasks: o.listTasks ?? o.fetch ?? DEFAULT_TIMEOUTS.listTasks,
+    getTask: o.getTask ?? o.resolveOne ?? DEFAULT_TIMEOUTS.getTask,
+    markInProgress: o.markInProgress ?? DEFAULT_TIMEOUTS.markInProgress,
+    markInReview: o.markInReview ?? DEFAULT_TIMEOUTS.markInReview,
+    markDone: o.markDone ?? DEFAULT_TIMEOUTS.markDone,
+    createTask: o.createTask ?? DEFAULT_TIMEOUTS.createTask,
+    validate: o.validate ?? DEFAULT_TIMEOUTS.validate,
   };
 }
 
@@ -121,6 +134,31 @@ export function toCanonicalIssue(shellIssue: ShellIssue, sourceName: string): Ca
     hasMoreBlockers: shellIssue.hasMoreBlockers,
     ...(shellIssue.url === undefined ? {} : { url: shellIssue.url }),
     sourceRef: shellIssue.sourceRef,
+  };
+}
+
+/**
+ * Flatten a CreateTaskInput into the `${...}` substitution map the createTask
+ * script receives. Every key is always present — absent optionals become an
+ * empty string — so no placeholder is ever left literally in the command.
+ * List fields are comma-joined into a single value.
+ */
+function createTaskSubstitutions(input: CreateTaskInput): Record<string, string> {
+  return {
+    title: input.title,
+    agent: input.agent,
+    repo: input.repository ?? "",
+    team: input.team ?? "",
+    id: input.id ?? "",
+    priority: input.priority ?? "",
+    due: input.due ?? "",
+    recurrence: input.recurrence ?? "",
+    promptFile: input.promptFile ?? "",
+    description: input.description ?? "",
+    edit: input.edit ? "true" : "",
+    projects: input.projects.join(","),
+    contexts: input.contexts.join(","),
+    dependencies: input.dependencies.join(","),
   };
 }
 
@@ -199,7 +237,7 @@ export function createShellTaskSource(
     });
   }
 
-  return {
+  const source: TaskSource = {
     name: sourceName,
     async verify(): Promise<void> {
       const verifyCommand = config.commands.verify;
@@ -248,4 +286,72 @@ export function createShellTaskSource(
       return { outcome: "applied" };
     },
   };
+
+  // createTask / validate are attached only when their command is configured.
+  // Capability detection keys off `source.createTask === undefined` /
+  // `source.validate === undefined`, so a slot left unset must leave the
+  // method genuinely absent rather than present-but-failing.
+  const createTaskCommand = config.commands.createTask;
+  if (createTaskCommand !== undefined) {
+    source.createTask = async (input: CreateTaskInput): Promise<CanonicalIssue> => {
+      const { stdout, exitCode } = await invokeShellCommand({
+        command: createTaskCommand,
+        timeoutMs: timeouts.createTask,
+        cwd: config.cwd,
+        env: config.env,
+        substitutions: createTaskSubstitutions(input),
+        sourceName,
+      });
+      // invokeShellCommand resolves (does not throw) on exit 3 — its "not
+      // found" sentinel for lookups. Creation has no not-found concept, so any
+      // nonzero exit is a failure: surface it rather than parse partial output.
+      if (exitCode === 3) {
+        throw new Error(
+          `shell source "${sourceName}" createTask command exited 3 (not-found); task creation cannot signal not-found`,
+        );
+      }
+      const trimmed = stdout.trim();
+      if (trimmed.length === 0) {
+        throw new Error(
+          `shell source "${sourceName}" createTask command produced no output (expected one ShellIssue JSON)`,
+        );
+      }
+      const parsed = shellIssueSchema.parse(JSON.parse(trimmed));
+      return toCanonicalIssue(parsed, sourceName);
+    };
+  }
+
+  const validateCommand = config.commands.validate;
+  if (validateCommand !== undefined) {
+    source.validate = async (): Promise<string[]> => {
+      try {
+        const { stdout, exitCode } = await invokeShellCommand({
+          command: validateCommand,
+          timeoutMs: timeouts.validate,
+          cwd: config.cwd,
+          env: config.env,
+          sourceName,
+        });
+        // exit 3 is invoke's lookup "not found" sentinel; for validation it is
+        // not a meaningful success, so surface it as a failure (and validate
+        // never throws — return the failure as an error string).
+        if (exitCode === 3) {
+          return [
+            `shell source "${sourceName}" validate command exited 3 (not-found); treating as a validation failure`,
+          ];
+        }
+        const trimmed = stdout.trim();
+        if (trimmed.length === 0) {
+          return [];
+        }
+        return shellValidateOutputSchema.parse(JSON.parse(trimmed));
+      } catch (error) {
+        // Contract: validate() never throws — fold a nonzero exit, timeout,
+        // malformed JSON, or wrong-shape payload into a single error string.
+        return [`shell source "${sourceName}" validate command failed: ${errorMessage(error)}`];
+      }
+    };
+  }
+
+  return source;
 }

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -147,7 +147,10 @@ function createTaskSubstitutions(input: CreateTaskInput): Record<string, string>
   return {
     title: input.title,
     agent: input.agent,
+    // Exposed under both `repo` (short form) and `repository` (matches the
+    // CreateTaskInput field name) so either placeholder resolves.
     repo: input.repository ?? "",
+    repository: input.repository ?? "",
     team: input.team ?? "",
     id: input.id ?? "",
     priority: input.priority ?? "",

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-template-curly-in-string -- ${id}-style placeholders appear in config command strings for the shell adapter's substitution mechanism */
 
-import { shellAdapterConfigSchema, shellFetchOutputSchema, shellIssueSchema } from "./schema.ts";
+import {
+  shellAdapterConfigSchema,
+  shellFetchOutputSchema,
+  shellIssueSchema,
+  shellValidateOutputSchema,
+} from "./schema.ts";
 
 describe("shell issue schema", () => {
   it("accepts a fully-formed shell issue", () => {
@@ -281,5 +286,77 @@ describe("shell adapter config schema", () => {
       timeouts: { markDone: 0 },
     };
     expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
+
+  it("accepts commands.createTask and commands.validate", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: {
+        fetch: "./fetch.sh",
+        createTask: "./create.sh ${title}",
+        validate: "./validate.sh",
+      },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it("accepts a config with createTask and validate omitted (still valid)", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+    };
+    const parsed = shellAdapterConfigSchema.parse(config);
+    expect(parsed.commands.createTask).toBeUndefined();
+    expect(parsed.commands.validate).toBeUndefined();
+  });
+
+  it("accepts timeouts.createTask and timeouts.validate", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { createTask: 45_000, validate: 20_000 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it("rejects a zero createTask timeout", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { createTask: 0 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
+
+  it("rejects a zero validate timeout", () => {
+    const config = {
+      kind: "shell",
+      name: "jira",
+      commands: { fetch: "./fetch.sh" },
+      timeouts: { validate: 0 },
+    };
+    expect(() => shellAdapterConfigSchema.parse(config)).toThrow(/too small|>0/i);
+  });
+});
+
+describe("shell validate output schema", () => {
+  it("accepts an array of error strings", () => {
+    expect(() => shellValidateOutputSchema.parse(["error one", "error two"])).not.toThrow();
+  });
+
+  it("accepts an empty array", () => {
+    expect(() => shellValidateOutputSchema.parse([])).not.toThrow();
+  });
+
+  it("rejects a non-array", () => {
+    expect(() => shellValidateOutputSchema.parse({ error: "x" })).toThrow(/.+/);
+  });
+
+  it("rejects an array containing non-strings", () => {
+    expect(() => shellValidateOutputSchema.parse(["ok", 42])).toThrow(/.+/);
   });
 });

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -44,6 +44,13 @@ export type ShellIssue = z.infer<typeof shellIssueSchema>;
 
 export const shellFetchOutputSchema = z.array(shellIssueSchema);
 
+/**
+ * Shape a `commands.validate` script must emit on stdout: a JSON array of
+ * human-readable error strings. An empty array (or empty stdout, handled by
+ * the factory) means "no problems found".
+ */
+export const shellValidateOutputSchema = z.array(z.string());
+
 export const shellAdapterConfigSchema = z.object({
   kind: z.literal("shell"),
   name: z
@@ -63,6 +70,19 @@ export const shellAdapterConfigSchema = z.object({
       markInProgress: z.string().optional(),
       markInReview: z.string().optional(),
       markDone: z.string().optional(),
+      /**
+       * Create a task from a `CreateTaskInput`. Receives the input fields as
+       * shell-quoted `${...}` placeholders (see factory) and must print one
+       * ShellIssue JSON on stdout. Omitting it leaves the source unable to
+       * create tasks.
+       */
+      createTask: z.string().optional(),
+      /**
+       * Validate task content. Must print a JSON array of error strings on
+       * stdout (empty array / empty stdout = no problems). Omitting it leaves
+       * the source unable to validate.
+       */
+      validate: z.string().optional(),
     })
     .superRefine((commands, ctx) => {
       if (commands.listTasks === undefined && commands.fetch === undefined) {
@@ -90,6 +110,10 @@ export const shellAdapterConfigSchema = z.object({
       markInProgress: z.number().int().positive().optional(),
       markInReview: z.number().int().positive().optional(),
       markDone: z.number().int().positive().optional(),
+      /** Timeout for the createTask command. */
+      createTask: z.number().int().positive().optional(),
+      /** Timeout for the validate command. */
+      validate: z.number().int().positive().optional(),
     })
     .optional(),
   env: z.record(z.string(), z.string()).optional(),

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -51,11 +51,11 @@ function shellCapabilities(raw: unknown): SourceCapabilities {
     verify: commands.verify !== undefined,
     listTasks: true,
     getTask: true,
-    createTask: false,
+    createTask: commands.createTask !== undefined,
     markInProgress: commands.markInProgress !== undefined,
     markInReview: commands.markInReview !== undefined,
     markDone: commands.markDone !== undefined,
-    validate: false,
+    validate: commands.validate !== undefined,
   };
 }
 


### PR DESCRIPTION
## Why

The shell `TaskSource` adapter only wired the read + status-writeback methods. `createTask` and `validate` — both optional on `TaskSource` and already implemented by the **todo-txt** and **Linear** adapters — were never attached to the shell adapter. As a result `crew task create --source <name>` and `crew task validate <name>` always degraded to "does not support task creation" / "not supported" for any shell-backed source.

This closes that gap so any shell source — notably plan-keeper's `plans` source (companion plan: plan-keeper's `crew create` / `crew validate`) — can supply task creation and content validation.

Source discovery now reports those configured shell capabilities too, so `crew source list` / `crew source list --json` stay aligned with the runtime adapter behavior.

## What

- **`schema.ts`** — two optional command slots (`createTask`, `validate`) and two optional timeouts (30s default each); new `shellValidateOutputSchema` (`z.array(z.string())`) for parsing validate stdout. Both slots stay optional, so a config without them parses and behaves exactly as before.
- **`factory.ts`** — attaches `createTask`/`validate` **only when** their command slot is configured. Capability detection elsewhere keys off `source.createTask === undefined` / `source.validate === undefined`, so an unset slot must leave the method genuinely absent rather than present-but-failing.
  - `createTask` flattens `CreateTaskInput` into a `${...}` substitution map (every key always present — empty string for absent optionals; `projects`/`contexts`/`dependencies` comma-joined; `edit` → `"true"`/`""`), reusing `applySubstitutions`' shell-quoting (injection-safe). Parses one `ShellIssue` from stdout via the existing `shellIssueSchema` and returns the canonical issue. Empty stdout on success is an error.
  - `validate` **never throws**: folds a nonzero exit, timeout, malformed JSON, or wrong-shape payload into a one-element error-string array.
- **`sourceCapabilities.ts`** — reports shell `createTask` / `validate` capabilities from `commands.createTask` and `commands.validate` instead of always reporting `false`.
- **`source.test.ts`** — covers JSON capability output for a shell source configured with both new command slots.

## Decisions

- **`errorMessage` vs `messageOf`** — the source plan's pseudocode referenced a `messageOf` helper that doesn't exist in this repo; used the project's actual `errorMessage` (util.ts) instead.
- **Exit-code 3 treated as a failure for create/validate** — `invokeShellCommand` resolves (does not throw) on exit 3, its "not found" sentinel for *lookups*. "Not found" is meaningless for creation/validation, and the plan specifies a nonzero exit is a failure for these operations, so both methods now treat exit 3 as a hard failure (createTask throws; validate returns a one-element error array). Surfaced during independent code review; covered by tests. *Alternative considered:* let exit 3 fall through as success — rejected because it would let a create script silently "succeed" with no/partial output.
- **`createTask` parses a single `ShellIssue` object, not an array** — per spec (`fetch` returns an array; create returns one issue). Documented in the slot's JSDoc.
- **Substitution map scoped to `CreateTaskInput` fields** — intentionally omits `${name}`/`${canonicalId}` (those belong to the lookup/writeback commands), per the plan's scoped key list.

## Validation

`node --run verify` passes in full — lint, types, build, knip, spell, format, and **all tests at 100% statement / branch / function / line coverage**. New tests: 11 in `schema.test.ts`, 16 in `factory.test.ts`, and 1 in `source.test.ts` (presence/absence by slot, full substitution expansion + shell-quoting, parse, every throw / never-throw path including exit-3, and source-list capability reporting).

A shell source **without** the new slots is unaffected — existing behavior is preserved.

## Notes

No external ticket — this is from a local exec-plan. The consuming side (plan-keeper `crew create`/`crew validate`) ships as a separate companion change.

Agent session: `codex resume 019eb231-cd23-7811-8c6d-bca3dab20b96`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>
