### PR TITLE
fix: default clearance allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ crew init --global --project-dir ~/dev --repo OWNER/REPO --agent claude
 
 # 3. Run the clone commands printed by `crew init`.
 
-# 4. Set the clearance egress proxy allowlist.
-export CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts"
+# 4. Safehouse runs use groundcrew's bundled clearance allowlist automatically.
+#    Add extra hosts later via CLEARANCE_ALLOW_HOSTS or CLEARANCE_ALLOW_HOSTS_FILES.
 
 # 5. Using Linear? Export your API key. (Jira and other trackers: see Task Pickup.)
 export GROUNDCREW_LINEAR_API_KEY="lin_api_..."

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -13,19 +13,21 @@
 
 ## Safehouse Clearance Allowlist
 
-Only applies when `local.runner` resolves to `safehouse`. Groundcrew starts `clearance` on `http://127.0.0.1:19999` and runs the agent through the bundled `safehouse-clearance` wrapper. Clearance refuses to start without an allowlist.
+Only applies when `local.runner` resolves to `safehouse`. Groundcrew starts `clearance` on `http://127.0.0.1:19999` and runs the agent through the bundled `safehouse-clearance` wrapper. Groundcrew automatically points clearance at its shipped starter allowlist, so a fresh install does not need a `CLEARANCE_ALLOW_HOSTS_FILES` export.
 
-Shortest path:
+Groundcrew ships that starter file at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`, covering model APIs, Linear, Notion, Slack, Datadog, GitHub, npm, and common dev tooling.
+
+To add ad hoc hosts for one run, use `CLEARANCE_ALLOW_HOSTS`:
 
 ```bash
 CLEARANCE_ALLOW_HOSTS="api.openai.com,auth.openai.com,api.anthropic.com,mcp.linear.app,api.linear.app" \
 crew run --watch
 ```
 
-Groundcrew ships a starter file covering model APIs, Linear, Notion, Slack, Datadog, GitHub, npm, and common dev tooling at `$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts`. Point clearance at it, optionally with a personal file:
+To keep personal hosts in a file, set `CLEARANCE_ALLOW_HOSTS_FILES` to only the additional files. Groundcrew prepends its shipped file automatically:
 
 ```bash
-CLEARANCE_ALLOW_HOSTS_FILES="$(npm root -g)/@clipboard-health/groundcrew/clearance-allow-hosts:$HOME/.config/clearance/personal-allow-hosts" \
+CLEARANCE_ALLOW_HOSTS_FILES="$HOME/.config/clearance/personal-allow-hosts" \
 crew run --watch
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.27.1",
+  "version": "4.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.27.1",
+      "version": "4.28.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.52",
-        "@clipboard-health/clearance": "1.1.14",
+        "@clipboard-health/clearance": "1.2.0",
         "@linear/sdk": "86.0.0",
         "cosmiconfig": "9.0.1",
         "tslib": "2.8.1",
@@ -1632,9 +1632,9 @@
       "license": "MIT"
     },
     "node_modules/@clipboard-health/clearance": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.1.14.tgz",
