### PR TITLE
fix: validate todo task creation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ crew task get GC-20260608-001 --source todo
 crew task get todo:GC-20260608-001 --prompt
 ```
 
-`crew task create "Short title" --source <source> [--agent <agent>]` creates a task in a source that supports creation. When `--agent` is omitted, it defaults to `any`. Todo.txt creation appends the todo line, defaults to priority `A` unless `--priority` is provided, writes `.tasks/<id>.md`, and leaves `status:todo` as the final meaningful token, so no separate ready command is required. Hand-written todo-txt lines can omit `.tasks/<id>.md` when the line has a non-empty title; that title becomes the prompt text.
+`crew task create "Short title" --source <source> [--agent <agent>]` creates a task in a source that supports creation. When `--agent` is omitted, it defaults to `any`. Todo.txt creation requires `--repo <repo>` unless the source configures `defaultRepository`, appends the todo line, writes `.tasks/<id>.md`, and leaves `status:todo` as the final meaningful token, so no separate ready command is required. Pass `--priority <letter>` to add a todo.txt priority marker. Hand-written todo-txt lines can omit `.tasks/<id>.md` when the line has a non-empty title; that title becomes the prompt text.
 
 ```bash
 crew task create "Fix cancellation retry race" \

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -78,7 +78,7 @@ export default {
 };
 ```
 
-Creating a todo task appends a line with `status:todo` as the final meaningful token and writes the prompt to `.tasks/<id>.md`. New todo tasks default to priority `A`; pass `--priority <letter>` to override it. If `--agent` is omitted, the task uses `agent:any`.
+Creating a todo task appends a line with `status:todo` as the final meaningful token and writes the prompt to `.tasks/<id>.md`. Pass `--repo <repo>` unless the source configures `defaultRepository`. Pass `--priority <letter>` to add a todo.txt priority marker. If `--agent` is omitted, the task uses `agent:any`.
 
 ```bash
 crew task create "Fix cancellation retry race" \
@@ -91,7 +91,7 @@ crew task create "Fix cancellation retry race" \
 ```
 
 ```txt
