### PR TITLE
feat: hour units for todo-txt rec: recurrence

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -137,6 +137,7 @@
     "sdlc",
     "tspan",
     "dwmy",
+    "dwmyh",
     "recurrence",
     "todopath",
     "todotxt",

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -215,6 +215,24 @@ describe("TodoTxtTaskSource", () => {
     expect(readFileSync(path.join(tmp.tasksDir, "PROMPT-1.md"), "utf8")).toBe("Existing prompt.\n");
   });
 
+  it("createTask accepts hourly recurrence", async () => {
+    tmp.writeTodo("");
+
+    const source = makeSource(tmp);
+    await source.createTask?.({
+      title: "Hourly sweep",
+      agent: "claude",
+      id: "SWEEP-1",
+      projects: [],
+      contexts: [],
+      dependencies: [],
+      edit: false,
+      recurrence: "2h",
+    });
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toContain("rec:2h status:todo");
+  });
+
   it("creates the todo file when it does not exist", async () => {
     const source = makeSource(tmp);
 

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -1337,6 +1337,178 @@ describe("TodoTxtTaskSource", () => {
     expect(updated).toContain("due:2026-06-09");
   });
 
+  it("markDone with rec:2h advances t: from the completion instant (non-strict)", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T10:30 rec:2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    // Non-strict hourly recurrence advances from completion, not the stale
+    // t:10:30, so daemon downtime cannot cause a catch-up stampede.
+    expect(recurResult?.newId).toBe("sweep-20260608-002");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T17:47");
+  });
+
+  it("markDone with strict rec:+2h accepts a seconds-bearing t:", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T10:30:15 rec:+2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z");
+    await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T12:30");
+  });
+
+  it("markDone with strict rec:+2h treats a date-only t: as midnight", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08 rec:+2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z");
+    await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T02:00");
+  });
+
+  it("markDone with rec:2h carries a verify-rejected due: forward unchanged", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T10:30 due:2026-06-20 rec:2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z");
+    await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    // Hour units never feed due: into date-only advancement; the (verify-
+    // rejected) combination degrades to carrying due: forward unchanged.
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T17:47");
+    expect(updated.match(/due:2026-06-20/g)).toHaveLength(2);
+  });
+
+  it("markDone with strict rec:+2h advances t: from its previous value", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T10:30 rec:+2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z");
+    await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T12:30");
+  });
+
+  it("markDone with rec:2h crossing midnight advances the id date", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T21:00 rec:2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T23:30:00Z");
+    const recurResult = await updateTaskStatus(
+      { todoPath: tmp.todoPath, ref: sourceRef(assertDefined(task, "task")), now },
+      "done",
+    );
+
+    expect(recurResult?.newId).toBe("sweep-20260609");
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-09T01:30");
+  });
+
+  it("markDone with rec:2h computes the completion instant in the source timezone", async () => {
+    tmp.writeTodo(
+      "id:sweep-20260608 agent:any t:2026-06-08T05:00 rec:2h status:in-progress Hourly sweep\n",
+    );
+    tmp.writeTask("sweep-20260608", "Sweep prompt.");
+
+    const source = makeSource(tmp);
+    const task = await source.resolveOne("sweep-20260608");
+
+    const { updateTaskStatus } = await import("./writeback.ts");
+    const now = new Date("2026-06-08T15:47:00Z"); // 10:47 in Chicago (CDT)
+    await updateTaskStatus(
+      {
+        todoPath: tmp.todoPath,
+        ref: sourceRef(assertDefined(task, "task")),
+        now,
+        timezone: "America/Chicago",
+      },
+      "done",
+    );
+
+    const updated = readFileSync(tmp.todoPath, "utf8");
+    expect(updated).toContain("t:2026-06-08T12:47");
+  });
+
+  it("verify() accepts hourly rec: with a t: threshold", async () => {
+    tmp.writeTodo("id:GC-H1 agent:codex t:2026-06-09T10:00 rec:2h status:in-progress\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).resolves.toBeUndefined();
+  });
+
+  it("verify() rejects hourly rec: without t:", async () => {
+    tmp.writeTodo("id:GC-H2 agent:codex rec:2h status:in-progress\n");
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/hourly rec/);
+  });
+
+  it("verify() rejects hourly rec: combined with due:", async () => {
+    tmp.writeTodo(
+      "id:GC-H3 agent:codex t:2026-06-09T10:00 due:2026-06-09 rec:2h status:in-progress\n",
+    );
+    const source = makeSource(tmp);
+    await expect(source.verify()).rejects.toThrow(/hourly rec/);
+  });
+
   it("markDone with rec:1d advances a datetime t: preserving the time component", async () => {
     tmp.writeTodo(
       "id:sweep-20260608 agent:any t:2026-06-08T10:30 rec:1d status:in-progress Recurring sweep\n",

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -464,7 +464,10 @@ export function createTodoTxtTaskSource(
     async markDone(issue: Issue): Promise<MarkDoneResult> {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- TodoTxtTaskSource always writes TodoTxtSourceRef
       const ref = issue.sourceRef as TodoTxtSourceRef;
-      const recurResult = await updateTaskStatus({ todoPath, ref }, "done");
+      const recurResult = await updateTaskStatus(
+        { todoPath, ref, timezone: config.timezone },
+        "done",
+      );
       if (recurResult !== undefined) {
         copyPromptFile(recurResult.oldPromptPath, recurResult.newPromptPath);
       }

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -18,7 +18,7 @@ import { DATE_RE, getMetadataFirst, parseAllLines, type ParsedTodoLine } from ".
 import type { TodoTxtAdapterConfig } from "./schema.ts";
 import { copyPromptFile, updateTaskStatus, validateTodoFile, withLock } from "./writeback.ts";
 
-const RECURRENCE_RE = /^\+?\d+[dwmy]$/;
+const RECURRENCE_RE = /^\+?\d+[dwmyh]$/;
 
 function readPromptFile(promptPath: string): string | undefined {
   try {
@@ -244,7 +244,7 @@ function buildTodoLine(id: string, input: CreateTaskInput): string {
   }
   if (input.recurrence !== undefined) {
     if (!RECURRENCE_RE.test(input.recurrence)) {
-      throw new Error("todo-txt: recurrence must look like 1d, 1w, 1m, 1y, or +1m");
+      throw new Error("todo-txt: recurrence must look like 1d, 1w, 1m, 1y, 2h, or +1m");
     }
     tokens.push(metadataToken("rec", input.recurrence));
   }

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -46,11 +46,11 @@ function addMonths(dateStr: string, months: number): string {
 
 interface Recurrence {
   amount: number;
-  unit: "d" | "w" | "m" | "y";
+  unit: "d" | "w" | "m" | "y" | "h";
   strict: boolean;
 }
 
-const REC_RE = /^(?<strict>\+?)(?<amount>\d+)(?<unit>[dwmy])$/;
+const REC_RE = /^(?<strict>\+?)(?<amount>\d+)(?<unit>[dwmyh])$/;
 
 function parseRecurrence(rec: string): Recurrence | undefined {
   const m = REC_RE.exec(rec);
@@ -58,8 +58,8 @@ function parseRecurrence(rec: string): Recurrence | undefined {
     return undefined;
   }
   const [, strictStr, amountStr, unit] = m;
-  /* v8 ignore next @preserve -- regex [dwmy] guarantees unit is always one of d/w/m/y */
-  if (unit !== "d" && unit !== "w" && unit !== "m" && unit !== "y") {
+  /* v8 ignore next @preserve -- regex [dwmyh] guarantees unit is always one of d/w/m/y/h */
+  if (unit !== "d" && unit !== "w" && unit !== "m" && unit !== "y" && unit !== "h") {
     return undefined;
   }
   return {
@@ -84,20 +84,78 @@ function advanceDate(dateStr: string, rec: Recurrence): string {
   return addMonths(dateStr, amount * 12);
 }
 
+// Add hours to a (timezone-naive wall-clock) datetime, minute precision.
+function addHours(dateTime: string, hours: number): string {
+  const padded = dateTime.length === 16 ? `${dateTime}:00` : dateTime;
+  const ms = Date.parse(`${padded}Z`);
+  return new Date(ms + hours * 60 * 60 * 1000).toISOString().slice(0, 16);
+}
+
 // t: may carry a datetime threshold; advance its date part and keep the time
 // component so a recurring task stays scheduled at the same instant of day.
-function advanceThreshold(threshold: string, rec: Recurrence): string {
+//
+// Hour units advance differently: non-strict rec:Nh advances from the
+// completion instant (the source-timezone wall clock), so a task that sat
+// through daemon downtime re-arms N hours from now instead of stampeding
+// through every missed slot. Strict rec:+Nh keeps schedule-aligned
+// advancement from the previous threshold, matching due:'s strict semantics.
+function advanceThreshold(threshold: string, rec: Recurrence, completionWall: string): string {
+  if (rec.unit === "h") {
+    let base = completionWall;
+    if (rec.strict) {
+      base = threshold.length === 10 ? `${threshold}T00:00` : threshold;
+    }
+    return addHours(base, rec.amount);
+  }
   const [datePart, timePart] = threshold.split("T");
   /* v8 ignore next @preserve -- split always yields a first element */
   const nextDate = advanceDate(datePart ?? threshold, rec);
   return timePart === undefined ? nextDate : `${nextDate}T${timePart}`;
 }
 
+// "YYYY-MM-DDTHH:MM" wall-clock time for `now` in the given timezone.
+function wallClockDateTime(timeZone: string, now: Date): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(now);
+  const get = (type: string): string | undefined => parts.find((part) => part.type === type)?.value;
+  const year = get("year");
+  const month = get("month");
+  const day = get("day");
+  const hour = get("hour");
+  const minute = get("minute");
+  /* v8 ignore next 3 @preserve -- Intl.DateTimeFormat with these options always returns the parts */
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined ||
+    minute === undefined
+  ) {
+    throw new Error(`todo-txt: could not format datetime in timezone "${timeZone}"`);
+  }
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
 function advanceId(id: string, newDate: Date): string {
   const dateCompact = compactDate(newDate);
   // Replace the first 8-digit run (compact date) in the id
   const replaced = id.replace(/\d{8}/, dateCompact);
-  return replaced === id ? `${id}-${dateCompact}` : replaced;
+  if (replaced !== id) {
+    return replaced;
+  }
+  // Unchanged: either the id has no date run (append one), or the date run
+  // already equals the new date — same-day hourly recurrence. For the latter,
+  // strip any prior collision suffixes and let buildUniqueId number this
+  // cycle (-002, -003, …) instead of growing a suffix chain.
+  const base = id.replace(/(?:-\d{3})+$/, "");
+  return base.includes(dateCompact) ? base : `${id}-${dateCompact}`;
 }
 
 function buildUniqueId(baseNewId: string, existingIds: Set<string>): string {
@@ -192,6 +250,8 @@ export interface UpdateOptions {
   todoPath: string;
   ref: TodoTxtSourceRef;
   now?: Date;
+  /** Source timezone for hour-unit recurrence wall-clock math. Defaults to UTC. */
+  timezone?: string;
 }
 
 export async function withLock<T>(lockPath: string, fn: () => T | Promise<T>): Promise<T> {
@@ -238,6 +298,7 @@ function buildRecurResult(
   originalLine: string,
   ref: TodoTxtSourceRef,
   completionDateStr: string,
+  completionWallStr: string,
   now: Date,
 ): RecurResult | undefined {
   const recStr = parsed.metadata["rec"]?.[0];
@@ -260,13 +321,19 @@ function buildRecurResult(
   const oldDue = parsed.metadata["due"]?.[0];
   const oldT = parsed.metadata["t"]?.[0];
 
-  // due: advances from old due (strict) or completion date (normal)
+  // due: advances from old due (strict) or completion date (normal). Hour
+  // units never advance due: — validate() rejects the combination, and a line
+  // that bypassed verify carries its due forward unchanged rather than
+  // feeding an hour recurrence into date-only math.
   /* v8 ignore next @preserve -- oldDue undefined with rec: is unusual; callers typically pair rec: with due: */
   const dueBase = rec.strict ? (oldDue ?? completionDateStr) : completionDateStr;
-  /* v8 ignore next @preserve -- oldDue undefined means skip due advancement */
-  const newDue = oldDue === undefined ? undefined : advanceDate(dueBase, rec);
-  // t: always advances from its own current value by the same period
-  const newT = oldT === undefined ? undefined : advanceThreshold(oldT, rec);
+  let newDue: string | undefined;
+  if (oldDue !== undefined) {
+    newDue = rec.unit === "h" ? oldDue : advanceDate(dueBase, rec);
+  }
+  // t: advances from its own current value by the same period (hour units:
+  // see advanceThreshold for strict vs non-strict base)
+  const newT = oldT === undefined ? undefined : advanceThreshold(oldT, rec, completionWallStr);
 
   // Compute new date for id advancement: prefer due:, then t:, so ids stay
   // schedule-aligned for t:-only recurring tasks. Slice to the date part —
@@ -341,8 +408,17 @@ export async function updateTaskStatus(
 
     if (newStatus === "done") {
       const completionDateStr = isoDate(now);
+      const completionWallStr = wallClockDateTime(options.timezone ?? "UTC", now);
       updatedLine = buildDoneLine(originalLine, completionDateStr);
-      recurResult = buildRecurResult(parsed, parsedAll, originalLine, ref, completionDateStr, now);
+      recurResult = buildRecurResult(
+        parsed,
+        parsedAll,
+        originalLine,
+        ref,
+        completionDateStr,
+        completionWallStr,
+        now,
+      );
     } else {
       updatedLine = replaceStatusToken(originalLine, newStatus);
     }
@@ -428,9 +504,15 @@ function validateDepsAndDates(
   }
 
   const recVal = parsed.metadata["rec"]?.[0];
-  if (recVal !== undefined && parseRecurrence(recVal) === undefined) {
+  const recParsed = recVal === undefined ? undefined : parseRecurrence(recVal);
+  if (recParsed?.unit === "h" && (tVal === undefined || dueVal !== undefined)) {
     errors.push(
-      `${prefix}: malformed rec: "${recVal}" for task "${id}" (expected e.g. 1d, 1w, +1m)`,
+      `${prefix}: hourly rec: "${recVal}" for task "${id}" requires a t: threshold and is incompatible with due:`,
+    );
+  }
+  if (recVal !== undefined && recParsed === undefined) {
+    errors.push(
+      `${prefix}: malformed rec: "${recVal}" for task "${id}" (expected e.g. 1d, 1w, +1m, 2h)`,
     );
   }
 }


### PR DESCRIPTION
## Summary

`rec:Nh` advances a `t:` threshold by N hours on completion — the second half of sub-day recurring tasks (datetime thresholds landed in #218). Design choices:

- **Non-strict `rec:2h` advances from the completion instant** (source-timezone wall clock), not the previous `t:`. This is the stampede guard: after daemon downtime, the task re-arms N hours from now rather than burning through every missed slot in quick succession. **Strict `rec:+2h`** keeps schedule-aligned advancement from the previous threshold, mirroring `due:`'s documented strict semantics.
- **Hourly requires `t:` and is incompatible with `due:`** — `verify()` enforces it; a line that bypassed verify degrades gracefully (due: carried forward unchanged) instead of feeding hours into date-only math.
- **Same-day id evolution fixed:** `advanceId` previously appended the (unchanged) compact date for same-date recurrence — `sweep-20260608-20260608`, growing each cycle. It now reuses the base id and lets `buildUniqueId` number cycles (-002, -003, …); the existing date-advance path is byte-identical.

## Validation

- TDD, red first: 8 new tests — non-strict from-completion, strict from-previous (datetime, seconds-bearing, and date-only-as-midnight forms), midnight crossing advances the id date, source-timezone wall-clock math (America/Chicago), verify accepts `rec:2h`+`t:`, rejects hourly without `t:` and hourly+`due:`, and the due-carry-forward degradation.
- `node --run verify` fully green; coverage 100% (2884/2884 branches).

## Notes

- Wall-clock hour math ignores DST transitions deliberately (a sweep at 2h cadence doesn't care); documented in `advanceThreshold`.
- Deployment: restart the daemon after merging, then the recurring flaky-triage todo line switches to `rec:2h` with a datetime `t:` (already staged in ~/v/todo.md).

Agent session: `claude --resume b2a3a577-12d9-4bd3-bf10-1c16957f6da4`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>