### PR TITLE
feat: add first-class safehouse.gitSshToHttps config

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -798,24 +798,24 @@ describe("loadConfig", () => {
     expect(actual.agents.definitions["claude"]?.color).toBeTypeOf("string");
   });
 
-  it("merges safehouse.gitRewrite through an override and preserves cmd/color defaults", async () => {
+  it("merges safehouse.gitSshToHttps through an override and preserves cmd/color defaults", async () => {
     const configPath = writeConfigFile(
       temporary,
       configSource({
         workspace: VALID_WORKSPACE(temporary),
-        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+        agents: { definitions: { claude: { safehouse: { gitSshToHttps: "enabled" } } } },
       }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     setEnvironmentVariable("GITHUB_TOKEN", "ghp_test_token");
     const { loadConfig } = await loadFreshConfig();
     const actual = await loadConfig();
-    expect(actual.agents.definitions["claude"]?.safehouse?.gitRewrite).toBe("ssh-to-https");
+    expect(actual.agents.definitions["claude"]?.safehouse?.gitSshToHttps).toBe("enabled");
     expect(actual.agents.definitions["claude"]?.cmd).toBeTypeOf("string");
     expect(actual.agents.definitions["claude"]?.color).toBeTypeOf("string");
   });
 
-  it("accepts an empty safehouse block and leaves gitRewrite unset", async () => {
+  it("accepts an empty safehouse block and leaves gitSshToHttps unset", async () => {
     const configPath = writeConfigFile(
       temporary,
       configSource({
@@ -827,20 +827,20 @@ describe("loadConfig", () => {
     const { loadConfig } = await loadFreshConfig();
     const actual = await loadConfig();
     expect(actual.agents.definitions["claude"]?.safehouse).toStrictEqual({});
-    expect(actual.agents.definitions["claude"]?.safehouse?.gitRewrite).toBeUndefined();
+    expect(actual.agents.definitions["claude"]?.safehouse?.gitSshToHttps).toBeUndefined();
   });
 
-  it("rejects an unknown safehouse.gitRewrite value", async () => {
-    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: { gitRewrite: "bogus" } } } } };`;
+  it("rejects an unknown safehouse.gitSshToHttps value", async () => {
+    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: { gitSshToHttps: "bogus" } } } } };`;
     setEnvironmentVariable("GROUNDCREW_CONFIG", writeConfigFile(temporary, source));
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
-      /agents\.definitions\.claude\.safehouse\.gitRewrite must be one of ssh-to-https/,
+      /agents\.definitions\.claude\.safehouse\.gitSshToHttps must be one of enabled/,
     );
   });
 
   it("rejects a non-object safehouse block", async () => {
-    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: "ssh-to-https" } } } };`;
+    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: "enabled" } } } };`;
     setEnvironmentVariable("GROUNDCREW_CONFIG", writeConfigFile(temporary, source));
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
@@ -848,35 +848,35 @@ describe("loadConfig", () => {
     );
   });
 
-  it("rejects safehouse.gitRewrite when GITHUB_TOKEN is unset", async () => {
+  it("rejects safehouse.gitSshToHttps when GITHUB_TOKEN is unset", async () => {
     const configPath = writeConfigFile(
       temporary,
       configSource({
         workspace: VALID_WORKSPACE(temporary),
-        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+        agents: { definitions: { claude: { safehouse: { gitSshToHttps: "enabled" } } } },
       }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     deleteEnvironmentVariable("GITHUB_TOKEN");
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
-      /agents\.definitions\.claude\.safehouse\.gitRewrite is set to "ssh-to-https" but GITHUB_TOKEN is not set/,
+      /agents\.definitions\.claude\.safehouse\.gitSshToHttps is set to "enabled" but GITHUB_TOKEN is not set/,
     );
   });
 
-  it("rejects safehouse.gitRewrite when GITHUB_TOKEN is empty", async () => {
+  it("rejects safehouse.gitSshToHttps when GITHUB_TOKEN is empty", async () => {
     const configPath = writeConfigFile(
       temporary,
       configSource({
         workspace: VALID_WORKSPACE(temporary),
-        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+        agents: { definitions: { claude: { safehouse: { gitSshToHttps: "enabled" } } } },
       }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     setEnvironmentVariable("GITHUB_TOKEN", "   ");
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
-      /agents\.definitions\.claude\.safehouse\.gitRewrite is set to "ssh-to-https" but GITHUB_TOKEN is not set/,
+      /agents\.definitions\.claude\.safehouse\.gitSshToHttps is set to "enabled" but GITHUB_TOKEN is not set/,
     );
   });
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -792,6 +792,55 @@ describe("loadConfig", () => {
     expect(actual.agents.definitions["claude"]?.color).toBeTypeOf("string");
   });
 
+  it("merges safehouse.gitRewrite through an override and preserves cmd/color defaults", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({
+        workspace: VALID_WORKSPACE(temporary),
+        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.agents.definitions["claude"]?.safehouse?.gitRewrite).toBe("ssh-to-https");
+    expect(actual.agents.definitions["claude"]?.cmd).toBeTypeOf("string");
+    expect(actual.agents.definitions["claude"]?.color).toBeTypeOf("string");
+  });
+
+  it("accepts an empty safehouse block and leaves gitRewrite unset", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({
+        workspace: VALID_WORKSPACE(temporary),
+        agents: { definitions: { claude: { safehouse: {} } } },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.agents.definitions["claude"]?.safehouse).toStrictEqual({});
+    expect(actual.agents.definitions["claude"]?.safehouse?.gitRewrite).toBeUndefined();
+  });
+
+  it("rejects an unknown safehouse.gitRewrite value", async () => {
+    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: { gitRewrite: "bogus" } } } } };`;
+    setEnvironmentVariable("GROUNDCREW_CONFIG", writeConfigFile(temporary, source));
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /agents\.definitions\.claude\.safehouse\.gitRewrite must be one of ssh-to-https/,
+    );
+  });
+
+  it("rejects a non-object safehouse block", async () => {
+    const source = `export const config = { workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))}, agents: { definitions: { claude: { safehouse: "ssh-to-https" } } } };`;
+    setEnvironmentVariable("GROUNDCREW_CONFIG", writeConfigFile(temporary, source));
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /agents\.definitions\.claude\.safehouse must be an object/,
+    );
+  });
+
   it("rejects a non-array preLaunchEnv", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -45,7 +45,13 @@ function validConfigSource(config: Config): string {
 
 describe("loadConfig", () => {
   const originalEnvironment = snapshotEnvironmentVariables();
-  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME"] as const;
+  const ENV_KEYS = [
+    "GROUNDCREW_CONFIG",
+    "HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_STATE_HOME",
+    "GITHUB_TOKEN",
+  ] as const;
   let temporary: string;
 
   beforeEach(() => {
@@ -801,6 +807,7 @@ describe("loadConfig", () => {
       }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    setEnvironmentVariable("GITHUB_TOKEN", "ghp_test_token");
     const { loadConfig } = await loadFreshConfig();
     const actual = await loadConfig();
     expect(actual.agents.definitions["claude"]?.safehouse?.gitRewrite).toBe("ssh-to-https");
@@ -838,6 +845,38 @@ describe("loadConfig", () => {
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
       /agents\.definitions\.claude\.safehouse must be an object/,
+    );
+  });
+
+  it("rejects safehouse.gitRewrite when GITHUB_TOKEN is unset", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({
+        workspace: VALID_WORKSPACE(temporary),
+        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    deleteEnvironmentVariable("GITHUB_TOKEN");
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /agents\.definitions\.claude\.safehouse\.gitRewrite is set to "ssh-to-https" but GITHUB_TOKEN is not set/,
+    );
+  });
+
+  it("rejects safehouse.gitRewrite when GITHUB_TOKEN is empty", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({
+        workspace: VALID_WORKSPACE(temporary),
+        agents: { definitions: { claude: { safehouse: { gitRewrite: "ssh-to-https" } } } },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    setEnvironmentVariable("GITHUB_TOKEN", "   ");
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /agents\.definitions\.claude\.safehouse\.gitRewrite is set to "ssh-to-https" but GITHUB_TOKEN is not set/,
     );
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -88,6 +88,34 @@ export interface SandboxDefinition {
   agent: string;
 }
 
+/**
+ * Closed set of declarative git URL-rewrites groundcrew knows how to inject
+ * for a safehouse-wrapped agent. Kept a closed enum (not free key/value) on
+ * purpose — see the design doc trade-offs: an open rewrite surface would just
+ * re-create the opaque `env GIT_CONFIG_*` cmd-string problem with extra steps.
+ *
+ *   "ssh-to-https" → url.https://github.com/.insteadOf git@github.com:
+ */
+export const GIT_REWRITES = ["ssh-to-https"] as const;
+export type GitRewrite = (typeof GIT_REWRITES)[number];
+
+/**
+ * First-class per-launch safehouse sandbox parameters for an agent. Replaces
+ * the previous practice of smuggling an `env GIT_CONFIG_* …` prefix into `cmd`
+ * with a typed, introspectable block.
+ */
+export interface SafehouseAgentConfig {
+  /**
+   * git URL-rewrite to inject for the agent, emitted as an additive
+   * GIT_CONFIG layer (GIT_CONFIG_COUNT/KEY/VALUE — preserves the agent's
+   * global config + gh credential helper, unlike GIT_CONFIG_GLOBAL which
+   * replaces it). Needed whenever the sandbox blocks SSH egress but the
+   * worktree carries SSH remotes (e.g. graft sparse-checkouts of an SSH
+   * monorepo).
+   */
+  gitRewrite?: GitRewrite;
+}
+
 export interface AgentDefinition {
   /**
    * Shell command launched for the agent. Wrapped with Safehouse/clearance
@@ -132,6 +160,12 @@ export interface AgentDefinition {
    * or `none` without surprise.
    */
   sandbox?: SandboxDefinition;
+  /**
+   * First-class safehouse sandbox parameters. Declarative replacement for the
+   * hand-written `env GIT_CONFIG_* …` cmd prefix. Only consulted under the
+   * `safehouse` runner.
+   */
+  safehouse?: SafehouseAgentConfig;
 }
 
 /**
@@ -661,6 +695,27 @@ function normalizeSandbox(value: unknown, configKey: string): SandboxDefinition 
   return { agent: trimmedAgent };
 }
 
+function isGitRewrite(value: unknown): value is GitRewrite {
+  return typeof value === "string" && (GIT_REWRITES as readonly string[]).includes(value);
+}
+
+function normalizeSafehouse(value: unknown, configKey: string): SafehouseAgentConfig {
+  if (!isPlainObject(value)) {
+    fail(`${configKey} must be an object`);
+  }
+  const safehouse: SafehouseAgentConfig = {};
+  const { gitRewrite } = value;
+  if (gitRewrite !== undefined) {
+    if (!isGitRewrite(gitRewrite)) {
+      fail(
+        `${configKey}.gitRewrite must be one of ${GIT_REWRITES.join(", ")} (got ${JSON.stringify(gitRewrite)})`,
+      );
+    }
+    safehouse.gitRewrite = gitRewrite;
+  }
+  return safehouse;
+}
+
 function failRemovedConfigKey(configKey: string, reason: string): never {
   fail(
     `${configKey} is no longer supported: ${reason} ` +
@@ -736,6 +791,12 @@ function buildOverrideCandidate(
   if (override.preLaunchEnv !== undefined) {
     candidate.preLaunchEnv = override.preLaunchEnv;
   }
+  if (override.safehouse !== undefined) {
+    candidate.safehouse = normalizeSafehouse(
+      override.safehouse,
+      `agents.definitions.${name}.safehouse`,
+    );
+  }
   return candidate;
 }
 
@@ -754,7 +815,7 @@ function mergeDefinitions(
 
     const builtIn = BUILT_IN_AGENT_DEFINITIONS[name];
     const candidate = buildOverrideCandidate(name, override, builtIn);
-    const { cmd, color, usage, sandbox, preLaunch, preLaunchEnv } = candidate;
+    const { cmd, color, usage, sandbox, preLaunch, preLaunchEnv, safehouse } = candidate;
     if (typeof cmd !== "string" || cmd.length === 0) {
       fail(`agents.definitions.${name}.cmd must be a non-empty string`);
     }
@@ -773,6 +834,9 @@ function mergeDefinitions(
     }
     if (preLaunchEnv !== undefined) {
       definition.preLaunchEnv = preLaunchEnv;
+    }
+    if (safehouse !== undefined) {
+      definition.safehouse = safehouse;
     }
     merged[name] = definition;
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -89,15 +89,15 @@ export interface SandboxDefinition {
 }
 
 /**
- * Closed set of declarative git URL-rewrites groundcrew knows how to inject
- * for a safehouse-wrapped agent. Kept a closed enum (not free key/value) on
- * purpose — see the design doc trade-offs: an open rewrite surface would just
- * re-create the opaque `env GIT_CONFIG_*` cmd-string problem with extra steps.
+ * Closed toggle for serving a safehouse-wrapped agent's git SSH remotes over
+ * HTTPS. Kept a closed string enum (not a bare boolean) to match the config's
+ * `auto`/enum house style and to leave room for future modes (e.g. "disabled"
+ * or "auto") without a breaking rename.
  *
- *   "ssh-to-https" → url.https://github.com/.insteadOf git@github.com:
+ *   "enabled" → url.https://github.com/.insteadOf git@github.com:
  */
-export const GIT_REWRITES = ["ssh-to-https"] as const;
-export type GitRewrite = (typeof GIT_REWRITES)[number];
+export const GIT_SSH_TO_HTTPS_SETTINGS = ["enabled"] as const;
+export type GitSshToHttps = (typeof GIT_SSH_TO_HTTPS_SETTINGS)[number];
 
 /**
  * First-class per-launch safehouse sandbox parameters for an agent. Replaces
@@ -106,19 +106,19 @@ export type GitRewrite = (typeof GIT_REWRITES)[number];
  */
 export interface SafehouseAgentConfig {
   /**
-   * git URL-rewrite to inject for the agent, emitted as an additive
-   * GIT_CONFIG layer (GIT_CONFIG_COUNT/KEY/VALUE — preserves the agent's
-   * global config + gh credential helper, unlike GIT_CONFIG_GLOBAL which
-   * replaces it). Needed whenever the sandbox blocks SSH egress but the
+   * When `"enabled"`, serve the agent's git SSH remotes over HTTPS, emitted as
+   * an additive GIT_CONFIG layer (GIT_CONFIG_COUNT/KEY/VALUE — preserves the
+   * agent's global config + gh credential helper, unlike GIT_CONFIG_GLOBAL
+   * which replaces it). Needed whenever the sandbox blocks SSH egress but the
    * worktree carries SSH remotes (e.g. graft sparse-checkouts of an SSH
-   * monorepo).
+   * monorepo). Omit to leave git untouched (the default).
    *
    * Self-contained: setting this also auto-forwards GITHUB_TOKEN into the
    * agent wrap, because the HTTPS remotes it produces only authenticate if the
    * agent's gh credential helper can read the token. No separate
    * `preLaunchEnv: ["GITHUB_TOKEN"]` pairing is required.
    */
-  gitRewrite?: GitRewrite;
+  gitSshToHttps?: GitSshToHttps;
 }
 
 export interface AgentDefinition {
@@ -700,8 +700,10 @@ function normalizeSandbox(value: unknown, configKey: string): SandboxDefinition 
   return { agent: trimmedAgent };
 }
 
-function isGitRewrite(value: unknown): value is GitRewrite {
-  return typeof value === "string" && (GIT_REWRITES as readonly string[]).includes(value);
+function isGitSshToHttps(value: unknown): value is GitSshToHttps {
+  return (
+    typeof value === "string" && (GIT_SSH_TO_HTTPS_SETTINGS as readonly string[]).includes(value)
+  );
 }
 
 function normalizeSafehouse(value: unknown, configKey: string): SafehouseAgentConfig {
@@ -709,14 +711,14 @@ function normalizeSafehouse(value: unknown, configKey: string): SafehouseAgentCo
     fail(`${configKey} must be an object`);
   }
   const safehouse: SafehouseAgentConfig = {};
-  const { gitRewrite } = value;
-  if (gitRewrite !== undefined) {
-    if (!isGitRewrite(gitRewrite)) {
+  const { gitSshToHttps } = value;
+  if (gitSshToHttps !== undefined) {
+    if (!isGitSshToHttps(gitSshToHttps)) {
       fail(
-        `${configKey}.gitRewrite must be one of ${GIT_REWRITES.join(", ")} (got ${JSON.stringify(gitRewrite)})`,
+        `${configKey}.gitSshToHttps must be one of ${GIT_SSH_TO_HTTPS_SETTINGS.join(", ")} (got ${JSON.stringify(gitSshToHttps)})`,
       );
     }
-    safehouse.gitRewrite = gitRewrite;
+    safehouse.gitSshToHttps = gitSshToHttps;
   }
   return safehouse;
 }
@@ -1204,15 +1206,15 @@ function validate(config: ResolvedConfig): void {
     if (definition.preLaunchEnv !== undefined) {
       validatePreLaunchEnv(name, definition.preLaunchEnv);
     }
-    if (definition.safehouse?.gitRewrite !== undefined) {
-      // The SSH→HTTPS rewrite only authenticates if the agent's gh credential
-      // helper can read GITHUB_TOKEN inside the sandbox (groundcrew forwards it
-      // automatically). Fail loudly at load time rather than letting pushes
-      // silently fail inside the sandbox once the agent is already running.
+    if (definition.safehouse?.gitSshToHttps !== undefined) {
+      // Serving SSH remotes over HTTPS only authenticates if the agent's gh
+      // credential helper can read GITHUB_TOKEN inside the sandbox (groundcrew
+      // forwards it automatically). Fail loudly at load time rather than letting
+      // pushes silently fail inside the sandbox once the agent is already running.
       const token = readEnvironmentVariable("GITHUB_TOKEN");
       if (token === undefined || token.trim().length === 0) {
         fail(
-          `agents.definitions.${name}.safehouse.gitRewrite is set to ${JSON.stringify(definition.safehouse.gitRewrite)} but GITHUB_TOKEN is not set in the environment; the rewritten HTTPS remotes only authenticate via the agent's gh credential helper, which reads GITHUB_TOKEN`,
+          `agents.definitions.${name}.safehouse.gitSshToHttps is set to ${JSON.stringify(definition.safehouse.gitSshToHttps)} but GITHUB_TOKEN is not set in the environment; the HTTPS remotes only authenticate via the agent's gh credential helper, which reads GITHUB_TOKEN`,
         );
       }
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1204,6 +1204,18 @@ function validate(config: ResolvedConfig): void {
     if (definition.preLaunchEnv !== undefined) {
       validatePreLaunchEnv(name, definition.preLaunchEnv);
     }
+    if (definition.safehouse?.gitRewrite !== undefined) {
+      // The SSH→HTTPS rewrite only authenticates if the agent's gh credential
+      // helper can read GITHUB_TOKEN inside the sandbox (groundcrew forwards it
+      // automatically). Fail loudly at load time rather than letting pushes
+      // silently fail inside the sandbox once the agent is already running.
+      const token = readEnvironmentVariable("GITHUB_TOKEN");
+      if (token === undefined || token.trim().length === 0) {
+        fail(
+          `agents.definitions.${name}.safehouse.gitRewrite is set to ${JSON.stringify(definition.safehouse.gitRewrite)} but GITHUB_TOKEN is not set in the environment; the rewritten HTTPS remotes only authenticate via the agent's gh credential helper, which reads GITHUB_TOKEN`,
+        );
+      }
+    }
   }
 
   /* v8 ignore next 5 @preserve -- normalizeLocalRunner rejects invalid strings before validate() runs; this is a belt-and-suspenders guard */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -112,6 +112,11 @@ export interface SafehouseAgentConfig {
    * replaces it). Needed whenever the sandbox blocks SSH egress but the
    * worktree carries SSH remotes (e.g. graft sparse-checkouts of an SSH
    * monorepo).
+   *
+   * Self-contained: setting this also auto-forwards GITHUB_TOKEN into the
+   * agent wrap, because the HTTPS remotes it produces only authenticate if the
+   * agent's gh credential helper can read the token. No separate
+   * `preLaunchEnv: ["GITHUB_TOKEN"]` pairing is required.
    */
   gitRewrite?: GitRewrite;
 }

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -393,11 +393,64 @@ describe(buildLaunchCommand, () => {
         definition: {
           cmd: "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: claude --permission-mode bypassPermissions",
           color: "#fff",
+          // The declarative form auto-forwards GITHUB_TOKEN; the hand-written
+          // prefix needed it spelled out as preLaunchEnv to authenticate pushes.
+          preLaunchEnv: ["GITHUB_TOKEN"],
         },
       }),
     );
 
     expect(declarative).toBe(handWritten);
