### PR TITLE
docs: rename model to agent references in all markdown files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,7 @@ The environment that executes the agent command for a task. Groundcrew is cross-
 - **macOS** — uses `safehouse`: requires `safehouse` on `PATH`, starts `clearance`, and launches the model command through `safehouse-clearance` inside the host worktree.
 - **Linux / WSL** — uses `sbx` (cross-platform default): `sbx` must be on `PATH`.
 
-There is no `models.isolation` strategy or remote runner. Legacy `.sbx` worktrees and persistent Docker Sandboxes state are no longer discovered or cleaned up by groundcrew; users remove old state manually with `sbx` if needed.
+There is no `agents.isolation` strategy or remote runner. Legacy `.sbx` worktrees and persistent Docker Sandboxes state are no longer discovered or cleaned up by groundcrew; users remove old state manually with `sbx` if needed.
 
 ## Dispatcher
 
@@ -56,6 +56,6 @@ The Linear adapter that turns the project's GraphQL state into a `BoardState` sn
 
 Lifecycle lives in `src/lib/boardSource.ts`. Callers ask `boardSource.verify()` once at startup (fail-fast on a missing project) and `boardSource.fetch()` per tick; nothing else in the package reaches Linear's GraphQL API. The module owns label-based model parsing (`agent-*` labels) and description-based repository parsing — callers consume a typed `Issue[]`.
 
