### PR TITLE
fix: allow crew resume into a restored-but-empty cmux workspace

### DIFF
--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -443,6 +443,24 @@ describe(resumeWorkspace, () => {
     expect(workspacesOpenMock).not.toHaveBeenCalled();
   });
 
+  it("proceeds when the workspace was restored after a reboot and reports as exited", async () => {
+    // A cmux tab cmux re-painted after a reboot: present in `names` but flagged
+    // exited because no agent is running inside it. Resume must relaunch.
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+
+    await resumeWorkspace(config, { task: "team-1" });
+
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+    expect(lastRecordedRunState()).toMatchObject({ task: "team-1", state: "resumed" });
+  });
+
   it("fails closed when workspace liveness cannot be verified", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
 

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -146,7 +146,11 @@ async function failIfWorkspaceAlreadyLive(config: ResolvedConfig, task: string):
       `Could not verify whether workspace for ${task} is already live${detail}. Retry or inspect the workspace backend manually before resuming.`,
     );
   }
-  if (probe.names.has(task)) {
+  // `names` includes restored-but-dead workspaces the backend reports as
+  // exited (e.g. a cmux tab cmux re-painted after a reboot with no agent
+  // inside). Those must not block resume — only a workspace with a live agent
+  // session should, so we never spawn a duplicate alongside a running one.
+  if (probe.names.has(task) && probe.exitedNames?.has(task) !== true) {
     throw new Error(`Workspace for ${task} is already live; attach to it instead of resuming.`);
   }
 }

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -2,15 +2,31 @@
  * cmux Workspace backend. cmux is the macOS TUI; workspaces surface in its
  * own app, so `accessHint` has nothing concise to emit. cmux can paint a
  * per-workspace status pill, which `open` applies best-effort.
+ *
+ * Reboot liveness: cmux persists and restores workspace tabs across a reboot,
+ * but the agent process inside a restored tab is dead. `cmux list-workspaces`
+ * has no per-workspace local-liveness field (`remote.active_terminal_sessions`
+ * covers SSH sessions only), so it would report every restored tab as live and
+ * wrongly block `crew resume`. To distinguish a live workspace from a
+ * restored-empty one, `open` stamps a per-workspace marker with the host boot
+ * epoch and `list` compares it: a marker that predates the current boot means
+ * the machine rebooted since the agent launched, so the workspace is reported
+ * `exited` (see WorkspaceProbe in `workspaceAdapter.ts`). This mirrors the
+ * zellij exit-marker approach, keyed to boot identity rather than command exit.
  */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, uptime } from "node:os";
+import path from "node:path";
 
 import {
   type Adapter,
   isSignalAborted,
   runWorkspaceCommand,
+  type Workspace,
   type WorkspaceStatus,
 } from "./workspaceAdapter.ts";
