### PR TITLE
fix: include config path in validation errors

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -85,6 +85,19 @@ describe("loadConfig", () => {
     await expect(loadConfig()).rejects.toThrow(/disabled: true` is no longer supported/);
   });
 
+  it("includes the config filepath in migration errors", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({ workspace: VALID_WORKSPACE(temporary) }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(`groundcrew config: ${configPath}:`);
+    await expect(loadConfig()).rejects.toThrow(/configuration migration required/);
+  });
+
   it("loads an explicit built-in agent and applies defaults", async () => {
     const configPath = writeConfigFile(
       temporary,
@@ -1441,6 +1454,25 @@ describe("loadConfig", () => {
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(/workspace must be an object/);
+  });
+
+  it("does not rewrite unexpected loader errors as config validation errors", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        "  get workspace() {",
+        '    throw new Error("workspace getter exploded");',
+        "  },",
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow("workspace getter exploded");
+    await expect(loadConfig()).rejects.not.toThrow(configPath);
   });
 
   it("fails when knownRepositories is not an array", async () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -459,13 +459,28 @@ const PROMPT_PLACEHOLDER_RE = /{{[^{}]*}}/g;
 
 const PERCENT_MIN_EXCLUSIVE = 0;
 const PERCENT_MAX = 100;
+const CONFIG_ERROR_PREFIX = "groundcrew config: ";
 
 function defaultLogFile(): string {
   return xdgStatePath("groundcrew", "groundcrew.log");
 }
 
 function fail(message: string): never {
-  throw new Error(`groundcrew config: ${message}`);
+  throw new Error(`${CONFIG_ERROR_PREFIX}${message}`);
+}
+
+interface ConfigErrorContext {
+  error: unknown;
+  filepath: string;
+}
+
+function rethrowWithConfigPath({ error, filepath }: ConfigErrorContext): never {
+  if (error instanceof Error && error.message.startsWith(CONFIG_ERROR_PREFIX)) {
+    const message = error.message.slice(CONFIG_ERROR_PREFIX.length);
+    throw new Error(`${CONFIG_ERROR_PREFIX}${filepath}: ${message}`, { cause: error });
+  }
+
+  throw error;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -1297,10 +1312,14 @@ export async function loadConfigWithSource(): Promise<Readonly<LoadedConfig>> {
   }
   debug(`Loaded config from ${filepath}`);
 
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- runtime fields are validated by applyDefaults/validate
-  const resolved = applyDefaults(userConfig as unknown as Config, path.dirname(filepath));
-
-  validate(resolved);
+  let resolved: ResolvedConfig;
+  try {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- runtime fields are validated by applyDefaults/validate
+    resolved = applyDefaults(userConfig as unknown as Config, path.dirname(filepath));
+    validate(resolved);
+  } catch (error) {
+    rethrowWithConfigPath({ error, filepath });
+  }
 
   setLogFile(resolved.logging.file);
 


### PR DESCRIPTION
## Summary

Config migration and validation failures now include the resolved config filepath once the loader has discovered the file. This makes errors like the required agents migration point users to the config they need to edit while leaving unexpected loader errors unchanged.

## Validation

- `npx vitest run src/lib/config.test.ts`
- `node --run verify`
- Pre-push hook reran `node --run verify` successfully during `git push`.

Agent session: `codex resume 019ebd16-937a-7663-ab2a-993f5017588e`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>