-The `BoardIssues` GraphQL filter is scoped server-side on two axes: state name (Todo / In-Progress / Done / extra terminal states) and labels (`labels.some.name.startsWith: "agent-"`). Unlabeled tasks are filtered out by Linear's API and never appear in the board snapshot, so dashboard counts, blocker accounting, and dispatcher selection are all already scoped to groundcrew-eligible work. `fetchResolvedIssue` (manual `crew setup`) does not apply the label filter — it's an explicit per-task opt-in and keeps the historic default to `models.default` when the task has no `agent-*` label.
+The `BoardIssues` GraphQL filter is scoped server-side on two axes: state name (Todo / In-Progress / Done / extra terminal states) and labels (`labels.some.name.startsWith: "agent-"`). Unlabeled tasks are filtered out by Linear's API and never appear in the board snapshot, so dashboard counts, blocker accounting, and dispatcher selection are all already scoped to groundcrew-eligible work. `fetchResolvedIssue` (manual `crew setup`) does not apply the label filter — it's an explicit per-task opt-in and keeps the historic default to `agents.default` when the task has no `agent-*` label.
 
 The client-side narrowing (`parseModel` returning `undefined`, `Issue.model`/`Issue.repository` typed as `string | undefined`, `GroundcrewIssue` + `isGroundcrewIssue`, the dispatcher's predicate filter) is retained as defense-in-depth against query drift — if the GraphQL filter is ever loosened, the dispatcher still won't pick up unlabeled tasks. In normal operation the narrowing is a no-op.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -57,7 +57,7 @@ crew status ENG-123
 ===================
 task: eng-123  in-progress  https://linear.app/example/issue/ENG-123
 title: Multi-event extractor: year inference can produce date_start > date_end
-run: running; model=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
+run: running; agent=claude; updated=2026-05-26T00:01:00.000Z; resumes=0
 workspace: live
 
 Worktrees
@@ -77,9 +77,9 @@ Recent logs
 
 ## Doctor
 
-`crew doctor` checks host prerequisites only: config validity, task-source reachability, required binaries on PATH, workspace backend availability, `workspace.projectDir`, local runner capability, and enabled model commands.
+`crew doctor` checks host prerequisites only: config validity, task-source reachability, required binaries on PATH, workspace backend availability, `workspace.projectDir`, local runner capability, and enabled agent commands.
 
-Doctor's command introspection is intentionally shallow. It reports the resolved local runner and tokenizes each model `cmd`, then checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments, shell pipelines, and subshells are not parsed.
+Doctor's command introspection is intentionally shallow. It reports the resolved local runner and tokenizes each agent `cmd`, then checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments, shell pipelines, and subshells are not parsed.
 
 ## Start
 
@@ -106,4 +106,4 @@ The command closes the cmux/tmux/zellij workspace if present, records local run 
 
 `crew resume <TASK>` reopens an existing task worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew start <task>`.
 
-The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded model, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the model and task context.
+The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded agent, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the agent and task context.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,13 @@
 # Configuration
 
-Workspace settings and at least one enabled model are required; everything else has a default.
+Workspace settings and at least one enabled agent are required; everything else has a default.
 
 | Key                           | What                                                                 |
 | ----------------------------- | -------------------------------------------------------------------- |
 | `workspace.projectDir`        | Parent dir for cloned repos and the default task worktree root.      |
 | `workspace.worktreeDir`       | Optional parent dir for task worktrees.                              |
 | `workspace.knownRepositories` | Repos searched for in task descriptions to infer where work belongs. |
-| `models.definitions`          | Enabled model set. Built-in presets can be enabled with `{}`.        |
+| `agents.definitions`          | Enabled agent set. Built-in presets can be enabled with `{}`.        |
 
 The branch prefix (`<prefix>-<TASK>`) defaults to `os.userInfo().username`; override it with `git.branchPrefix` (see the full reference below). Changing it only affects newly created worktrees; existing local branches keep their original names until cleaned up. Groundcrew picks up every issue assigned to your API key's viewer that carries an `agent-*` label across every visible team and project, governed by a single `orchestrator.maximumInProgress` budget.
 
@@ -92,11 +92,11 @@ The "Loaded config from ..." line at startup tells you which config won.
 
 ## Agent Label Routing
 
-- `agent-claude`, `agent-codex`, `agent-<name>` routes to that enabled model.
-- `agent-any` routes to the model with the most session headroom, after skipping models over their session limit or weekly paced budget.
-- Unknown `agent-<name>` falls back to `models.default`.
-- A built-in `agent-<name>` label whose model is not enabled falls back to `models.default` with a warning.
-- No `agent-*` label is ignored by `crew run`. Dispatch on demand with `crew start <TASK>`, which falls back to `models.default`.
+- `agent-claude`, `agent-codex`, `agent-<name>` routes to that enabled agent.
+- `agent-any` routes to the agent with the most session headroom, after skipping agents over their session limit or weekly paced budget.
+- Unknown `agent-<name>` falls back to `agents.default`.
+- A built-in `agent-<name>` label whose agent is not enabled falls back to `agents.default` with a warning.
+- No `agent-*` label is ignored by `crew run`. Dispatch on demand with `crew start <TASK>`, which falls back to `agents.default`.
 - Todo tasks blocked by non-terminal blockers are skipped until their blockers reach a terminal status.
 
 Status classification uses Linear's default status names `In Progress` and `In Review` to disambiguate multiple `started` workflow states. Statuses that do not match those names fall back to Linear's workflow `state.type` (`unstarted`, `started`, `completed`, `canceled`, `duplicate`), so broad lifecycle classification still works without configuration. Parent issues with children are ignored; sub-issues are the work items.
@@ -136,13 +136,13 @@ export default {
 };
 ```
 
-## Enabling Model Presets
+## Enabling Agent Presets
 
-Groundcrew ships built-in presets for `claude` and `codex`, but models are not enabled by default. List the models you want in `models.definitions`:
+Groundcrew ships built-in presets for `claude` and `codex`, but agents are not enabled by default. List the agents you want in `agents.definitions`:
 
 ```ts
 export default {
-  models: {
+  agents: {
     default: "claude",
     definitions: {
       claude: {},
@@ -155,7 +155,7 @@ To keep both shipped presets enabled:
 
 ```ts
 export default {
-  models: {
+  agents: {
     default: "claude",
     definitions: {
       claude: {},
@@ -167,15 +167,15 @@ export default {
 
 Rules:
 
-- `models.definitions` is the enabled model set; `crew doctor` only probes listed models.
+- `agents.definitions` is the enabled agent set; `crew doctor` only probes listed agents.
 - Built-in entries can be `{}` or partial overrides such as `{ cmd: "..." }`.
-- Custom model names must provide `cmd` and `color`.
-- `models.default` must point at an enabled model.
-- Legacy model entries like `codex: { disabled: true }` are rejected with migration guidance; remove unwanted entries instead.
+- Custom agent names must provide `cmd` and `color`.
+- `agents.default` must point at an enabled agent.
+- Legacy agent entries like `codex: { disabled: true }` are rejected with migration guidance; remove unwanted entries instead.
 
 ## Prompt Customization
 
-Groundcrew ships one model-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.
+Groundcrew ships one agent-agnostic unattended prompt by default. It tells the agent to make reasonable assumptions, follow repository instructions, run documented verification, review its diff, open a PR when GitHub/`gh` is available, and include a workspace continuation hint when known.
 
 This prompt describes how the agent works, not what it does. The task is the task description, which groundcrew passes through unchanged. Keep source-specific instructions, acceptance criteria, links, and output requirements in the task body. Override `prompts.initial` only to change the execution contract for every dispatched task — team-wide review rules, required verification, local tool conventions — not to encode behavior for a single task type.
 
@@ -242,15 +242,15 @@ and hook contract.
 | `defaults.hooks.prepareWorktree`         | optional             | Fallback repo-preparation command used only when the worktree does not define `.groundcrew/config.json` `hooks.prepareWorktree`. The hook runs after worktree creation and before the agent starts. Repo-local config wins.                                                                                                                                                                                                                                                                                                 |
 | `orchestrator.maximumInProgress`         | `4`                  | Cap on in-progress tasks at once for this `crew` instance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `orchestrator.pollIntervalMilliseconds`  | `120_000`            | Poll interval in `--watch` mode.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `orchestrator.sessionLimitPercentage`    | `85`                 | Number in `(0, 100]`. A model whose codexbar session window exceeds this percentage is skipped that tick. Models are also skipped when codexbar reports weekly usage over the current weekly paced budget.                                                                                                                                                                                                                                                                                                                  |
-| `models.default`                         | `"claude"`           | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew start <TASK>` for unlabeled tasks. `crew run` ignores unlabeled tasks and does not apply this default. Must exist in `models.definitions`. If you enable only `codex`, set `default: "codex"`.                                                                                                                                                                                                               |
-| `models.definitions`                     | **required**         | Enabled model set. Built-in keys (`claude`, `codex`) can use `{}` to opt into the shipped preset. Custom model names must provide `cmd` and `color`.                                                                                                                                                                                                                                                                                                                                                                        |
-| `models.definitions.<name>.cmd`          | preset for built-ins | Shell command launched for the model. Required for custom models. Runs in the worktree through the resolved `local.runner`. `{{worktree}}` is replaced before launch; `{{sandbox}}` expands to the sbx sandbox name under the sdx runner and an empty string otherwise.                                                                                                                                                                                                                                                     |
-| `models.definitions.<name>.color`        | preset for built-ins | Color for the workspace status pill (cmux only; tmux and zellij silently drop it). Required for custom models.                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `models.definitions.<name>.usage`        | preset for built-ins | If set, codexbar usage is fetched for this model and gated by `sessionLimitPercentage` plus the weekly paced budget when codexbar exposes a weekly window. When `usage.codexbar.source` is omitted, groundcrew uses `oauth` for Codex/Claude on macOS, `auto` for other macOS providers, and `cli` elsewhere. Set to `{ disabled: true }` to disable usage gating while keeping the model enabled.                                                                                                                          |
-| `models.definitions.<name>.sandbox`      | optional             | Docker Sandboxes binding for the model. Required at launch when `local.runner` resolves to `sdx`. Field: `agent` (required sbx agent name). Groundcrew assumes the `groundcrew-<agent>` sandbox already exists.                                                                                                                                                                                                                                                                                                             |
-| `models.definitions.<name>.preLaunch`    | optional             | Host-only shell snippet run before the agent exec and outside Safehouse/sdx. Exports survive into the launch shell; under the default `safehouse` runner they are only forwarded to the agent when listed via `preLaunchEnv` or when `cmd` includes its own `safehouse --env-pass=NAMES`. `{{worktree}}` is substituted. A non-zero exit aborts launch. Not supported when `local.runner` resolves to `sdx` in v1.                                                                                                          |
-| `models.definitions.<name>.preLaunchEnv` | optional             | Companion to `preLaunch`: list of env var names to append to groundcrew's `safehouse-clearance` `--env-pass=` flag, so `preLaunch` exports reach the agent without overriding `cmd` and losing the project's egress allowlist. Each entry must match `[A-Za-z_][A-Za-z0-9_]*`. Under `runner: "none"` exports already inherit and `preLaunchEnv` is a no-op. An empty array is a uniform no-op in every runner; a non-empty list is rejected when `cmd` already starts with `safehouse` or when `runner` resolves to `sdx`. |
+| `orchestrator.sessionLimitPercentage`    | `85`                 | Number in `(0, 100]`. An agent whose codexbar session window exceeds this percentage is skipped that tick. Agents are also skipped when codexbar reports weekly usage over the current weekly paced budget.                                                                                                                                                                                                                                                                                                                 |
+| `agents.default`                         | `"claude"`           | Tiebreak for `agent-any` resolution and fallback for explicit but unknown `agent-*` labels. Also used by `crew start <TASK>` for unlabeled tasks. `crew run` ignores unlabeled tasks and does not apply this default. Must exist in `agents.definitions`. If you enable only `codex`, set `default: "codex"`.                                                                                                                                                                                                               |
+| `agents.definitions`                     | **required**         | Enabled agent set. Built-in keys (`claude`, `codex`) can use `{}` to opt into the shipped preset. Custom agent names must provide `cmd` and `color`.                                                                                                                                                                                                                                                                                                                                                                        |
+| `agents.definitions.<name>.cmd`          | preset for built-ins | Shell command launched for the agent. Required for custom agents. Runs in the worktree through the resolved `local.runner`. `{{worktree}}` is replaced before launch; `{{sandbox}}` expands to the sbx sandbox name under the sdx runner and an empty string otherwise.                                                                                                                                                                                                                                                     |
+| `agents.definitions.<name>.color`        | preset for built-ins | Color for the workspace status pill (cmux only; tmux and zellij silently drop it). Required for custom agents.                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `agents.definitions.<name>.usage`        | preset for built-ins | If set, codexbar usage is fetched for this agent and gated by `sessionLimitPercentage` plus the weekly paced budget when codexbar exposes a weekly window. When `usage.codexbar.source` is omitted, groundcrew uses `oauth` for Codex/Claude on macOS, `auto` for other macOS providers, and `cli` elsewhere. Set to `{ disabled: true }` to disable usage gating while keeping the agent enabled.                                                                                                                          |
+| `agents.definitions.<name>.sandbox`      | optional             | Docker Sandboxes binding for the agent. Required at launch when `local.runner` resolves to `sdx`. Field: `agent` (required sbx agent name). Groundcrew assumes the `groundcrew-<agent>` sandbox already exists.                                                                                                                                                                                                                                                                                                             |
+| `agents.definitions.<name>.preLaunch`    | optional             | Host-only shell snippet run before the agent exec and outside Safehouse/sdx. Exports survive into the launch shell; under the default `safehouse` runner they are only forwarded to the agent when listed via `preLaunchEnv` or when `cmd` includes its own `safehouse --env-pass=NAMES`. `{{worktree}}` is substituted. A non-zero exit aborts launch. Not supported when `local.runner` resolves to `sdx` in v1.                                                                                                          |
+| `agents.definitions.<name>.preLaunchEnv` | optional             | Companion to `preLaunch`: list of env var names to append to groundcrew's `safehouse-clearance` `--env-pass=` flag, so `preLaunch` exports reach the agent without overriding `cmd` and losing the project's egress allowlist. Each entry must match `[A-Za-z_][A-Za-z0-9_]*`. Under `runner: "none"` exports already inherit and `preLaunchEnv` is a no-op. An empty array is a uniform no-op in every runner; a non-empty list is rejected when `cmd` already starts with `safehouse` or when `runner` resolves to `sdx`. |
 | `prompts.initial`                        | unattended template  | First message sent to the agent: the execution wrapper around each task. The task description is the task-specific prompt. Placeholders: `{{task}}`, `{{worktree}}`, `{{title}}`, `{{description}}`. Override only to change the execution contract for every task, such as team-wide review rules or tool conventions. Mutually exclusive with `prompts.promptFile`.                                                                                                                                                       |
 | `prompts.promptFile`                     | optional             | Path to a UTF-8 file whose contents become `prompts.initial`, read at load time. Resolved relative to the config file's directory; `~` is expanded and absolute paths are used as-is. The JSON-friendly alternative to inlining a large prompt or `readFileSync`. Mutually exclusive with `prompts.initial`.                                                                                                                                                                                                                |
 | `workspaceKind`                          | `"auto"`             | Terminal session manager. `"auto"` picks `cmux` when on PATH, else `tmux`. Set to `"cmux"`, `"tmux"`, or `"zellij"` to fail loudly when the chosen backend is missing.                                                                                                                                                                                                                                                                                                                                                      |

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -52,7 +52,7 @@ The "preLaunch never sees build secrets" contract is enforced differently per ru
 Under the default `safehouse` runner, the agent runs under a sanitized env allowlist. Exports from `preLaunch` land in the launch shell but are stripped before reaching the agent unless they are forwarded. `preLaunchEnv` is the supported way to forward them:
 
 ```ts
-models: {
+agents: {
   definitions: {
     claude: {
       preLaunch: "SESSION_TOKEN=$(your-mint-command) && export SESSION_TOKEN",
@@ -69,7 +69,7 @@ Under `runner: "none"`, exports flow through unchanged and `preLaunchEnv` is a n
 <details>
 <summary>Manual fallback when <code>cmd</code> brings its own <code>safehouse</code> wrap</summary>
 
-If your `cmd` already starts with `safehouse`, groundcrew will not auto-compose `--env-pass=` for you and a non-empty `preLaunchEnv` is rejected at launch. Add the names to your own `cmd` instead. This opts the model out of groundcrew's default `safehouse-clearance` wrap, so re-supply `--append-profile` / `--env` yourself if you need it:
+If your `cmd` already starts with `safehouse`, groundcrew will not auto-compose `--env-pass=` for you and a non-empty `preLaunchEnv` is rejected at launch. Add the names to your own `cmd` instead. This opts the agent out of groundcrew's default `safehouse-clearance` wrap, so re-supply `--append-profile` / `--env` yourself if you need it:
 
 ```ts
 claude: {

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -49,7 +49,7 @@ Groundcrew generates a per-launch policy itself (Safehouse's `.sb` profiles have
 
 - **Reads**: the home region (`/Users` on macOS, `/home`+`/root`+`/mnt` on Linux — `/mnt` covers WSL's Windows drive mounts) is denied, then the worktree, the repo's git metadata, the language toolchains needed to run the agent, and the agent's own config dirs (`~/.claude`, `~/.codex`, …) are re-opened. On macOS the user keychain dir (`~/Library/Keychains`) is also re-opened read-only so keychain-authenticated agents (claude) can sign in under the home mask. The agent cannot read `~/.ssh`, `~/.aws`, shell history, or unrelated repos.
 - **Writes**: allow-only, and the host-CLI persistence vector (planting hooks, `mcpServers`, `commands/`, `plugins/`, … that run on the user's next host invocation) is closed per agent. **claude** keeps a writable `~/.claude` (its Bash tool needs scratch/session state there) but every fixed-path executable/instruction surface — `~/.claude.json` (`mcpServers`), `settings.json` and its hooks, `commands/`, `agents/`, `plugins/`, `skills/`, `statusline.sh`, `CLAUDE.md`, the bundled `chrome` binary, `.git/{hooks,config}` — is denied; claude tolerates those write denials. **codex** hard-fails with a read-only home, so it is pointed at a per-launch relocated config dir (`CODEX_HOME`) seeded with its credentials, leaving the real `~/.codex` entirely unwritten. The git common dir is granted as a **narrow allowlist** of only what `status/diff/add/commit/push/gc` write (`objects`, `refs`, `logs`, `packed-refs`, this worktree's gitdir, …) — never wholesale, so the repo `config`/`hooks`, the per-worktree gitdir redirection files, and **sibling worktree gitdirs** stay unwritable. Global toolchain bins (`~/.cargo/bin`, global `node_modules`, the npx cache, …) are never writable either.
-- **Environment**: each `srt` invocation runs under a sanitized env (`env -i` + a benign baseline). Unlike safehouse and sdx, the `srt` CLI inherits the host env, so without this an ambient `AWS_*`, `GITHUB_TOKEN`, etc. would reach the agent and bypass the read mask. Credentials the agent legitimately needs from the environment must be forwarded explicitly via the model's `preLaunchEnv` (the same opt-in pass-list safehouse uses).
+- **Environment**: each `srt` invocation runs under a sanitized env (`env -i` + a benign baseline). Unlike safehouse and sdx, the `srt` CLI inherits the host env, so without this an ambient `AWS_*`, `GITHUB_TOKEN`, etc. would reach the agent and bypass the read mask. Credentials the agent legitimately needs from the environment must be forwarded explicitly via the agent's `preLaunchEnv` (the same opt-in pass-list safehouse uses).
 - **Network**: allow-only, **reused from the same Clearance allowlist** (`CLEARANCE_ALLOW_HOSTS` / `CLEARANCE_ALLOW_HOSTS_FILES`, including the shipped `clearance-allow-hosts`) so there is one source of truth. Local binding and unix sockets stay off (never the Docker socket).
 
 ### Linux / WSL prerequisites
@@ -76,7 +76,7 @@ sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
 ## Docker Sandboxes Setup
 
-Each model that runs under `sdx` needs a `sandbox: { agent: "<sbx-agent>" }` block in `crew.config.ts`. Groundcrew addresses the sandbox as `groundcrew-<agent>` and reuses one existing sandbox per agent across repos and tasks.
+Each agent that runs under `sdx` needs a `sandbox: { agent: "<sbx-agent>" }` block in `crew.config.ts`. Groundcrew addresses the sandbox as `groundcrew-<agent>` and reuses one existing sandbox per agent across repos and tasks.
 
 First-time setup is manual:
 
@@ -86,4 +86,4 @@ sbx exec -it groundcrew-claude claude auth login
 sbx exec -it groundcrew-claude gh auth login
 ```
 
-Replace `claude` with the sbx agent for the model and `<projectDir>` with `workspace.projectDir` from `crew.config.ts`. Manage lifecycle and auth with `sbx` directly (`sbx ls`, `sbx exec`, `sbx rm`). Groundcrew does not create, authenticate, regenerate, list, or remove sandboxes.
+Replace `claude` with the sbx agent name for your agent and `<projectDir>` with `workspace.projectDir` from `crew.config.ts`. Manage lifecycle and auth with `sbx` directly (`sbx ls`, `sbx exec`, `sbx rm`). Groundcrew does not create, authenticate, regenerate, list, or remove sandboxes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,12 +2,12 @@
 
 First stop for "what exists locally right now": `crew status <task>` shows the task's worktrees, workspace presence, run state, logs, and task-source status. Use `crew doctor` when you need to verify host setup.
 
-## Missing Model CLI
+## Missing Agent CLI
 
-`crew doctor` probes every model listed in `models.definitions`. If you do not have `codex` installed, initialize with `crew init --model claude` or leave `codex` out of the enabled model set:
+`crew doctor` probes every agent listed in `agents.definitions`. If you do not have `codex` installed, initialize with `crew init --agent claude` or leave `codex` out of the enabled agent set:
 
 ```ts
-models: {
+agents: {
   default: "claude",
   definitions: {
     claude: {},
@@ -19,7 +19,7 @@ If `codex: {}` is listed, doctor expects the `codex` CLI to be installed because
 
 ## Safehouse-Wrapped Commands Are Not Re-Wrapped
 
-If a `models.definitions.<name>.cmd` already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the `safehouse-clearance` wrapper a second time. Changing the proxy's allowlist after it is running requires killing the PID in `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid` so the next launch picks up the new env.
+If a `agents.definitions.<name>.cmd` already starts with `safehouse`, groundcrew assumes that command owns its Safehouse flags and does not add the `safehouse-clearance` wrapper a second time. Changing the proxy's allowlist after it is running requires killing the PID in `${XDG_CACHE_HOME:-$HOME/.cache}/clearance/clearance.pid` so the next launch picks up the new env.
 
 ## Dead Tmux Windows Vanish By Default
 
@@ -33,11 +33,11 @@ Groundcrew marks a task `In Progress` when it provisions a workspace. When a PR 
 
 ## Claude Launches In Auto Mode By Default
 
-Groundcrew creates isolated per-task worktrees for unattended runs, so the shipped `claude` command is `claude --permission-mode auto` to let Claude proceed without stopping for clarifying questions while keeping its built-in safety prompts intact. Override `models.definitions.claude.cmd` for `bypassPermissions` if you need to suppress tool-permission prompts entirely, or for a stricter mode.
+Groundcrew creates isolated per-task worktrees for unattended runs, so the shipped `claude` command is `claude --permission-mode auto` to let Claude proceed without stopping for clarifying questions while keeping its built-in safety prompts intact. Override `agents.definitions.claude.cmd` for `bypassPermissions` if you need to suppress tool-permission prompts entirely, or for a stricter mode.
 
 ## Doctor's Command Introspection Is Shallow
 
-Doctor reports the resolved local runner and whether its prerequisites are met, then tokenizes model `cmd` and checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed. When `local.runner` is `"none"`, doctor surfaces a single WARNING line.
+Doctor reports the resolved local runner and whether its prerequisites are met, then tokenizes agent `cmd` and checks the first two non-flag tokens against PATH. Boolean flags without values, env-var assignments (`FOO=1`), shell pipelines, and subshells are not parsed. When `local.runner` is `"none"`, doctor surfaces a single WARNING line.
 
 ## Switch To Tmux If Cmux Is Misbehaving
 

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -720,8 +720,6 @@ describe(setupWorkspace, () => {
   });
 
   it("wraps the agent command with Safehouse and runs the default prepareWorktree hook", async () => {
-    vi.stubEnv("NPM_TOKEN", "");
-    vi.stubEnv("BUF_TOKEN", "");
     detectHostMock.mockResolvedValue(host());
     const config = {
       ...makeConfig({
@@ -754,15 +752,14 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain("npm ci");
     expect(launchScript).not.toContain(".groundcrew/setup.sh");
     // Both wraps grant the worktree root and git common dir so git works in the
-    // prepareWorktree hook and the agent. The grant flag precedes the wrapped
-    // command (no build secrets are set in this test, so no --env-pass follows it).
-    const addDirsFlag = "--add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git'";
-    expect(launchScript).toContain(
-      `/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' ${addDirsFlag} sh -c`,
-    );
+    // prepareWorktree hook and the agent. The grant flag precedes the wrapped command;
+    // optional flags (e.g. --env-pass from ambient build secrets) may appear between them.
+    const addDirsPattern = `--add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/\\.git'`;
+    const safehouseWithDirs = `safehouse-clearance' ${addDirsPattern}`;
+    expect(launchScript).toMatch(new RegExp(`${safehouseWithDirs}(?: --\\S+)* sh -c`));
     // The agent runs inside the wrap (after prepareWorktree), so the prompt is the sh -c arg.
-    expect(launchScript).toContain(
-      `/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' ${addDirsFlag} "$_safehouse_shim" -c`,
+    expect(launchScript).toMatch(
+      new RegExp(`${safehouseWithDirs}(?: --\\S+)* "\\$_safehouse_shim" -c`),
     );
     expect(launchScript).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
     expect(launchScript).not.toContain("--enable=all-agents");

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -720,6 +720,8 @@ describe(setupWorkspace, () => {
   });
 
   it("wraps the agent command with Safehouse and runs the default prepareWorktree hook", async () => {
+    vi.stubEnv("NPM_TOKEN", "");
+    vi.stubEnv("BUF_TOKEN", "");
     detectHostMock.mockResolvedValue(host());
     const config = {
       ...makeConfig({

--- a/src/lib/stagedLaunch.test.ts
+++ b/src/lib/stagedLaunch.test.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { BUILD_SECRET_NAMES } from "./config.ts";
+import { stageBuildSecrets } from "./stagedLaunch.ts";
+
+describe(stageBuildSecrets, () => {
+  let promptDir: string;
+
+  beforeEach(() => {
+    promptDir = mkdtempSync(path.join(os.tmpdir(), "groundcrew-test-"));
+    for (const name of BUILD_SECRET_NAMES) {
+      vi.stubEnv(name, "");
+    }
+  });
+
+  afterEach(() => {
+    rmSync(promptDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when no build secrets are set", () => {
+    expect(stageBuildSecrets(promptDir)).toBeUndefined();
+  });
+
+  it("writes a secrets file and returns its path when secrets are present", () => {
+    vi.stubEnv("NPM_TOKEN", "my-npm-token");
+
+    const result = stageBuildSecrets(promptDir);
+    const expected = path.join(promptDir, "secrets.env");
+
+    expect(result).toBe(expected);
+    expect(readFileSync(expected, "utf8")).toContain("NPM_TOKEN='my-npm-token'");
+  });
+});

--- a/src/lib/stagedLaunch.test.ts
+++ b/src/lib/stagedLaunch.test.ts
@@ -16,6 +16,7 @@ describe(stageBuildSecrets, () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     rmSync(promptDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Renames all stale \`models.*\` references to \`agents.*\` across the documentation and context files, reflecting the config namespace rename. Fixes brittle test assertions in \`setupWorkspace.test.ts\` that broke when ambient \`NPM_TOKEN\`/\`BUF_TOKEN\` env vars were present, and adds \`stagedLaunch.test.ts\` to cover the \`return undefined\` branch of \`stageBuildSecrets\` (restoring 100% coverage).

## Validation

- \`node --run verify\` passed: 1655 tests, 100% coverage (statements, branches, functions, lines)

<sub>🤖 <code>commit-push-pr:created v1 core@3.8.0</code></sub>