-import { debug, errorMessage, log } from "./util.ts";
+import { debug, errorMessage, log, readEnvironmentVariable } from "./util.ts";
 
 export const cmuxAdapter: Adapter = {
   async open(spec, signal) {
@@ -35,6 +51,7 @@ export const cmuxAdapter: Adapter = {
       );
       throw new Error(`Unexpected cmux output: ${output}`);
     }
+    recordLiveness(spec.name);
     if (spec.status !== undefined) {
       try {
         await applyCmuxStatus(workspaceId, spec.status, signal);
@@ -50,7 +67,10 @@ export const cmuxAdapter: Adapter = {
   },
   async list(signal) {
     const raw = await listCmuxRaw(signal);
-    return raw?.map((ws) => ({ name: ws.title }));
+    return raw?.map(
+      (ws): Workspace =>
+        isRestoredAfterReboot(ws.title) ? { name: ws.title, state: "exited" } : { name: ws.title },
+    );
   },
   async close(name, signal) {
     const raw = await listCmuxRaw(signal);
@@ -67,6 +87,7 @@ export const cmuxAdapter: Adapter = {
     }
     try {
       await closeCmuxWorkspace(match.id, signal);
+      clearLiveness(name);
       return { kind: "closed" };
     } catch (error) {
       if (isSignalAborted(signal)) {
@@ -78,6 +99,7 @@ export const cmuxAdapter: Adapter = {
       }
       const isStillPresent = remaining.some((ws) => ws.title === name);
       if (!isStillPresent) {
+        clearLiveness(name);
         return { kind: "closed" };
       }
       throw error;
@@ -195,4 +217,66 @@ async function closeCmuxWorkspace(workspaceId: string, signal?: AbortSignal): Pr
 
 function isCmuxSetStatusUnsupported(error: unknown): boolean {
   return errorMessage(error).includes('unknown command "set-status"');
+}
+
+// --- reboot liveness markers -------------------------------------------------
+
+// A reboot shifts the boot epoch by far more than this; the only drift within a
+// single boot is sub-second Date.now()/uptime rounding jitter, so the tolerance
+// just prevents a 1s rounding difference from flagging a live workspace as dead.
+const BOOT_EPOCH_TOLERANCE_SECONDS = 5;
+
+// One marker file per workspace title, under a tmpdir the macOS launchd cleaner
+// leaves intact across a reboot (so the pre-reboot boot epoch survives to be
+// compared). Overridable via env so tests can isolate it.
+function livenessDir(): string {
+  return (
+    readEnvironmentVariable("GROUNDCREW_CMUX_LIVENESS_DIR") ??
+    path.join(tmpdir(), "groundcrew-cmux-liveness")
+  );
+}
+
+function livenessPath(name: string): string {
+  return path.join(livenessDir(), name.replaceAll(/[^a-zA-Z0-9_-]/g, "_"));
+}
+
+// Host boot time in whole seconds, derived from uptime to stay cross-platform
+// and subprocess-free.
+function hostBootEpochSeconds(): number {
+  return Math.round(Date.now() / 1000 - uptime());
+}
+
+function recordLiveness(name: string): void {
+  try {
+    mkdirSync(livenessDir(), { recursive: true });
+    writeFileSync(livenessPath(name), String(hostBootEpochSeconds()));
+  } catch (error) {
+    // Best-effort: a failed marker only disables reboot detection, leaving the
+    // prior "every restored workspace counts as live" behavior intact.
+    debug(`cmux: failed to record liveness for ${name}: ${errorMessage(error)}`);
+  }
+}
+
+function clearLiveness(name: string): void {
+  rmSync(livenessPath(name), { force: true });
+}
+
+/**
+ * Whether the workspace's recorded boot epoch predates the current boot — i.e.
+ * cmux restored the tab after a reboot and the agent inside it is dead. A
+ * missing or unparseable marker means we have no liveness record (the workspace
+ * wasn't opened by this groundcrew, or the marker was lost): treat it as live
+ * so a running agent's slot is never wrongly freed.
+ */
+function isRestoredAfterReboot(name: string): boolean {
+  let recorded: number;
+  try {
+    recorded = Number(readFileSync(livenessPath(name), "utf8").trim());
+  } catch {
+    return false;
+  }
+  if (!Number.isFinite(recorded)) {
+    return false;
+  }
+  return Math.abs(hostBootEpochSeconds() - recorded) > BOOT_EPOCH_TOLERANCE_SECONDS;
 }

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -101,13 +101,19 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
   };
 }
 
+const CMUX_LIVENESS_DIR = path.join(tmpdir(), "groundcrew-cmux-liveness-test");
+
 function commonBeforeEach(): void {
   runMock.mockReturnValue("");
   detectHostMock.mockResolvedValue(makeHost());
+  setEnvironmentVariable("GROUNDCREW_CMUX_LIVENESS_DIR", CMUX_LIVENESS_DIR);
+  rmSync(CMUX_LIVENESS_DIR, { recursive: true, force: true });
 }
 
 function commonAfterEach(): void {
   deleteEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
+  deleteEnvironmentVariable("GROUNDCREW_CMUX_LIVENESS_DIR");
+  rmSync(CMUX_LIVENESS_DIR, { recursive: true, force: true });
   vi.resetAllMocks();
 }
 
@@ -291,6 +297,21 @@ describe("workspaces.open (cmux)", () => {
 
     expect(detectHostMock).toHaveBeenCalledTimes(1);
   });
+
+  it("opens the workspace even when the liveness marker cannot be written (best-effort)", async () => {
+    // A path under /dev/null can't be created, so the marker write fails — open
+    // must still succeed and only log the miss; reboot detection is disabled.
+    setEnvironmentVariable("GROUNDCREW_CMUX_LIVENESS_DIR", "/dev/null/cmux-liveness");
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).resolves.toBeUndefined();
+
+    expect(debugMock).toHaveBeenCalledWith(
+      expect.stringContaining("failed to record liveness for TEAM-1"),
+    );
+  });
 });
 
 describe("workspaces.probe (cmux)", () => {
@@ -359,6 +380,53 @@ describe("workspaces.probe (cmux)", () => {
         workspaces: [{ title: "TEAM-1", id: "id-1" }, { title: "TEAM-2" }],
       }),
     );
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1"]),
+    });
+  });
+
+  it("reports a restored cmux workspace as exited when its liveness marker predates the current boot", async () => {
+    // A boot epoch of 0 is decades before any real boot, so it always reads as
+    // "rebooted since open" — the restored-but-empty case `crew resume` must allow.
+    mkdirSync(CMUX_LIVENESS_DIR, { recursive: true });
+    writeFileSync(path.join(CMUX_LIVENESS_DIR, "TEAM-1"), "0");
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }));
+
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1"]),
+      exitedNames: new Set(["TEAM-1"]),
+    });
+  });
+
+  it("keeps a cmux workspace live when its liveness marker matches the current boot", async () => {
+    const config = makeConfig();
+    // open() stamps the marker with the current boot epoch.
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:1" }));
+    await workspaces.open(config, { name: "TEAM-1", cwd: "/cwd", command: "x" });
+
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }));
+    await expect(workspaces.probe(config)).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1"]),
+    });
+  });
+
+  it("treats a cmux workspace with no liveness marker as live (no record to prove a reboot)", async () => {
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-9", id: "id-9" }] }));
+
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-9"]),
+    });
+  });
+
+  it("treats a cmux workspace with a corrupt liveness marker as live", async () => {
+    mkdirSync(CMUX_LIVENESS_DIR, { recursive: true });
+    writeFileSync(path.join(CMUX_LIVENESS_DIR, "TEAM-1"), "not-a-number");
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "id-1" }] }));
+
     await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
       kind: "ok",
       names: new Set(["TEAM-1"]),


