### PR TITLE
fix: omit unsupported task completion command

### DIFF
--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -40,10 +40,11 @@ completed no-PR work. If omitted, groundcrew treats done advancement as
 unsupported and leaves the task for the source's own integration to close out.
 `${id}`, `${canonicalId}`, and `${name}` placeholders are shell-quoted before substitution.
 
-Workers receive `GROUNDCREW_TASK_ID` and `GROUNDCREW_COMPLETE` in their launch
-environment. The default prompt tells them to run `GROUNDCREW_COMPLETE` only
-when the requested work is complete, no PR is needed, and any dirty worktree
-state is expected or explicitly allowed.
+Workers receive `GROUNDCREW_TASK_ID` in their launch environment. They receive
+`GROUNDCREW_COMPLETE` only when the source supports done writeback. The default
+prompt tells them to run `GROUNDCREW_COMPLETE` only when it is set, the
+requested work is complete, no PR is needed, and any dirty worktree state is
+expected or explicitly allowed.
 
 ```json
 [

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -8,8 +8,10 @@
  */
 
 import type { Board } from "../lib/board.ts";
+import { sourcesFromConfig } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
 import { dispatchableRepository, formatKnownRepositories } from "../lib/repositoryValidation.ts";
+import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
 import {
   type BoardState,
   type GroundcrewIssue,
@@ -86,6 +88,7 @@ function logMissingRepositorySkip(
 
 export function createDispatcher(deps: DispatcherDeps): Dispatcher {
   const { config, board } = deps;
+  const rawSources = sourcesFromConfig(config);
 
   function buildExhaustedSet(usage: UsageByAgent): Set<string> {
     const exhausted = new Set<string>();
@@ -130,6 +133,10 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
           repository: issue.repository,
           task: taskId,
           completionTaskId: issue.id,
+          completionMarkDoneSupported: sourceSupportsMarkDone({
+            rawSources,
+            sourceName: issue.source,
+          }),
           agent: issue.agent,
           details: {
             title: issue.title,

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -296,26 +296,50 @@ describe(resumeWorkspace, () => {
     );
   });
 
-  it("uses the recorded canonical completion task id for worker self-completion env", async () => {
+  it("omits worker self-completion command when the recorded source cannot mark done", async () => {
     readRunStateMock.mockReturnValue(makeRunState({ completionTaskId: "linear:team-1" }));
 
     await resumeWorkspace(config, { task: "team-1" });
 
     const launchScript = stagedLaunchScript();
     expect(launchScript).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
-    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done linear:team-1'");
+    expect(launchScript).not.toContain("GROUNDCREW_COMPLETE");
     expect(lastRecordedRunState().completionTaskId).toBe("linear:team-1");
   });
 
-  it("uses the task id for worker self-completion env when old state lacks a completion task id", async () => {
+  it("omits worker self-completion command for old state when the only source cannot mark done", async () => {
     readRunStateMock.mockReturnValue(makeRunState());
 
     await resumeWorkspace(config, { task: "team-1" });
 
     const launchScript = stagedLaunchScript();
     expect(launchScript).toContain("export GROUNDCREW_TASK_ID='team-1'");
-    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done team-1'");
+    expect(launchScript).not.toContain("GROUNDCREW_COMPLETE");
     expect(lastRecordedRunState().completionTaskId).toBe("team-1");
+  });
+
+  it("sets worker self-completion command when the recorded source can mark done", async () => {
+    const todoConfig: ResolvedConfig = {
+      ...config,
+      sources: [
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "todo.txt",
+          tasksDir: ".tasks",
+          idPrefix: "GC",
+          timezone: "UTC",
+        },
+      ],
+    };
+    readRunStateMock.mockReturnValue(makeRunState({ completionTaskId: "todo:sweep-1" }));
+
+    await resumeWorkspace(todoConfig, { task: "team-1" });
+
+    const launchScript = stagedLaunchScript();
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='todo:sweep-1'");
+    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done todo:sweep-1'");
+    expect(lastRecordedRunState().completionTaskId).toBe("todo:sweep-1");
   });
 
   it("falls back to the task id when Linear detail lookup fails during state resume", async () => {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -318,6 +318,43 @@ describe(resumeWorkspace, () => {
     expect(lastRecordedRunState().completionTaskId).toBe("team-1");
   });
 
+  it("omits worker self-completion command for old state when no source can be inferred", async () => {
+    const noSourceConfig: ResolvedConfig = { ...config, sources: [] };
+    readRunStateMock.mockReturnValue(makeRunState());
+
+    await resumeWorkspace(noSourceConfig, { task: "team-1" });
+
+    const launchScript = stagedLaunchScript();
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='team-1'");
+    expect(launchScript).not.toContain("GROUNDCREW_COMPLETE");
+    expect(lastRecordedRunState().completionTaskId).toBe("team-1");
+  });
+
+  it("omits worker self-completion command for old state when multiple sources are possible", async () => {
+    const multiSourceConfig: ResolvedConfig = {
+      ...config,
+      sources: [
+        { kind: "linear" },
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "todo.txt",
+          tasksDir: ".tasks",
+          idPrefix: "GC",
+          timezone: "UTC",
+        },
+      ],
+    };
+    readRunStateMock.mockReturnValue(makeRunState());
+
+    await resumeWorkspace(multiSourceConfig, { task: "team-1" });
+
+    const launchScript = stagedLaunchScript();
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='team-1'");
+    expect(launchScript).not.toContain("GROUNDCREW_COMPLETE");
+    expect(lastRecordedRunState().completionTaskId).toBe("team-1");
+  });
+
   it("sets worker self-completion command when the recorded source can mark done", async () => {
     const todoConfig: ResolvedConfig = {
       ...config,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,10 +1,11 @@
 import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
-import { isLinearEnabled } from "../lib/buildSources.ts";
+import { isLinearEnabled, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
+import { taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
 import {
   removeStagedPrompt,
   stageBuildSecrets,
@@ -33,6 +34,7 @@ interface ResumeContext {
   title: string;
   description: string;
   completionTaskId: string;
+  completionMarkDoneSupported: boolean;
   reason?: string;
   resumeCount: number;
 }
@@ -64,6 +66,7 @@ async function contextFromLinear(
   worktree: WorktreeEntry,
 ): Promise<ResumeContext> {
   const resolved = await fetchResolvedIssue({ client: getLinearClient(), config, task });
+  const completionTaskId = toCanonicalId("linear", task);
   return {
     task,
     repository: resolved.repository,
@@ -71,7 +74,11 @@ async function contextFromLinear(
     worktree,
     title: resolved.title,
     description: resolved.description,
-    completionTaskId: toCanonicalId("linear", task),
+    completionTaskId,
+    completionMarkDoneSupported: taskSupportsCompletionCommand({
+      rawSources: sourcesFromConfig(config),
+      taskId: completionTaskId,
+    }),
     resumeCount: 0,
   };
 }
@@ -86,6 +93,7 @@ async function contextFromState(
   // missing-API-key error logs noisily even though resume only needs it to
   // enrich the prompt title/description (which falls back to the task id).
   const details = isLinearEnabled(config) ? await fetchTaskDetails(task) : undefined;
+  const completionTaskId = state.completionTaskId ?? task;
   return {
     task,
     repository: state.repository,
@@ -93,7 +101,11 @@ async function contextFromState(
     worktree,
     title: details?.title ?? task.toUpperCase(),
     description: details?.description ?? "",
-    completionTaskId: state.completionTaskId ?? task,
+    completionTaskId,
+    completionMarkDoneSupported: taskSupportsCompletionCommand({
+      rawSources: sourcesFromConfig(config),
+      taskId: completionTaskId,
+    }),
     ...(state.reason === undefined ? {} : { reason: state.reason }),
     resumeCount: state.resumeCount,
   };
@@ -201,7 +213,10 @@ export async function resumeWorkspace(
       secretsFile,
       sandboxName,
       workspaceKind,
-      workerEnvironment: workerEnvironmentForTask(context.completionTaskId),
+      workerEnvironment: workerEnvironmentForTask({
+        taskId: context.completionTaskId,
+        markDoneSupported: context.completionMarkDoneSupported,
+      }),
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -7,7 +7,7 @@ import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { recordRunState } from "../lib/runState.ts";
-import { canonicalLinearIssue } from "../lib/testing/canonicalFixtures.ts";
+import { canonicalLinearIssue, canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { createBoard, type Board } from "../lib/board.ts";
 import type * as boardModule from "../lib/board.ts";
 import { buildSources } from "../lib/buildSources.ts";
@@ -1898,13 +1898,48 @@ describe(setupWorkspaceCli, () => {
     );
   });
 
-  it("sets worker self-completion env from the resolved canonical task id", async () => {
+  it("omits worker self-completion command when the resolved source cannot mark done", async () => {
     await setupWorkspaceCli("team-1");
 
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(launchScript).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
-    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done linear:team-1'");
+    expect(launchScript).not.toContain("GROUNDCREW_COMPLETE");
     expect(lastRecordedRunState().completionTaskId).toBe("linear:team-1");
+  });
+
+  it("sets worker self-completion command when the resolved source can mark done", async () => {
+    loadConfigMock.mockResolvedValueOnce({
+      ...makeConfig(),
+      sources: [
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "todo.txt",
+          tasksDir: ".tasks",
+          idPrefix: "GC",
+          timezone: "UTC",
+        },
+      ],
+    });
+    createBoardMock.mockReturnValueOnce(
+      fakeBoard(
+        canonicalShellIssue({
+          naturalId: "sweep-1",
+          sourceName: "todo",
+          repository: "repo-a",
+          agent: "claude",
+          title: "Title",
+          description: "Body",
+        }),
+      ),
+    );
+
+    await setupWorkspaceCli("todo:sweep-1");
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(launchScript).toContain("export GROUNDCREW_TASK_ID='todo:sweep-1'");
+    expect(launchScript).toContain("export GROUNDCREW_COMPLETE='crew task done todo:sweep-1'");
+    expect(lastRecordedRunState().completionTaskId).toBe("todo:sweep-1");
   });
 
   it("passes title and description from the resolved issue as details", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -6,6 +6,7 @@ import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
+import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
 import {
   stageBuildSecrets,
   stagePromptFromTemplate,
@@ -33,6 +34,8 @@ export interface SetupWorkspaceOptions {
   task: string;
   /** Canonical source id for worker self-completion; falls back to `task`. */
   completionTaskId?: string;
+  /** Whether the task source can apply `crew task done`; defaults to true for direct calls. */
+  completionMarkDoneSupported?: boolean;
   repository: string;
   agent: string;
   details: TaskDetails;
@@ -130,6 +133,7 @@ export async function setupWorkspace(
     const secretsFile =
       prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
     const completionTaskId = options.completionTaskId ?? task;
+    const completionMarkDoneSupported = options.completionMarkDoneSupported ?? true;
     const { launchCommand, srtSettingsDir: stagedSrtSettingsDir } = composeAgentLaunch({
       runner,
       task,
@@ -141,7 +145,10 @@ export async function setupWorkspace(
       prepareWorktreeCommand,
       sandboxName,
       workspaceKind,
-      workerEnvironment: workerEnvironmentForTask(completionTaskId),
+      workerEnvironment: workerEnvironmentForTask({
+        taskId: completionTaskId,
+        markDoneSupported: completionMarkDoneSupported,
+      }),
     });
     srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);
@@ -343,9 +350,10 @@ export async function setupWorkspaceCli(
   options: { dryRun?: boolean } = {},
 ): Promise<void> {
   const config = await loadConfig();
+  const rawSources = sourcesFromConfig(config);
   let sources;
   try {
-    sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+    sources = await buildSources(rawSources, { globalConfig: config });
   } catch (error) {
     /* v8 ignore next @preserve -- catch re-throw always receives an Error; String(error) is an unreachable fallback */
     const message = error instanceof Error ? error.message : String(error);
@@ -377,6 +385,10 @@ export async function setupWorkspaceCli(
   await setupWorkspace(config, {
     task: naturalId,
     completionTaskId: resolved.id,
+    completionMarkDoneSupported: sourceSupportsMarkDone({
+      rawSources,
+      sourceName: resolved.source,
+    }),
     repository: resolved.repository,
     agent: resolved.agent,
     details: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -445,7 +445,7 @@ const DEFAULT_PROMPT_INITIAL = [
   "2. Implement the smallest sensible change that completes the task.",
   "3. Run the repo's documented verification command. If no documented command exists, run the smallest relevant test suite you can find and fix failures you introduced before continuing.",
   "4. Follow the task description for output. If no output instructions exist, open a PR with `Closes {{task}}` in the description. If you cannot open one, leave the branch ready and record the blocker.",
-  "5. If the requested work is complete, no PR is needed, and any dirty worktree state is expected or explicitly allowed, run the command in `GROUNDCREW_COMPLETE` to mark the task done.",
+  "5. If the requested work is complete, no PR is needed, `GROUNDCREW_COMPLETE` is set, and any dirty worktree state is expected or explicitly allowed, run the command in `GROUNDCREW_COMPLETE` to mark the task done.",
 ].join("\n");
 
 const ALLOWED_PROMPT_PLACEHOLDERS = new Set([

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -16,6 +16,10 @@ const WORKER_ENVIRONMENT = {
   GROUNDCREW_COMPLETE: "crew task done todo:gc-1",
 } as const;
 
+const WORKER_ENVIRONMENT_WITHOUT_COMPLETION = {
+  GROUNDCREW_TASK_ID: "linear:team-1",
+} as const;
+
 function arguments_(
   overrides: Partial<Parameters<typeof buildLaunchCommand>[0]> = {},
 ): Parameters<typeof buildLaunchCommand>[0] {
@@ -228,6 +232,20 @@ describe(`${buildLaunchCommand.name} (runner='srt')`, () => {
     expect(afterPrepare).toContain(`GROUNDCREW_TASK_ID="$GROUNDCREW_TASK_ID"`);
     expect(afterPrepare).toContain(`GROUNDCREW_COMPLETE="$GROUNDCREW_COMPLETE"`);
     expect(prepareSegment).not.toContain("GROUNDCREW_COMPLETE");
+  });
+
+  it("omits the completion command when the task source cannot mark done", () => {
+    const out = buildLaunchCommand(
+      srtArguments({
+        prepareWorktreeCommand: "npm ci",
+        workerEnvironment: WORKER_ENVIRONMENT_WITHOUT_COMPLETION,
+      }),
+    );
+
+    const afterPrepare = out.slice(out.indexOf("npm ci"));
+    expect(out).toContain("export GROUNDCREW_TASK_ID='linear:team-1'");
+    expect(out).not.toContain("GROUNDCREW_COMPLETE");
+    expect(afterPrepare).toContain(`GROUNDCREW_TASK_ID="$GROUNDCREW_TASK_ID"`);
   });
 
   it("omits the config-home env for read-only agents (claude) that don't relocate", () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -323,28 +323,43 @@ const WORKER_ENVIRONMENT_NAMES = ["GROUNDCREW_TASK_ID", "GROUNDCREW_COMPLETE"] a
 
 type WorkerEnvironmentName = (typeof WORKER_ENVIRONMENT_NAMES)[number];
 
-export type WorkerEnvironment = Readonly<Record<WorkerEnvironmentName, string>>;
+export type WorkerEnvironment = Readonly<{
+  GROUNDCREW_TASK_ID: string;
+  GROUNDCREW_COMPLETE?: string;
+}>;
 
-export function workerEnvironmentForTask(taskId: string): WorkerEnvironment {
+export function workerEnvironmentForTask(arguments_: {
+  taskId: string;
+  markDoneSupported: boolean;
+}): WorkerEnvironment {
+  const { taskId, markDoneSupported } = arguments_;
   return {
     GROUNDCREW_TASK_ID: taskId,
-    GROUNDCREW_COMPLETE: `crew task done ${taskId}`,
+    ...(markDoneSupported ? { GROUNDCREW_COMPLETE: `crew task done ${taskId}` } : {}),
   };
 }
 
 function workerEnvironmentNames(
   workerEnvironment: WorkerEnvironment | undefined,
 ): readonly WorkerEnvironmentName[] {
-  return workerEnvironment === undefined ? [] : WORKER_ENVIRONMENT_NAMES;
+  if (workerEnvironment === undefined) {
+    return [];
+  }
+  return WORKER_ENVIRONMENT_NAMES.filter((name) => workerEnvironment[name] !== undefined);
 }
 
 function workerEnvironmentExports(workerEnvironment: WorkerEnvironment | undefined): string[] {
   if (workerEnvironment === undefined) {
     return [];
   }
-  return WORKER_ENVIRONMENT_NAMES.map(
-    (name) => `export ${name}=${shellSingleQuote(workerEnvironment[name])}`,
-  );
+  const exports: string[] = [];
+  for (const name of WORKER_ENVIRONMENT_NAMES) {
+    const value = workerEnvironment[name];
+    if (value !== undefined) {
+      exports.push(`export ${name}=${shellSingleQuote(value)}`);
+    }
+  }
+  return exports;
 }
 
 function envPassFlag(names: readonly string[]): string {

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -1,4 +1,4 @@
-import { sourceSupportsMarkDone } from "./sourceCapabilities.ts";
+import { sourceSupportsMarkDone, taskSupportsCompletionCommand } from "./sourceCapabilities.ts";
 
 describe(sourceSupportsMarkDone, () => {
   it("continues past non-matching sources before returning the markDone capability", () => {
@@ -17,5 +17,24 @@ describe(sourceSupportsMarkDone, () => {
     const actual = sourceSupportsMarkDone({ rawSources, sourceName: "todo" });
 
     expect(actual).toBe(true);
+  });
+});
+
+describe(taskSupportsCompletionCommand, () => {
+  it("returns false for unprefixed task ids when the source is ambiguous", () => {
+    const rawSources = [
+      { kind: "linear" },
+      {
+        kind: "todo-txt",
+        name: "todo",
+        todoPath: "todo.txt",
+        tasksDir: ".tasks",
+        idPrefix: "GC",
+        timezone: "UTC",
+      },
+    ];
+
+    expect(taskSupportsCompletionCommand({ rawSources: [], taskId: "team-1" })).toBe(false);
+    expect(taskSupportsCompletionCommand({ rawSources, taskId: "team-1" })).toBe(false);
   });
 });

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -1,0 +1,21 @@
+import { sourceSupportsMarkDone } from "./sourceCapabilities.ts";
+
+describe(sourceSupportsMarkDone, () => {
+  it("continues past non-matching sources before returning the markDone capability", () => {
+    const rawSources = [
+      { kind: "linear" },
+      {
+        kind: "todo-txt",
+        name: "todo",
+        todoPath: "todo.txt",
+        tasksDir: ".tasks",
+        idPrefix: "GC",
+        timezone: "UTC",
+      },
+    ];
+
+    const actual = sourceSupportsMarkDone({ rawSources, sourceName: "todo" });
+
+    expect(actual).toBe(true);
+  });
+});

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { shellAdapterConfigSchema } from "./adapters/shell/schema.ts";
-import { kindShape } from "./buildSources.ts";
 
 interface SourceCapabilities {
   verify: boolean;
@@ -21,6 +20,7 @@ export interface SourceSummary {
 }
 
 const nameShape = z.looseObject({ name: z.string().optional() });
+const kindShape = z.object({ kind: z.string() });
 
 const LINEAR_CAPABILITIES: SourceCapabilities = {
   verify: true,
@@ -87,4 +87,37 @@ export function summarizeSource(raw: unknown): SourceSummary {
   }
 
   return { name: sourceName, kind, capabilities };
+}
+
+export function sourceSupportsMarkDone(arguments_: {
+  rawSources: readonly unknown[];
+  sourceName: string;
+}): boolean {
+  const { rawSources, sourceName } = arguments_;
+  for (const rawSource of rawSources) {
+    const source = summarizeSource(rawSource);
+    if (source.name === sourceName) {
+      return source.capabilities.markDone;
+    }
+  }
+  return false;
+}
+
+export function taskSupportsCompletionCommand(arguments_: {
+  rawSources: readonly unknown[];
+  taskId: string;
+}): boolean {
+  const { rawSources, taskId } = arguments_;
+  const colonIndex = taskId.indexOf(":");
+  if (colonIndex === -1) {
+    const [singleSource] = rawSources;
+    if (rawSources.length === 1 && singleSource !== undefined) {
+      return summarizeSource(singleSource).capabilities.markDone;
+    }
+    return true;
+  }
+  return sourceSupportsMarkDone({
+    rawSources,
+    sourceName: taskId.slice(0, colonIndex),
+  });
 }

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -114,7 +114,7 @@ export function taskSupportsCompletionCommand(arguments_: {
     if (rawSources.length === 1 && singleSource !== undefined) {
       return summarizeSource(singleSource).capabilities.markDone;
     }
-    return true;
+    return false;
   }
   return sourceSupportsMarkDone({
     rawSources,


### PR DESCRIPTION
## Summary

- Only exports `GROUNDCREW_COMPLETE` when the resolved task source supports done writeback, so Linear workers keep `GROUNDCREW_TASK_ID` but are not prompted to run a command that cannot complete the task.
- Threads source markDone capabilities through dispatch, setup, and resume launches, including old run state with a single configured source.
- Updates the default prompt and task-source docs to treat `GROUNDCREW_COMPLETE` as conditional.

## Validation

- `node --run verify`
- Pre-push hook: `node --run verify`

## Notes

Agent session: `codex resume 019ec121-e00a-7f21-b1f4-43eac44eb43c`

<sub><code>cb-ship:created v1 core@3.8.0</code></sub>