### PR TITLE
feat: support cmux safehouse agent integration

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -147,6 +147,7 @@
     "nostatus",
     "norec",
     "nodone",
+    "unreviewed",
     "linejoin",
     "Neue",
     "qlmanage"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.35.0",
+  "version": "4.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.35.0",
+      "version": "4.35.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.52",
-        "@clipboard-health/clearance": "1.2.0",
+        "@clipboard-health/clearance": "1.3.2",
         "@linear/sdk": "86.0.0",
         "cosmiconfig": "9.0.1",
         "tslib": "2.8.1",
@@ -1632,9 +1632,9 @@
       "license": "MIT"
     },
     "node_modules/@clipboard-health/clearance": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.2.0.tgz",
-      "integrity": "sha512-ccCcKg8vVCY2gHJbo48dh0jsRTZ/XQCczqLkIQhgYDAeEJ7Y1770V/QSIgzmKHC7wKANMby5ZCxY9XarZIXa9A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.3.2.tgz",
+      "integrity": "sha512-pJ6FEt2GE32bdAXKj6Fgq6YrA7N/BBZSqNS2Kw4+OfG6y0BvDIIu8a5epjOUMu0EDmFzqD5vcJFvXBpVVw9q8g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.52",
-    "@clipboard-health/clearance": "1.2.0",
+    "@clipboard-health/clearance": "1.3.2",
     "@linear/sdk": "86.0.0",
     "cosmiconfig": "9.0.1",
     "tslib": "2.8.1",

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1,17 +1,14 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 
-import { ensureClearance } from "@clipboard-health/clearance";
+import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-health/clearance";
 
 import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
-import {
-  safehouseCmuxIntegrationFixture,
-  type SafehouseCmuxIntegrationFixture,
-} from "../testHelpers/safehouseCmuxIntegration.ts";
+import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
@@ -23,7 +20,7 @@ interface NodeFsMock extends Omit<typeof nodeFs, "mkdtempSync" | "rmSync" | "wri
 }
 
 const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() =>
-  vi.fn<() => SafehouseCmuxIntegrationFixture>(),
+  vi.fn<() => SafehouseCmuxIntegration>(),
 );
 
 vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -8,6 +8,10 @@ import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import {
+  safehouseCmuxIntegrationFixture,
+  type SafehouseCmuxIntegrationFixture,
+} from "../testHelpers/safehouseCmuxIntegration.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
@@ -17,6 +21,10 @@ interface NodeFsMock extends Omit<typeof nodeFs, "mkdtempSync" | "rmSync" | "wri
   rmSync: ReturnType<typeof vi.fn<typeof rmSync>>;
   writeFileSync: ReturnType<typeof vi.fn<typeof writeFileSync>>;
 }
+
+const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() =>
+  vi.fn<() => SafehouseCmuxIntegrationFixture>(),
+);
 
 vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
   const actual = await importOriginal<typeof nodeFs>();
@@ -29,7 +37,11 @@ vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
 });
 vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, ensureClearance: vi.fn<typeof ensureClearance>() };
