### PR TITLE
test: split config source and path tests

### DIFF
--- a/src/lib/config.paths.test.ts
+++ b/src/lib/config.paths.test.ts
@@ -1,0 +1,56 @@
+import { repositoryBaseDir, worktreeBaseDir, type ResolvedConfig } from "./config.ts";
+
+function resolvedConfigWithWorkspace(workspace: ResolvedConfig["workspace"]): ResolvedConfig {
+  return {
+    sources: [],
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace,
+    defaults: { hooks: {} },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    agents: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto" },
+    logging: { file: "/tmp/x.log" },
+  };
+}
+
+describe("workspace path accessors", () => {
+  const resolved = resolvedConfigWithWorkspace;
+
+  it("worktreeBaseDir falls back to projectDir when worktreeDir is unset", () => {
+    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
+    expect(worktreeBaseDir(config)).toBe("/p");
+  });
+
+  it("worktreeBaseDir prefers worktreeDir when set", () => {
+    const config = resolved({
+      projectDir: "/p",
+      worktreeDir: "/w",
+      knownRepositories: ["a"],
+    });
+    expect(worktreeBaseDir(config)).toBe("/w");
+  });
+
+  it("repositoryBaseDir falls back to projectDir without an override", () => {
+    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
+    expect(repositoryBaseDir(config, "a")).toBe("/p");
+  });
+
+  it("repositoryBaseDir uses the per-repo override when present", () => {
+    const config = resolved({
+      projectDir: "/p",
+      knownRepositories: ["a", "b"],
+      repositoryDirs: { b: "/other" },
+    });
+    expect(repositoryBaseDir(config, "b")).toBe("/other");
+    expect(repositoryBaseDir(config, "a")).toBe("/p");
+  });
+});