-(A) Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo
+Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo
 ```
 
 For hand-written todo lines, a non-empty title is enough prompt text when `.tasks/<id>.md` is absent. Omit `agent:` to default to `agent:any`:

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -11,12 +11,14 @@ import type { TodoTxtSourceRef } from "./normalizer.ts";
 function makeAdapterContext(options: {
   defaultAgent: string;
   definitions: ResolvedConfig["agents"]["definitions"];
+  knownRepositories?: string[];
 }): AdapterContext {
-  const { defaultAgent, definitions } = options;
+  const { defaultAgent, definitions, knownRepositories = ["ClipboardHealth/api"] } = options;
   return {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- partial config sufficient for source tests
     globalConfig: {
       agents: { default: defaultAgent, definitions },
+      workspace: { knownRepositories },
     } as unknown as ResolvedConfig,
   };
 }
@@ -156,7 +158,7 @@ describe("TodoTxtTaskSource", () => {
 
     expect(created?.id).toBe("todo:gc-20260608-001");
     expect(readFileSync(tmp.todoPath, "utf8")).toBe(
-      "(A) Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo\n",
+      "Fix cancellation retry race +marketplace @backend id:GC-20260608-001 repo:ClipboardHealth/api agent:codex status:todo\n",
     );
     expect(readFileSync(path.join(tmp.tasksDir, "GC-20260608-001.md"), "utf8")).toBe(
       "Investigate retry handling.\n",
@@ -170,7 +172,7 @@ describe("TodoTxtTaskSource", () => {
       "\nTask outside sequence id:OTHER-1 agent:codex status:todo\nNo id task agent:codex status:todo\nNonnumeric sequence id:GC-20260608-ABC agent:codex status:todo\nExisting task id:GC-20260608-001 agent:codex status:todo\nLower sequence id:GC-20260608-000 agent:codex status:todo",
     );
 
-    const source = makeSource(tmp);
+    const source = makeSource(tmp, "ClipboardHealth/api");
     const created = await source.createTask?.({
       title: "Generated task",
       agent: "codex",
@@ -181,8 +183,9 @@ describe("TodoTxtTaskSource", () => {
     });
 
     expect(created?.id).toBe("todo:gc-20260608-002");
+    expect(created?.repository).toBe("ClipboardHealth/api");
     expect(readFileSync(tmp.todoPath, "utf8")).toContain(
-      "\n(A) Generated task id:GC-20260608-002 agent:codex status:todo\n",
+      "\nGenerated task id:GC-20260608-002 agent:codex status:todo\n",
     );
     expect(readFileSync(path.join(tmp.tasksDir, "GC-20260608-002.md"), "utf8")).toBe(
       "Generated task\n",
@@ -194,7 +197,7 @@ describe("TodoTxtTaskSource", () => {
     writeFileSync(promptFile, "Existing prompt.\n", "utf8");
     tmp.writeTodo("");
 
-    const source = makeSource(tmp);
+    const source = makeSource(tmp, "ClipboardHealth/api");
     await source.createTask?.({
       title: "Prompt file task",
       agent: "claude",
@@ -218,7 +221,7 @@ describe("TodoTxtTaskSource", () => {
   it("createTask accepts hourly recurrence", async () => {
     tmp.writeTodo("");
 
-    const source = makeSource(tmp);
+    const source = makeSource(tmp, "ClipboardHealth/api");
     await source.createTask?.({
       title: "Hourly sweep",
       agent: "claude",
@@ -234,7 +237,7 @@ describe("TodoTxtTaskSource", () => {
   });
 
   it("creates the todo file when it does not exist", async () => {
-    const source = makeSource(tmp);
+    const source = makeSource(tmp, "ClipboardHealth/api");
 
     await source.createTask?.({
       title: "No existing todo",
@@ -247,11 +250,72 @@ describe("TodoTxtTaskSource", () => {
     });
 
     expect(readFileSync(tmp.todoPath, "utf8")).toBe(
-      "(A) No existing todo id:NO-FILE-1 agent:codex status:todo\n",
+      "No existing todo id:NO-FILE-1 agent:codex status:todo\n",
     );
     expect(readFileSync(path.join(tmp.tasksDir, "NO-FILE-1.md"), "utf8")).toBe(
       "No existing todo\n",
     );
+  });
+
+  it("rejects task creation without a repository or defaultRepository", async () => {
+    tmp.writeTodo("");
+    const source = makeSource(tmp);
+
+    await expect(
+      source.createTask?.({
+        title: "No repository",
+        agent: "codex",
+        id: "NO-REPO",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: false,
+      }),
+    ).rejects.toThrow("--repo is required");
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe("");
+    expect(existsSync(path.join(tmp.tasksDir, "NO-REPO.md"))).toBe(false);
+  });
+
+  it("rejects task creation when the repository is not known", async () => {
+    tmp.writeTodo("");
+    const source = makeSource(tmp);
+
+    await expect(
+      source.createTask?.({
+        title: "Unknown repository",
+        agent: "codex",
+        repository: "unknown/repo",
+        id: "UNKNOWN-REPO",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: false,
+      }),
+    ).rejects.toThrow('repository "unknown/repo" is not in workspace.knownRepositories');
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe("");
+    expect(existsSync(path.join(tmp.tasksDir, "UNKNOWN-REPO.md"))).toBe(false);
+  });
+
+  it("rejects task creation when the defaultRepository is not known", async () => {
+    tmp.writeTodo("");
+    const source = makeSource(tmp, "unknown/repo");
+
+    await expect(
+      source.createTask?.({
+        title: "Unknown default repository",
+        agent: "codex",
+        id: "UNKNOWN-DEFAULT-REPO",
+        projects: [],
+        contexts: [],
+        dependencies: [],
+        edit: false,
+      }),
+    ).rejects.toThrow('repository "unknown/repo" is not in workspace.knownRepositories');
+
+    expect(readFileSync(tmp.todoPath, "utf8")).toBe("");
+    expect(existsSync(path.join(tmp.tasksDir, "UNKNOWN-DEFAULT-REPO.md"))).toBe(false);
   });
 
   it("rethrows unexpected todo file read errors while creating a task", async () => {
@@ -262,6 +326,7 @@ describe("TodoTxtTaskSource", () => {
       source.createTask?.({
         title: "Directory todo path",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "DIR-TODO",
         projects: [],
         contexts: [],
@@ -275,49 +340,83 @@ describe("TodoTxtTaskSource", () => {
     {
       name: "duplicate id",
       existing: "id:DUP-1 agent:codex status:todo Existing\n",
-      input: { title: "Duplicate", agent: "codex", id: "DUP-1" },
+      input: { title: "Duplicate", agent: "codex", repository: "ClipboardHealth/api", id: "DUP-1" },
       message: "already exists",
     },
     {
       name: "empty title",
       existing: "",
-      input: { title: "   ", agent: "codex", id: "EMPTY-TITLE" },
+      input: { title: "   ", agent: "codex", repository: "ClipboardHealth/api", id: "EMPTY-TITLE" },
       message: "title is required",
     },
     {
       name: "multiline title",
       existing: "",
-      input: { title: "Line one\nLine two", agent: "codex", id: "MULTILINE-TITLE" },
+      input: {
+        title: "Line one\nLine two",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "MULTILINE-TITLE",
+      },
       message: "single line",
     },
     {
       name: "path-like id",
       existing: "",
-      input: { title: "Bad id", agent: "codex", id: "../outside" },
+      input: {
+        title: "Bad id",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "../outside",
+      },
       message: "filename-safe",
     },
     {
       name: "bad priority",
       existing: "",
-      input: { title: "Bad priority", agent: "codex", id: "BAD-PRI", priority: "AA" },
+      input: {
+        title: "Bad priority",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "BAD-PRI",
+        priority: "AA",
+      },
       message: "priority",
     },
     {
       name: "bad project token",
       existing: "",
-      input: { title: "Bad project", agent: "codex", id: "BAD-PROJ", projects: ["bad token"] },
+      input: {
+        title: "Bad project",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "BAD-PROJ",
+        projects: ["bad token"],
+      },
       message: "project",
     },
     {
       name: "bad due date",
       existing: "",
-      input: { title: "Bad due", agent: "codex", id: "BAD-DUE", due: "tomorrow" },
+      input: {
+        title: "Bad due",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "BAD-DUE",
+        due: "tomorrow",
+      },
       message: "due date",
     },
     {
       name: "bad recurrence",
       existing: "",
-      input: { title: "Bad rec", agent: "codex", id: "BAD-REC", recurrence: "weekly" },
+      input: {
+        title: "Bad rec",
+        agent: "codex",
+        repository: "ClipboardHealth/api",
+        id: "BAD-REC",
+        recurrence: "weekly",
+      },
       message: "recurrence",
     },
     {
@@ -326,6 +425,7 @@ describe("TodoTxtTaskSource", () => {
       input: {
         title: "Too many prompts",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "PROMPT-CONFLICT",
         promptFile: "prompt.md",
         description: "Prompt",
@@ -357,6 +457,7 @@ describe("TodoTxtTaskSource", () => {
       source.createTask?.({
         title: "Edit task",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "EDIT-1",
         projects: [],
         contexts: [],
@@ -376,6 +477,7 @@ describe("TodoTxtTaskSource", () => {
       source.createTask?.({
         title: "Editor fallback",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "EDITOR-FALLBACK",
         projects: [],
         contexts: [],
@@ -395,6 +497,7 @@ describe("TodoTxtTaskSource", () => {
       source.createTask?.({
         title: "No editor",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "NO-EDITOR",
         projects: [],
         contexts: [],
@@ -414,6 +517,7 @@ describe("TodoTxtTaskSource", () => {
       source.createTask?.({
         title: "Editor fails",
         agent: "codex",
+        repository: "ClipboardHealth/api",
         id: "EDITOR-FAIL",
         projects: [],
         contexts: [],

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -12,6 +12,7 @@ import {
   type TaskSource,
   toCanonicalId,
 } from "../../taskSource.ts";
+import { formatKnownRepositories } from "../../repositoryValidation.ts";
 import { readEnvironmentVariable } from "../../util.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
 import { DATE_RE, getMetadataFirst, parseAllLines, type ParsedTodoLine } from "./parser.ts";
@@ -19,6 +20,13 @@ import type { TodoTxtAdapterConfig } from "./schema.ts";
 import { copyPromptFile, updateTaskStatus, validateTodoFile, withLock } from "./writeback.ts";
 
 const RECURRENCE_RE = /^\+?\d+[dwmyh]$/;
+
+interface AssertCreateRepositoryArguments {
+  defaultRepository: string | undefined;
+  input: CreateTaskInput;
+  knownRepositories: readonly string[];
+  sourceName: string;
+}
 
 function readPromptFile(promptPath: string): string | undefined {
   try {
@@ -205,6 +213,23 @@ function assertNewId(id: string, parsedAll: ReturnType<typeof parseAllLines>): v
   }
 }
 
+function assertCreateRepository(arguments_: AssertCreateRepositoryArguments): void {
+  const { defaultRepository, input, knownRepositories, sourceName } = arguments_;
+  const repository = input.repository ?? defaultRepository;
+  /* v8 ignore else @preserve -- both missing and resolved repository paths are covered; full-suite V8 coverage remaps the synthetic else inconsistently. */
+  if (repository === undefined) {
+    throw new Error(
+      `todo-txt: --repo is required unless source "${sourceName}" configures defaultRepository. Known repositories: ${formatKnownRepositories(knownRepositories)}`,
+    );
+  }
+  /* v8 ignore else @preserve -- both known and unknown repository paths are covered; full-suite V8 coverage remaps the synthetic else inconsistently. */
+  if (!knownRepositories.includes(repository)) {
+    throw new Error(
+      `todo-txt: repository "${repository}" is not in workspace.knownRepositories: ${formatKnownRepositories(knownRepositories)}`,
+    );
+  }
+}
+
 function buildTodoLine(id: string, input: CreateTaskInput): string {
   const title = input.title.trim();
   /* v8 ignore else @preserve -- no explicit else branch; full-suite V8 coverage remaps the synthetic else inconsistently. */
@@ -217,12 +242,14 @@ function buildTodoLine(id: string, input: CreateTaskInput): string {
   }
 
   const tokens: string[] = [];
-  const priority = input.priority ?? "A";
-  /* v8 ignore else @preserve -- no explicit else branch; full-suite V8 coverage remaps the synthetic else inconsistently. */
-  if (!/^[A-Z]$/.test(priority)) {
-    throw new Error("todo-txt: priority must be a single uppercase letter");
+  /* v8 ignore else @preserve -- both priority-present and priority-absent creation paths are covered; full-suite V8 coverage remaps the synthetic else inconsistently. */
+  if (input.priority !== undefined) {
+    /* v8 ignore else @preserve -- no explicit else branch; full-suite V8 coverage remaps the synthetic else inconsistently. */
+    if (!/^[A-Z]$/.test(input.priority)) {
+      throw new Error("todo-txt: priority must be a single uppercase letter");
+    }
+    tokens.push(`(${input.priority})`);
   }
-  tokens.push(`(${priority})`);
   tokens.push(title);
 
   for (const rawProject of input.projects) {
@@ -445,6 +472,12 @@ export function createTodoTxtTaskSource(
         const id = input.id ?? nextGeneratedId(config, parsedAll);
         assertCreateId(id);
         assertNewId(id, parsedAll);
+        assertCreateRepository({
+          defaultRepository: config.defaultRepository,
+          input,
+          knownRepositories: context.globalConfig.workspace.knownRepositories,
+          sourceName,
+        });
 
         const promptPath = path.join(tasksDir, `${id}.md`);
         const promptContent = promptContentFor(input);


### PR DESCRIPTION
## Summary

- Reject todo-txt task creation before writing files when neither `--repo` nor a known `defaultRepository` can route the task to `workspace.knownRepositories`.
- Stop defaulting created todo-txt tasks to priority `A`; todo priority markers are now only emitted when `--priority <letter>` is provided.
- Update task creation docs to describe the repo requirement and explicit priority behavior.

## Validation

- `npx vitest run src/lib/adapters/todo-txt/source.test.ts`
- `node --run verify`
- Pre-push hook: `node --run verify`

## Notes

Agent session: `codex resume 019eb768-cd3c-7f90-8201-a43443bdab96`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>