+  return {
+    ...actual,
+    ensureClearance: vi.fn<typeof ensureClearance>(),
+    resolveSafehouseCmuxIntegration: resolveSafehouseCmuxIntegrationMock,
+  };
 });
 vi.mock(import("../lib/adapters/linear/fetch.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -248,6 +260,7 @@ describe(resumeWorkspace, () => {
       port: 19_999,
       status: "already-running",
     });
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(safehouseCmuxIntegrationFixture());
   });
 
   afterEach(() => {
@@ -518,6 +531,7 @@ describe(resumeWorkspaceCli, () => {
       port: 19_999,
       status: "already-running",
     });
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(safehouseCmuxIntegrationFixture());
   });
 
   afterEach(() => {

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -168,7 +168,7 @@ export async function resumeWorkspace(
     throw new Error(`Unknown agent: ${context.agent}`);
   }
 
-  const { runner, sandboxName, ensureReady } = await prepareAgentLaunch({
+  const { runner, sandboxName, workspaceKind, ensureReady } = await prepareAgentLaunch({
     config,
     agent: context.agent,
     definition,
@@ -200,6 +200,7 @@ export async function resumeWorkspace(
       workingDir: launchDir,
       secretsFile,
       sandboxName,
+      workspaceKind,
       workerEnvironment: workerEnvironmentForTask(context.completionTaskId),
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -17,6 +17,10 @@ import type * as utilModule from "../lib/util.ts";
 import { debug, log } from "../lib/util.ts";
 import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+import {
+  safehouseCmuxIntegrationFixture,
+  type SafehouseCmuxIntegrationFixture,
+} from "../testHelpers/safehouseCmuxIntegration.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import {
   setupWorkspace,
@@ -34,6 +38,10 @@ interface NodeFsMock extends Omit<
   rmSync: ReturnType<typeof vi.fn<typeof rmSync>>;
   writeFileSync: ReturnType<typeof vi.fn<typeof writeFileSync>>;
 }
+
+const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() =>
+  vi.fn<() => SafehouseCmuxIntegrationFixture>(),
+);
 
 vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {
   const actual = await importOriginal<typeof nodeFs>();
@@ -58,6 +66,7 @@ vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
   return {
     ...actual,
     ensureClearance: vi.fn<typeof ensureClearance>(),
+    resolveSafehouseCmuxIntegration: resolveSafehouseCmuxIntegrationMock,
   };
 });
 type RunCommandMock = (
@@ -378,6 +387,7 @@ describe(setupWorkspace, () => {
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
     ensureClearanceMock.mockResolvedValue(clearanceResult());
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(safehouseCmuxIntegrationFixture());
     mkdtempMock.mockReturnValue("/tmp/groundcrew-team-1-x");
     runCommandMock.mockReturnValue("");
     teardownMock.mockResolvedValue(emptyTeardownResult());
@@ -848,12 +858,9 @@ describe(setupWorkspace, () => {
     );
     expect(launchScript).toContain("--add-dirs-ro='/Applications/cmux.app:");
     expect(launchScript).toContain(
-      "--env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE,CMUX_BUNDLED_CLI_PATH",
+      "--env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE,CMUX_SURFACE_ID,CMUX_SOCKET_PATH",
     );
-    expect(launchScript).toContain("CMUX_CLAUDE_WRAPPER_SHIM_ROOT");
-    expect(launchScript).toContain(
-      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
-    );
+    expect(launchScript).toContain("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
     expect(launchScript).toContain('"$_safehouse_shim" -c');
   });
 
@@ -1771,6 +1778,7 @@ describe(setupWorkspaceCli, () => {
     mkdtempMock.mockReturnValue("/tmp/groundcrew-team-1-x");
     runCommandMock.mockReturnValue(JSON.stringify({ ref: "workspace:1" }));
     loadConfigMock.mockResolvedValue(makeConfig());
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(safehouseCmuxIntegrationFixture());
     defaultBoard = fakeBoard(
       canonicalLinearIssue({
         naturalId: "team-1",

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 import path from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
-import { ensureClearance } from "@clipboard-health/clearance";
+import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-health/clearance";
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
@@ -17,10 +17,7 @@ import type * as utilModule from "../lib/util.ts";
 import { debug, log } from "../lib/util.ts";
 import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
-import {
-  safehouseCmuxIntegrationFixture,
-  type SafehouseCmuxIntegrationFixture,
-} from "../testHelpers/safehouseCmuxIntegration.ts";
+import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import {
   setupWorkspace,
@@ -40,7 +37,7 @@ interface NodeFsMock extends Omit<
 }
 
 const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() =>
-  vi.fn<() => SafehouseCmuxIntegrationFixture>(),
+  vi.fn<() => SafehouseCmuxIntegration>(),
 );
 
 vi.mock("node:fs", async (importOriginal): Promise<NodeFsMock> => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -844,8 +844,17 @@ describe(setupWorkspace, () => {
     expect(launchScript).not.toContain("groundcrew prepareWorktree hook exited");
     expect(launchScript).not.toContain(".groundcrew/setup.sh");
     expect(launchScript).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git' --env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE \"$_safehouse_shim\" -c",
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' --add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git'",
     );
+    expect(launchScript).toContain("--add-dirs-ro='/Applications/cmux.app:");
+    expect(launchScript).toContain(
+      "--env-pass=GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE,CMUX_BUNDLED_CLI_PATH",
+    );
+    expect(launchScript).toContain("CMUX_CLAUDE_WRAPPER_SHIM_ROOT");
+    expect(launchScript).toContain(
+      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
+    );
+    expect(launchScript).toContain('"$_safehouse_shim" -c');
   });
 
   it("wraps the agent in an sbx exec call and skips ensureClearance when runner='sdx'", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -74,7 +74,7 @@ export async function setupWorkspace(
   if (!definition) {
     throw new Error(`Unknown agent: ${agent}`);
   }
-  const { runner, sandboxName, ensureReady } = await prepareAgentLaunch({
+  const { runner, sandboxName, workspaceKind, ensureReady } = await prepareAgentLaunch({
     config,
     agent,
     definition,
@@ -140,6 +140,7 @@ export async function setupWorkspace(
       secretsFile,
       prepareWorktreeCommand,
       sandboxName,
+      workspaceKind,
       workerEnvironment: workerEnvironmentForTask(completionTaskId),
     });
     srtSettingsDir = stagedSrtSettingsDir;

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -1,0 +1,100 @@
+import type { AgentDefinition } from "./config.ts";
+import { composeAgentLaunch } from "./agentLaunch.ts";
+import { readEnvironmentVariable } from "./util.ts";
+import { xdgStatePath } from "./xdg.ts";
+import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+
+const runCommandMock = vi.hoisted(() =>
+  vi.fn<(command: string, arguments_: readonly string[]) => string>(),
+);
+
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    runCommand: runCommandMock,
+  };
+});
+
+const ORIGINAL_CMUX_SOCKET_PATH = readEnvironmentVariable("CMUX_SOCKET_PATH");
+
+function restoreCmuxSocketPath(): void {
+  if (ORIGINAL_CMUX_SOCKET_PATH === undefined) {
+    deleteEnvironmentVariable("CMUX_SOCKET_PATH");
+    return;
+  }
+  setEnvironmentVariable("CMUX_SOCKET_PATH", ORIGINAL_CMUX_SOCKET_PATH);
+}
+
+function definition(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    cmd: "claude --permission-mode auto",
+    color: "#fff",
+    ...overrides,
+  };
+}
+
+function compose(overrides: Partial<Parameters<typeof composeAgentLaunch>[0]> = {}): string {
+  return composeAgentLaunch({
+    runner: "safehouse",
+    task: "team-1",
+    definition: definition(),
+    promptFile: "/tmp/prompt-team-1/prompt.txt",
+    worktreeDir: "/work/repo-a-team-1",
+    workingDir: "/work/repo-a-team-1",
+    workspaceKind: "cmux",
+    ...overrides,
+  }).launchCommand;
+}
+
+describe(composeAgentLaunch, () => {
+  beforeEach(() => {
+    runCommandMock.mockReturnValue("/tmp/repo-a.git");
+    deleteEnvironmentVariable("CMUX_SOCKET_PATH");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    restoreCmuxSocketPath();
+  });
+
+  it("adds cmux Safehouse grants, env, and Claude real-binary prelude for cmux-hosted Claude", () => {
+    const launchCommand = compose();
+
+    expect(launchCommand).toContain("--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git'");
+    expect(launchCommand).toContain(
+      `--add-dirs-ro='/Applications/cmux.app:${xdgStatePath("cmux")}'`,
+    );
+    expect(launchCommand).toContain("CMUX_CLAUDE_WRAPPER_SHIM_ROOT");
+    expect(launchCommand).toContain("CMUX_SOCKET_PATH");
+    expect(launchCommand).toContain("CMUX_CUSTOM_CLAUDE_PATH");
+    expect(launchCommand).toContain("*/cmux-cli-shims/*|*/cmux-cli-shims)");
+    expect(launchCommand).toContain(
+      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
+    );
+    expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
+  });
+
+  it("adds the runtime cmux socket directory when the launch environment provides it", () => {
+    setEnvironmentVariable("CMUX_SOCKET_PATH", "/tmp/cmux-state/cmux.sock");
+
+    const launchCommand = compose({
+      definition: definition({ cmd: "codex", color: "#000" }),
+    });
+
+    expect(launchCommand).toContain("/tmp/cmux-state");
+    expect(launchCommand).toContain("CMUX_SOCKET_PATH");
+    expect(launchCommand).not.toContain(
+      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
+    );
+    expect(launchCommand).toContain('exec codex "$@"');
+  });
+
+  it("does not add cmux Safehouse integration for non-cmux workspace backends", () => {
+    const launchCommand = compose({ workspaceKind: "tmux" });
+
+    expect(launchCommand).not.toContain("--add-dirs-ro");
+    expect(launchCommand).not.toContain("CMUX_SOCKET_PATH");
+    expect(launchCommand).not.toContain("cmux-cli-shims");
+  });
+});

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -1,3 +1,5 @@
+import type { SafehouseCmuxIntegration } from "@clipboard-health/clearance";
+
 import type { AgentDefinition } from "./config.ts";
 import { composeAgentLaunch } from "./agentLaunch.ts";
 import { readEnvironmentVariable } from "./util.ts";
@@ -7,7 +9,14 @@ import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxInt
 const runCommandMock = vi.hoisted(() =>
   vi.fn<(command: string, arguments_: readonly string[]) => string>(),
 );
-const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() => vi.fn<() => unknown>());
+const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() =>
+  vi.fn<() => SafehouseCmuxIntegration>(),
+);
+const safehouseCmuxIntegrationWarningLinesMock = vi.hoisted(() =>
+  vi.fn<
+    (input: { commandName: string; unreviewedEnvNames: readonly string[] }) => readonly string[]
+  >(),
+);
 const writeErrorMock = vi.hoisted(() => vi.fn<(message: string) => void>());
 
 vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
@@ -22,6 +31,7 @@ vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
   return {
     ...actual,
     resolveSafehouseCmuxIntegration: resolveSafehouseCmuxIntegrationMock,
+    safehouseCmuxIntegrationWarningLines: safehouseCmuxIntegrationWarningLinesMock,
   };
 });
 vi.mock(import("./util.ts"), async (importOriginal) => {
@@ -77,6 +87,7 @@ describe(composeAgentLaunch, () => {
         ],
       }),
     );
+    safehouseCmuxIntegrationWarningLinesMock.mockReturnValue([]);
     writeErrorMock.mockReset();
     deleteEnvironmentVariable("CMUX_SOCKET_PATH");
   });
@@ -102,6 +113,10 @@ describe(composeAgentLaunch, () => {
   });
 
   it("warns when clearance reports unreviewed cmux Claude wrapper env names", () => {
+    safehouseCmuxIntegrationWarningLinesMock.mockReturnValue([
+      "groundcrew: clearance-owned warning one",
+      "groundcrew: clearance-owned warning two",
+    ]);
     resolveSafehouseCmuxIntegrationMock.mockReturnValue(
       safehouseCmuxIntegrationFixture({
         addDirsReadOnly: ["/Applications/cmux.app"],
@@ -113,20 +128,14 @@ describe(composeAgentLaunch, () => {
 
     compose();
 
-    expect(writeErrorMock).toHaveBeenCalledWith(
-      "groundcrew: cmux Claude wrapper references unreviewed env vars: CMUX_NEW_REQUIRED_SETTING",
-    );
-    expect(writeErrorMock).toHaveBeenCalledWith(
-      "groundcrew: update @clipboard-health/clearance after reviewing the cmux change.",
-    );
-  });
-
-  it("fails clearly when clearance returns an invalid cmux Safehouse integration", () => {
-    resolveSafehouseCmuxIntegrationMock.mockReturnValue(null);
-
-    expect(() => compose()).toThrow(
-      "@clipboard-health/clearance returned an invalid cmux Safehouse integration.",
-    );
+    expect(safehouseCmuxIntegrationWarningLinesMock).toHaveBeenCalledWith({
+      commandName: "groundcrew",
+      unreviewedEnvNames: ["CMUX_NEW_REQUIRED_SETTING"],
+    });
+    expect(writeErrorMock.mock.calls.map((call) => call[0])).toStrictEqual([
+      "groundcrew: clearance-owned warning one",
+      "groundcrew: clearance-owned warning two",
+    ]);
   });
 
   it("adds the runtime cmux socket directory when the launch environment provides it", () => {

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -1,18 +1,34 @@
 import type { AgentDefinition } from "./config.ts";
 import { composeAgentLaunch } from "./agentLaunch.ts";
 import { readEnvironmentVariable } from "./util.ts";
-import { xdgStatePath } from "./xdg.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
+import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
 
 const runCommandMock = vi.hoisted(() =>
   vi.fn<(command: string, arguments_: readonly string[]) => string>(),
 );
+const resolveSafehouseCmuxIntegrationMock = vi.hoisted(() => vi.fn<() => unknown>());
+const writeErrorMock = vi.hoisted(() => vi.fn<(message: string) => void>());
 
 vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
     runCommand: runCommandMock,
+  };
+});
+vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    resolveSafehouseCmuxIntegration: resolveSafehouseCmuxIntegrationMock,
+  };
+});
+vi.mock(import("./util.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    writeError: writeErrorMock,
   };
 });
 
@@ -50,6 +66,18 @@ function compose(overrides: Partial<Parameters<typeof composeAgentLaunch>[0]> = 
 describe(composeAgentLaunch, () => {
   beforeEach(() => {
     runCommandMock.mockReturnValue("/tmp/repo-a.git");
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(
+      safehouseCmuxIntegrationFixture({
+        envPass: [
+          "CMUX_SURFACE_ID",
+          "CMUX_SOCKET_PATH",
+          "CMUX_CLAUDE_WRAPPER_SHIM",
+          "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+          "CMUX_CUSTOM_CLAUDE_PATH",
+        ],
+      }),
+    );
+    writeErrorMock.mockReset();
     deleteEnvironmentVariable("CMUX_SOCKET_PATH");
   });
 
@@ -62,17 +90,43 @@ describe(composeAgentLaunch, () => {
     const launchCommand = compose();
 
     expect(launchCommand).toContain("--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git'");
+    expect(resolveSafehouseCmuxIntegrationMock).toHaveBeenCalledTimes(1);
     expect(launchCommand).toContain(
-      `--add-dirs-ro='/Applications/cmux.app:${xdgStatePath("cmux")}'`,
+      "--add-dirs-ro='/Applications/cmux.app:/Users/dev/.local/state/cmux'",
     );
     expect(launchCommand).toContain("CMUX_CLAUDE_WRAPPER_SHIM_ROOT");
     expect(launchCommand).toContain("CMUX_SOCKET_PATH");
     expect(launchCommand).toContain("CMUX_CUSTOM_CLAUDE_PATH");
-    expect(launchCommand).toContain("*/cmux-cli-shims/*|*/cmux-cli-shims)");
-    expect(launchCommand).toContain(
-      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
-    );
+    expect(launchCommand).toContain("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
     expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
+  });
+
+  it("warns when clearance reports unreviewed cmux Claude wrapper env names", () => {
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(
+      safehouseCmuxIntegrationFixture({
+        addDirsReadOnly: ["/Applications/cmux.app"],
+        claudeCommandPrelude: "",
+        envPass: ["CMUX_SOCKET_PATH"],
+        unreviewedEnvNames: ["CMUX_NEW_REQUIRED_SETTING"],
+      }),
+    );
+
+    compose();
+
+    expect(writeErrorMock).toHaveBeenCalledWith(
+      "groundcrew: cmux Claude wrapper references unreviewed env vars: CMUX_NEW_REQUIRED_SETTING",
+    );
+    expect(writeErrorMock).toHaveBeenCalledWith(
+      "groundcrew: update @clipboard-health/clearance after reviewing the cmux change.",
+    );
+  });
+
+  it("fails clearly when clearance returns an invalid cmux Safehouse integration", () => {
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(null);
+
+    expect(() => compose()).toThrow(
+      "@clipboard-health/clearance returned an invalid cmux Safehouse integration.",
+    );
   });
 
   it("adds the runtime cmux socket directory when the launch environment provides it", () => {
@@ -82,11 +136,9 @@ describe(composeAgentLaunch, () => {
       definition: definition({ cmd: "codex", color: "#000" }),
     });
 
-    expect(launchCommand).toContain("/tmp/cmux-state");
+    expect(resolveSafehouseCmuxIntegrationMock).toHaveBeenCalledTimes(1);
     expect(launchCommand).toContain("CMUX_SOCKET_PATH");
-    expect(launchCommand).not.toContain(
-      'export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude"',
-    );
+    expect(launchCommand).not.toContain("export CMUX_CUSTOM_CLAUDE_PATH");
     expect(launchCommand).toContain('exec codex "$@"');
   });
 
@@ -95,6 +147,6 @@ describe(composeAgentLaunch, () => {
 
     expect(launchCommand).not.toContain("--add-dirs-ro");
     expect(launchCommand).not.toContain("CMUX_SOCKET_PATH");
-    expect(launchCommand).not.toContain("cmux-cli-shims");
+    expect(resolveSafehouseCmuxIntegrationMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -1,5 +1,4 @@
-import { ensureClearance } from "@clipboard-health/clearance";
-import path from "node:path";
+import * as clearance from "@clipboard-health/clearance";
 
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import {
@@ -18,10 +17,9 @@ import {
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "./localRunner.ts";
 import { sandboxNameFor } from "./sandboxName.ts";
 import { buildAndStageSrtLaunch, resolveGitCommonDir } from "./srtLaunch.ts";
-import { debug, readEnvironmentVariable, sleep } from "./util.ts";
+import { debug, sleep, writeError } from "./util.ts";
 import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
 import type { WorkspaceKind } from "./workspaceAdapter.ts";
-import { xdgStatePath } from "./xdg.ts";
 
 /**
  * Stage any srt settings and build the workspace launch command — the assembly
@@ -96,32 +94,6 @@ function resolveSafehouseAddDirs(worktreeDir: string): readonly string[] {
   return [...new Set([worktreeDir, resolveGitCommonDir(worktreeDir)])];
 }
 
-const CMUX_AGENT_ENV_PASS: readonly string[] = [
-  "CMUX_BUNDLED_CLI_PATH",
-  "CMUX_CLAUDE_HOOKS_DISABLED",
-  "CMUX_CLAUDE_WRAPPER_SHIM",
-  "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
-  "CMUX_CUSTOM_CLAUDE_PATH",
-  "CMUX_PANEL_ID",
-  "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV",
-  "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS",
-  "CMUX_SOCKET_PATH",
-  "CMUX_SUPPRESS_SUBAGENT_NOTIFICATIONS",
-  "CMUX_SURFACE_ID",
-  "CMUX_TAB_ID",
-  "CMUX_WORKSPACE_ID",
-];
-
-const CMUX_CLAUDE_WRAPPER_PRELUDE = [
-  `if [ -n "\${CMUX_SURFACE_ID:-}" ] && [ -z "\${CMUX_CUSTOM_CLAUDE_PATH:-}" ]; then`,
-  "_groundcrew_cmux_path=;",
-  "_groundcrew_cmux_remaining_path=$PATH:;",
-  `while [ -n "$_groundcrew_cmux_remaining_path" ]; do _groundcrew_cmux_path_entry=\${_groundcrew_cmux_remaining_path%%:*}; _groundcrew_cmux_remaining_path=\${_groundcrew_cmux_remaining_path#*:}; case "$_groundcrew_cmux_path_entry" in */cmux-cli-shims/*|*/cmux-cli-shims) ;; *) _groundcrew_cmux_path="\${_groundcrew_cmux_path:+$_groundcrew_cmux_path:}$_groundcrew_cmux_path_entry" ;; esac; done;`,
-  'if _groundcrew_cmux_real_claude=$(PATH="$_groundcrew_cmux_path" command -v claude 2>/dev/null); then case "$_groundcrew_cmux_real_claude" in */cmux-cli-shims/*|*/cmux-cli-shims/claude) ;; *) export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude" ;; esac; fi;',
-  "unset _groundcrew_cmux_path _groundcrew_cmux_remaining_path _groundcrew_cmux_path_entry _groundcrew_cmux_real_claude;",
-  "fi",
-].join(" ");
-
 function safehouseAgentIntegrationFor(
   workspaceKind: WorkspaceKind,
   definition: AgentDefinition,
@@ -130,22 +102,87 @@ function safehouseAgentIntegrationFor(
     return undefined;
   }
   const isClaudeAgent = inferAgentCommandName(definition.cmd) === "claude";
+  const cmuxIntegration = resolveClearanceSafehouseCmuxIntegration();
+  if (isClaudeAgent) {
+    warnOnCmuxIntegrationDrift({ unreviewedEnvNames: cmuxIntegration.unreviewedEnvNames });
+  }
+
   return {
-    addDirsReadOnly: resolveCmuxSafehouseReadOnlyDirs(),
-    envPass: CMUX_AGENT_ENV_PASS,
-    commandPreludes: isClaudeAgent ? [CMUX_CLAUDE_WRAPPER_PRELUDE] : [],
+    addDirsReadOnly: cmuxIntegration.addDirsReadOnly,
+    envPass: cmuxIntegration.envPass,
+    commandPreludes: isClaudeAgent ? [cmuxIntegration.claudeCommandPrelude] : [],
   };
 }
 
-function resolveCmuxSafehouseReadOnlyDirs(): readonly string[] {
-  const socketPath = readEnvironmentVariable("CMUX_SOCKET_PATH");
-  return [
-    ...new Set([
-      "/Applications/cmux.app",
-      xdgStatePath("cmux"),
-      ...(socketPath === undefined ? [] : [path.dirname(socketPath)]),
-    ]),
-  ];
+function warnOnCmuxIntegrationDrift(input: { unreviewedEnvNames: readonly string[] }): void {
+  if (input.unreviewedEnvNames.length === 0) {
+    return;
+  }
+
+  writeError(
+    `groundcrew: cmux Claude wrapper references unreviewed env vars: ${input.unreviewedEnvNames.join(", ")}`,
+  );
+  writeError("groundcrew: update @clipboard-health/clearance after reviewing the cmux change.");
+}
+
+interface ClearanceSafehouseCmuxIntegration {
+  addDirsReadOnly: readonly string[];
+  claudeCommandPrelude: string;
+  envPass: readonly string[];
+  unreviewedEnvNames: readonly string[];
+}
+
+type ClearanceSafehouseCmuxResolver = () => unknown;
+
+function resolveClearanceSafehouseCmuxIntegration(): ClearanceSafehouseCmuxIntegration {
+  const resolveSafehouseCmuxIntegration = clearanceSafehouseCmuxResolver();
+  /* v8 ignore next 4 @preserve -- Runtime guard for older clearance versions before the cmux helper exists. */
+  if (resolveSafehouseCmuxIntegration === undefined) {
+    throw new Error(
+      "cmux Safehouse integration requires @clipboard-health/clearance with resolveSafehouseCmuxIntegration. Update @clipboard-health/clearance before using workspaceKind='cmux' with local.runner='safehouse'.",
+    );
+  }
+
+  const integration = resolveSafehouseCmuxIntegration();
+  if (!isClearanceSafehouseCmuxIntegration(integration)) {
+    throw new TypeError(
+      "@clipboard-health/clearance returned an invalid cmux Safehouse integration.",
+    );
+  }
+  return integration;
+}
+
+function clearanceSafehouseCmuxResolver(): ClearanceSafehouseCmuxResolver | undefined {
+  const maybeResolver: unknown = Reflect.get(clearance, "resolveSafehouseCmuxIntegration");
+  /* v8 ignore next 3 @preserve -- Runtime guard for older clearance versions before the cmux helper exists. */
+  if (typeof maybeResolver !== "function") {
+    return undefined;
+  }
+
+  return (): unknown => Reflect.apply(maybeResolver, undefined, []);
+}
+
+function isClearanceSafehouseCmuxIntegration(
+  value: unknown,
+): value is ClearanceSafehouseCmuxIntegration {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const addDirsReadOnly: unknown = Reflect.get(value, "addDirsReadOnly");
+  const claudeCommandPrelude: unknown = Reflect.get(value, "claudeCommandPrelude");
+  const envPass: unknown = Reflect.get(value, "envPass");
+  const unreviewedEnvNames: unknown = Reflect.get(value, "unreviewedEnvNames");
+  return (
+    isStringList(addDirsReadOnly) &&
+    typeof claudeCommandPrelude === "string" &&
+    isStringList(envPass) &&
+    isStringList(unreviewedEnvNames)
+  );
+}
+
+function isStringList(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 interface PreparedAgentLaunch {
@@ -222,7 +259,7 @@ async function alreadyReady(): Promise<void> {
 }
 
 async function ensureSafehouseClearance(signal?: AbortSignal): Promise<void> {
-  await ensureClearance({
+  await clearance.ensureClearance({
     envOverrides: {
       CLEARANCE_ALLOW_HOSTS_FILES: clearanceAllowHostsFilesFromEnvironment(),
     },

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -1,4 +1,5 @@
 import { ensureClearance } from "@clipboard-health/clearance";
+import path from "node:path";
 
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import {
@@ -8,12 +9,19 @@ import {
   type ResolvedConfig,
 } from "./config.ts";
 import { detectHostCapabilities } from "./host.ts";
-import { buildLaunchCommand, type WorkerEnvironment } from "./launchCommand.ts";
+import {
+  buildLaunchCommand,
+  inferAgentCommandName,
+  type SafehouseAgentIntegration,
+  type WorkerEnvironment,
+} from "./launchCommand.ts";
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "./localRunner.ts";
 import { sandboxNameFor } from "./sandboxName.ts";
 import { buildAndStageSrtLaunch, resolveGitCommonDir } from "./srtLaunch.ts";
-import { debug, sleep } from "./util.ts";
-import { workspaces } from "./workspaces.ts";
+import { debug, readEnvironmentVariable, sleep } from "./util.ts";
+import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
+import type { WorkspaceKind } from "./workspaceAdapter.ts";
+import { xdgStatePath } from "./xdg.ts";
 
 /**
  * Stage any srt settings and build the workspace launch command — the assembly
@@ -32,6 +40,7 @@ export function composeAgentLaunch(input: {
   secretsFile?: string | undefined;
   prepareWorktreeCommand?: string | undefined;
   sandboxName?: string | undefined;
+  workspaceKind: WorkspaceKind;
   workerEnvironment?: WorkerEnvironment | undefined;
 }): { launchCommand: string; srtSettingsDir: string | undefined } {
   const staged =
@@ -41,6 +50,10 @@ export function composeAgentLaunch(input: {
           worktreeDir: input.worktreeDir,
           definition: input.definition,
         })
+      : undefined;
+  const safehouseAgentIntegration =
+    input.runner === "safehouse"
+      ? safehouseAgentIntegrationFor(input.workspaceKind, input.definition)
       : undefined;
   const launchCommand = buildLaunchCommand({
     definition: input.definition,
@@ -58,6 +71,7 @@ export function composeAgentLaunch(input: {
     workerEnvironment: input.workerEnvironment,
     safehouseAddDirs:
       input.runner === "safehouse" ? resolveSafehouseAddDirs(input.worktreeDir) : undefined,
+    safehouseAgentIntegration,
   });
   return { launchCommand, srtSettingsDir: staged?.directory };
 }
@@ -82,9 +96,62 @@ function resolveSafehouseAddDirs(worktreeDir: string): readonly string[] {
   return [...new Set([worktreeDir, resolveGitCommonDir(worktreeDir)])];
 }
 
+const CMUX_AGENT_ENV_PASS: readonly string[] = [
+  "CMUX_BUNDLED_CLI_PATH",
+  "CMUX_CLAUDE_HOOKS_DISABLED",
+  "CMUX_CLAUDE_WRAPPER_SHIM",
+  "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+  "CMUX_CUSTOM_CLAUDE_PATH",
+  "CMUX_PANEL_ID",
+  "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV",
+  "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS",
+  "CMUX_SOCKET_PATH",
+  "CMUX_SUPPRESS_SUBAGENT_NOTIFICATIONS",
+  "CMUX_SURFACE_ID",
+  "CMUX_TAB_ID",
+  "CMUX_WORKSPACE_ID",
+];
+
+const CMUX_CLAUDE_WRAPPER_PRELUDE = [
+  `if [ -n "\${CMUX_SURFACE_ID:-}" ] && [ -z "\${CMUX_CUSTOM_CLAUDE_PATH:-}" ]; then`,
+  "_groundcrew_cmux_path=;",
+  "_groundcrew_cmux_remaining_path=$PATH:;",
+  `while [ -n "$_groundcrew_cmux_remaining_path" ]; do _groundcrew_cmux_path_entry=\${_groundcrew_cmux_remaining_path%%:*}; _groundcrew_cmux_remaining_path=\${_groundcrew_cmux_remaining_path#*:}; case "$_groundcrew_cmux_path_entry" in */cmux-cli-shims/*|*/cmux-cli-shims) ;; *) _groundcrew_cmux_path="\${_groundcrew_cmux_path:+$_groundcrew_cmux_path:}$_groundcrew_cmux_path_entry" ;; esac; done;`,
+  'if _groundcrew_cmux_real_claude=$(PATH="$_groundcrew_cmux_path" command -v claude 2>/dev/null); then case "$_groundcrew_cmux_real_claude" in */cmux-cli-shims/*|*/cmux-cli-shims/claude) ;; *) export CMUX_CUSTOM_CLAUDE_PATH="$_groundcrew_cmux_real_claude" ;; esac; fi;',
+  "unset _groundcrew_cmux_path _groundcrew_cmux_remaining_path _groundcrew_cmux_path_entry _groundcrew_cmux_real_claude;",
+  "fi",
+].join(" ");
+
+function safehouseAgentIntegrationFor(
+  workspaceKind: WorkspaceKind,
+  definition: AgentDefinition,
+): SafehouseAgentIntegration | undefined {
+  if (workspaceKind !== "cmux") {
+    return undefined;
+  }
+  const isClaudeAgent = inferAgentCommandName(definition.cmd) === "claude";
+  return {
+    addDirsReadOnly: resolveCmuxSafehouseReadOnlyDirs(),
+    envPass: CMUX_AGENT_ENV_PASS,
+    commandPreludes: isClaudeAgent ? [CMUX_CLAUDE_WRAPPER_PRELUDE] : [],
+  };
+}
+
+function resolveCmuxSafehouseReadOnlyDirs(): readonly string[] {
+  const socketPath = readEnvironmentVariable("CMUX_SOCKET_PATH");
+  return [
+    ...new Set([
+      "/Applications/cmux.app",
+      xdgStatePath("cmux"),
+      ...(socketPath === undefined ? [] : [path.dirname(socketPath)]),
+    ]),
+  ];
+}
+
 interface PreparedAgentLaunch {
   runner: LocalRunner;
   sandboxName: string | undefined;
+  workspaceKind: WorkspaceKind;
   ensureReady: () => Promise<void>;
 }
 
@@ -97,6 +164,7 @@ export async function prepareAgentLaunch(input: {
 }): Promise<PreparedAgentLaunch> {
   const host = await detectHostCapabilities(input.signal);
   const runner = resolveLocalRunner(input.config.local.runner, host);
+  const workspaceKind = resolveWorkspaceKind({ config: input.config, host }).resolved;
   assertLocalRunnerRequirements(host, runner);
   const ensureReady =
     runner === "safehouse"
@@ -146,7 +214,7 @@ export async function prepareAgentLaunch(input: {
     runner === "sdx" && input.definition.sandbox !== undefined
       ? sandboxNameFor({ agent: input.definition.sandbox.agent })
       : undefined;
-  return { runner, sandboxName, ensureReady };
+  return { runner, sandboxName, workspaceKind, ensureReady };
 }
 
 async function alreadyReady(): Promise<void> {

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -1,4 +1,8 @@
-import * as clearance from "@clipboard-health/clearance";
+import {
+  ensureClearance,
+  resolveSafehouseCmuxIntegration,
+  safehouseCmuxIntegrationWarningLines,
+} from "@clipboard-health/clearance";
 
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import {
@@ -102,7 +106,7 @@ function safehouseAgentIntegrationFor(
     return undefined;
   }
   const isClaudeAgent = inferAgentCommandName(definition.cmd) === "claude";
-  const cmuxIntegration = resolveClearanceSafehouseCmuxIntegration();
+  const cmuxIntegration = resolveSafehouseCmuxIntegration();
   if (isClaudeAgent) {
     warnOnCmuxIntegrationDrift({ unreviewedEnvNames: cmuxIntegration.unreviewedEnvNames });
   }
@@ -115,74 +119,12 @@ function safehouseAgentIntegrationFor(
 }
 
 function warnOnCmuxIntegrationDrift(input: { unreviewedEnvNames: readonly string[] }): void {
-  if (input.unreviewedEnvNames.length === 0) {
-    return;
+  for (const warningLine of safehouseCmuxIntegrationWarningLines({
+    commandName: "groundcrew",
+    unreviewedEnvNames: input.unreviewedEnvNames,
+  })) {
+    writeError(warningLine);
   }
-
-  writeError(
-    `groundcrew: cmux Claude wrapper references unreviewed env vars: ${input.unreviewedEnvNames.join(", ")}`,
-  );
-  writeError("groundcrew: update @clipboard-health/clearance after reviewing the cmux change.");
-}
-
-interface ClearanceSafehouseCmuxIntegration {
-  addDirsReadOnly: readonly string[];
-  claudeCommandPrelude: string;
-  envPass: readonly string[];
-  unreviewedEnvNames: readonly string[];
-}
-
-type ClearanceSafehouseCmuxResolver = () => unknown;
-
-function resolveClearanceSafehouseCmuxIntegration(): ClearanceSafehouseCmuxIntegration {
-  const resolveSafehouseCmuxIntegration = clearanceSafehouseCmuxResolver();
-  /* v8 ignore next 4 @preserve -- Runtime guard for older clearance versions before the cmux helper exists. */
-  if (resolveSafehouseCmuxIntegration === undefined) {
-    throw new Error(
-      "cmux Safehouse integration requires @clipboard-health/clearance with resolveSafehouseCmuxIntegration. Update @clipboard-health/clearance before using workspaceKind='cmux' with local.runner='safehouse'.",
-    );
-  }
-
-  const integration = resolveSafehouseCmuxIntegration();
-  if (!isClearanceSafehouseCmuxIntegration(integration)) {
-    throw new TypeError(
-      "@clipboard-health/clearance returned an invalid cmux Safehouse integration.",
-    );
-  }
-  return integration;
-}
-
-function clearanceSafehouseCmuxResolver(): ClearanceSafehouseCmuxResolver | undefined {
-  const maybeResolver: unknown = Reflect.get(clearance, "resolveSafehouseCmuxIntegration");
-  /* v8 ignore next 3 @preserve -- Runtime guard for older clearance versions before the cmux helper exists. */
-  if (typeof maybeResolver !== "function") {
-    return undefined;
-  }
-
-  return (): unknown => Reflect.apply(maybeResolver, undefined, []);
-}
-
-function isClearanceSafehouseCmuxIntegration(
-  value: unknown,
-): value is ClearanceSafehouseCmuxIntegration {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const addDirsReadOnly: unknown = Reflect.get(value, "addDirsReadOnly");
-  const claudeCommandPrelude: unknown = Reflect.get(value, "claudeCommandPrelude");
-  const envPass: unknown = Reflect.get(value, "envPass");
-  const unreviewedEnvNames: unknown = Reflect.get(value, "unreviewedEnvNames");
-  return (
-    isStringList(addDirsReadOnly) &&
-    typeof claudeCommandPrelude === "string" &&
-    isStringList(envPass) &&
-    isStringList(unreviewedEnvNames)
-  );
-}
-
-function isStringList(value: unknown): value is readonly string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 interface PreparedAgentLaunch {
@@ -259,7 +201,7 @@ async function alreadyReady(): Promise<void> {
 }
 
 async function ensureSafehouseClearance(signal?: AbortSignal): Promise<void> {
-  await clearance.ensureClearance({
+  await ensureClearance({
     envOverrides: {
       CLEARANCE_ALLOW_HOSTS_FILES: clearanceAllowHostsFilesFromEnvironment(),
     },

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -342,6 +342,51 @@ describe(buildLaunchCommand, () => {
     expect(out).not.toContain("--enable=all-agents");
   });
 
+  it("can grant a workspace shim integration to the Safehouse agent without stripping PATH", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        definition: { cmd: "claude --permission-mode auto", color: "#fff" },
+        prepareWorktreeCommand: "npm ci",
+        safehouseAgentIntegration: {
+          addDirsReadOnly: ["/Applications/cmux.app", "/Users/dev/.local/state/cmux"],
+          envPass: [
+            "CMUX_SURFACE_ID",
+            "CMUX_SOCKET_PATH",
+            "CMUX_CLAUDE_WRAPPER_SHIM",
+            "CMUX_CLAUDE_WRAPPER_SHIM_ROOT",
+            "CMUX_CUSTOM_CLAUDE_PATH",
+          ],
+          commandPreludes: ["export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude"],
+        },
+      }),
+    );
+
+    const prepareWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
+    const readOnlyGrantIndex = out.indexOf(
+      "--add-dirs-ro='/Applications/cmux.app:/Users/dev/.local/state/cmux'",
+    );
+    const envPassIndex = out.indexOf(
+      "--env-pass=CMUX_SURFACE_ID,CMUX_SOCKET_PATH,CMUX_CLAUDE_WRAPPER_SHIM,CMUX_CLAUDE_WRAPPER_SHIM_ROOT,CMUX_CUSTOM_CLAUDE_PATH",
+    );
+    const shimSetupIndex = out.indexOf("_safehouse_shim_dir=", prepareWrapIndex);
+    const preludeIndex = out.indexOf("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
+    const execIndex = out.indexOf('exec claude --permission-mode auto "$@"');
+    expect(prepareWrapIndex).toBeGreaterThan(-1);
+    expect(readOnlyGrantIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(readOnlyGrantIndex).toBeLessThan(agentWrapIndex);
+    expect(envPassIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(envPassIndex).toBeLessThan(agentWrapIndex);
+    expect(preludeIndex).toBeGreaterThan(agentWrapIndex);
+    expect(execIndex).toBeGreaterThan(preludeIndex);
+    expect(shimSetupIndex).toBeGreaterThan(prepareWrapIndex);
+    const prepareWrap = out.slice(prepareWrapIndex, shimSetupIndex);
+    expect(prepareWrap).not.toContain("--add-dirs-ro");
+    expect(prepareWrap).not.toContain("CMUX_SURFACE_ID");
+    expect(prepareWrap).not.toContain("CMUX_SOCKET_PATH");
+    expect(out).not.toContain("_groundcrew_path_without_cmux");
+  });
+
   it("infers the Safehouse profile command from an absolute agent path", () => {
     const out = buildLaunchCommand(
       arguments_({

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -352,6 +352,12 @@ function envPassFlag(names: readonly string[]): string {
   return uniqueNames.length === 0 ? "" : `--env-pass=${uniqueNames.join(",")} `;
 }
 
+export interface SafehouseAgentIntegration {
+  addDirsReadOnly: readonly string[];
+  envPass: readonly string[];
+  commandPreludes: readonly string[];
+}
+
 interface LaunchCommandArguments {
   definition: AgentDefinition;
   promptFile: string;
@@ -423,6 +429,13 @@ interface LaunchCommandArguments {
    * pre-existing behavior). Only consumed by the safehouse wrap.
    */
   safehouseAddDirs?: readonly string[] | undefined;
+  /**
+   * Extra host-terminal integration surface granted only to the Safehouse agent
+   * wrap. The agent may need to execute host shims and reach their sockets
+   * while repo-controlled prepareWorktree hooks should not inherit those paths
+   * or env vars.
+   */
+  safehouseAgentIntegration?: SafehouseAgentIntegration | undefined;
   /**
    * Groundcrew-managed task metadata exposed to the launched worker. Forwarded
    * to the agent process, not the prepareWorktree hook.
@@ -558,7 +571,13 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  const { agentCommand, prepareWorktreeCommand } = renderPrepareAndAgentCommand(arguments_);
+  const { agentCommand: rawAgentCommand, prepareWorktreeCommand } =
+    renderPrepareAndAgentCommand(arguments_);
+  const { safehouseAgentIntegration } = arguments_;
+  const agentCommand = [
+    ...(safehouseAgentIntegration?.commandPreludes ?? []),
+    rawAgentCommand,
+  ].join("; ");
 
   // Split --env-pass per wrap: the prepareWorktree wrap only needs build secrets (so
   // `npm install` etc. can authenticate); the agent wrap only needs the
@@ -571,15 +590,21 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   const agentEnvPassFlag = envPassFlag([
     ...(arguments_.definition.preLaunchEnv ?? []),
     ...workerEnvironmentNames(arguments_.workerEnvironment),
+    ...(safehouseAgentIntegration?.envPass ?? []),
   ]);
   // safehouse reads colon-separated paths from `--add-dirs`; both wraps get the
   // same grant so the prepareWorktree hook and the agent can each reach git.
   // Quote the whole value so shell-special chars survive; the trailing space
   // separates it from the next argv token. See `resolveSafehouseAddDirs` for
   // which paths these are and why.
-  const addDirs = arguments_.safehouseAddDirs ?? [];
-  const safehouseAddDirsFlag =
-    addDirs.length === 0 ? "" : `--add-dirs=${shellSingleQuote(addDirs.join(":"))} `;
+  const safehouseAddDirsFlag = safehousePathListFlag(
+    "--add-dirs",
+    arguments_.safehouseAddDirs ?? [],
+  );
+  const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
+    "--add-dirs-ro",
+    safehouseAgentIntegration?.addDirsReadOnly ?? [],
+  );
   const safehouseWrapper = safehouseClearanceWrapperCommand();
 
   // Defensive shim+promptDir trap: by the time we arm it, `rm -rf <promptDir>`
@@ -620,9 +645,16 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     // Running the real launch chain as `sh -c` would make it see `sh`, so use
     // an agent-named symlink to /bin/sh. This preserves per-agent profile
     // selection without enabling every agent profile.
-    `{ ${safehouseWrapper} ${safehouseAddDirsFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
+    `{ ${safehouseWrapper} ${safehouseAddDirsFlag}${safehouseAgentAddDirsReadOnlyFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
   );
   return lines.join(" && ");
+}
+
+function safehousePathListFlag(
+  flagName: "--add-dirs" | "--add-dirs-ro",
+  paths: readonly string[],
+): string {
+  return paths.length === 0 ? "" : `${flagName}=${shellSingleQuote(paths.join(":"))} `;
 }
 
 /**

--- a/src/testHelpers/safehouseCmuxIntegration.ts
+++ b/src/testHelpers/safehouseCmuxIntegration.ts
@@ -1,0 +1,18 @@
+export interface SafehouseCmuxIntegrationFixture {
+  addDirsReadOnly: readonly string[];
+  claudeCommandPrelude: string;
+  envPass: readonly string[];
+  unreviewedEnvNames: readonly string[];
+}
+
+export function safehouseCmuxIntegrationFixture(
+  overrides: Partial<SafehouseCmuxIntegrationFixture> = {},
+): SafehouseCmuxIntegrationFixture {
+  return {
+    addDirsReadOnly: ["/Applications/cmux.app", "/Users/dev/.local/state/cmux"],
+    claudeCommandPrelude: "export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude",
+    envPass: ["CMUX_SURFACE_ID", "CMUX_SOCKET_PATH"],
+    unreviewedEnvNames: [],
+    ...overrides,
+  };
+}

--- a/src/testHelpers/safehouseCmuxIntegration.ts
+++ b/src/testHelpers/safehouseCmuxIntegration.ts
@@ -1,17 +1,13 @@
-export interface SafehouseCmuxIntegrationFixture {
-  addDirsReadOnly: readonly string[];
-  claudeCommandPrelude: string;
-  envPass: readonly string[];
-  unreviewedEnvNames: readonly string[];
-}
+import type { SafehouseCmuxIntegration } from "@clipboard-health/clearance";
 
 export function safehouseCmuxIntegrationFixture(
-  overrides: Partial<SafehouseCmuxIntegrationFixture> = {},
-): SafehouseCmuxIntegrationFixture {
+  overrides: Partial<SafehouseCmuxIntegration> = {},
+): SafehouseCmuxIntegration {
   return {
     addDirsReadOnly: ["/Applications/cmux.app", "/Users/dev/.local/state/cmux"],
     claudeCommandPrelude: "export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude",
     envPass: ["CMUX_SURFACE_ID", "CMUX_SOCKET_PATH"],
+    isActive: true,
     unreviewedEnvNames: [],
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Refactors cmux Safehouse agent launch to consume `@clipboard-health/clearance`'s published cmux integration helper instead of carrying Groundcrew-local cmux env/prelude/read-dir logic.

Groundcrew now depends on `@clipboard-health/clearance@1.3.2`. It still renders the operator-facing drift warning during cmux-hosted Claude launches when clearance reports unreviewed cmux wrapper env names, but clearance owns the warning text, drift detector, and reviewed env contract.

This preserves cmux's Claude shim functionality while keeping cmux-specific Safehouse knowledge out of Groundcrew's multiplexer plumbing.

## Validation

- `mise exec node@24.14.1 -- npm run build`
- `mise exec node@24.14.1 -- npm run lint`
- `mise exec node@24.14.1 -- npm run format:check`
- `mise exec node@24.14.1 -- npm test` (rerun after one transient V8 branch-coverage miss; passed at 100%)
- `mise exec node@24.14.1 -- npm run verify`
- `mise exec node@24.14.1 -- git push origin HEAD` pre-push hook: `node --run hook:pre-push` / `node --run verify`

## Notes

Consumes the published clearance change from https://github.com/ClipboardHealth/core-utils/pull/726.

Agent session: `codex resume 019ebc6f-d284-7530-9995-e0b5190b7e45`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>