### PR TITLE
fix: surface source-output errors gracefully in doctor and run

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -84,6 +84,7 @@
     "pipefail",
     "Pipfile",
     "pipenv",
+    "plankeeper",
     "pmem",
     "prereqs",
     "productionresultssa",

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,7 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 
-import { type Board, createBoard } from "../lib/board.ts";
-import { buildSources, type sourcesFromConfig } from "../lib/buildSources.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import {
   type ConfigSource,
@@ -37,16 +36,13 @@ vi.mock(import("../lib/host.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, detectHostCapabilities: vi.fn<typeof detectHostCapabilities>() };
 });
-// Full replacements (no importOriginal): pulling in the real buildSources/board
+// Full replacement (no importOriginal): pulling in the real buildSources
 // would load the adapter registry, which scans the adapters directory and
 // imports each adapter — dragging the real config module into the graph and
 // defeating the config.ts mock when this suite runs alongside others.
 vi.mock(import("../lib/buildSources.ts"), () => ({
   buildSources: vi.fn<typeof buildSources>(),
   sourcesFromConfig: vi.fn<typeof sourcesFromConfig>(() => []),
-}));
-vi.mock(import("../lib/board.ts"), () => ({
-  createBoard: vi.fn<typeof createBoard>(),
 }));
 type RunCommandMock = (
   command: string,
@@ -69,26 +65,10 @@ vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
 const existsMock = vi.mocked(existsSync);
 const statMock = vi.mocked(statSync);
 const buildSourcesMock = vi.mocked(buildSources);
-const createBoardMock = vi.mocked(createBoard);
+const sourcesFromConfigMock = vi.mocked(sourcesFromConfig);
 const loadConfigWithSourceMock = vi.mocked(loadConfigWithSource);
 const detectHostMock = vi.mocked(detectHostCapabilities);
-const boardVerifyMock = vi.fn<Board["verify"]>();
 const DEFAULT_CONFIG_SOURCE: ConfigSource = { kind: "project", filepath: "/work/crew.config.ts" };
-
-/**
- * A minimal Board whose `verify()` is the controllable mock. The other
- * Board methods are unused by the source-probe check, so they're stubbed.
- */
-function stubBoard(): Board {
-  return {
-    verify: boardVerifyMock,
-    fetch: vi.fn<Board["fetch"]>(),
-    resolveOne: vi.fn<Board["resolveOne"]>(),
-    markInProgress: vi.fn<Board["markInProgress"]>(),
-    markInReview: vi.fn<Board["markInReview"]>(),
-    markDone: vi.fn<Board["markDone"]>(),
-  };
-}
 
 function stubSource(name: string): TaskSource {
   return {
@@ -217,9 +197,8 @@ describe(doctor, () => {
     existsMock.mockReturnValue(true);
     statMock.mockReturnValue(statsWithDirectoryValue(true));
     detectHostMock.mockResolvedValue(host());
+    sourcesFromConfigMock.mockReturnValue([]);
     buildSourcesMock.mockResolvedValue([stubSource("linear")]);
-    createBoardMock.mockReturnValue(stubBoard());
-    boardVerifyMock.mockResolvedValue();
     runCommandMock.mockImplementation((_cmd, arguments_) => {
       const target = firstArgument(arguments_);
       return `/usr/bin/${target}\n`;
@@ -269,23 +248,90 @@ describe(doctor, () => {
 
     expect(actual).toBe(true);
     expect(buildSourcesMock).toHaveBeenCalledTimes(1);
-    expect(boardVerifyMock).toHaveBeenCalledTimes(1);
     const output = consoleLog.output();
-    expect(output).toContain("[ok] source probe");
-    expect(output).toContain("1 source(s) verified");
+    expect(output).toContain("[ok] source: linear  — verified");
     expect(output).toContain("All required checks passed");
   });
 
-  it("reports a source probe failure when board verification throws", async () => {
+  it("enumerates each configured source with its own status line", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
-    boardVerifyMock.mockRejectedValue(new Error("viewer lookup failed"));
+    buildSourcesMock.mockResolvedValue([stubSource("plankeeper"), stubSource("linear")]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const output = consoleLog.output();
+    expect(output).toContain("[ok] source: plankeeper");
+    expect(output).toContain("[ok] source: linear");
+  });
+
+  it("reports a failed source when its verify throws, leaving siblings green", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    const failing = stubSource("linear");
+    vi.mocked(failing.verify).mockRejectedValue(new Error("viewer lookup failed"));
+    const healthy = stubSource("plankeeper");
+    buildSourcesMock.mockResolvedValue([healthy, failing]);
 
     const actual = await doctor();
 
     expect(actual).toBe(false);
     const output = consoleLog.output();
-    expect(output).toContain("[--] source probe");
+    expect(output).toContain("[ok] source: plankeeper");
+    expect(output).toContain("[--] source: linear");
     expect(output).toContain("viewer lookup failed");
+  });
+
+  it("deep-probes shell sources via listTasks so malformed task output fails doctor", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockRejectedValue(
+      new Error('source "plankeeper": the listTasks command returned task JSON …'),
+    );
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(vi.mocked(shellSource.verify)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(shellSource.listTasks)).toHaveBeenCalledTimes(1);
+    const output = consoleLog.output();
+    expect(output).toContain("[--] source: plankeeper");
+    expect(output).toContain("returned task JSON");
+  });
+
+  it("reports a fatal source build failure as a single check", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    buildSourcesMock.mockRejectedValue(new Error('Unknown source kind "bogus"'));
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    const output = consoleLog.output();
+    expect(output).toContain('[--] sources  — Unknown source kind "bogus"');
+  });
+
+  it("fails with a single check when no sources are configured", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    buildSourcesMock.mockResolvedValue([]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    expect(consoleLog.output()).toContain("[--] sources  — no task sources configured");
+  });
+
+  it("reports the fetched task count for a healthy shell source", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockResolvedValue([]);
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    expect(consoleLog.output()).toContain("[ok] source: plankeeper  — verified; fetched 0 task(s)");
   });
 
   it("returns false when a required CLI tool is missing", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -9,7 +9,7 @@ import {
   type ResolvedConfig,
 } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
-import type { TaskSource } from "../lib/taskSource.ts";
+import type { Task, TaskSource } from "../lib/taskSource.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { doctor } from "./doctor.ts";
 
@@ -69,6 +69,23 @@ const sourcesFromConfigMock = vi.mocked(sourcesFromConfig);
 const loadConfigWithSourceMock = vi.mocked(loadConfigWithSource);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const DEFAULT_CONFIG_SOURCE: ConfigSource = { kind: "project", filepath: "/work/crew.config.ts" };
+
+function taskStub(id: string): Task {
+  return {
+    id,
+    source: "plankeeper",
+    title: "T",
+    description: "",
+    status: "todo",
+    repository: undefined,
+    agent: undefined,
+    assignee: "",
+    updatedAt: "2026-01-01T00:00:00Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: undefined,
+  };
+}
 
 function stubSource(name: string): TaskSource {
   return {
@@ -332,6 +349,40 @@ describe(doctor, () => {
 
     expect(actual).toBe(true);
     expect(consoleLog.output()).toContain("[ok] source: plankeeper  — verified; fetched 0 task(s)");
+  });
+
+  it("round-trips a fetched id through getTask for a healthy shell source", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
+    vi.mocked(shellSource.getTask).mockResolvedValue(taskStub("plankeeper:p-1"));
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    // getTask receives the natural (unprefixed) id.
+    expect(vi.mocked(shellSource.getTask)).toHaveBeenCalledWith("p-1");
+    expect(consoleLog.output()).toContain(
+      "[ok] source: plankeeper  — verified; fetched 1 task(s); getTask round-trips",
+    );
+  });
+
+  it("fails the shell source when a fetched id does not resolve via getTask", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
+    vi.mocked(shellSource.getTask).mockResolvedValue(null);
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    const output = consoleLog.output();
+    expect(output).toContain("[--] source: plankeeper");
+    expect(output).toContain('getTask("p-1") returned nothing');
   });
 
   it("returns false when a required CLI tool is missing", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -300,7 +300,9 @@ describe(doctor, () => {
 
   it("deep-probes shell sources via listTasks so malformed task output fails doctor", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
-    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "shell", name: "plankeeper", commands: { fetch: "./list.sh" } },
+    ]);
     const shellSource = stubSource("plankeeper");
     vi.mocked(shellSource.listTasks).mockRejectedValue(
       new Error('source "plankeeper": the listTasks command returned task JSON …'),
@@ -351,9 +353,29 @@ describe(doctor, () => {
     expect(consoleLog.output()).toContain("[ok] source: plankeeper  — verified; fetched 0 task(s)");
   });
 
+  it("does not round-trip through fallback getTask when a shell source has no explicit getTask command", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "shell", name: "plankeeper", commands: { fetch: "./list.sh" } },
+    ]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    expect(vi.mocked(shellSource.getTask)).not.toHaveBeenCalled();
+    const output = consoleLog.output();
+    expect(output).toContain("[ok] source: plankeeper  — verified; fetched 1 task(s)");
+    expect(output).not.toContain("getTask round-trips");
+  });
+
   it("round-trips a fetched id through getTask for a healthy shell source", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
-    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "shell", name: "plankeeper", commands: { getTask: `./get.sh \${id}` } },
+    ]);
     const shellSource = stubSource("plankeeper");
     vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
     vi.mocked(shellSource.getTask).mockResolvedValue(taskStub("plankeeper:p-1"));
@@ -371,7 +393,9 @@ describe(doctor, () => {
 
   it("fails the shell source when getTask resolves a different task than listTasks emitted", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
-    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "shell", name: "plankeeper", commands: { resolveOne: `./resolve.sh \${id}` } },
+    ]);
     const shellSource = stubSource("plankeeper");
     vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
     vi.mocked(shellSource.getTask).mockResolvedValue(taskStub("plankeeper:p-2"));
@@ -387,7 +411,9 @@ describe(doctor, () => {
 
   it("fails the shell source when a fetched id does not resolve via getTask", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
-    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    sourcesFromConfigMock.mockReturnValue([
+      { kind: "shell", name: "plankeeper", commands: { getTask: `./get.sh \${id}` } },
+    ]);
     const shellSource = stubSource("plankeeper");
     vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
     vi.mocked(shellSource.getTask).mockResolvedValue(null);

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -369,6 +369,22 @@ describe(doctor, () => {
     );
   });
 
+  it("fails the shell source when getTask resolves a different task than listTasks emitted", async () => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);
+    const shellSource = stubSource("plankeeper");
+    vi.mocked(shellSource.listTasks).mockResolvedValue([taskStub("plankeeper:p-1")]);
+    vi.mocked(shellSource.getTask).mockResolvedValue(taskStub("plankeeper:p-2"));
+    buildSourcesMock.mockResolvedValue([shellSource]);
+
+    const actual = await doctor();
+
+    expect(actual).toBe(false);
+    const output = consoleLog.output();
+    expect(output).toContain("[--] source: plankeeper");
+    expect(output).toContain('resolved "plankeeper:p-2", but listTasks emitted "plankeeper:p-1"');
+  });
+
   it("fails the shell source when a fetched id does not resolve via getTask", async () => {
     loadConfigMock.mockResolvedValue(makeConfig());
     sourcesFromConfigMock.mockReturnValue([{ kind: "shell", name: "plankeeper" }]);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -55,11 +55,8 @@ async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<
 }
 
 /**
- * Source-agnostic reachability check: build every configured task source
- * and run the Board's `verify()` fan-out. Replaces the old Linear-only
- * "api key + reachability" probe so a misconfigured shell (or future Jira)
- * source surfaces here too. A missing Linear API key still fails verify with
- * its own user-facing message, so the prior behavior is preserved.
+ * True when a raw source config entry declares `kind: "shell"`. Gates the
+ * shell-only deep probe (listTasks output validation + getTask round-trip).
  */
 function isShellSource(raw: unknown): boolean {
   return typeof raw === "object" && raw !== null && (raw as { kind?: unknown }).kind === "shell";

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,7 +5,6 @@
 
 import { existsSync, statSync } from "node:fs";
 
-import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import {
   type ConfigSourceKind,
@@ -18,6 +17,7 @@ import {
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { isEnvironmentAssignment } from "../lib/launchCommand.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
+import type { TaskSource } from "../lib/taskSource.ts";
 import { gatedAgents } from "../lib/usage.ts";
 import { errorMessage, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
@@ -61,19 +61,56 @@ async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<
  * source surfaces here too. A missing Linear API key still fails verify with
  * its own user-facing message, so the prior behavior is preserved.
  */
-async function checkSourceProbe(config: ResolvedConfig): Promise<Check> {
+function isShellSource(raw: unknown): boolean {
+  return typeof raw === "object" && raw !== null && (raw as { kind?: unknown }).kind === "shell";
+}
+
+/**
+ * Probe each configured task source independently and emit one `Check` per
+ * source (named `source: <name>`), so a single broken source is attributable
+ * instead of hidden behind an aggregate "N source(s) verified" line.
+ *
+ * Every source runs its `verify()`. Shell sources are additionally deep-probed
+ * via `listTasks()`: their `verify` command can discard stdout (e.g.
+ * `... fetch >/dev/null`), so a malformed task payload sails through verify and
+ * only blows up later in `crew run`. Running listTasks here surfaces a
+ * wrong-shape payload (a `TaskSourceOutputError` with a readable message) at
+ * doctor time. Non-shell sources (Linear) are left to `verify()` alone — their
+ * fetch is an expensive network call that verify already exercises.
+ */
+async function checkSourceProbes(config: ResolvedConfig): Promise<Check[]> {
+  const rawSources = sourcesFromConfig(config);
+  let sources: TaskSource[];
   try {
-    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
-    const board: Board = createBoard(sources);
-    await board.verify();
-    return {
-      name: "source probe",
-      ok: true,
-      required: true,
-      hint: `${sources.length} source(s) verified`,
-    };
+    sources = await buildSources(rawSources, { globalConfig: config });
   } catch (error) {
-    return { name: "source probe", ok: false, required: true, hint: errorMessage(error) };
+    // Building sources failed before any individual probe (bad config / unknown
+    // kind). Surface it as a single failed check rather than per-source.
+    return [{ name: "sources", ok: false, required: true, hint: errorMessage(error) }];
+  }
+  if (sources.length === 0) {
+    return [{ name: "sources", ok: false, required: true, hint: "no task sources configured" }];
+  }
+  const checks: Check[] = [];
+  for (const [index, source] of sources.entries()) {
+    const shell = isShellSource(rawSources[index]);
+    // oxlint-disable-next-line no-await-in-loop -- sequential keeps each verdict attributable to one source
+    checks.push(await probeSource(source, shell));
+  }
+  return checks;
+}
+
+async function probeSource(source: TaskSource, shell: boolean): Promise<Check> {
+  const name = `source: ${source.name}`;
+  try {
+    await source.verify();
+    if (shell) {
+      const tasks = await source.listTasks();
+      return { name, ok: true, required: true, hint: `verified; fetched ${tasks.length} task(s)` };
+    }
+    return { name, ok: true, required: true, hint: "verified" };
+  } catch (error) {
+    return { name, ok: false, required: true, hint: errorMessage(error) };
   }
 }
 
@@ -220,7 +257,7 @@ export async function doctor(): Promise<boolean> {
   reportWorkspaceKind(config, workspaceOutcome);
 
   const checks: Check[] = [
-    await checkSourceProbe(config),
+    ...(await checkSourceProbes(config)),
     await checkCmd("git", true, "https://git-scm.com/"),
     ...(await workspaceChecks(workspaceOutcome)),
     checkDir(config.workspace.projectDir, "workspace.projectDir"),

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -40,6 +40,8 @@ interface Check {
   hint?: string;
 }
 
+type ShellReadProbe = "none" | "listTasks" | "listTasksAndGetTask";
+
 async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<Check> {
   const path = await which(cmd);
   const resolvedHint = path ?? hint;
@@ -54,12 +56,36 @@ async function checkCmd(cmd: string, required: boolean, hint?: string): Promise<
   return result;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 /**
  * True when a raw source config entry declares `kind: "shell"`. Gates the
- * shell-only deep probe (listTasks output validation + getTask round-trip).
+ * shell-only read probe.
  */
-function isShellSource(raw: unknown): boolean {
-  return typeof raw === "object" && raw !== null && (raw as { kind?: unknown }).kind === "shell";
+function isShellSource(raw: unknown): raw is Record<string, unknown> & { kind: "shell" } {
+  if (!isRecord(raw)) {
+    return false;
+  }
+  const { kind } = raw;
+  return kind === "shell";
+}
+
+function hasExplicitGetTaskCommand(raw: Record<string, unknown>): boolean {
+  const { commands } = raw;
+  if (!isRecord(commands)) {
+    return false;
+  }
+  const { getTask, resolveOne } = commands;
+  return typeof getTask === "string" || typeof resolveOne === "string";
+}
+
+function shellReadProbeFor(raw: unknown): ShellReadProbe {
+  if (!isShellSource(raw)) {
+    return "none";
+  }
+  return hasExplicitGetTaskCommand(raw) ? "listTasksAndGetTask" : "listTasks";
 }
 
 /**
@@ -90,26 +116,27 @@ async function checkSourceProbes(config: ResolvedConfig): Promise<Check[]> {
   }
   const checks: Check[] = [];
   for (const [index, source] of sources.entries()) {
-    const shell = isShellSource(rawSources[index]);
+    const shellReadProbe = shellReadProbeFor(rawSources[index]);
     // oxlint-disable-next-line no-await-in-loop -- sequential keeps each verdict attributable to one source
-    checks.push(await probeSource(source, shell));
+    checks.push(await probeSource(source, shellReadProbe));
   }
   return checks;
 }
 
-async function probeSource(source: TaskSource, shell: boolean): Promise<Check> {
+async function probeSource(source: TaskSource, shellReadProbe: ShellReadProbe): Promise<Check> {
   const name = `source: ${source.name}`;
   try {
     await source.verify();
-    if (!shell) {
+    if (shellReadProbe === "none") {
       return { name, ok: true, required: true, hint: "verified" };
     }
     const tasks = await source.listTasks();
     const parts = [`fetched ${tasks.length} task(s)`];
     // Read-path symmetry: an id listTasks emitted must resolve via getTask.
-    // Skipped on an empty board — there's nothing to round-trip.
+    // Skipped when getTask is only the adapter's listTasks fallback, since that
+    // would just re-run listTasks and can race changing source output.
     const [first] = tasks;
-    if (first !== undefined) {
+    if (first !== undefined && shellReadProbe === "listTasksAndGetTask") {
       const naturalId = naturalIdFromCanonical(first.id);
       const resolved = await source.getTask(naturalId);
       if (resolved === null) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -115,6 +115,11 @@ async function probeSource(source: TaskSource, shell: boolean): Promise<Check> {
       if (resolved === null) {
         throw new Error(`getTask("${naturalId}") returned nothing, but listTasks emitted it`);
       }
+      if (resolved.id !== first.id) {
+        throw new Error(
+          `getTask("${naturalId}") resolved "${resolved.id}", but listTasks emitted "${first.id}"`,
+        );
+      }
       parts.push("getTask round-trips");
     }
     return { name, ok: true, required: true, hint: `verified; ${parts.join("; ")}` };

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -17,7 +17,7 @@ import {
 import { detectHostCapabilities, type HostCapabilities, which } from "../lib/host.ts";
 import { isEnvironmentAssignment } from "../lib/launchCommand.ts";
 import { resolveLocalRunner } from "../lib/localRunner.ts";
-import type { TaskSource } from "../lib/taskSource.ts";
+import { naturalIdFromCanonical, type TaskSource } from "../lib/taskSource.ts";
 import { gatedAgents } from "../lib/usage.ts";
 import { errorMessage, writeOutput } from "../lib/util.ts";
 import { resolveWorkspaceKind, type WorkspaceResolution } from "../lib/workspaces.ts";
@@ -104,11 +104,23 @@ async function probeSource(source: TaskSource, shell: boolean): Promise<Check> {
   const name = `source: ${source.name}`;
   try {
     await source.verify();
-    if (shell) {
-      const tasks = await source.listTasks();
-      return { name, ok: true, required: true, hint: `verified; fetched ${tasks.length} task(s)` };
+    if (!shell) {
+      return { name, ok: true, required: true, hint: "verified" };
     }
-    return { name, ok: true, required: true, hint: "verified" };
+    const tasks = await source.listTasks();
+    const parts = [`fetched ${tasks.length} task(s)`];
+    // Read-path symmetry: an id listTasks emitted must resolve via getTask.
+    // Skipped on an empty board — there's nothing to round-trip.
+    const [first] = tasks;
+    if (first !== undefined) {
+      const naturalId = naturalIdFromCanonical(first.id);
+      const resolved = await source.getTask(naturalId);
+      if (resolved === null) {
+        throw new Error(`getTask("${naturalId}") returned nothing, but listTasks emitted it`);
+      }
+      parts.push("getTask round-trips");
+    }
+    return { name, ok: true, required: true, hint: `verified; ${parts.join("; ")}` };
   } catch (error) {
     return { name, ok: false, required: true, hint: errorMessage(error) };
   }

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1716,6 +1716,30 @@ JSON
     expect(out).toContain("Retrying in");
   });
 
+  it("does not retry a deterministic source-output error (no backoff spam)", async () => {
+    // A shell source whose fetch emits issues missing required fields throws a
+    // TaskSourceOutputError. Re-running yields the same bad output, so withRetry
+    // must surface it immediately rather than burning three backoff attempts.
+    loadConfigMock.mockResolvedValue(
+      makeLoadedConfig(
+        makeConfig({
+          sources: [
+            {
+              kind: "shell",
+              name: "plankeeper",
+              commands: { fetch: `printf '%s' '[{"id":"a"}]'` },
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(orchestrate({ watch: false, dryRun: false })).rejects.toThrow(
+      /source "plankeeper"[\s\S]*missing the required/,
+    );
+    expect(consoleLog.output()).not.toContain("Retrying in");
+  });
+
   it("exits the watch loop when SIGINT arrives during retry backoff", async () => {
     const client = makeClient({});
     mockBoardFailuresThenEmpty(client, 1, "Rate limit exceeded");

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -9,7 +9,11 @@ import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfigWithSource, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
-import { type BoardState, RepositoryResolutionError } from "../lib/taskSource.ts";
+import {
+  type BoardState,
+  RepositoryResolutionError,
+  TaskSourceOutputError,
+} from "../lib/taskSource.ts";
 import { getUsageByAgent, type UsageByAgent } from "../lib/usage.ts";
 import { errorMessage, log, sleep, writeOutput } from "../lib/util.ts";
 import { worktrees } from "../lib/worktrees.ts";
@@ -35,6 +39,11 @@ async function withRetry<T>(
     } catch (error) {
       /* v8 ignore next 2 @preserve -- fetch() warns-and-skips since PR#88; guard is a defensive no-op in practice */
       if (error instanceof RepositoryResolutionError) {
+        throw error;
+      }
+      // A source returned unparseable output — deterministic, so retrying just
+      // delays a guaranteed failure behind confusing "Retrying in Ns" lines.
+      if (error instanceof TaskSourceOutputError) {
         throw error;
       }
       if (attempt === maxRetries) {

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -250,6 +250,22 @@ describe(createShellTaskSource, () => {
     await expect(source.fetch()).rejects.toThrow(/.+/);
   });
 
+  it("listTasks() surfaces a readable error (not a Zod blob) when issues omit `agent`", async () => {
+    // Reproduces the plan-keeper mismatch: the script emits `model` instead of
+    // the contract's `agent`, so the key is absent and the schema rejects it.
+    const issue = { ...shellIssue({ id: "P-1" }), model: "claude" };
+    delete (issue as { agent?: unknown }).agent;
+    const script = dir.writeScript("no-agent.sh", `cat <<'JSON'\n${JSON.stringify([issue])}\nJSON`);
+    const source = createShellTaskSource(
+      { kind: "shell", name: "plankeeper", commands: { listTasks: script } },
+      fakeContext,
+    );
+
+    await expect(source.listTasks()).rejects.toThrow(
+      /source "plankeeper"[\s\S]*missing the required "agent" field[\s\S]*rename it to "agent"/,
+    );
+  });
+
   it("verify() is a silent no-op when not configured", async () => {
     const source = createShellTaskSource(
       { kind: "shell", name: "test", commands: { fetch: "echo '[]'" } },

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -262,7 +262,7 @@ describe(createShellTaskSource, () => {
     );
 
     await expect(source.listTasks()).rejects.toThrow(
-      /source "plankeeper"[\s\S]*missing the required "agent" field[\s\S]*rename it to "agent"/,
+      /source "plankeeper"[\s\S]*missing the required "agent" field/,
     );
   });
 

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -33,6 +33,7 @@ import {
 import { errorMessage, writeError } from "../../util.ts";
 
 import { invokeShellCommand } from "./invoke.ts";
+import { parseShellJson } from "./parseOutput.ts";
 import {
   type ShellAdapterConfig,
   shellFetchOutputSchema,
@@ -182,7 +183,10 @@ export function createShellTaskSource(
       env: config.env,
       sourceName,
     });
-    const parsed = shellFetchOutputSchema.parse(JSON.parse(stdout));
+    const parsed = parseShellJson(shellFetchOutputSchema, stdout, {
+      sourceName,
+      command: "listTasks",
+    });
     return parsed.map((si) => toCanonicalIssue(si, sourceName));
   }
 
@@ -207,7 +211,10 @@ export function createShellTaskSource(
     if (result.exitCode === 3 || result.stdout.trim().length === 0) {
       return null;
     }
-    const parsed = shellIssueSchema.parse(JSON.parse(result.stdout));
+    const parsed = parseShellJson(shellIssueSchema, result.stdout, {
+      sourceName,
+      command: "getTask",
+    });
     return toCanonicalIssue(parsed, sourceName);
   }
 
@@ -319,7 +326,10 @@ export function createShellTaskSource(
           `shell source "${sourceName}" createTask command produced no output (expected one ShellIssue JSON)`,
         );
       }
-      const parsed = shellIssueSchema.parse(JSON.parse(trimmed));
+      const parsed = parseShellJson(shellIssueSchema, trimmed, {
+        sourceName,
+        command: "createTask",
+      });
       return toCanonicalIssue(parsed, sourceName);
     };
   }

--- a/src/lib/adapters/shell/parseOutput.test.ts
+++ b/src/lib/adapters/shell/parseOutput.test.ts
@@ -1,0 +1,99 @@
+import { TaskSourceOutputError } from "../../taskSource.ts";
+import { errorMessage } from "../../util.ts";
+
+import { parseShellJson, type ShellParseContext } from "./parseOutput.ts";
+import { shellFetchOutputSchema, type ShellIssue, shellIssueSchema } from "./schema.ts";
+
+const context: ShellParseContext = { sourceName: "plankeeper", command: "listTasks" };
+
+function wellFormed(overrides: Partial<ShellIssue> = {}): ShellIssue {
+  return {
+    id: "P-1",
+    title: "Title",
+    description: "",
+    status: "todo",
+    repository: null,
+    agent: null,
+    assignee: "u",
+    updatedAt: "2026-01-01T00:00:00Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: { path: "/tmp/p.md" },
+    ...overrides,
+  };
+}
+
+/** Like plan-keeper's output: a `model` field where `agent` should be, so `agent` is absent. */
+function issueWithModelNotAgent(id: string): Record<string, unknown> {
+  const { agent: _agent, ...rest } = wellFormed({ id });
+  return { ...rest, model: "claude" };
+}
+
+/** Capture the thrown error's message without an in-test conditional. */
+function messageFromThrow(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return errorMessage(error);
+  }
+  throw new Error("expected the call to throw, but it returned");
+}
+
+describe(parseShellJson, () => {
+  it("returns the validated value for well-formed JSON", () => {
+    const parsed = parseShellJson(shellFetchOutputSchema, JSON.stringify([wellFormed()]), context);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.id).toBe("P-1");
+  });
+
+  it("throws a source-attributed error when stdout is not JSON", () => {
+    const run = (): unknown => parseShellJson(shellFetchOutputSchema, "not json", context);
+
+    expect(run).toThrow(TaskSourceOutputError);
+    expect(run).toThrow(/source "plankeeper": the listTasks command did not return valid JSON/);
+  });
+
+  it("collapses N issues missing `agent` into one counted line with a rename hint", () => {
+    const withoutAgent = [issueWithModelNotAgent("P-1"), issueWithModelNotAgent("P-2")];
+    const message = messageFromThrow(() =>
+      parseShellJson(shellFetchOutputSchema, JSON.stringify(withoutAgent), context),
+    );
+
+    expect(message).toContain('source "plankeeper"');
+    expect(message).toContain('2 issue(s) are missing the required "agent" field');
+    expect(message).toContain('rename it to "agent"');
+    // The collapse means the field name appears once, not once per issue.
+    expect(message.match(/missing the required "agent"/g)).toHaveLength(1);
+  });
+
+  it("describes a top-level shape mismatch (no field path) without crashing", () => {
+    // A non-array payload fails `shellFetchOutputSchema` at the root, so the
+    // issue path is empty and there is no field name to report.
+    const message = messageFromThrow(() => parseShellJson(shellFetchOutputSchema, "{}", context));
+
+    expect(message).toContain('source "plankeeper"');
+    expect(message).toContain("have an invalid field");
+    expect(message).not.toContain("rename it to");
+  });
+
+  it("names the nearest field when the failure is inside a nested array", () => {
+    // A bad blocker element makes the issue path end in an array index
+    // (`[0, "blockers", 0]`); the reported field is the nearest named one.
+    const payload = JSON.stringify([{ ...wellFormed(), blockers: ["not-an-object"] }]);
+    const message = messageFromThrow(() =>
+      parseShellJson(shellFetchOutputSchema, payload, context),
+    );
+
+    expect(message).toContain('"blockers"');
+  });
+
+  it("omits the agent rename hint for unrelated schema failures", () => {
+    // `agent` is present (null); a different field is wrong, so no hint.
+    const payload = JSON.stringify({ ...wellFormed(), status: "nope" });
+    const message = messageFromThrow(() => parseShellJson(shellIssueSchema, payload, context));
+
+    expect(message).toContain('source "plankeeper"');
+    expect(message).not.toContain("rename it to");
+  });
+});

--- a/src/lib/adapters/shell/parseOutput.test.ts
+++ b/src/lib/adapters/shell/parseOutput.test.ts
@@ -54,7 +54,7 @@ describe(parseShellJson, () => {
     expect(run).toThrow(/source "plankeeper": the listTasks command did not return valid JSON/);
   });
 
-  it("collapses N issues missing `agent` into one counted line with a rename hint", () => {
+  it("collapses N issues missing `agent` into one counted line", () => {
     const withoutAgent = [issueWithModelNotAgent("P-1"), issueWithModelNotAgent("P-2")];
     const message = messageFromThrow(() =>
       parseShellJson(shellFetchOutputSchema, JSON.stringify(withoutAgent), context),
@@ -62,7 +62,6 @@ describe(parseShellJson, () => {
 
     expect(message).toContain('source "plankeeper"');
     expect(message).toContain('2 issue(s) are missing the required "agent" field');
-    expect(message).toContain('rename it to "agent"');
     // The collapse means the field name appears once, not once per issue.
     expect(message.match(/missing the required "agent"/g)).toHaveLength(1);
   });
@@ -88,12 +87,11 @@ describe(parseShellJson, () => {
     expect(message).toContain('"blockers"');
   });
 
-  it("omits the agent rename hint for unrelated schema failures", () => {
-    // `agent` is present (null); a different field is wrong, so no hint.
+  it("names the invalid field for a wrong-value (non-missing) failure", () => {
     const payload = JSON.stringify({ ...wellFormed(), status: "nope" });
     const message = messageFromThrow(() => parseShellJson(shellIssueSchema, payload, context));
 
     expect(message).toContain('source "plankeeper"');
-    expect(message).not.toContain("rename it to");
+    expect(message).toContain('"status"');
   });
 });

--- a/src/lib/adapters/shell/parseOutput.ts
+++ b/src/lib/adapters/shell/parseOutput.ts
@@ -1,0 +1,96 @@
+/**
+ * Friendly stdout parsing for the shell adapter. A shell source emits JSON on
+ * stdout; both `JSON.parse` and the Zod schema can reject it. A raw `ZodError`
+ * stringifies to a JSON array of issues — cryptic, unattributed, and (for a
+ * fetch array) repeated once per task. This module collapses that into a
+ * single user-facing `TaskSourceOutputError` that names the source, the
+ * command, and the offending field(s), with a targeted hint for the common
+ * "missing `agent`" mistake.
+ */
+
+import type { z } from "zod";
+
+import { TaskSourceOutputError } from "../../taskSource.ts";
+import { errorMessage } from "../../util.ts";
+
+export interface ShellParseContext {
+  /** The source's configured `name`, surfaced so the user knows which source broke. */
+  sourceName: string;
+  /** The contract method that produced the output, e.g. `"listTasks"` or `"getTask"`. */
+  command: string;
+}
+
+/**
+ * Parse `stdout` as JSON and validate it against `schema`. On any failure,
+ * throws a `TaskSourceOutputError` with a readable, source-attributed message
+ * instead of a raw `SyntaxError` / `ZodError`.
+ */
+export function parseShellJson<T>(
+  schema: z.ZodType<T>,
+  stdout: string,
+  context: ShellParseContext,
+): T {
+  let json: unknown;
+  try {
+    json = JSON.parse(stdout);
+  } catch (error) {
+    throw new TaskSourceOutputError(
+      `source "${context.sourceName}": the ${context.command} command did not return valid JSON (${errorMessage(error)}).`,
+    );
+  }
+  const result = schema.safeParse(json);
+  if (result.success) {
+    return result.data;
+  }
+  throw new TaskSourceOutputError(formatSchemaError(result.error, context));
+}
+
+/** The last string segment of an issue path — the field name, ignoring array indices. */
+function fieldName(path: readonly PropertyKey[]): string | undefined {
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    const segment = path[index];
+    if (typeof segment === "string") {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+type ZodIssue = z.ZodError["issues"][number];
+
+/** One human-readable phrase describing what's wrong with a single issue. */
+function describeIssue(issue: ZodIssue): string {
+  const field = fieldName(issue.path);
+  const label = field === undefined ? "field" : `"${field}"`;
+  // Zod v4 reports a missing required key as an `invalid_type` whose message
+  // ends in "received undefined"; there is no separate `received` property to
+  // branch on, so we match the message.
+  if (issue.code === "invalid_type" && issue.message.includes("received undefined")) {
+    return `are missing the required ${label} field`;
+  }
+  return `have an invalid ${label} field: ${issue.message}`;
+}
+
+function formatSchemaError(error: z.ZodError, context: ShellParseContext): string {
+  // A fetch array yields one issue per task (48 tasks missing `agent` → 48
+  // identical issues). Collapse identical phrasings into a single counted line,
+  // preserving first-seen order via the Map's insertion order.
+  const counts = new Map<string, number>();
+  for (const issue of error.issues) {
+    const description = describeIssue(issue);
+    counts.set(description, (counts.get(description) ?? 0) + 1);
+  }
+  const lines = [...counts].map(([description, count]) => `  • ${count} issue(s) ${description}`);
+  const missingAgent = [...counts.keys()].some(
+    (description) => description.includes('"agent"') && description.includes("missing"),
+  );
+  const hint = missingAgent
+    ? '\n  Hint: if your script emits the agent under a different field name (e.g. "model"), rename it to "agent".'
+    : "";
+  return [
+    `source "${context.sourceName}": the ${context.command} command returned task JSON that doesn't match the expected shape:`,
+    ...lines,
+  ]
+    .join("\n")
+    .concat(hint);
+}

--- a/src/lib/adapters/shell/parseOutput.ts
+++ b/src/lib/adapters/shell/parseOutput.ts
@@ -81,16 +81,8 @@ function formatSchemaError(error: z.ZodError, context: ShellParseContext): strin
     counts.set(description, (counts.get(description) ?? 0) + 1);
   }
   const lines = [...counts].map(([description, count]) => `  • ${count} issue(s) ${description}`);
-  const missingAgent = [...counts.keys()].some(
-    (description) => description.includes('"agent"') && description.includes("missing"),
-  );
-  const hint = missingAgent
-    ? '\n  Hint: if your script emits the agent under a different field name (e.g. "model"), rename it to "agent".'
-    : "";
   return [
     `source "${context.sourceName}": the ${context.command} command returned task JSON that doesn't match the expected shape:`,
     ...lines,
-  ]
-    .join("\n")
-    .concat(hint);
+  ].join("\n");
 }

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -221,6 +221,23 @@ export class RepositoryResolutionError extends Error {
   }
 }
 
+/**
+ * A task source returned output that groundcrew could not parse — non-JSON
+ * stdout, or JSON that doesn't match the source's contract (e.g. a shell
+ * script's `listTasks` payload missing the required `agent` field). Carries a
+ * user-facing message that names the source and what was wrong.
+ *
+ * Marked deterministic: re-running the same command yields the same bad
+ * output, so the orchestrator's `withRetry` must NOT retry it (retrying only
+ * delays a guaranteed failure behind confusing "Retrying in Ns" lines).
+ */
+export class TaskSourceOutputError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = "TaskSourceOutputError";
+  }
+}
+
 export class AmbiguousTaskError extends Error {
   public constructor(arguments_: { naturalId: string; matches: readonly string[] }) {
     const { naturalId, matches } = arguments_;


### PR DESCRIPTION
## Why

A shell task source whose `listTasks`/`getTask` output failed schema validation was handled badly across the board:

- **`crew run`** dumped the raw `ZodError` — a JSON array of issues, repeated once per task — with no indication of *which* source produced it. (In a mixed Linear + shell config, the `Resolved Linear viewer` progress line printing just before it made the failure look like Linear's fault when it wasn't.)
- It **retried 3×** with backoff, even though a schema violation is deterministic — re-running yields the same bad output, so the "Retrying in 1s/2s/4s" lines were pure delay.
- **`crew doctor` reported green.** Its source probe only ran each source's `verify` command, which for a shell source can discard stdout (e.g. `… fetch >/dev/null`). So a malformed `listTasks` payload sailed past doctor while `run` broke on the same data — and the aggregate `N source(s) verified` line hid which source was at fault.

Real-world trigger: a shell source emitting a `model` field where the contract wants `agent`, so the required `agent` key is absent → `expected string, received undefined`, once per issue.

## What

**Graceful, attributable source-output errors**
- **`parseShellJson`** (new, `src/lib/adapters/shell/parseOutput.ts`) wraps the three shell parse sites (`listTasks` / `getTask` / `createTask`) and turns parse failures into a readable, source-attributed `TaskSourceOutputError`: it names the source and command and collapses repeated issues into one counted line. Bad JSON gets a clear "did not return valid JSON" message too.
- **`TaskSourceOutputError`** (new, in `taskSource.ts`) is treated as deterministic by the orchestrator's `withRetry`, so it surfaces immediately instead of after three backoff attempts.

**Per-source doctor enumeration + read-hook deep-probe**
- `doctor` now emits **one status line per source** (`source: <name>`) instead of an aggregate, so a single broken source is attributable.
- For **shell** sources it **deep-probes the read hooks**: it runs `listTasks` and validates the output (a wrong-shape payload now fails doctor with the same readable message). When the source explicitly configures `getTask`/`resolveOne`, doctor also round-trips a fetched id through `getTask` — taking the first emitted id, stripping the `<source>:` prefix, and failing the source if an id `listTasks` just emitted doesn't resolve or resolves to a different task. The round-trip is skipped on an empty board and when `getTask` would only be the adapter's `listTasks` fallback, avoiding a second fetch that can race changing source output.
- Non-shell sources (Linear) are left to `verify` alone — their fetch is an expensive network call `verify` already exercises. Write hooks (`markInProgress`/`markInReview`/`markDone`/`createTask`) are intentionally **not** probed: they mutate, so they can't be safely exercised in a health check.

Example doctor output:

```
[--] source: plankeeper  — source "plankeeper": the listTasks command returned task JSON that doesn't match the expected shape:
  • 50 issue(s) are missing the required "agent" field
[ok] source: linear  — verified
```

…and a healthy shell source with an explicit `getTask`/`resolveOne` command:

```
[ok] source: plankeeper  — verified; fetched 12 task(s); getTask round-trips
```

## Validation

- `node --run verify` green: **1659 tests pass, 100% coverage**, lint/format/spell/architecture/cpd all clean.
- New tests: `parseOutput.test.ts` (message shaping, JSON failure, counted collapse, nested-array field naming, wrong-value field naming); `factory.test.ts` (end-to-end missing-`agent` through the real shell adapter); `orchestrator.test.ts` (deterministic error is not retried); `doctor.test.ts` (per-source enumeration, shell `listTasks` deep-probe, `getTask` round-trip success/failure, skipped fallback `getTask` round-trip, build/empty-source failures).
- Verified end-to-end against a real mixed `shell + linear` config — doctor names the broken source with the actionable message instead of a Zod blob.

## Notes

- The underlying data bug (a `plan-keeper`-style script emitting `model` instead of `agent`) lives in the producing tool; this PR makes groundcrew **degrade legibly** rather than silently/cryptically. No behavior change for well-formed sources.

Agent session: `codex resume 019eb9a3-6fed-7c83-91ca-470a1a7b99c9`

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>
