### PR TITLE
fix: accept canonical source-prefixed id in crew resume

### DIFF
--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -474,6 +474,16 @@ describe(resumeWorkspaceCli, () => {
     );
   });
 
+  it("strips a source prefix so the canonical id resumes the natural-id worktree", async () => {
+    await resumeWorkspaceCli(["linear:TEAM-1"]);
+
+    expect(findByTaskMock).toHaveBeenCalledWith(config, "team-1");
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ name: "team-1" }),
+    );
+  });
+
   it("rejects missing task", async () => {
     await expect(resumeWorkspaceCli([])).rejects.toThrow(/Usage: crew resume/);
   });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -12,6 +12,7 @@ import {
   stagePromptText,
   stageWorkspaceLaunchCommand,
 } from "../lib/stagedLaunch.ts";
+import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
@@ -41,7 +42,7 @@ function parseArguments(argv: string[]): ResumeWorkspaceOptions {
   if (task === undefined || task.length === 0 || extras.length > 0 || task.startsWith("-")) {
     throw new Error("Usage: crew resume <task>");
   }
-  return { task: task.toLowerCase() };
+  return { task: naturalIdFromCanonical(task).toLowerCase() };
 }
 
 async function fetchTaskDetails(task: string): Promise<TaskDetails | undefined> {


### PR DESCRIPTION
## Why

Tasks are surfaced in their canonical `<source>:<id>` form (e.g. `linear:act-4928`) in the task list, so passing that id straight into `crew resume linear:act-4928` is the natural thing to do. But resume matched the literal argument against `WorktreeEntry.task`, which is keyed by the bare natural id (`act-4928`). So `findByTask` returned nothing and resume failed with `No worktree found for linear:act-4928; cannot resume.` — even though the worktree was sitting right there on disk. The mismatch is purely that the id is surfaced in canonical form while resume only accepted the natural one.

## What

Normalize the resume argument through `naturalIdFromCanonical` (the same helper the dispatcher and `crew status` already use to go canonical → natural) in `parseArguments`. Both forms now resolve to the same worktree:

- `crew resume linear:act-4928` ✅
- `crew resume LINEAR:ACT-4928` ✅ (still lower-cased after stripping)
- `crew resume act-4928` ✅ (unchanged)

`cleanup` still accepts the bare id only; left as a follow-up to keep this change focused.

## Testing

- Added a `resumeWorkspaceCli` test: a `linear:`-prefixed id calls `findByTask` with the bare `team-1` and opens the workspace as `team-1`.
- `node --run verify`: lint, typecheck, format, and full suite green (one pre-existing, unrelated `setupWorkspace` Safehouse failure reproduces on clean `main`).
- Manually verified against a real worktree: `crew resume linear:act-4928` now resolves and resumes `act-4928`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)