### PR TITLE
feat: add task done command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ crew source list|verify [<source>]                       # inspect configured ta
 crew task list [--source <name>]                         # list tasks across sources
 crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or its prompt
 crew task create "Title" --source <name> [--agent <name>] # create a source task
+crew task done <TASK> [--allow-dirty]                    # mark a no-PR task done
 crew task validate [<source>]                            # validate task content
 crew status [<TASK>]                                   # inspect current state or one task
 crew run [--watch]                                       # one-shot or --watch forever

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -41,6 +41,44 @@ crew task create "Fix cancellation retry race" \
   --description "Investigate retry handling."
 ```
 
+`crew task done <task-id>` marks one task done through its source adapter. Use
+it for completed work that intentionally does not produce a PR. The command
+resolves canonical IDs such as `todo:flaky-triage-1` directly, or natural IDs
+when they match exactly one configured source. Sources without a done writeback
+return an unsupported error.
+
+Groundcrew checks matching local worktrees before marking a task done. Clean
+worktrees, and tasks with no local worktree, are allowed. A dirty worktree with
+no matching PR is refused by default so later cleanup does not discard
+uncommitted work; pass `--allow-dirty` only when that dirty state is expected.
+
+```bash
+# PR-producing tasks usually complete automatically:
+# open PR -> in-review, merged PR -> done.
+
+# Manual completion for no-PR operational work:
+crew task done todo:flaky-triage-1
+
+# Explicit override when a no-PR task intentionally leaves local changes:
+crew task done todo:docs-refresh-1 --allow-dirty
+```
+
+For recurring no-PR tasks, keep recurrence in the source and complete the
+current task with `crew task done`. The todo-txt source marks the current line
+done and schedules the next `status:todo` recurrence itself.
+
+```bash
+crew task create "Run flaky triage sweep" \
+  --source todo \
+  --agent codex \
+  --repo ClipboardHealth/groundcrew \
+  --id flaky-triage-1 \
+  --rec 2h \
+  --description "Triage the flaky queue. No PR is needed when the queue is updated."
+
+crew task done todo:flaky-triage-1
+```
+
 ## Status
 
 `crew status <TASK>` prints a read-only snapshot for one task: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the task status from the configured task source.

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -35,9 +35,15 @@ tasks only). If omitted, groundcrew treats in-review advancement as unsupported
 for that source and does not claim the transition succeeded. `commands.markDone`,
 when set, receives the same `sourceRef` and is run after groundcrew sees a
 **merged** PR on the task's worktree branch (a merged PR never advances to
-in-review). If omitted, groundcrew treats done advancement as unsupported and
-leaves the task for the source's own integration to close out. `${id}`,
-`${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
+in-review), or when a human or worker runs `crew task done <task-id>` for
+completed no-PR work. If omitted, groundcrew treats done advancement as
+unsupported and leaves the task for the source's own integration to close out.
+`${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
+
+Workers receive `GROUNDCREW_TASK_ID` and `GROUNDCREW_COMPLETE` in their launch
+environment. The default prompt tells them to run `GROUNDCREW_COMPLETE` only
+when the requested work is complete, no PR is needed, and any dirty worktree
+state is expected or explicitly allowed.
 
 ```json
 [

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,8 @@ This applies to the tmux backend only.
 
 Groundcrew marks a task `In Progress` when it provisions a workspace. When a PR opens on that worktree branch, the reviewer pass attempts to mark the task `In Review`. Linear's default `In Review` status works out of the box; if your team renamed it, configure `sources: [{ kind: "linear", statuses: { inReview: ["Code Review"] } }]`.
 
+If the task intentionally has no PR, mark it complete with `crew task done <task-id>`. Groundcrew refuses dirty matching worktrees with no PR unless you pass `--allow-dirty`, so inspect or commit/stash unexpected changes first. For todo-txt tasks with `rec:`, this completion path also lets the source schedule the next recurrence.
+
 ## Claude Launches In Auto Mode By Default
 
 Groundcrew creates isolated per-task worktrees for unattended runs, so the shipped `claude` command is `claude --permission-mode auto` to let Claude proceed without stopping for clarifying questions while keeping its built-in safety prompts intact. Override `agents.definitions.claude.cmd` for `bypassPermissions` if you need to suppress tool-permission prompts entirely, or for a stricter mode.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -148,7 +148,7 @@ describe(run, () => {
     expect(helpOutput).toContain("[--repo <repo>]...");
     expect(helpOutput).toContain("--runner <runner>");
     expect(helpOutput).toContain("--agent <agent>");
-    expect(helpOutput).toContain("crew task <list|get|create>");
+    expect(helpOutput).toContain("crew task <list|get|create|done>");
     expect(helpOutput).not.toContain("sandbox");
     expect(process.exitCode).toBe(1);
   });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -148,7 +148,7 @@ describe(run, () => {
     expect(helpOutput).toContain("[--repo <repo>]...");
     expect(helpOutput).toContain("--runner <runner>");
     expect(helpOutput).toContain("--agent <agent>");
-    expect(helpOutput).toContain("crew task <list|get|create|done>");
+    expect(helpOutput).toContain("crew task <list|get|create|done|validate>");
     expect(helpOutput).not.toContain("sandbox");
     expect(process.exitCode).toBe(1);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,8 +182,8 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: sourceCli,
   },
   task: {
-    summary: "List, get, and create tasks across configured sources",
-    usage: "<list|get|create> [...]",
+    summary: "List, get, create, and complete tasks across configured sources",
+    usage: "<list|get|create|done> [...]",
     invoke: taskCli,
   },
   status: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,7 +183,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   task: {
     summary: "List, get, create, and complete tasks across configured sources",
-    usage: "<list|get|create|done> [...]",
+    usage: "<list|get|create|done|validate> [...]",
     invoke: taskCli,
   },
   status: {

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -129,6 +129,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
         const setupOptions = {
           repository: issue.repository,
           task: taskId,
+          completionTaskId: issue.id,
           agent: issue.agent,
           details: {
             title: issue.title,

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -297,6 +297,17 @@ describe(resumeWorkspace, () => {
     expect(lastRecordedRunState().completionTaskId).toBe("linear:team-1");
   });
 
+  it("uses the task id for worker self-completion env when old state lacks a completion task id", async () => {
+    readRunStateMock.mockReturnValue(makeRunState());
+
+    await resumeWorkspace(config, { task: "team-1" });
+
+    const launchScript = stagedLaunchScript();
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='team-1'");
+    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done team-1'");
+    expect(lastRecordedRunState().completionTaskId).toBe("team-1");
+  });
+
   it("falls back to the task id when Linear detail lookup fails during state resume", async () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
     getLinearClientMock.mockReturnValue({

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -286,6 +286,17 @@ describe(resumeWorkspace, () => {
     );
   });
 
+  it("uses the recorded canonical completion task id for worker self-completion env", async () => {
+    readRunStateMock.mockReturnValue(makeRunState({ completionTaskId: "linear:team-1" }));
+
+    await resumeWorkspace(config, { task: "team-1" });
+
+    const launchScript = stagedLaunchScript();
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
+    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done linear:team-1'");
+    expect(lastRecordedRunState().completionTaskId).toBe("linear:team-1");
+  });
+
   it("falls back to the task id when Linear detail lookup fails during state resume", async () => {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- resume tests stub only the issue lookup surface.
     getLinearClientMock.mockReturnValue({

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -11,7 +11,7 @@ import {
   stagePromptText,
   stageWorkspaceLaunchCommand,
 } from "../lib/stagedLaunch.ts";
-import { naturalIdFromCanonical } from "../lib/taskSource.ts";
+import { naturalIdFromCanonical, toCanonicalId } from "../lib/taskSource.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
@@ -32,6 +32,7 @@ interface ResumeContext {
   worktree: WorktreeEntry;
   title: string;
   description: string;
+  completionTaskId: string;
   reason?: string;
   resumeCount: number;
 }
@@ -70,6 +71,7 @@ async function contextFromLinear(
     worktree,
     title: resolved.title,
     description: resolved.description,
+    completionTaskId: toCanonicalId("linear", task),
     resumeCount: 0,
   };
 }
@@ -91,6 +93,7 @@ async function contextFromState(
     worktree,
     title: details?.title ?? task.toUpperCase(),
     description: details?.description ?? "",
+    completionTaskId: state.completionTaskId ?? task,
     ...(state.reason === undefined ? {} : { reason: state.reason }),
     resumeCount: state.resumeCount,
   };
@@ -197,7 +200,7 @@ export async function resumeWorkspace(
       workingDir: launchDir,
       secretsFile,
       sandboxName,
-      workerEnvironment: workerEnvironmentForTask(task),
+      workerEnvironment: workerEnvironmentForTask(context.completionTaskId),
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({
@@ -228,6 +231,7 @@ export async function resumeWorkspace(
       workspaceName: task,
       state: "resumed",
       resumeCount: context.resumeCount + 1,
+      completionTaskId: context.completionTaskId,
       ...(context.reason === undefined ? {} : { reason: context.reason }),
     },
   });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -196,6 +196,10 @@ export async function resumeWorkspace(
       workingDir: launchDir,
       secretsFile,
       sandboxName,
+      workerEnvironment: {
+        GROUNDCREW_TASK_ID: task,
+        GROUNDCREW_COMPLETE: `crew task done ${task}`,
+      },
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -3,6 +3,7 @@ import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { isLinearEnabled } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
+import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import {
   removeStagedPrompt,
@@ -196,10 +197,7 @@ export async function resumeWorkspace(
       workingDir: launchDir,
       secretsFile,
       sandboxName,
-      workerEnvironment: {
-        GROUNDCREW_TASK_ID: task,
-        GROUNDCREW_COMPLETE: `crew task done ${task}`,
-      },
+      workerEnvironment: workerEnvironmentForTask(task),
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1890,6 +1890,7 @@ describe(setupWorkspaceCli, () => {
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(launchScript).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
     expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done linear:team-1'");
+    expect(lastRecordedRunState().completionTaskId).toBe("linear:team-1");
   });
 
   it("passes title and description from the resolved issue as details", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -936,32 +936,27 @@ describe(setupWorkspace, () => {
     );
   });
 
-  it("does not double-wrap when the cmd already starts with safehouse", async () => {
+  it("fails before creating a worktree when worker env is required with a safehouse-prefixed cmd", async () => {
     detectHostMock.mockResolvedValue(host());
     const config = makeConfig({
       definitions: {
         claude: {
-          // A user upgrading from main has `safehouse` baked into their cmd;
-          // local wrapping must not produce `safehouse safehouse claude ...`.
           cmd: "safehouse claude --permission-mode auto",
           color: "#fff",
         },
       },
     });
-    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
-    await setupWorkspace(config, {
-      task: "team-1",
-      repository: "repo-a",
-      agent: "claude",
-      details: { title: "Test Title", description: "Body" },
-    });
+    await expect(
+      setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
+    ).rejects.toThrow(/cannot inject worker self-completion env when 'cmd' already starts/);
 
-    const command = lastRunArgumentFromCallWithArgument("new-workspace");
-    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
-    expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
-    expect(launchScript).toContain('exec safehouse claude --permission-mode auto "$_p"');
-    expect(launchScript).not.toContain("safehouse safehouse");
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   describe("build-time secret shuttling", () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -844,7 +844,7 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain("groundcrew prepareWorktree hook exited");
     expect(launchScript).not.toContain(".groundcrew/setup.sh");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git' \"$_safehouse_shim\" -c",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git' --env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE \"$_safehouse_shim\" -c",
     );
   });
 
@@ -1887,6 +1887,14 @@ describe(setupWorkspaceCli, () => {
       expect.anything(),
       expect.objectContaining({ task: "staff-508" }),
     );
+  });
+
+  it("sets worker self-completion env from the resolved canonical task id", async () => {
+    await setupWorkspaceCli("team-1");
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
+    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done linear:team-1'");
   });
 
   it("passes title and description from the resolved issue as details", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -129,6 +129,7 @@ export async function setupWorkspace(
     });
     const secretsFile =
       prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
+    const completionTaskId = options.completionTaskId ?? task;
     const { launchCommand, srtSettingsDir: stagedSrtSettingsDir } = composeAgentLaunch({
       runner,
       task,
@@ -139,7 +140,7 @@ export async function setupWorkspace(
       secretsFile,
       prepareWorktreeCommand,
       sandboxName,
-      workerEnvironment: workerEnvironmentForTask(options.completionTaskId ?? task),
+      workerEnvironment: workerEnvironmentForTask(completionTaskId),
     });
     srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);
@@ -164,6 +165,7 @@ export async function setupWorkspace(
       workspaceName: task,
       state: "running",
       title: taskDetails.title,
+      completionTaskId,
       ...(taskDetails.url === undefined ? {} : { url: taskDetails.url }),
     });
 
@@ -186,6 +188,7 @@ export async function setupWorkspace(
       state: "failed-to-launch",
       detail: errorMessage(error),
       title: options.details.title,
+      completionTaskId: options.completionTaskId ?? task,
       ...(options.details.url === undefined ? {} : { url: options.details.url }),
     });
     throw error;
@@ -262,6 +265,7 @@ function recordRunStateBestEffort(arguments_: {
   title: string;
   detail?: string;
   url?: string;
+  completionTaskId: string;
 }): void {
   try {
     recordRunState({
@@ -275,6 +279,7 @@ function recordRunStateBestEffort(arguments_: {
         workspaceName: arguments_.workspaceName,
         state: arguments_.state,
         title: arguments_.title,
+        completionTaskId: arguments_.completionTaskId,
         ...(arguments_.detail === undefined ? {} : { detail: arguments_.detail }),
         ...(arguments_.url === undefined ? {} : { url: arguments_.url }),
       },

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -3,6 +3,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
+import type { WorkerEnvironment } from "../lib/launchCommand.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
 import {
@@ -30,6 +31,8 @@ export interface TaskDetails {
 
 export interface SetupWorkspaceOptions {
   task: string;
+  /** Canonical source id for worker self-completion; falls back to `task`. */
+  completionTaskId?: string;
   repository: string;
   agent: string;
   details: TaskDetails;
@@ -58,6 +61,13 @@ function stagePrompt(input: {
       workspaceContinuationInstruction: input.workspaceContinuationInstruction,
     },
   });
+}
+
+function workerEnvironmentForTask(taskId: string): WorkerEnvironment {
+  return {
+    GROUNDCREW_TASK_ID: taskId,
+    GROUNDCREW_COMPLETE: `crew task done ${taskId}`,
+  };
 }
 
 export async function setupWorkspace(
@@ -136,6 +146,7 @@ export async function setupWorkspace(
       secretsFile,
       prepareWorktreeCommand,
       sandboxName,
+      workerEnvironment: workerEnvironmentForTask(options.completionTaskId ?? task),
     });
     srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);
@@ -366,6 +377,7 @@ export async function setupWorkspaceCli(
 
   await setupWorkspace(config, {
     task: naturalId,
+    completionTaskId: resolved.id,
     repository: resolved.repository,
     agent: resolved.agent,
     details: {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -3,7 +3,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import type { WorkerEnvironment } from "../lib/launchCommand.ts";
+import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
 import {
@@ -61,13 +61,6 @@ function stagePrompt(input: {
       workspaceContinuationInstruction: input.workspaceContinuationInstruction,
     },
   });
-}
-
-function workerEnvironmentForTask(taskId: string): WorkerEnvironment {
-  return {
-    GROUNDCREW_TASK_ID: taskId,
-    GROUNDCREW_COMPLETE: `crew task done ${taskId}`,
-  };
 }
 
 export async function setupWorkspace(

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -1,6 +1,14 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { AdapterContext } from "../lib/adapterDefinition.ts";
+import { createTodoTxtTaskSource } from "../lib/adapters/todo-txt/source.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { naturalIdFromCanonical, type TaskSource, type Issue } from "../lib/taskSource.ts";
+import { worktrees, type WorktreeEntry } from "../lib/worktrees.ts";
 import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 
 import { taskCli } from "./task.ts";
@@ -22,9 +30,34 @@ vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
   };
 });
 
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      findByTask: vi.fn<typeof actual.worktrees.findByTask>().mockReturnValue([]),
+      probeWorkingTree: vi
+        .fn<typeof actual.worktrees.probeWorkingTree>()
+        .mockResolvedValue({ kind: "clean" }),
+    },
+  };
+});
+
+vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    findPullRequestsForBranch: vi.fn<typeof findPullRequestsForBranch>().mockResolvedValue([]),
+  };
+});
+
 const loadConfigMock = vi.mocked(loadConfig);
 const buildSourcesMock = vi.mocked(buildSources);
 const sourcesFromConfigMock = vi.mocked(sourcesFromConfig);
+const findWorktreesByTaskMock = vi.mocked(worktrees.findByTask);
+const probeWorkingTreeMock = vi.mocked(worktrees.probeWorkingTree);
+const findPullRequestsForBranchMock = vi.mocked(findPullRequestsForBranch);
 
 function makeConfig(): ResolvedConfig {
   return {
@@ -94,6 +127,31 @@ function stubSource(
     markInReview: vi.fn<TaskSource["markInReview"]>(),
     ...overrides,
   };
+}
+
+function hostEntryFor(task: string, overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
+  return {
+    repository: "ClipboardHealth/api",
+    task,
+    branchName: `dev-${task}`,
+    dir: `/work/ClipboardHealth/api-${task}`,
+    kind: "host",
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Partial<PullRequestSummary> = {}): PullRequestSummary {
+  return {
+    url: overrides.url ?? "https://github.com/ClipboardHealth/api/pull/1",
+    number: overrides.number ?? 1,
+    state: overrides.state ?? "open",
+    title: overrides.title ?? "Ready",
+    headRefOid: overrides.headRefOid ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  };
+}
+
+function makeAdapterContext(config: ResolvedConfig): AdapterContext {
+  return { globalConfig: config };
 }
 
 describe("crew task list", () => {
@@ -524,6 +582,195 @@ describe("crew task create", () => {
       message: "requires a value",
     },
   ])("rejects invalid create arguments: $argv", async ({ argv, message }) => {
+    await expect(taskCli(argv)).rejects.toThrow(message);
+  });
+});
+
+describe("crew task done", () => {
+  beforeEach(() => {
+    loadConfigMock.mockResolvedValue(makeConfig());
+    sourcesFromConfigMock.mockReturnValue([{ kind: "todo-txt", name: "todo" }]);
+    findWorktreesByTaskMock.mockReturnValue([]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
+    findPullRequestsForBranchMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("resolves the task and marks it done when no matching worktree exists", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    const todo = stubSource("todo", [issue], { markDone });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["done", "todo:GC-1"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.getTask).toHaveBeenCalledWith("GC-1");
+    expect(findWorktreesByTaskMock).toHaveBeenCalledWith(expect.anything(), "gc-1");
+    expect(markDone).toHaveBeenCalledWith(issue);
+    expect(log.output()).toBe("Marked todo:gc-1 done.");
+  });
+
+  it("allows a clean matching worktree without checking PRs", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["done", "todo:GC-1"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(findPullRequestsForBranchMock).not.toHaveBeenCalled();
+    expect(markDone).toHaveBeenCalledWith(issue);
+  });
+
+  it("fails when the task cannot be resolved", async () => {
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [])]);
+
+    await expect(taskCli(["done", "todo:GC-404"])).rejects.toThrow(
+      "Task todo:GC-404 not found across configured sources.",
+    );
+  });
+
+  it("surfaces unsupported done writeback from the owning source", async () => {
+    const todo = stubSource("todo", [makeIssue({ id: "todo:gc-1" })]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    await expect(taskCli(["done", "todo:GC-1"])).rejects.toThrow(
+      'crew task done: source "todo" does not support markDone',
+    );
+  });
+
+  it("refuses a dirty matching worktree when there is no matching PR", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 1, untracked: 2 });
+    findPullRequestsForBranchMock.mockResolvedValue([]);
+
+    await expect(taskCli(["done", "todo:GC-1"])).rejects.toThrow(
+      /refusing to mark todo:gc-1 done.*1 modified, 2 untracked.*--allow-dirty/,
+    );
+    expect(findPullRequestsForBranchMock).toHaveBeenCalledWith({
+      cwd: "/work/ClipboardHealth/api-gc-1",
+      branchName: "dev-gc-1",
+    });
+    expect(markDone).not.toHaveBeenCalled();
+  });
+
+  it("refuses a worktree when git status cannot be verified", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "unknown" });
+
+    await expect(taskCli(["done", "todo:GC-1"])).rejects.toThrow(/unknown git status/);
+    expect(findPullRequestsForBranchMock).not.toHaveBeenCalled();
+    expect(markDone).not.toHaveBeenCalled();
+  });
+
+  it("allows a dirty matching worktree when the current branch has a PR", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 1, untracked: 0 });
+    findPullRequestsForBranchMock.mockResolvedValue([pullRequest()]);
+
+    await taskCli(["done", "todo:GC-1"]);
+
+    expect(markDone).toHaveBeenCalledWith(issue);
+  });
+
+  it("allows --allow-dirty to mark done without checking PRs", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+
+    await taskCli(["done", "todo:GC-1", "--allow-dirty"]);
+
+    expect(probeWorkingTreeMock).not.toHaveBeenCalled();
+    expect(findPullRequestsForBranchMock).not.toHaveBeenCalled();
+    expect(markDone).toHaveBeenCalledWith(issue);
+  });
+
+  it("completes a recurring todo-txt task through source-owned markDone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-08T15:47:00.000Z"));
+    const temporary = mkdtempSync(path.join(tmpdir(), "groundcrew-task-done-"));
+    const todoPath = path.join(temporary, "todo.txt");
+    const tasksDir = path.join(temporary, ".tasks");
+    mkdirSync(tasksDir);
+    writeFileSync(
+      todoPath,
+      "id:sweep-20260608 agent:codex repo:ClipboardHealth/api t:2026-06-08T10:30 rec:2h status:in-progress Hourly sweep\n",
+      "utf8",
+    );
+    writeFileSync(path.join(tasksDir, "sweep-20260608.md"), "Sweep prompt.", "utf8");
+    const source = createTodoTxtTaskSource(
+      {
+        kind: "todo-txt",
+        name: "todo",
+        todoPath,
+        tasksDir,
+        idPrefix: "GC",
+        timezone: "UTC",
+      },
+      makeAdapterContext(makeConfig()),
+    );
+    buildSourcesMock.mockResolvedValue([source]);
+
+    try {
+      await taskCli(["done", "todo:sweep-20260608"]);
+
+      const updated = readFileSync(todoPath, "utf8");
+      expect(updated).toContain("x 2026-06-08");
+      expect(updated).toContain("id:sweep-20260608");
+      expect(updated).toContain("status:done");
+      expect(updated).toContain("id:sweep-20260608-002");
+      expect(updated).toContain("t:2026-06-08T17:47");
+      expect(updated).toMatch(/id:sweep-20260608-002.*rec:2h.*status:todo/);
+      expect(readFileSync(path.join(tasksDir, "sweep-20260608-002.md"), "utf8")).toBe(
+        "Sweep prompt.",
+      );
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { argv: ["done"], message: "Usage: crew task done" },
+    { argv: ["done", "GC-1", "--bogus"], message: "unknown option" },
+    { argv: ["done", "GC-1", "extra"], message: "Usage: crew task done" },
+  ])("rejects invalid done arguments: $argv", async ({ argv, message }) => {
     await expect(taskCli(argv)).rejects.toThrow(message);
   });
 });

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -1,13 +1,17 @@
+import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { AGENT_ANY, loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import {
   type CanonicalStatus,
   type CreateTaskInput,
+  type Issue,
   naturalIdFromCanonical,
   type Task,
   type TaskSource,
 } from "../lib/taskSource.ts";
 import { parseSourceFilterArgs, writeOutput } from "../lib/util.ts";
+import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 const TASK_USAGE = `Usage: crew task <subcommand>
 
@@ -15,6 +19,7 @@ Subcommands:
   list [options]                  List tasks across configured sources
   get <task-id> [options]         Get one task
   create "Short title" [options]  Create one task
+  done <task-id> [options]        Mark one task done
   validate [source] [options]     Validate task content`;
 
 const LIST_USAGE = `Usage: crew task list [options]
@@ -37,6 +42,8 @@ Options:
   --prompt         Print only the task description/prompt.`;
 
 const CREATE_USAGE = `Usage: crew task create "Short title" --source <source> [--agent <agent>] [options]`;
+
+const DONE_USAGE = `Usage: crew task done <task-id> [--allow-dirty]`;
 
 const CANONICAL_STATUSES: readonly CanonicalStatus[] = [
   "todo",
@@ -71,6 +78,11 @@ interface CreateOptions {
   sourceName: string;
   input: CreateTaskInput;
   json: boolean;
+}
+
+interface DoneOptions {
+  taskId: string;
+  allowDirty: boolean;
 }
 
 interface CreateParseState {
@@ -349,9 +361,37 @@ function parseCreateOptions(argv: readonly string[]): CreateOptions {
   return { title, sourceName: state.sourceName, input, json: state.json };
 }
 
+function parseDoneOptions(argv: readonly string[]): DoneOptions {
+  const positionals: string[] = [];
+  let allowDirty = false;
+
+  for (const argument of argv) {
+    if (argument === "--allow-dirty") {
+      allowDirty = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(`crew task done: unknown option: ${argument}\n${DONE_USAGE}`);
+    }
+    positionals.push(argument);
+  }
+
+  const [taskId, ...extras] = positionals;
+  if (taskId === undefined || taskId.length === 0 || extras.length > 0) {
+    throw new Error(DONE_USAGE);
+  }
+  return { taskId, allowDirty };
+}
+
 async function loadTaskSources(): Promise<TaskSource[]> {
   const config: ResolvedConfig = await loadConfig();
   return await buildSources(sourcesFromConfig(config), { globalConfig: config });
+}
+
+async function loadTaskBoard(): Promise<{ config: ResolvedConfig; board: Board }> {
+  const config: ResolvedConfig = await loadConfig();
+  const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  return { config, board: createBoard(sources) };
 }
 
 function findSource(sources: readonly TaskSource[], sourceName: string): TaskSource {
@@ -611,6 +651,79 @@ async function taskCreateCli(argv: readonly string[]): Promise<void> {
   writeOutput(created.id);
 }
 
+function matchingWorktreeEntries(arguments_: {
+  config: ResolvedConfig;
+  issue: Issue;
+}): WorktreeEntry[] {
+  const task = naturalIdFromCanonical(arguments_.issue.id);
+  return worktrees
+    .findByTask(arguments_.config, task)
+    .filter(
+      (entry) =>
+        arguments_.issue.repository === undefined ||
+        entry.repository === arguments_.issue.repository,
+    );
+}
+
+function describeDirtiness(dirtiness: WorktreeDirtiness): string {
+  if (dirtiness.kind === "dirty") {
+    return `${dirtiness.modified} modified, ${dirtiness.untracked} untracked`;
+  }
+  return "unknown git status";
+}
+
+async function worktreeHasPullRequest(entry: WorktreeEntry): Promise<boolean> {
+  const pullRequests = await findPullRequestsForBranch({
+    cwd: entry.dir,
+    branchName: entry.branchName,
+  });
+  return pullRequests.length > 0;
+}
+
+async function assertCanMarkDone(arguments_: {
+  config: ResolvedConfig;
+  issue: Issue;
+  allowDirty: boolean;
+}): Promise<void> {
+  if (arguments_.allowDirty) {
+    return;
+  }
+
+  for (const entry of matchingWorktreeEntries({
+    config: arguments_.config,
+    issue: arguments_.issue,
+  })) {
+    // oxlint-disable-next-line no-await-in-loop -- one git status per matching worktree keeps diagnostics deterministic.
+    const dirtiness = await worktrees.probeWorkingTree({ worktreeDir: entry.dir });
+    if (dirtiness.kind === "clean") {
+      continue;
+    }
+    // oxlint-disable-next-line no-await-in-loop -- only dirty/unknown worktrees need the PR lookup.
+    if (dirtiness.kind === "dirty" && (await worktreeHasPullRequest(entry))) {
+      continue;
+    }
+    throw new Error(
+      `crew task done: refusing to mark ${arguments_.issue.id} done because ${entry.dir} has ${describeDirtiness(dirtiness)} and no matching PR. Commit or stash the work, open a PR, or rerun with --allow-dirty.`,
+    );
+  }
+}
+
+async function taskDoneCli(argv: readonly string[]): Promise<void> {
+  const options = parseDoneOptions(argv);
+  const { config, board } = await loadTaskBoard();
+  const issue = await board.resolveOne(options.taskId);
+  if (issue === undefined) {
+    throw new Error(`Task ${options.taskId} not found across configured sources.`);
+  }
+
+  await assertCanMarkDone({ config, issue, allowDirty: options.allowDirty });
+  const result = await board.markDone(issue);
+  if (result.outcome === "unsupported") {
+    throw new Error(`crew task done: ${result.reason}`);
+  }
+  writeOutput(`Marked ${issue.id} done.`);
+}
+
 const VALIDATE_USAGE = `Usage: crew task validate [source]
 
 Options:
@@ -701,6 +814,10 @@ export async function taskCli(argv: string[]): Promise<void> {
   }
   if (verb === "create") {
     await taskCreateCli(rest);
+    return;
+  }
+  if (verb === "done") {
+    await taskDoneCli(rest);
     return;
   }
   if (verb === "validate") {

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -135,6 +135,12 @@ export async function prepareAgentLaunch(input: {
         "Your cmd owns the wrap, so add the names to its own '--env-pass=' flag, or drop the 'safehouse' prefix from 'cmd' to let groundcrew compose the flag for you.",
     );
   }
+  if (runner === "safehouse" && /^safehouse(?:\s|$)/.test(input.definition.cmd)) {
+    throw new Error(
+      `Local groundcrew ${input.purpose} on agent '${input.agent}' cannot inject worker self-completion env when 'cmd' already starts with 'safehouse'. ` +
+        "Your cmd owns the wrap, so add GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE to its own '--env-pass=' flag, or drop the 'safehouse' prefix from 'cmd' to let groundcrew compose the flag for you.",
+    );
+  }
 
   const sandboxName =
     runner === "sdx" && input.definition.sandbox !== undefined

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -8,7 +8,7 @@ import {
   type ResolvedConfig,
 } from "./config.ts";
 import { detectHostCapabilities } from "./host.ts";
-import { buildLaunchCommand } from "./launchCommand.ts";
+import { buildLaunchCommand, type WorkerEnvironment } from "./launchCommand.ts";
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "./localRunner.ts";
 import { sandboxNameFor } from "./sandboxName.ts";
 import { buildAndStageSrtLaunch, resolveGitCommonDir } from "./srtLaunch.ts";
@@ -32,6 +32,7 @@ export function composeAgentLaunch(input: {
   secretsFile?: string | undefined;
   prepareWorktreeCommand?: string | undefined;
   sandboxName?: string | undefined;
+  workerEnvironment?: WorkerEnvironment | undefined;
 }): { launchCommand: string; srtSettingsDir: string | undefined } {
   const staged =
     input.runner === "srt"
@@ -54,6 +55,7 @@ export function composeAgentLaunch(input: {
     srtAgentSettingsFile: staged?.agentFile,
     srtSettingsDir: staged?.directory,
     srtAgentConfigDirEnv: staged?.agentConfigDirEnv,
+    workerEnvironment: input.workerEnvironment,
     safehouseAddDirs:
       input.runner === "safehouse" ? resolveSafehouseAddDirs(input.worktreeDir) : undefined,
   });

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -124,6 +124,8 @@ describe("loadConfig", () => {
     );
     expect(actual.prompts.initial).toMatch(/documented verification/i);
     expect(actual.prompts.initial).toMatch(/open a PR/i);
+    expect(actual.prompts.initial).toContain("GROUNDCREW_COMPLETE");
+    expect(actual.prompts.initial).toMatch(/no PR is needed/i);
     expect(actual.prompts.initial).toContain("{{workspaceContinuationInstruction}}");
     expect(actual.prompts.initial).not.toContain("tmux attach -t groundcrew:{{task}}");
   });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -445,6 +445,7 @@ const DEFAULT_PROMPT_INITIAL = [
   "2. Implement the smallest sensible change that completes the task.",
   "3. Run the repo's documented verification command. If no documented command exists, run the smallest relevant test suite you can find and fix failures you introduced before continuing.",
   "4. Follow the task description for output. If no output instructions exist, open a PR with `Closes {{task}}` in the description. If you cannot open one, leave the branch ready and record the blocker.",
+  "5. If the requested work is complete, no PR is needed, and any dirty worktree state is expected or explicitly allowed, run the command in `GROUNDCREW_COMPLETE` to mark the task done.",
 ].join("\n");
 
 const ALLOWED_PROMPT_PLACEHOLDERS = new Set([

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -1112,6 +1112,20 @@ describe(buildLaunchCommand, () => {
       ).toThrow(/preLaunchEnv cannot be injected when `cmd` starts with `safehouse`/);
     });
 
+    it("throws when workerEnvironment is set with a cmd that already starts with safehouse", () => {
+      expect(() =>
+        buildLaunchCommand(
+          arguments_({
+            definition: {
+              cmd: "safehouse --env-pass=OTHER my-agent",
+              color: "#fff",
+            },
+            workerEnvironment: WORKER_ENVIRONMENT,
+          }),
+        ),
+      ).toThrow(/workerEnvironment cannot be injected when `cmd` starts with `safehouse`/);
+    });
+
     it("treats preLaunchEnv: [] as a no-op when cmd already starts with safehouse", () => {
       // Same contract on the safehouse-prefixed-cmd path: an empty list has
       // nothing to inject, so the user-owns-the-wrap guard must not fire,

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -11,6 +11,11 @@ import {
   srtBinEntry,
 } from "./launchCommand.ts";
 
+const WORKER_ENVIRONMENT = {
+  GROUNDCREW_TASK_ID: "todo:gc-1",
+  GROUNDCREW_COMPLETE: "crew task done todo:gc-1",
+} as const;
+
 function arguments_(
   overrides: Partial<Parameters<typeof buildLaunchCommand>[0]> = {},
 ): Parameters<typeof buildLaunchCommand>[0] {
@@ -208,6 +213,23 @@ describe(`${buildLaunchCommand.name} (runner='srt')`, () => {
     expect(prepareSegment).not.toContain("CODEX_HOME");
   });
 
+  it("forwards worker completion env into the agent wrap only", () => {
+    const out = buildLaunchCommand(
+      srtArguments({
+        prepareWorktreeCommand: "npm ci",
+        workerEnvironment: WORKER_ENVIRONMENT,
+      }),
+    );
+
+    const prepareSegment = out.slice(0, out.indexOf("npm ci"));
+    const afterPrepare = out.slice(out.indexOf("npm ci"));
+    expect(out).toContain("export GROUNDCREW_TASK_ID='todo:gc-1'");
+    expect(out).toContain("export GROUNDCREW_COMPLETE='crew task done todo:gc-1'");
+    expect(afterPrepare).toContain(`GROUNDCREW_TASK_ID="$GROUNDCREW_TASK_ID"`);
+    expect(afterPrepare).toContain(`GROUNDCREW_COMPLETE="$GROUNDCREW_COMPLETE"`);
+    expect(prepareSegment).not.toContain("GROUNDCREW_COMPLETE");
+  });
+
   it("omits the config-home env for read-only agents (claude) that don't relocate", () => {
     const out = buildLaunchCommand(srtArguments());
 
@@ -272,6 +294,27 @@ describe(buildLaunchCommand, () => {
     expect(out.split(addDirsFlag).length - 1).toBe(2);
     expect(out).toContain(`${addDirsFlag} sh -c`);
     expect(out).toContain(`${addDirsFlag} "$_safehouse_shim" -c`);
+  });
+
+  it("forwards worker completion env into the Safehouse agent wrap only", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        prepareWorktreeCommand: "npm ci",
+        workerEnvironment: WORKER_ENVIRONMENT,
+      }),
+    );
+
+    const setupWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+    const setupIndex = out.indexOf("npm ci");
+    const exportIndex = out.indexOf("export GROUNDCREW_TASK_ID='todo:gc-1'");
+    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
+    expect(exportIndex).toBeGreaterThan(setupIndex);
+    expect(exportIndex).toBeLessThan(agentWrapIndex);
+    expect(out).toContain("export GROUNDCREW_COMPLETE='crew task done todo:gc-1'");
+    expect(out.slice(setupWrapIndex, setupIndex)).not.toContain("GROUNDCREW_COMPLETE");
+    expect(out.slice(agentWrapIndex - 100, agentWrapIndex)).toContain(
+      "--env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE ",
+    );
   });
 
   it("omits --add-dirs when no extra filesystem grants are requested", () => {
@@ -536,6 +579,21 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("safehouse-clearance");
       expect(out).not.toContain("--enable=all-agents");
       expect(out).toMatch(/exec claude "\$_p"$/);
+    });
+
+    it("exports worker completion env before executing the agent", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          runner: "none",
+          workerEnvironment: WORKER_ENVIRONMENT,
+        }),
+      );
+
+      const exportIndex = out.indexOf("export GROUNDCREW_TASK_ID='todo:gc-1'");
+      const execIndex = out.indexOf('exec claude "$_p"');
+      expect(exportIndex).toBeGreaterThan(-1);
+      expect(exportIndex).toBeLessThan(execIndex);
+      expect(out).toContain("export GROUNDCREW_COMPLETE='crew task done todo:gc-1'");
     });
 
     it("cds into workingDir while {{worktree}} still expands to the worktree root", () => {
@@ -1159,6 +1217,24 @@ describe(buildLaunchCommand, () => {
       expect(out).toContain(". '/tmp/prompt-team-1/secrets.env'");
       expect(out).toContain("-e NPM_TOKEN -e BUF_TOKEN");
       expect(out).toContain("unset NPM_TOKEN BUF_TOKEN");
+    });
+
+    it("exports worker completion env inside the sandbox after prepareWorktree", () => {
+      const out = buildLaunchCommand(
+        sdxArguments({
+          prepareWorktreeCommand: "npm ci",
+          workerEnvironment: WORKER_ENVIRONMENT,
+        }),
+      );
+
+      const prepareIndex = out.indexOf("npm ci");
+      const exportIndex = out.indexOf("export GROUNDCREW_TASK_ID=");
+      const agentIndex = out.indexOf("exec claude");
+      expect(exportIndex).toBeGreaterThan(prepareIndex);
+      expect(exportIndex).toBeLessThan(agentIndex);
+      expect(out).toContain("export GROUNDCREW_COMPLETE=");
+      expect(out).not.toContain("-e GROUNDCREW_TASK_ID");
+      expect(out).not.toContain("-e GROUNDCREW_COMPLETE");
     });
 
     it("omits -e KEY flags when no secretsFile is staged", () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -325,6 +325,13 @@ type WorkerEnvironmentName = (typeof WORKER_ENVIRONMENT_NAMES)[number];
 
 export type WorkerEnvironment = Readonly<Record<WorkerEnvironmentName, string>>;
 
+export function workerEnvironmentForTask(taskId: string): WorkerEnvironment {
+  return {
+    GROUNDCREW_TASK_ID: taskId,
+    GROUNDCREW_COMPLETE: `crew task done ${taskId}`,
+  };
+}
+
 function workerEnvironmentNames(
   workerEnvironment: WorkerEnvironment | undefined,
 ): readonly WorkerEnvironmentName[] {
@@ -457,6 +464,11 @@ export function buildLaunchCommand(arguments_: LaunchCommandArguments): string {
     // inject into. Fail loudly instead of silently dropping the contract.
     throw new Error(
       "preLaunchEnv cannot be injected when `cmd` starts with `safehouse` — your cmd owns the wrap, so add the names to its own `--env-pass=` flag, or drop the `safehouse` prefix from `cmd` to let groundcrew compose the flag for you.",
+    );
+  }
+  if (arguments_.workerEnvironment !== undefined && arguments_.runner === "safehouse") {
+    throw new Error(
+      "workerEnvironment cannot be injected when `cmd` starts with `safehouse` — your cmd owns the wrap, so add GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE to its own `--env-pass=` flag, or drop the `safehouse` prefix from `cmd` to let groundcrew compose the flag for you.",
     );
   }
   return buildUnwrappedHostLaunchCommand(arguments_);

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -319,6 +319,32 @@ export function inferAgentCommandName(agentCmd: string): string {
   return commandName;
 }
 
+const WORKER_ENVIRONMENT_NAMES = ["GROUNDCREW_TASK_ID", "GROUNDCREW_COMPLETE"] as const;
+
+type WorkerEnvironmentName = (typeof WORKER_ENVIRONMENT_NAMES)[number];
+
+export type WorkerEnvironment = Readonly<Record<WorkerEnvironmentName, string>>;
+
+function workerEnvironmentNames(
+  workerEnvironment: WorkerEnvironment | undefined,
+): readonly WorkerEnvironmentName[] {
+  return workerEnvironment === undefined ? [] : WORKER_ENVIRONMENT_NAMES;
+}
+
+function workerEnvironmentExports(workerEnvironment: WorkerEnvironment | undefined): string[] {
+  if (workerEnvironment === undefined) {
+    return [];
+  }
+  return WORKER_ENVIRONMENT_NAMES.map(
+    (name) => `export ${name}=${shellSingleQuote(workerEnvironment[name])}`,
+  );
+}
+
+function envPassFlag(names: readonly string[]): string {
+  const uniqueNames = [...new Set(names)];
+  return uniqueNames.length === 0 ? "" : `--env-pass=${uniqueNames.join(",")} `;
+}
+
 interface LaunchCommandArguments {
   definition: AgentDefinition;
   promptFile: string;
@@ -390,6 +416,11 @@ interface LaunchCommandArguments {
    * pre-existing behavior). Only consumed by the safehouse wrap.
    */
   safehouseAddDirs?: readonly string[] | undefined;
+  /**
+   * Groundcrew-managed task metadata exposed to the launched worker. Forwarded
+   * to the agent process, not the prepareWorktree hook.
+   */
+  workerEnvironment?: WorkerEnvironment | undefined;
 }
 
 /**
@@ -469,6 +500,7 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
   if (arguments_.secretsFile !== undefined) {
     lines.push(unsetSecretsLine());
   }
+  lines.push(...workerEnvironmentExports(arguments_.workerEnvironment));
   lines.push(
     ...preLaunchPromptAndExec({
       definition: arguments_.definition,
@@ -524,9 +556,10 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   // Trailing space keeps each flag separated from the next argv token.
   const prepareWorktreeEnvPassFlag =
     arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
-  const preLaunchEnvNames = arguments_.definition.preLaunchEnv ?? [];
-  const agentEnvPassFlag =
-    preLaunchEnvNames.length === 0 ? "" : `--env-pass=${preLaunchEnvNames.join(",")} `;
+  const agentEnvPassFlag = envPassFlag([
+    ...(arguments_.definition.preLaunchEnv ?? []),
+    ...workerEnvironmentNames(arguments_.workerEnvironment),
+  ]);
   // safehouse reads colon-separated paths from `--add-dirs`; both wraps get the
   // same grant so the prepareWorktree hook and the agent can each reach git.
   // Quote the whole value so shell-special chars survive; the trailing space
@@ -566,6 +599,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     lines.push(unsetSecretsLine());
   }
   lines.push(
+    ...workerEnvironmentExports(arguments_.workerEnvironment),
     `_safehouse_shim_dir=$(mktemp -d "\${TMPDIR:-/tmp}/groundcrew-safehouse-XXXXXX")`,
     shimAndPromptTrap,
     `_safehouse_shim="$_safehouse_shim_dir/${safehouseCommandName}"`,
@@ -674,7 +708,10 @@ function buildSrtLaunchCommand(arguments_: LaunchCommandArguments): string {
     arguments_.srtAgentConfigDirEnv === undefined
       ? ""
       : ` ${arguments_.srtAgentConfigDirEnv.name}=${shellSingleQuote(arguments_.srtAgentConfigDirEnv.value)}`;
-  const agentWrap = `env -i ${baseline}${agentConfigDirAssignment}${srtForwardedEnv(arguments_.definition.preLaunchEnv ?? [])} ${agentTarget}`;
+  const agentWrap = `env -i ${baseline}${agentConfigDirAssignment}${srtForwardedEnv([
+    ...(arguments_.definition.preLaunchEnv ?? []),
+    ...workerEnvironmentNames(arguments_.workerEnvironment),
+  ])} ${agentTarget}`;
 
   // One EXIT trap wipes both the settings dir and the prompt dir, covering
   // every failure window between here and the post-wrap cleanup.
@@ -694,6 +731,7 @@ function buildSrtLaunchCommand(arguments_: LaunchCommandArguments): string {
     lines.push(`${prepareWrap} sh -c ${shellSingleQuote(prepareWorktreeCommand)}`);
   }
   lines.push(
+    ...workerEnvironmentExports(arguments_.workerEnvironment),
     `{ ${agentWrap} sh -c ${shellSingleQuote(agentCommand)} sh "$_p"; _srt_status=$?; rm -rf ${shellSingleQuote(arguments_.srtSettingsDir)}; trap - EXIT; exit "$_srt_status"; }`,
   );
   return lines.join(" && ");
@@ -715,16 +753,18 @@ function buildSdxLaunchCommand(arguments_: LaunchCommandArguments): string {
   if (arguments_.secretsFile !== undefined) {
     innerParts.push(unsetSecretsLine());
   }
+  innerParts.push(...workerEnvironmentExports(arguments_.workerEnvironment));
   innerParts.push(agentCommand);
   const innerCommand = innerParts.join("; ");
   // Passthrough form (`-e KEY` without `=VALUE`): sbx reads each value
   // from its own env at invocation time — populated by sourceSecretsLine
   // a few lines up. Avoids `-e KEY="$KEY"`, which would embed the value
   // in argv and break on `"`, `$`, or backticks in the token.
+  const sbxEnvironmentNames = arguments_.secretsFile === undefined ? [] : BUILD_SECRET_NAMES;
   const sbxEnvironmentFlags =
-    arguments_.secretsFile === undefined
+    sbxEnvironmentNames.length === 0
       ? ""
-      : `${BUILD_SECRET_NAMES.map((name) => `-e ${name}`).join(" ")} `;
+      : `${sbxEnvironmentNames.map((name) => `-e ${name}`).join(" ")} `;
   const lines: string[] = [trapCleanupLine(promptDir)];
   if (arguments_.secretsFile !== undefined) {
     lines.push(sourceSecretsLine(arguments_.secretsFile));

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -203,6 +203,44 @@ describe("run state store", () => {
     });
   });
 
+  it("round-trips the canonical completion task id and preserves it across transitions", () => {
+    recordRunState({
+      config,
+      state: {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "dev-team-1",
+        workspaceName: "team-1",
+        state: "running",
+        completionTaskId: "linear:team-1",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      completionTaskId: "linear:team-1",
+    });
+
+    recordRunState({
+      config,
+      state: {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branchName: "dev-team-1",
+        workspaceName: "team-1",
+        state: "interrupted",
+      },
+    });
+
+    expect(readRunState(config, "team-1")).toMatchObject({
+      state: "interrupted",
+      completionTaskId: "linear:team-1",
+    });
+  });
+
   it("prefers a freshly provided title over the previously-recorded one", () => {
     recordRunState({
       config,

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -32,6 +32,11 @@ export interface RunState {
    * just the task id.
    */
   url?: string;
+  /**
+   * Canonical source-prefixed id used for no-PR self-completion. Cached so
+   * resumed workers keep the same completion target as the original launch.
+   */
+  completionTaskId?: string;
 }
 
 export interface RunStateDraft {
@@ -47,6 +52,7 @@ export interface RunStateDraft {
   resumeCount?: number;
   title?: string;
   url?: string;
+  completionTaskId?: string;
 }
 
 export interface RecordRunStateInput {
@@ -115,6 +121,7 @@ function parseRunState(value: unknown): RunState | undefined {
   const detail = stringField(value, "detail");
   const title = stringField(value, "title");
   const url = stringField(value, "url");
+  const completionTaskId = stringField(value, "completionTaskId");
   if (
     task === undefined ||
     repository === undefined ||
@@ -146,6 +153,7 @@ function parseRunState(value: unknown): RunState | undefined {
     ...(detail === undefined ? {} : { detail }),
     ...(title === undefined ? {} : { title }),
     ...(url === undefined ? {} : { url }),
+    ...(completionTaskId === undefined ? {} : { completionTaskId }),
   };
 }
 
@@ -179,6 +187,7 @@ export function recordRunState(input: RecordRunStateInput): RunState {
   // transitions.
   const title = input.state.title ?? existing?.title;
   const url = input.state.url ?? existing?.url;
+  const completionTaskId = input.state.completionTaskId ?? existing?.completionTaskId;
   const state: RunState = {
     task: taskKey(input.state.task),
     repository: input.state.repository,
@@ -194,6 +203,7 @@ export function recordRunState(input: RecordRunStateInput): RunState {
     ...(input.state.detail === undefined ? {} : { detail: input.state.detail }),
     ...(title === undefined ? {} : { title }),
     ...(url === undefined ? {} : { url }),
+    ...(completionTaskId === undefined ? {} : { completionTaskId }),
   };
   writeState(input.config, state);
   return state;


### PR DESCRIPTION
## Summary

Adds `crew task done <task-id> [--allow-dirty]` so completed no-PR tasks can be marked done through their owning task source, with local worktree guardrails for dirty work.

Exposes `GROUNDCREW_TASK_ID` and `GROUNDCREW_COMPLETE` to launched workers across the local runners so agents can self-complete non-PR work, and documents the manual and recurring task flows.

## Validation

- `node --run verify`
- Pre-push hook re-ran `node --run verify`

## Notes

Agent session: `codex resume 019eb874-383e-7100-b84c-b15ed1553f2d`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>