### PR DESCRIPTION
## Why

`crew resume <task>` was incorrectly blocked after a machine reboot when the cmux workspace backend is in use.

cmux persists and restores workspace tabs across a reboot, but the agent process inside a restored tab is dead. The cmux probe mapped **every** restored workspace title to a live workspace (`src/lib/cmuxAdapter.ts:53`), so `failIfWorkspaceAlreadyLive` rejected the resume with `Workspace for <task> is already live; attach to it instead of resuming.` — even though nothing was running. Discovered via `op-crew resume tg-3807` failing after a reboot.

`cmux list-workspaces --json` exposes no per-workspace **local**-liveness signal — `remote.active_terminal_sessions` covers SSH sessions only — so there is nothing in the JSON to key on directly.

## What

**Boot-epoch liveness markers in the cmux adapter.** `open` stamps a per-workspace marker file with the host boot epoch (derived from `os.uptime()`, so it's cross-platform and subprocess-free). `list` compares it: a marker that predates the current boot means the machine rebooted since the agent launched, so the workspace is reported `state: "exited"` per the `WorkspaceProbe` contract. A missing or unparseable marker is treated as **live**, preserving the prior behavior and never freeing a running agent's slot. The marker lives under `tmpdir` (the macOS launchd cleaner leaves it intact across reboot, so the pre-reboot epoch survives to be compared) and is cleared on `close`.

This mirrors the existing **zellij exit-marker** pattern, keyed to boot identity rather than command exit. tmux and zellij are unaffected because neither restores tabs across a reboot — they expose real session liveness.

**Resume now blocks only on genuinely-live workspaces** (`src/commands/resumeWorkspace.ts`): present in `names` **and not** in `exitedNames`. A real running agent still prevents a duplicate; a restored-empty tab re-hydrates the worktree and relaunches.

### Why a marker rather than a cmux JSON field

The task notes `remote.active_terminal_sessions` is the only liveness-looking field and it's SSH-only. Rather than depend on an unverified/unstable cmux-internal field, the adapter owns an out-of-band liveness signal — the same design choice the zellij adapter already makes for a backend with no headless exit-state.

## Areas of concern

- Relies on `tmpdir` surviving a reboot on macOS (it does; only periodically cleaned). If a marker is cleaned away, the workspace falls back to "live" (current behavior) — conservative, never frees a running slot.
- A restored-dead cmux tab is left in place when resume relaunches (cmux titles aren't unique handles); the next `open` overwrites the marker. Closing the stale tab was deliberately left out to keep the change minimal, matching the task's accepted "relaunch into the existing workspace" outcome.

## Tested

- New unit tests in `src/lib/workspaces.test.ts` (cmux probe): reboot→exited, marker-matches→live, no-marker→live, corrupt-marker→live, and best-effort marker-write failure on `open`.
- New test in `src/commands/resumeWorkspace.test.ts`: resume proceeds for a probe-reported `exited` workspace; existing "already live" test still guards the live case.
- `node --run verify` passes — all checks green, 100% coverage (statements/branches/functions/lines).

Closes tg-3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)