-      "integrity": "sha512-+gfXU1RcCdq3SYHCeMWmS5hxoLux/a4wtPuvbapDG5FsFGxHjlk8kfjfNWwa7af1+chViYKDPU3b+qMfg0JReg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.2.0.tgz",
+      "integrity": "sha512-ccCcKg8vVCY2gHJbo48dh0jsRTZ/XQCczqLkIQhgYDAeEJ7Y1770V/QSIgzmKHC7wKANMby5ZCxY9XarZIXa9A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.52",
-    "@clipboard-health/clearance": "1.1.14",
+    "@clipboard-health/clearance": "1.2.0",
     "@linear/sdk": "86.0.0",
     "cosmiconfig": "9.0.1",
     "tslib": "2.8.1",

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -727,7 +727,9 @@ describe(setupWorkspace, () => {
 
       const allowHostsFile = bundledClearanceAllowHostsFile();
       const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
-      expect(lastEnsureClearanceInput().env?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(allowHostsFile);
+      expect(lastEnsureClearanceInput().envOverrides?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(
+        allowHostsFile,
+      );
       expect(launchScript).toContain(`CLEARANCE_ALLOW_HOSTS_FILES='${allowHostsFile}'`);
       expect(launchScript).toContain("safehouse-clearance");
     } finally {
@@ -752,7 +754,9 @@ describe(setupWorkspace, () => {
 
       const expectedFiles = `${bundledClearanceAllowHostsFile()}${path.delimiter}${personalAllowHostsFile}`;
       const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
-      expect(lastEnsureClearanceInput().env?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(expectedFiles);
+      expect(lastEnsureClearanceInput().envOverrides?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(
+        expectedFiles,
+      );
       expect(launchScript).toContain(`CLEARANCE_ALLOW_HOSTS_FILES='${expectedFiles}'`);
     } finally {
       vi.unstubAllEnvs();

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
+import path from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import { ensureClearance } from "@clipboard-health/clearance";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
@@ -266,8 +267,8 @@ function lastRunArgumentFromCallWithArgument(argument: string): string {
   return typeof lastArgument === "string" ? lastArgument : "";
 }
 
-function writtenFileContent(path: string): string {
-  const call = writeFileMock.mock.calls.find(([candidate]) => String(candidate) === path);
+function writtenFileContent(filePath: string): string {
+  const call = writeFileMock.mock.calls.find(([candidate]) => String(candidate) === filePath);
   const content = call?.[1];
   return typeof content === "string" ? content : "";
 }
@@ -326,6 +327,10 @@ function clearanceResult(): Awaited<ReturnType<typeof ensureClearance>> {
     port: 19_999,
     status: "already-running",
   };
+}
+
+function bundledClearanceAllowHostsFile(): string {
+  return path.resolve(import.meta.dirname, "..", "..", "clearance-allow-hosts");
 }
 
 async function waitForClearanceSleep(input: Parameters<typeof ensureClearance>[0]): Promise<void> {
@@ -704,6 +709,54 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain('sh "$_p"');
     // prepareWorktree status guard so a failed install still launches the agent
     expect(launchScript).toContain('"$prepare_status" -ne 0');
+  });
+
+  it("passes groundcrew's bundled clearance allowlist to Safehouse without requiring an export", async () => {
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");
+    detectHostMock.mockResolvedValue(host());
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    try {
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      const allowHostsFile = bundledClearanceAllowHostsFile();
+      const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+      expect(lastEnsureClearanceInput().env?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(allowHostsFile);
+      expect(launchScript).toContain(`CLEARANCE_ALLOW_HOSTS_FILES='${allowHostsFile}'`);
+      expect(launchScript).toContain("safehouse-clearance");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("keeps user-configured clearance allowlist files in addition to the bundled file", async () => {
+    const personalAllowHostsFile = "/tmp/personal-allow-hosts";
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", personalAllowHostsFile);
+    detectHostMock.mockResolvedValue(host());
+    const config = makeConfig();
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    try {
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      const expectedFiles = `${bundledClearanceAllowHostsFile()}${path.delimiter}${personalAllowHostsFile}`;
+      const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+      expect(lastEnsureClearanceInput().env?.["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(expectedFiles);
+      expect(launchScript).toContain(`CLEARANCE_ALLOW_HOSTS_FILES='${expectedFiles}'`);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("skips prepareWorktree when neither repo config nor defaults define it", async () => {

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -1,5 +1,6 @@
 import { ensureClearance } from "@clipboard-health/clearance";
 
+import { clearanceProxyEnv } from "./clearanceAllowlist.ts";
 import {
   hasPreLaunchEnv,
   type LocalRunner,
@@ -79,6 +80,7 @@ async function alreadyReady(): Promise<void> {
 
 async function ensureSafehouseClearance(signal?: AbortSignal): Promise<void> {
   await ensureClearance({
+    env: clearanceProxyEnv(),
     logger: debug,
     ...(signal === undefined
       ? {}

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -1,6 +1,6 @@
 import { ensureClearance } from "@clipboard-health/clearance";
 
-import { clearanceProxyEnv } from "./clearanceAllowlist.ts";
+import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import {
   hasPreLaunchEnv,
   type LocalRunner,
@@ -80,7 +80,9 @@ async function alreadyReady(): Promise<void> {
 
 async function ensureSafehouseClearance(signal?: AbortSignal): Promise<void> {
   await ensureClearance({
-    env: clearanceProxyEnv(),
+    envOverrides: {
+      CLEARANCE_ALLOW_HOSTS_FILES: clearanceAllowHostsFilesFromEnvironment(),
+    },
     logger: debug,
     ...(signal === undefined
       ? {}

--- a/src/lib/clearanceAllowlist.test.ts
+++ b/src/lib/clearanceAllowlist.test.ts
@@ -1,0 +1,79 @@
+import path from "node:path";
+
+import {
+  clearanceAllowHostsFilesFromEnvironment,
+  clearanceAllowHostsFilesValue,
+  clearanceProxyEnv,
+} from "./clearanceAllowlist.ts";
+
+function bundledClearanceAllowHostsFile(): string {
+  return path.resolve(import.meta.dirname, "..", "..", "clearance-allow-hosts");
+}
+
+describe(clearanceAllowHostsFilesValue, () => {
+  it("uses groundcrew's shipped allowlist when the user has no files configured", () => {
+    const actual = clearanceAllowHostsFilesValue({
+      defaultFile: "/opt/groundcrew/clearance-allow-hosts",
+    });
+
+    expect(actual).toBe("/opt/groundcrew/clearance-allow-hosts");
+  });
+
+  it("prepends the shipped allowlist to user-configured allowlist files", () => {
+    const actual = clearanceAllowHostsFilesValue({
+      defaultFile: "/opt/groundcrew/clearance-allow-hosts",
+      existingFiles: `/tmp/team-hosts${path.delimiter}/tmp/personal-hosts`,
+    });
+
+    expect(actual).toBe(
+      `/opt/groundcrew/clearance-allow-hosts${path.delimiter}/tmp/team-hosts${path.delimiter}/tmp/personal-hosts`,
+    );
+  });
+
+  it("does not duplicate the shipped allowlist when the user already exported it", () => {
+    const actual = clearanceAllowHostsFilesValue({
+      defaultFile: "/opt/groundcrew/clearance-allow-hosts",
+      existingFiles: `/opt/groundcrew/clearance-allow-hosts${path.delimiter}/tmp/personal-hosts`,
+    });
+
+    expect(actual).toBe(
+      `/opt/groundcrew/clearance-allow-hosts${path.delimiter}/tmp/personal-hosts`,
+    );
+  });
+});
+
+describe(clearanceAllowHostsFilesFromEnvironment, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the bundled allowlist before env-provided files", () => {
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "/tmp/personal-hosts");
+
+    const actual = clearanceAllowHostsFilesFromEnvironment();
+
+    expect(actual).toBe(`${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`);
+  });
+});
+
+describe(clearanceProxyEnv, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns clearance's forwarded env plus the bundled allowlist, without unrelated env vars", () => {
+    vi.stubEnv("AWS_SECRET_ACCESS_KEY", "not-forwarded");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "api.example.com");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "/tmp/personal-hosts");
+    vi.stubEnv("CLEARANCE_ALLOW_PORTS", "443,8443");
+
+    const actual = clearanceProxyEnv();
+
+    expect(actual["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
+    expect(actual["CLEARANCE_ALLOW_HOSTS"]).toBe("api.example.com");
+    expect(actual["CLEARANCE_ALLOW_PORTS"]).toBe("443,8443");
+    expect(actual["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(
+      `${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`,
+    );
+  });
+});

--- a/src/lib/clearanceAllowlist.test.ts
+++ b/src/lib/clearanceAllowlist.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import {
   clearanceAllowHostsFilesFromEnvironment,
   clearanceAllowHostsFilesValue,
-  clearanceProxyEnv,
 } from "./clearanceAllowlist.ts";
 
 function bundledClearanceAllowHostsFile(): string {
@@ -53,27 +52,5 @@ describe(clearanceAllowHostsFilesFromEnvironment, () => {
     const actual = clearanceAllowHostsFilesFromEnvironment();
 
     expect(actual).toBe(`${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`);
-  });
-});
-
-describe(clearanceProxyEnv, () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it("returns clearance's forwarded env plus the bundled allowlist, without unrelated env vars", () => {
-    vi.stubEnv("AWS_SECRET_ACCESS_KEY", "not-forwarded");
-    vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "api.example.com");
-    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "/tmp/personal-hosts");
-    vi.stubEnv("CLEARANCE_ALLOW_PORTS", "443,8443");
-
-    const actual = clearanceProxyEnv();
-
-    expect(actual["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
-    expect(actual["CLEARANCE_ALLOW_HOSTS"]).toBe("api.example.com");
-    expect(actual["CLEARANCE_ALLOW_PORTS"]).toBe("443,8443");
-    expect(actual["CLEARANCE_ALLOW_HOSTS_FILES"]).toBe(
-      `${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`,
-    );
   });
 });

--- a/src/lib/clearanceAllowlist.test.ts
+++ b/src/lib/clearanceAllowlist.test.ts
@@ -46,6 +46,15 @@ describe(clearanceAllowHostsFilesFromEnvironment, () => {
     vi.unstubAllEnvs();
   });
 
+  it("uses only the bundled allowlist when env-provided files are unset", () => {
+    // oxlint-disable-next-line unicorn/no-useless-undefined -- undefined is the unset signal here
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", undefined);
+
+    const actual = clearanceAllowHostsFilesFromEnvironment();
+
+    expect(actual).toBe(bundledClearanceAllowHostsFile());
+  });
+
   it("uses the bundled allowlist before env-provided files", () => {
     vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "/tmp/personal-hosts");
 

--- a/src/lib/clearanceAllowlist.ts
+++ b/src/lib/clearanceAllowlist.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+
+import { splitPathList } from "./pathList.ts";
+import { readEnvironmentVariable } from "./util.ts";
+
+const CLEARANCE_ALLOW_HOSTS_FILES = "CLEARANCE_ALLOW_HOSTS_FILES";
+
+const CLEARANCE_PROXY_ENV_NAMES = [
+  "CLEARANCE_ALLOW_HOSTS",
+  CLEARANCE_ALLOW_HOSTS_FILES,
+  "CLEARANCE_ALLOW_PORTS",
+  "CLEARANCE_ALLOW_PRIVATE_IPS",
+  "CLEARANCE_DNS_TTL_MS",
+  "CLEARANCE_IDLE_TIMEOUT_MS",
+  "CLEARANCE_MAX_SOCKETS",
+  "HOME",
+  "PATH",
+  "XDG_CACHE_HOME",
+] as const;
+
+interface ClearanceAllowHostsFilesInput {
+  defaultFile?: string | undefined;
+  existingFiles?: string | undefined;
+}
+
+function groundcrewClearanceAllowHostsFile(): string {
+  return path.resolve(import.meta.dirname, "..", "..", "clearance-allow-hosts");
+}
+
+export function clearanceAllowHostsFilesValue(input: ClearanceAllowHostsFilesInput = {}): string {
+  const defaultFile = input.defaultFile ?? groundcrewClearanceAllowHostsFile();
+  const files = [defaultFile, ...splitPathList(input.existingFiles)];
+  const seen = new Set<string>();
+  const uniqueFiles: string[] = [];
+  for (const file of files) {
+    if (seen.has(file)) {
+      continue;
+    }
+    seen.add(file);
+    uniqueFiles.push(file);
+  }
+  return uniqueFiles.join(path.delimiter);
+}
+
+export function clearanceAllowHostsFilesFromEnvironment(): string {
+  return clearanceAllowHostsFilesValue({
+    existingFiles: readEnvironmentVariable(CLEARANCE_ALLOW_HOSTS_FILES),
+  });
+}
+
+export function clearanceProxyEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of CLEARANCE_PROXY_ENV_NAMES) {
+    const value = readEnvironmentVariable(name);
+    if (value === undefined) {
+      continue;
+    }
+    env[name] = value;
+  }
+  env[CLEARANCE_ALLOW_HOSTS_FILES] = clearanceAllowHostsFilesValue({
+    existingFiles: env[CLEARANCE_ALLOW_HOSTS_FILES],
+  });
+  return env;
+}

--- a/src/lib/clearanceAllowlist.ts
+++ b/src/lib/clearanceAllowlist.ts
@@ -5,19 +5,6 @@ import { readEnvironmentVariable } from "./util.ts";
 
 const CLEARANCE_ALLOW_HOSTS_FILES = "CLEARANCE_ALLOW_HOSTS_FILES";
 
-const CLEARANCE_PROXY_ENV_NAMES = [
-  "CLEARANCE_ALLOW_HOSTS",
-  CLEARANCE_ALLOW_HOSTS_FILES,
-  "CLEARANCE_ALLOW_PORTS",
-  "CLEARANCE_ALLOW_PRIVATE_IPS",
-  "CLEARANCE_DNS_TTL_MS",
-  "CLEARANCE_IDLE_TIMEOUT_MS",
-  "CLEARANCE_MAX_SOCKETS",
-  "HOME",
-  "PATH",
-  "XDG_CACHE_HOME",
-] as const;
-
 interface ClearanceAllowHostsFilesInput {
   defaultFile?: string | undefined;
   existingFiles?: string | undefined;
@@ -46,19 +33,4 @@ export function clearanceAllowHostsFilesFromEnvironment(): string {
   return clearanceAllowHostsFilesValue({
     existingFiles: readEnvironmentVariable(CLEARANCE_ALLOW_HOSTS_FILES),
   });
-}
-
-export function clearanceProxyEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const name of CLEARANCE_PROXY_ENV_NAMES) {
-    const value = readEnvironmentVariable(name);
-    if (value === undefined) {
-      continue;
-    }
-    env[name] = value;
-  }
-  env[CLEARANCE_ALLOW_HOSTS_FILES] = clearanceAllowHostsFilesValue({
-    existingFiles: env[CLEARANCE_ALLOW_HOSTS_FILES],
-  });
-  return env;
 }

--- a/src/lib/clearanceHosts.ts
+++ b/src/lib/clearanceHosts.ts
@@ -15,8 +15,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import path from "node:path";
 
+import { splitPathList } from "./pathList.ts";
 import { debug } from "./util.ts";
 
 export interface CollectAllowedDomainsInput {
@@ -64,16 +64,6 @@ export function collectAllowedDomains(input: CollectAllowedDomainsInput): string
     }
   }
   return domains;
-}
-
-function splitPathList(value: string | undefined): string[] {
-  if (value === undefined || value.length === 0) {
-    return [];
-  }
-  return value
-    .split(path.delimiter)
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
 }
 
 /**

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -8,6 +8,7 @@ import {
   type LocalRunner,
   type AgentDefinition,
 } from "./config.ts";
+import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import { shellSingleQuote } from "./shell.ts";
 
 export { shellSingleQuote } from "./shell.ts";
@@ -129,6 +130,10 @@ function unsetEnvironmentLine(names: readonly string[]): string {
 
 function unsetSecretsLine(): string {
   return unsetEnvironmentLine(BUILD_SECRET_NAMES);
+}
+
+function safehouseClearanceWrapperCommand(): string {
+  return `CLEARANCE_ALLOW_HOSTS_FILES=${shellSingleQuote(clearanceAllowHostsFilesFromEnvironment())} ${shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH)}`;
 }
 
 function trapCleanupLine(promptDir: string): string {
@@ -506,7 +511,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   const preLaunchEnvNames = arguments_.definition.preLaunchEnv ?? [];
   const agentEnvPassFlag =
     preLaunchEnvNames.length === 0 ? "" : `--env-pass=${preLaunchEnvNames.join(",")} `;
-  const safehouseWrapper = shellSingleQuote(SAFEHOUSE_CLEARANCE_WRAPPER_PATH);
+  const safehouseWrapper = safehouseClearanceWrapperCommand();
 
   // Defensive shim+promptDir trap: by the time we arm it, `rm -rf <promptDir>`
   // has already run (line below) so the promptDir wipe is a no-op on the happy

--- a/src/lib/pathList.test.ts
+++ b/src/lib/pathList.test.ts
@@ -1,0 +1,31 @@
+import path from "node:path";
+
+import { splitPathList } from "./pathList.ts";
+
+describe(splitPathList, () => {
+  it("returns an empty array when the value is undefined", () => {
+    const input = new Map<string, string>().get("missing");
+
+    const actual = splitPathList(input);
+
+    expect(actual).toStrictEqual([]);
+  });
+
+  it("returns one path when the value has no delimiter", () => {
+    const actual = splitPathList("/tmp/allow-hosts");
+
+    expect(actual).toStrictEqual(["/tmp/allow-hosts"]);
+  });
+
+  it("splits multiple paths on the platform delimiter", () => {
+    const actual = splitPathList(`/tmp/team${path.delimiter}/tmp/personal`);
+
+    expect(actual).toStrictEqual(["/tmp/team", "/tmp/personal"]);
+  });
+
+  it("trims whitespace and filters empty entries", () => {
+    const actual = splitPathList(` /tmp/team ${path.delimiter} ${path.delimiter}/tmp/personal `);
+
+    expect(actual).toStrictEqual(["/tmp/team", "/tmp/personal"]);
+  });
+});

--- a/src/lib/pathList.ts
+++ b/src/lib/pathList.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+
+export function splitPathList(value: string | undefined): string[] {
+  const paths: string[] = [];
+  for (const entry of value?.split(path.delimiter) ?? []) {
+    const pathEntry = entry.trim();
+    if (pathEntry.length > 0) {
+      paths.push(pathEntry);
+    }
+  }
+  return paths;
+}

--- a/src/lib/srtLaunch.test.ts
+++ b/src/lib/srtLaunch.test.ts
@@ -125,6 +125,42 @@ describe(buildAndStageSrtLaunch, () => {
     expect(JSON.stringify(readSettings(result.agentFile))).toContain(expectedGitDir);
   });
 
+  it("uses groundcrew's shipped clearance allowlist for network policy when no env files are exported", () => {
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");
+
+    try {
+      const result = stage("claude --permission-mode auto");
+
+      expect(readSettings(result.agentFile).network.allowedDomains).toContain("api.openai.com");
+      expect(readSettings(result.prepareFile).network.allowedDomains).toContain("api.openai.com");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("preserves user clearance allowlist files in addition to the shipped file for srt", () => {
+    const personalDir = mkdtempSync(path.join(os.tmpdir(), "srt-launch-personal-hosts-"));
+    staged.push(personalDir);
+    const personalFile = path.join(personalDir, "allow-hosts");
+    writeFileSync(personalFile, "personal.example.com\n");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "");
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", personalFile);
+
+    try {
+      const result = stage("claude --permission-mode auto");
+      const agentDomains = readSettings(result.agentFile).network.allowedDomains;
+      const prepareDomains = readSettings(result.prepareFile).network.allowedDomains;
+
+      expect(agentDomains).toContain("api.openai.com");
+      expect(agentDomains).toContain("personal.example.com");
+      expect(prepareDomains).toContain("api.openai.com");
+      expect(prepareDomains).toContain("personal.example.com");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("skips missing seed files (best-effort) so a not-logged-in agent still stages", () => {
     const realCodex = path.join(fakeHome, ".codex");
     mkdirSync(realCodex, { recursive: true });

--- a/src/lib/srtLaunch.ts
+++ b/src/lib/srtLaunch.ts
@@ -2,6 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from 
 import os from "node:os";
 import path from "node:path";
 
+import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import { collectAllowedDomains } from "./clearanceHosts.ts";
 import { type AgentDefinition, type ResolvedConfig, repositoryBaseDir } from "./config.ts";
 import { inferAgentCommandName } from "./launchCommand.ts";
@@ -59,7 +60,7 @@ export function buildAndStageSrtLaunch(input: {
     gitCommonDir: path.join(repoDir, ".git"),
     allowedDomains: collectAllowedDomains({
       hosts: readEnvironmentVariable("CLEARANCE_ALLOW_HOSTS"),
-      files: readEnvironmentVariable("CLEARANCE_ALLOW_HOSTS_FILES"),
+      files: clearanceAllowHostsFilesFromEnvironment(),
     }),
   };
 


### PR DESCRIPTION
## Summary

Groundcrew now provides its bundled `clearance-allow-hosts` file to clearance automatically for Safehouse launches and srt policy generation, while preserving any user-provided `CLEARANCE_ALLOW_HOSTS_FILES` entries as additive personal allowlists. This removes the need for users to export the bundled allowlist manually.

The Safehouse readiness path now consumes `@clipboard-health/clearance@1.2.0` and passes only `CLEARANCE_ALLOW_HOSTS_FILES` through `ensureClearance({ envOverrides })`, so clearance remains the owner of its forwarded-env allowlist.

## Validation

- `npm exec vitest run src/lib/clearanceAllowlist.test.ts src/commands/setupWorkspace.test.ts`
- `node --run verify`
- Pre-push hook: `node --run verify`

## Notes

- `@clipboard-health/clearance@1.2.0` is published on the `latest` dist-tag from https://github.com/ClipboardHealth/core-utils/actions/runs/27294660179.

Agent session: `codex resume 019eb26d-2d27-7883-b0c5-2b9ab2a2c033`

<sub>🤖 <code>commit-push-pr:created v1 core@3.7.1</code></sub>