+  });
+
+  it("auto-forwards GITHUB_TOKEN into the agent wrap when safehouse.gitRewrite is set", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "claude --permission-mode bypassPermissions",
+          color: "#fff",
+          safehouse: { gitRewrite: "ssh-to-https" },
+        },
+      }),
+    );
+
+    // The rewrite points remotes at HTTPS, which only authenticates if the
+    // agent's gh credential helper can read GITHUB_TOKEN — so the setting
+    // forwards it itself instead of relying on a manual preLaunchEnv pairing.
+    expect(out).toContain('--env-pass=GITHUB_TOKEN "$_safehouse_shim"');
+  });
+
+  it("merges GITHUB_TOKEN with explicit preLaunchEnv and dedupes when gitRewrite is set", () => {
+    const merged = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "claude",
+          color: "#fff",
+          preLaunchEnv: ["FOO"],
+          safehouse: { gitRewrite: "ssh-to-https" },
+        },
+      }),
+    );
+    expect(merged).toContain('--env-pass=FOO,GITHUB_TOKEN "$_safehouse_shim"');
+
+    const deduped = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "claude",
+          color: "#fff",
+          preLaunchEnv: ["GITHUB_TOKEN"],
+          safehouse: { gitRewrite: "ssh-to-https" },
+        },
+      }),
+    );
+    expect(deduped).toContain('--env-pass=GITHUB_TOKEN "$_safehouse_shim"');
+    expect(deduped).not.toContain("GITHUB_TOKEN,GITHUB_TOKEN");
+  });
+
+  it("does not forward GITHUB_TOKEN when safehouse.gitRewrite is unset", () => {
+    const out = buildLaunchCommand(arguments_());
+
+    expect(out).not.toContain("GITHUB_TOKEN");
   });
 
   it("skips `env` and quoted environment assignments when inferring the Safehouse profile command", () => {

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -352,13 +352,13 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain('exec ANTHROPIC_MODEL=sonnet claude --permission-mode auto "$@"');
   });
 