--- a/src/lib/config.source.test.ts
+++ b/src/lib/config.source.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  deleteEnvironmentVariable,
+  setEnvironmentVariable,
+  snapshotEnvironmentVariables,
+} from "../testHelpers/env.ts";
+import type { Config, LoadedConfig } from "./config.ts";
+
+interface ConfigModule {
+  loadConfigWithSource: () => Promise<Readonly<LoadedConfig>>;
+}
+
+async function loadFreshConfig(): Promise<ConfigModule> {
+  vi.resetModules();
+  return await import("./config.ts");
+}
+
+const VALID_WORKSPACE = (projectDir: string) => ({
+  projectDir,
+  knownRepositories: ["repo-a"],
+});
+
+function writeConfigFile(dir: string, body: string): string {
+  const configPath = path.join(dir, `config-${Math.random().toString(36).slice(2)}.ts`);
+  writeFileSync(configPath, body);
+  return configPath;
+}
+
+function configSource(config: Config): string {
+  return `export default ${JSON.stringify(config, undefined, 2)};\n`;
+}
+
+function validConfigSource(config: Config): string {
+  return configSource({
+    ...config,
+    agents: {
+      definitions: { claude: {} },
+      ...config.agents,
+    },
+  });
+}
+
+describe("loadConfigWithSource", () => {
+  const originalEnvironment = snapshotEnvironmentVariables();
+  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME"] as const;
+  let temporary: string;
+
+  beforeEach(() => {
+    temporary = mkdtempSync(path.join(tmpdir(), "groundcrew-resolve-"));
+    for (const key of ENV_KEYS) {
+      deleteEnvironmentVariable(key);
+    }
+    setEnvironmentVariable("XDG_CONFIG_HOME", path.join(temporary, "xdg-config"));
+    vi.spyOn(process, "cwd").mockReturnValue(temporary);
+  });
+
+  afterEach(() => {
+    rmSync(temporary, { recursive: true, force: true });
+    for (const key of ENV_KEYS) {
+      const original = originalEnvironment[key];
+      if (original === undefined) {
+        deleteEnvironmentVariable(key);
+      } else {
+        setEnvironmentVariable(key, original);
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("reports an env-override source", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
+
+    expect(actual.source).toStrictEqual({ kind: "env", filepath: path.resolve(configPath) });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
+  });
+
+  it("reports a project-search source", async () => {
+    const projectConfigPath = path.join(temporary, "crew.config.ts");
+    writeFileSync(projectConfigPath, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
+
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
+
+    expect(actual.source).toStrictEqual({ kind: "project", filepath: projectConfigPath });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
+  });
+
+  it("reports an XDG fallback source", async () => {
+    const xdgDir = path.join(temporary, "xdg-config", "groundcrew");
+    mkdirSync(xdgDir, { recursive: true });
+    const xdgConfigPath_ = path.join(xdgDir, "crew.config.ts");
+    writeFileSync(xdgConfigPath_, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
+
+    const { loadConfigWithSource } = await loadFreshConfig();
+    const actual = await loadConfigWithSource();
+
+    expect(actual.source).toStrictEqual({ kind: "xdg", filepath: xdgConfigPath_ });
+    expect(actual.config.workspace.projectDir).toBe(temporary);
+  });
+});

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1901,10 +1901,7 @@ function resolvedConfigWithWorkspace(workspace: ResolvedConfig["workspace"]): Re
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
-    agents: {
-      default: "claude",
-      definitions: { claude: { cmd: "claude", color: "#fff" } },
-    },
+    agents: { default: "claude", definitions: { claude: { cmd: "claude", color: "#fff" } } },
     prompts: { initial: "x" },
     workspaceKind: "auto",
     local: { runner: "auto" },
@@ -1921,11 +1918,7 @@ describe("workspace path accessors", () => {
   });
 
   it("worktreeBaseDir prefers worktreeDir when set", () => {
-    const config = resolved({
-      projectDir: "/p",
-      worktreeDir: "/w",
-      knownRepositories: ["a"],
-    });
+    const config = resolved({ projectDir: "/p", worktreeDir: "/w", knownRepositories: ["a"] });
     expect(worktreeBaseDir(config)).toBe("/w");
   });
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -7,17 +7,10 @@ import {
   setEnvironmentVariable,
   snapshotEnvironmentVariables,
 } from "../testHelpers/env.ts";
-import {
-  repositoryBaseDir,
-  worktreeBaseDir,
-  type Config,
-  type LoadedConfig,
-  type ResolvedConfig,
-} from "./config.ts";
+import type { Config, ResolvedConfig } from "./config.ts";
 
 interface ConfigModule {
   loadConfig: () => Promise<Readonly<ResolvedConfig>>;
-  loadConfigWithSource: () => Promise<Readonly<LoadedConfig>>;
 }
 
 async function loadFreshConfig(): Promise<ConfigModule> {
@@ -1821,119 +1814,5 @@ describe("loadConfig", () => {
   it("fails with a discovery error when no config exists anywhere", async () => {
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(/no crew config found/);
-  });
-});
-
-describe("loadConfigWithSource", () => {
-  const originalEnvironment = snapshotEnvironmentVariables();
-  const ENV_KEYS = ["GROUNDCREW_CONFIG", "HOME", "XDG_CONFIG_HOME"] as const;
-  let temporary: string;
-
-  beforeEach(() => {
-    temporary = mkdtempSync(path.join(tmpdir(), "groundcrew-resolve-"));
-    for (const key of ENV_KEYS) {
-      deleteEnvironmentVariable(key);
-    }
-    setEnvironmentVariable("XDG_CONFIG_HOME", path.join(temporary, "xdg-config"));
-    vi.spyOn(process, "cwd").mockReturnValue(temporary);
-  });
-
-  afterEach(() => {
-    rmSync(temporary, { recursive: true, force: true });
-    for (const key of ENV_KEYS) {
-      const original = originalEnvironment[key];
-      if (original === undefined) {
-        deleteEnvironmentVariable(key);
-      } else {
-        setEnvironmentVariable(key, original);
-      }
-    }
-    vi.restoreAllMocks();
-  });
-
-  it("reports an env-override source", async () => {
-    const configPath = writeConfigFile(
-      temporary,
-      validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
-    );
-    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
-
-    const { loadConfigWithSource } = await loadFreshConfig();
-    const actual = await loadConfigWithSource();
-
-    expect(actual.source).toStrictEqual({ kind: "env", filepath: path.resolve(configPath) });
-    expect(actual.config.workspace.projectDir).toBe(temporary);
-  });
-
-  it("reports a project-search source", async () => {
-    const projectConfigPath = path.join(temporary, "crew.config.ts");
-    writeFileSync(projectConfigPath, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
-
-    const { loadConfigWithSource } = await loadFreshConfig();
-    const actual = await loadConfigWithSource();
-
-    expect(actual.source).toStrictEqual({ kind: "project", filepath: projectConfigPath });
-    expect(actual.config.workspace.projectDir).toBe(temporary);
-  });
-
-  it("reports an XDG fallback source", async () => {
-    const xdgDir = path.join(temporary, "xdg-config", "groundcrew");
-    mkdirSync(xdgDir, { recursive: true });
-    const xdgConfigPath_ = path.join(xdgDir, "crew.config.ts");
-    writeFileSync(xdgConfigPath_, validConfigSource({ workspace: VALID_WORKSPACE(temporary) }));
-
-    const { loadConfigWithSource } = await loadFreshConfig();
-    const actual = await loadConfigWithSource();
-
-    expect(actual.source).toStrictEqual({ kind: "xdg", filepath: xdgConfigPath_ });
-    expect(actual.config.workspace.projectDir).toBe(temporary);
-  });
-});
-
-function resolvedConfigWithWorkspace(workspace: ResolvedConfig["workspace"]): ResolvedConfig {
-  return {
-    sources: [],
-    git: { remote: "origin", defaultBranch: "main" },
-    workspace,
-    defaults: { hooks: {} },
-    orchestrator: {
-      maximumInProgress: 4,
-      pollIntervalMilliseconds: 1000,
-      sessionLimitPercentage: 85,
-    },
-    agents: { default: "claude", definitions: { claude: { cmd: "claude", color: "#fff" } } },
-    prompts: { initial: "x" },
-    workspaceKind: "auto",
-    local: { runner: "auto" },
-    logging: { file: "/tmp/x.log" },
-  };
-}
-
-describe("workspace path accessors", () => {
-  const resolved = resolvedConfigWithWorkspace;
-
-  it("worktreeBaseDir falls back to projectDir when worktreeDir is unset", () => {
-    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
-    expect(worktreeBaseDir(config)).toBe("/p");
-  });
-
-  it("worktreeBaseDir prefers worktreeDir when set", () => {
-    const config = resolved({ projectDir: "/p", worktreeDir: "/w", knownRepositories: ["a"] });
-    expect(worktreeBaseDir(config)).toBe("/w");
-  });
-
-  it("repositoryBaseDir falls back to projectDir without an override", () => {
-    const config = resolved({ projectDir: "/p", knownRepositories: ["a"] });
-    expect(repositoryBaseDir(config, "a")).toBe("/p");
-  });
-
-  it("repositoryBaseDir uses the per-repo override when present", () => {
-    const config = resolved({
-      projectDir: "/p",
-      knownRepositories: ["a", "b"],
-      repositoryDirs: { b: "/other" },
-    });
-    expect(repositoryBaseDir(config, "b")).toBe("/other");
-    expect(repositoryBaseDir(config, "a")).toBe("/p");
   });
 });


### PR DESCRIPTION
## Summary

Split the two independent sections at the bottom of `src/lib/config.test.ts` into focused test files:

- `loadConfigWithSource` source-reporting coverage now lives in `src/lib/config.source.test.ts`.
- Workspace path accessor coverage now lives in `src/lib/config.paths.test.ts`.

This keeps the main `loadConfig` suite intact while reducing `src/lib/config.test.ts` from 1946 to 1864 lines after merging current `main`, giving it real headroom under the 2000-line limit without returning to the broader per-topic split.

## Validation

- `node --run verify` passes locally after the merge conflict resolution: architecture, build, cpd, format, knip, lint, markdown, spell, syncpack, and test.
- Pre-push hook reran `node --run verify` and passed before pushing.
- Full suite passed with 58 test files, 1608 tests, and 100% statements/branches/functions/lines coverage.

## Notes

No production code changes from this PR. The merge conflict with `main` was resolved by keeping `main`'s newer config test coverage and moving only the source/path accessor sections into the new focused files.

Agent session: `codex resume 019eb231-d7ff-7372-bf3b-70e1c296341c`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>