-  it("injects the gitRewrite GIT_CONFIG env prefix into the agent wrap when safehouse.gitRewrite is set", () => {
+  it("injects the gitSshToHttps GIT_CONFIG env prefix into the agent wrap when safehouse.gitSshToHttps is set", () => {
     const out = buildLaunchCommand(
       arguments_({
         definition: {
           cmd: "claude --permission-mode bypassPermissions",
           color: "#fff",
-          safehouse: { gitRewrite: "ssh-to-https" },
+          safehouse: { gitSshToHttps: "enabled" },
         },
       }),
     );
@@ -366,12 +366,12 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain(
       'exec env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: claude --permission-mode bypassPermissions "$@"',
     );
-    // The rewrite rides the groundcrew-composed agent command, so the profile
+    // The prefix rides the groundcrew-composed agent command, so the profile
     // shim is still keyed on the bare agent name, not `env`.
     expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
   });
 
-  it("omits the gitRewrite prefix when safehouse.gitRewrite is unset", () => {
+  it("omits the gitSshToHttps prefix when safehouse.gitSshToHttps is unset", () => {
     const out = buildLaunchCommand(arguments_());
 
     expect(out).not.toContain("GIT_CONFIG_COUNT");
@@ -384,7 +384,7 @@ describe(buildLaunchCommand, () => {
         definition: {
           cmd: "claude --permission-mode bypassPermissions",
           color: "#fff",
-          safehouse: { gitRewrite: "ssh-to-https" },
+          safehouse: { gitSshToHttps: "enabled" },
         },
       }),
     );
@@ -403,31 +403,31 @@ describe(buildLaunchCommand, () => {
     expect(declarative).toBe(handWritten);
   });
 
-  it("auto-forwards GITHUB_TOKEN into the agent wrap when safehouse.gitRewrite is set", () => {
+  it("auto-forwards GITHUB_TOKEN into the agent wrap when safehouse.gitSshToHttps is set", () => {
     const out = buildLaunchCommand(
       arguments_({
         definition: {
           cmd: "claude --permission-mode bypassPermissions",
           color: "#fff",
-          safehouse: { gitRewrite: "ssh-to-https" },
+          safehouse: { gitSshToHttps: "enabled" },
         },
       }),
     );
 
-    // The rewrite points remotes at HTTPS, which only authenticates if the
-    // agent's gh credential helper can read GITHUB_TOKEN — so the setting
-    // forwards it itself instead of relying on a manual preLaunchEnv pairing.
+    // Serving remotes over HTTPS only authenticates if the agent's gh
+    // credential helper can read GITHUB_TOKEN — so the setting forwards it
+    // itself instead of relying on a manual preLaunchEnv pairing.
     expect(out).toContain('--env-pass=GITHUB_TOKEN "$_safehouse_shim"');
   });
 
-  it("merges GITHUB_TOKEN with explicit preLaunchEnv and dedupes when gitRewrite is set", () => {
+  it("merges GITHUB_TOKEN with explicit preLaunchEnv and dedupes when gitSshToHttps is set", () => {
     const merged = buildLaunchCommand(
       arguments_({
         definition: {
           cmd: "claude",
           color: "#fff",
           preLaunchEnv: ["FOO"],
-          safehouse: { gitRewrite: "ssh-to-https" },
+          safehouse: { gitSshToHttps: "enabled" },
         },
       }),
     );
@@ -439,7 +439,7 @@ describe(buildLaunchCommand, () => {
           cmd: "claude",
           color: "#fff",
           preLaunchEnv: ["GITHUB_TOKEN"],
-          safehouse: { gitRewrite: "ssh-to-https" },
+          safehouse: { gitSshToHttps: "enabled" },
         },
       }),
     );
@@ -447,7 +447,7 @@ describe(buildLaunchCommand, () => {
     expect(deduped).not.toContain("GITHUB_TOKEN,GITHUB_TOKEN");
   });
 
-  it("does not forward GITHUB_TOKEN when safehouse.gitRewrite is unset", () => {
+  it("does not forward GITHUB_TOKEN when safehouse.gitSshToHttps is unset", () => {
     const out = buildLaunchCommand(arguments_());
 
     expect(out).not.toContain("GITHUB_TOKEN");

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -352,6 +352,54 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain('exec ANTHROPIC_MODEL=sonnet claude --permission-mode auto "$@"');
   });
 
+  it("injects the gitRewrite GIT_CONFIG env prefix into the agent wrap when safehouse.gitRewrite is set", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "claude --permission-mode bypassPermissions",
+          color: "#fff",
+          safehouse: { gitRewrite: "ssh-to-https" },
+        },
+      }),
+    );
+
+    expect(out).toContain(
+      'exec env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: claude --permission-mode bypassPermissions "$@"',
+    );
+    // The rewrite rides the groundcrew-composed agent command, so the profile
+    // shim is still keyed on the bare agent name, not `env`.
+    expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
+  });
+
+  it("omits the gitRewrite prefix when safehouse.gitRewrite is unset", () => {
+    const out = buildLaunchCommand(arguments_());
+
+    expect(out).not.toContain("GIT_CONFIG_COUNT");
+    expect(out).toContain('exec claude "$@"');
+  });
+
+  it("emits a launch command byte-identical to the hand-written `env GIT_CONFIG_*` cmd prefix", () => {
+    const declarative = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "claude --permission-mode bypassPermissions",
+          color: "#fff",
+          safehouse: { gitRewrite: "ssh-to-https" },
+        },
+      }),
+    );
+    const handWritten = buildLaunchCommand(
+      arguments_({
+        definition: {
+          cmd: "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: claude --permission-mode bypassPermissions",
+          color: "#fff",
+        },
+      }),
+    );
+
+    expect(declarative).toBe(handWritten);
+  });
+
   it("skips `env` and quoted environment assignments when inferring the Safehouse profile command", () => {
     const out = buildLaunchCommand(
       arguments_({

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -194,6 +194,11 @@ function preLaunchPromptAndExec(arguments_: {
  * it slots directly in front of the agent command. The `Record<GitRewrite, …>`
  * key set is exhaustiveness-checked, so widening `GIT_REWRITES` forces a new
  * entry here at compile time.
+ *
+ * `insteadOf` is a prefix-match, so injecting this on a repo whose remote is
+ * already HTTPS is a no-op: the HTTPS URL does not start with `git@github.com:`,
+ * so only scp-like SSH remotes are rewritten and everything else passes through
+ * untouched. (It matches the `git@github.com:` form, not `ssh://git@github.com/`.)
  */
 const GIT_REWRITE_ENV_PREFIXES: Record<GitRewrite, string> = {
   "ssh-to-https":

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   BUILD_SECRET_NAMES,
   hasPreLaunchEnv,
+  type GitRewrite,
   type LocalRunner,
   type AgentDefinition,
 } from "./config.ts";
@@ -186,11 +187,40 @@ function preLaunchPromptAndExec(arguments_: {
 }
 
 /**
+ * Additive `env GIT_CONFIG_*` prefix per declarative `safehouse.gitRewrite`.
+ * Additive (GIT_CONFIG_COUNT/KEY/VALUE) rather than `GIT_CONFIG_GLOBAL` so the
+ * agent's own global config and the gh credential helper survive — only the
+ * SSH→HTTPS rewrite is layered on. Each entry is trailing-space-terminated so
+ * it slots directly in front of the agent command. The `Record<GitRewrite, …>`
+ * key set is exhaustiveness-checked, so widening `GIT_REWRITES` forces a new
+ * entry here at compile time.
+ */
+const GIT_REWRITE_ENV_PREFIXES: Record<GitRewrite, string> = {
+  "ssh-to-https":
+    "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: ",
+};
+
+/**
+ * Env prefix for a declarative `safehouse.gitRewrite`, or "" when none is
+ * requested. First-class replacement for the previously hand-written `env
+ * GIT_CONFIG_* …` cmd prefix; emits a byte-identical token sequence.
+ */
+function gitRewriteEnvPrefix(gitRewrite: GitRewrite | undefined): string {
+  return gitRewrite === undefined ? "" : GIT_REWRITE_ENV_PREFIXES[gitRewrite];
+}
+
+/**
  * Shared by the safehouse, srt, and sdx builders: render the `exec <agent> "$@"`
  * inner command and the optional status-reported prepareWorktree hook. The
  * `{{sandbox}}` template is filled from `sandboxName` (empty for safehouse/srt).
+ * `agentEnvironmentPrefix` (empty for srt/sdx) is injected verbatim between
+ * `exec` and the agent command — the safehouse builder uses it to layer in the
+ * `gitRewrite` env prefix.
  */
-function renderPrepareAndAgentCommand(arguments_: LaunchCommandArguments): {
+function renderPrepareAndAgentCommand(
+  arguments_: LaunchCommandArguments,
+  agentEnvironmentPrefix = "",
+): {
   agentCommand: string;
   prepareWorktreeCommand: string | undefined;
 } {
@@ -200,7 +230,7 @@ function renderPrepareAndAgentCommand(arguments_: LaunchCommandArguments): {
     sandboxName: arguments_.sandboxName ?? "",
   });
   return {
-    agentCommand: `exec ${agentCmd} "$@"`,
+    agentCommand: `exec ${agentEnvironmentPrefix}${agentCmd} "$@"`,
     prepareWorktreeCommand:
       arguments_.prepareWorktreeCommand === undefined
         ? undefined
@@ -514,7 +544,10 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  const { agentCommand, prepareWorktreeCommand } = renderPrepareAndAgentCommand(arguments_);
+  const { agentCommand, prepareWorktreeCommand } = renderPrepareAndAgentCommand(
+    arguments_,
+    gitRewriteEnvPrefix(arguments_.definition.safehouse?.gitRewrite),
+  );
 
   // Split --env-pass per wrap: the prepareWorktree wrap only needs build secrets (so
   // `npm install` etc. can authenticate); the agent wrap only needs the

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import {
   BUILD_SECRET_NAMES,
   hasPreLaunchEnv,
-  type GitRewrite,
+  type GitSshToHttps,
   type LocalRunner,
   type AgentDefinition,
 } from "./config.ts";
@@ -187,31 +187,28 @@ function preLaunchPromptAndExec(arguments_: {
 }
 
 /**
- * Additive `env GIT_CONFIG_*` prefix per declarative `safehouse.gitRewrite`.
- * Additive (GIT_CONFIG_COUNT/KEY/VALUE) rather than `GIT_CONFIG_GLOBAL` so the
- * agent's own global config and the gh credential helper survive — only the
- * SSH→HTTPS rewrite is layered on. Each entry is trailing-space-terminated so
- * it slots directly in front of the agent command. The `Record<GitRewrite, …>`
- * key set is exhaustiveness-checked, so widening `GIT_REWRITES` forces a new
- * entry here at compile time.
+ * Additive `env GIT_CONFIG_*` prefix that serves git SSH remotes over HTTPS,
+ * injected when `safehouse.gitSshToHttps` is `"enabled"`. Additive
+ * (GIT_CONFIG_COUNT/KEY/VALUE) rather than `GIT_CONFIG_GLOBAL` so the agent's
+ * own global config and the gh credential helper survive — only the SSH→HTTPS
+ * mapping is layered on. Trailing-space-terminated so it slots directly in
+ * front of the agent command.
  *
  * `insteadOf` is a prefix-match, so injecting this on a repo whose remote is
  * already HTTPS is a no-op: the HTTPS URL does not start with `git@github.com:`,
  * so only scp-like SSH remotes are rewritten and everything else passes through
  * untouched. (It matches the `git@github.com:` form, not `ssh://git@github.com/`.)
  */
-const GIT_REWRITE_ENV_PREFIXES: Record<GitRewrite, string> = {
-  "ssh-to-https":
-    "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: ",
-};
+const GIT_SSH_TO_HTTPS_ENV_PREFIX =
+  "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: ";
 
 /**
- * Env prefix for a declarative `safehouse.gitRewrite`, or "" when none is
- * requested. First-class replacement for the previously hand-written `env
+ * Env prefix that serves git SSH remotes over HTTPS, or "" when the toggle is
+ * unset. First-class replacement for the previously hand-written `env
  * GIT_CONFIG_* …` cmd prefix; emits a byte-identical token sequence.
  */
-function gitRewriteEnvPrefix(gitRewrite: GitRewrite | undefined): string {
-  return gitRewrite === undefined ? "" : GIT_REWRITE_ENV_PREFIXES[gitRewrite];
+function gitSshToHttpsEnvPrefix(gitSshToHttps: GitSshToHttps | undefined): string {
+  return gitSshToHttps === "enabled" ? GIT_SSH_TO_HTTPS_ENV_PREFIX : "";
 }
 
 /**
@@ -220,7 +217,7 @@ function gitRewriteEnvPrefix(gitRewrite: GitRewrite | undefined): string {
  * `{{sandbox}}` template is filled from `sandboxName` (empty for safehouse/srt).
  * `agentEnvironmentPrefix` (empty for srt/sdx) is injected verbatim between
  * `exec` and the agent command — the safehouse builder uses it to layer in the
- * `gitRewrite` env prefix.
+ * `gitSshToHttps` env prefix.
  */
 function renderPrepareAndAgentCommand(
   arguments_: LaunchCommandArguments,
@@ -544,16 +541,16 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
  * `--env-pass` composition is split per wrap (deliberate, post PR #128):
  * - prepareWorktree wrap forwards build secrets only.
  * - Agent wrap forwards `preLaunchEnv` names, plus GITHUB_TOKEN when
- *   `safehouse.gitRewrite` is set (the HTTPS remotes that rewrite produces only
- *   authenticate via the agent's gh credential helper). preLaunch credentials
- *   never reach the profile-neutral prepare phase.
+ *   `safehouse.gitSshToHttps` is set (the HTTPS remotes only authenticate via
+ *   the agent's gh credential helper). preLaunch credentials never reach the
+ *   profile-neutral prepare phase.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
   const { agentCommand, prepareWorktreeCommand } = renderPrepareAndAgentCommand(
     arguments_,
-    gitRewriteEnvPrefix(arguments_.definition.safehouse?.gitRewrite),
+    gitSshToHttpsEnvPrefix(arguments_.definition.safehouse?.gitSshToHttps),
   );
 
   // Split --env-pass per wrap: the prepareWorktree wrap only needs build secrets (so
@@ -564,12 +561,12 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   // Trailing space keeps each flag separated from the next argv token.
   const prepareWorktreeEnvPassFlag =
     arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
-  // `gitRewrite` rewrites SSH remotes to HTTPS, which only authenticates if the
+  // `gitSshToHttps` serves SSH remotes over HTTPS, which only authenticates if the
   // agent's gh credential helper can read GITHUB_TOKEN inside the sandbox. Forward
   // it automatically so the setting is self-contained — no manual preLaunchEnv
   // pairing to remember. Deduped so an explicit GITHUB_TOKEN entry isn't doubled.
   const preLaunchEnvNames = arguments_.definition.preLaunchEnv ?? [];
-  const agentEnvNames = arguments_.definition.safehouse?.gitRewrite
+  const agentEnvNames = arguments_.definition.safehouse?.gitSshToHttps
     ? [...new Set([...preLaunchEnvNames, "GITHUB_TOKEN"])]
     : preLaunchEnvNames;
   const agentEnvPassFlag =

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -543,8 +543,10 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
  *
  * `--env-pass` composition is split per wrap (deliberate, post PR #128):
  * - prepareWorktree wrap forwards build secrets only.
- * - Agent wrap forwards `preLaunchEnv` names only. preLaunch credentials never
- *   reach the profile-neutral prepare phase.
+ * - Agent wrap forwards `preLaunchEnv` names, plus GITHUB_TOKEN when
+ *   `safehouse.gitRewrite` is set (the HTTPS remotes that rewrite produces only
+ *   authenticate via the agent's gh credential helper). preLaunch credentials
+ *   never reach the profile-neutral prepare phase.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
@@ -562,9 +564,16 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   // Trailing space keeps each flag separated from the next argv token.
   const prepareWorktreeEnvPassFlag =
     arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
+  // `gitRewrite` rewrites SSH remotes to HTTPS, which only authenticates if the
+  // agent's gh credential helper can read GITHUB_TOKEN inside the sandbox. Forward
+  // it automatically so the setting is self-contained — no manual preLaunchEnv
+  // pairing to remember. Deduped so an explicit GITHUB_TOKEN entry isn't doubled.
   const preLaunchEnvNames = arguments_.definition.preLaunchEnv ?? [];
+  const agentEnvNames = arguments_.definition.safehouse?.gitRewrite
+    ? [...new Set([...preLaunchEnvNames, "GITHUB_TOKEN"])]
+    : preLaunchEnvNames;
   const agentEnvPassFlag =
-    preLaunchEnvNames.length === 0 ? "" : `--env-pass=${preLaunchEnvNames.join(",")} `;
+    agentEnvNames.length === 0 ? "" : `--env-pass=${agentEnvNames.join(",")} `;
   // safehouse reads colon-separated paths from `--add-dirs`; both wraps get the
   // same grant so the prepareWorktree hook and the agent can each reach git.
   // Quote the whole value so shell-special chars survive; the trailing space


### PR DESCRIPTION
## Problem

groundcrew's safehouse runner sandboxes agents with `sandbox-exec`, which blocks raw SSH egress (port 22) — only HTTPS through the clearance proxy is reachable. But worktrees (e.g. graft sparse-checkouts of an SSH monorepo) carry SSH remotes, so any `git fetch`/`push` an agent runs inside the sandbox fails.

The workaround was to smuggle a raw `env GIT_CONFIG_* …` prefix into an agent's `cmd` string to serve those SSH remotes over HTTPS. That was:

- **Opaque** — a wall of `GIT_CONFIG_COUNT`/`KEY`/`VALUE` tokens nobody could re-derive by hand or a config UI could introspect.
- **Fragile** — the HTTPS remotes it produces only authenticate via the agent's `gh` credential helper, which reads `GITHUB_TOKEN`. So it had to be paired with a separate `preLaunchEnv: ["GITHUB_TOKEN"]` entry, in a different place. Set it without the token and pushes failed *silently* inside the sandbox, mid-run, long after launch.

```ts
// the old way — two coupled settings you just had to know were connected
claude: {
  cmd: "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf GIT_CONFIG_VALUE_0=git@github.com: claude --permission-mode bypassPermissions",
  preLaunchEnv: ["GITHUB_TOKEN"],
}
```

## Solution

A first-class, typed `safehouse` config block with a `gitSshToHttps: "enabled"` toggle:

```ts
// crew.config.ts
export default {
  workspace: {
    projectDir: "~/dev",
    knownRepositories: ["my-repo"],
  },
  agents: {
    definitions: {
      claude: {
        cmd: "claude --permission-mode bypassPermissions",
        safehouse: {
          gitSshToHttps: "enabled",
        },
      },
    },
  },
};
```

It's an opt-in toggle: **omit it (default) and git is left untouched** (SSH remotes still fail in the sandbox); **set `"enabled"`** and groundcrew serves the agent's SSH remotes over HTTPS. What that does under the hood:

- **Same additive mapping, composed by groundcrew.** `gitSshToHttps` expands to the same `GIT_CONFIG_COUNT`/`KEY`/`VALUE` layer onto the agent wrap — additive (not `GIT_CONFIG_GLOBAL`), so the agent's global git config and `gh` credential helper survive. The profile shim still keys on the bare agent name, so the emitted launch command is byte-identical to the old hand-written prefix.
- **Self-contained — no coupling to remember.** It auto-forwards `GITHUB_TOKEN` into the agent wrap, deduped against any explicit `preLaunchEnv` entry. No separate token pairing required. (Safe to forward: `GITHUB_TOKEN` is not a build secret, so it isn't scrubbed between the prepare and agent wraps.)
- **Fail-fast at load time.** If `gitSshToHttps` is `"enabled"` but `GITHUB_TOKEN` is unset (or empty) in the environment, the config load **throws** with a clear message — converting the old silent, mid-run push failure into an immediate, actionable error before any agent launches.

Scope is `gitSshToHttps` only. The companion `addDirs` (extra filesystem grants) field is intentionally deferred — a directory-granting field that silently did nothing would be a security footgun.

### Safety notes

- **Safe on repos already using HTTPS.** git's `insteadOf` is a prefix-match: it only rewrites URLs beginning with `git@github.com:`. An already-HTTPS remote doesn't match and passes through untouched; non-GitHub remotes are left alone. (Caveat: it matches the scp-like `git@github.com:` form, not `ssh://git@github.com/`.)
- **String enum, not a bare boolean.** `gitSshToHttps` is a closed enum (`"enabled"`) to match the config's `auto`/enum house style and leave room for future modes (e.g. `"disabled"`/`"auto"`) without a breaking rename. It is GitHub-only today; the name is host-agnostic so adding GitLab/Bitbucket later is a capability expansion, not a rename.

## Why is `safehouse` under `agents`, not top-level or per-repo?

There are deliberately two safehouse-related knobs at different levels:

| Knob | Level | Answers |
| --- | --- | --- |
| `local.runner` (`safehouse` / `sdx` / `none` / `auto`) | top-level | "Am I sandboxed at all, and by which backend?" |
| `agents.definitions.<name>.safehouse.gitSshToHttps` | per-agent | "Inside that sandbox, how does *this agent's* git/credentials behave?" |

The global "which sandbox" decision already *is* top-level (`local.runner`); per-agent `isolation` and `agents.isolation` were both removed to consolidate that choice. The `safehouse` block is the per-launch tuning that rides on top.

**Why `gitSshToHttps` is per-agent:**

- It's mechanically a property of the **agent's launch command** — it expands into an `env GIT_CONFIG_*` prefix on the agent wrap and auto-forwards `GITHUB_TOKEN` into *that agent's* `--env-pass`. The launch builder is handed an `AgentDefinition`, so that's the object it attaches to. It's also the typed replacement for what was literally a per-agent `cmd` prefix (same scope, byte-identical output).
- **Least privilege.** It injects a `GITHUB_TOKEN` into the agent. A read-only reviewer agent shouldn't get a token just because an implementer agent needs to push. A top-level setting would force it onto every agent. It also sits naturally alongside its per-agent siblings (`cmd`, `preLaunch`, `preLaunchEnv`, `sandbox`).

**Why not per-repo (a reasonable alternative):** conceptually the *cause* (SSH remotes the sandbox can't reach) is a property of the repository. But two things make per-agent the right first step today: (1) repository recipes carry only clone/provision concerns (`projectDirOverride`, `provision`, `workdir`) and never flow into the launch-command builder, so per-repo would need new dispatch-time `(repo, agent)` plumbing rather than a field move; and (2) a single agent definition is repo-agnostic — the same agent is dispatched against any known repo, so the setting has to attach to something present at launch. Per-repo remains a legitimate future shape if it proves to be repo-driven in practice (on for the SSH monorepo, off elsewhere) — the only per-repo cost worth scoping is the token forward, since the rewrite itself is a safe no-op on already-HTTPS/non-GitHub remotes.

## Validation

- `node --run verify` — all stages pass: `architecture:check`, `build`, `cpd`, `format:check`, `knip`, `lint`, `markdown:lint`, `spell:check`, `syncpack:lint`, and `test` at 100% coverage (1636 tests).
- TDD red → green throughout: config schema (merge / empty-block / reject-unknown / reject-non-object / reject-when-GITHUB_TOKEN-unset / reject-when-GITHUB_TOKEN-empty) in `config.test.ts`, and the GIT_CONFIG prefix injection + byte-equivalence + GITHUB_TOKEN auto-forward tests in `launchCommand.test.ts`.

## Notes

- Pushed from fork `paulb-instacart/groundcrew`; PR targets `ClipboardHealth/groundcrew:main`.
