### PR TITLE
fix: grant todo task source paths to sandboxed agents

### DIFF
--- a/config/markdownlint-cli2.jsonc
+++ b/config/markdownlint-cli2.jsonc
@@ -19,5 +19,5 @@
   },
   "gitignore": true,
   "globs": ["**/*.{md,mdx}"],
-  "ignores": [".agents/**"],
+  "ignores": [".agents/**", ".worktrees/**"],
 }

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -425,6 +425,29 @@ describe(resumeWorkspace, () => {
     expect(launchScript).not.toContain("safehouse-clearance");
   });
 
+  it("does not add task source sandbox grants for unsandboxed resume runners", async () => {
+    const noneConfig: ResolvedConfig = {
+      ...makeConfig(),
+      local: { runner: "none" },
+      sources: [
+        { kind: "linear" },
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "/Users/dev/v/todo.md",
+          tasksDir: "/Users/dev/v/.tasks",
+          idPrefix: "GC",
+          timezone: "UTC",
+        },
+      ],
+    };
+    readRunStateMock.mockReturnValue(makeRunState({ completionTaskId: "todo:gc-1" }));
+
+    await resumeWorkspace(noneConfig, { task: "team-1" });
+
+    expect(stagedLaunchScript()).not.toContain("/Users/dev/v");
+  });
+
   it("cds into the configured workdir subproject on resume", async () => {
     const cfg = makeConfig();
     cfg.workspace.repositories = [

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -11,6 +11,7 @@ import {
   stagePromptText,
   stageWorkspaceLaunchCommand,
 } from "../lib/stagedLaunch.ts";
+import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
 import { naturalIdFromCanonical, toCanonicalId } from "../lib/taskSource.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
@@ -191,6 +192,14 @@ export async function resumeWorkspace(
   let srtSettingsDir: string | undefined;
   try {
     let launchCommand: string;
+    const taskSourceWritePaths =
+      runner === "safehouse" || runner === "srt"
+        ? taskSourceWritePathsForCompletion({
+            config,
+            taskId: context.completionTaskId,
+            workingDir: launchDir,
+          })
+        : undefined;
     ({ launchCommand, srtSettingsDir } = composeAgentLaunch({
       runner,
       task,
@@ -202,6 +211,7 @@ export async function resumeWorkspace(
       sandboxName,
       workspaceKind,
       workerEnvironment: workerEnvironmentForTask(context.completionTaskId),
+      taskSourceWritePaths,
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -456,6 +456,36 @@ describe(setupWorkspace, () => {
     });
   });
 
+  it("grants matching todo-txt source paths to the worker completion sandbox", async () => {
+    const config: ResolvedConfig = {
+      ...makeConfig(),
+      sources: [
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "/Users/dev/v/todo.md",
+          tasksDir: "/Users/dev/v/.tasks",
+          idPrefix: "GC",
+          timezone: "UTC",
+        },
+      ],
+    };
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      task: "team-1",
+      completionTaskId: "todo:gc-1",
+      repository: "repo-a",
+      agent: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(launchScript).toContain(
+      "--add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/.git:/Users/dev/v:/Users/dev/v/.tasks'",
+    );
+  });
+
   it("records the task url even on the failed-to-launch rollback path", async () => {
     const config = makeConfig();
     mockCmuxFailure();

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -12,6 +12,7 @@ import {
   stageWorkspaceLaunchCommand,
   type StagedPrompt,
 } from "../lib/stagedLaunch.ts";
+import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
 import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
@@ -130,6 +131,14 @@ export async function setupWorkspace(
     const secretsFile =
       prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
     const completionTaskId = options.completionTaskId ?? task;
+    const taskSourceWritePaths =
+      runner === "safehouse" || runner === "srt"
+        ? taskSourceWritePathsForCompletion({
+            config,
+            taskId: completionTaskId,
+            workingDir: launchDir,
+          })
+        : undefined;
     const { launchCommand, srtSettingsDir: stagedSrtSettingsDir } = composeAgentLaunch({
       runner,
       task,
@@ -142,6 +151,7 @@ export async function setupWorkspace(
       sandboxName,
       workspaceKind,
       workerEnvironment: workerEnvironmentForTask(completionTaskId),
+      taskSourceWritePaths,
     });
     srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);

--- a/src/lib/adapters/todo-txt/fileErrors.test.ts
+++ b/src/lib/adapters/todo-txt/fileErrors.test.ts
@@ -1,0 +1,22 @@
+import { describeFileError, fileErrorCode, isFileErrorCode } from "./fileErrors.ts";
+
+describe("todo-txt file error helpers", () => {
+  it("extracts filesystem error codes", () => {
+    const error = Object.assign(new Error("blocked"), { code: "EPERM" });
+
+    expect(fileErrorCode(error)).toBe("EPERM");
+    expect(isFileErrorCode(error, "EPERM")).toBe(true);
+    expect(isFileErrorCode(error, "ENOENT")).toBe(false);
+  });
+
+  it("describes filesystem errors with their code", () => {
+    const error = Object.assign(new Error("blocked"), { code: "EPERM" });
+
+    expect(describeFileError(error)).toBe("EPERM: blocked");
+  });
+
+  it("falls back for non-filesystem throws", () => {
+    expect(fileErrorCode("blocked")).toBeUndefined();
+    expect(describeFileError("blocked")).toBe("blocked");
+  });
+});

--- a/src/lib/adapters/todo-txt/fileErrors.ts
+++ b/src/lib/adapters/todo-txt/fileErrors.ts
@@ -1,0 +1,23 @@
+export function fileErrorCode(error: unknown): string | undefined {
+  /* v8 ignore next @preserve -- fs failures are Error objects carrying a string code */
+  if (!(error instanceof Error) || !errorHasCode(error)) {
+    return undefined;
+  }
+  return String(error.code);
+}
+
+export function isFileErrorCode(error: unknown, code: string): boolean {
+  return fileErrorCode(error) === code;
+}
+
+function errorHasCode(error: Error): error is Error & { code: unknown } {
+  return Object.hasOwn(error, "code");
+}
+
+export function describeFileError(error: unknown): string {
+  const code = fileErrorCode(error);
+  /* v8 ignore next @preserve -- callers pass filesystem Error objects; fallback is defensive */
+  const message = error instanceof Error ? error.message : String(error);
+  /* v8 ignore next @preserve -- filesystem Error objects carry a code; fallback is defensive */
+  return code === undefined ? message : `${code}: ${message}`;
+}

--- a/src/lib/adapters/todo-txt/source.test.ts
+++ b/src/lib/adapters/todo-txt/source.test.ts
@@ -921,6 +921,25 @@ describe("TodoTxtTaskSource", () => {
     await expect(source.verify()).rejects.toThrow(/missing todo file/);
   });
 
+  it("verify() reports unreadable todo files separately from missing files", async () => {
+    tmp.writeTodo("(A) Good task id:GC-V1 agent:codex status:in-progress\n");
+    rmSync(tmp.todoPath);
+    mkdirSync(tmp.todoPath);
+    const source = makeSource(tmp);
+
+    await expect(source.verify()).rejects.toThrow(/could not read todo file/);
+    await expect(source.verify()).rejects.toThrow(/EISDIR|EACCES|EPERM/);
+  });
+
+  it("getTask() throws on unreadable todo files instead of treating them as empty", async () => {
+    tmp.writeTodo("(A) Good task id:GC-V1 agent:codex status:in-progress\n");
+    rmSync(tmp.todoPath);
+    mkdirSync(tmp.todoPath);
+    const source = makeSource(tmp);
+
+    await expect(source.getTask("GC-V1")).rejects.toThrow(/could not read todo file/);
+  });
+
   it("verify() catches duplicate id:", async () => {
     tmp.writeTodo("id:DUP agent:codex status:todo Task A\nid:DUP agent:codex status:todo Task B\n");
     tmp.writeTask("DUP", "Prompt.");

--- a/src/lib/adapters/todo-txt/source.ts
+++ b/src/lib/adapters/todo-txt/source.ts
@@ -14,6 +14,7 @@ import {
 } from "../../taskSource.ts";
 import { formatKnownRepositories } from "../../repositoryValidation.ts";
 import { readEnvironmentVariable } from "../../util.ts";
+import { describeFileError, isFileErrorCode } from "./fileErrors.ts";
 import { isActiveForFetch, normalizeToIssue, type TodoTxtSourceRef } from "./normalizer.ts";
 import { DATE_RE, getMetadataFirst, parseAllLines, type ParsedTodoLine } from "./parser.ts";
 import type { TodoTxtAdapterConfig } from "./schema.ts";
@@ -52,8 +53,11 @@ function descriptionFor(parsed: ParsedTodoLine, promptPath: string): string {
 function fileUpdatedAt(filePath: string): string {
   try {
     return new Date(statSync(filePath).mtimeMs).toISOString();
-  } catch {
-    /* v8 ignore next @preserve -- statSync failing means file missing; covered by empty-file tests */
+  } catch (error) {
+    /* v8 ignore next @preserve -- statSync failing with ENOENT means file missing; covered by empty-file tests */
+    if (!isFileErrorCode(error, "ENOENT")) {
+      throw todoFileAccessError("stat", filePath, error);
+    }
     return new Date().toISOString();
   }
 }
@@ -64,12 +68,21 @@ function readAndParseTodo(todoPath: string): {
   let content: string;
   try {
     content = readFileSync(todoPath, "utf8");
-  } catch {
+  } catch (error) {
+    if (!isFileErrorCode(error, "ENOENT")) {
+      throw todoFileAccessError("read", todoPath, error);
+    }
     content = "";
   }
   return {
     parsedAll: parseAllLines(content),
   };
+}
+
+function todoFileAccessError(operation: "read" | "stat", filePath: string, error: unknown): Error {
+  return new Error(
+    `todo-txt: could not ${operation} todo file ${filePath}: ${describeFileError(error)}`,
+  );
 }
 
 function buildIssue(options: {
@@ -315,8 +328,9 @@ function appendTodoLine(todoPath: string, line: string): void {
     const current = readFileSync(todoPath, "utf8");
     separator = current.length === 0 || current.endsWith("\n") ? "" : "\n";
   } catch (error: unknown) {
-    /* v8 ignore else @preserve -- no explicit else branch; full-suite V8 coverage remaps the synthetic else inconsistently. */
-    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+    /* v8 ignore next @preserve -- non-ENOENT append failures are an fs passthrough, not todo-txt logic */
+    if (!isFileErrorCode(error, "ENOENT")) {
+      /* v8 ignore next @preserve -- non-ENOENT append failures are an fs passthrough, not todo-txt logic */
       throw error;
     }
   }

--- a/src/lib/adapters/todo-txt/writeback.ts
+++ b/src/lib/adapters/todo-txt/writeback.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import { describeFileError, fileErrorCode } from "./fileErrors.ts";
 import { DATE_RE, hashLine, parseAllLines, type ParsedTodoLine } from "./parser.ts";
 import { isValidThresholdValue, type TodoTxtSourceRef } from "./normalizer.ts";
 
@@ -446,6 +447,14 @@ export function copyPromptFile(oldPath: string, newPath: string): void {
   }
 }
 
+function todoFileReadError(todoPath: string, error: unknown): string {
+  const code = fileErrorCode(error);
+  if (code === "ENOENT") {
+    return `missing todo file: ${todoPath}`;
+  }
+  return `could not read todo file ${todoPath}: ${describeFileError(error)}`;
+}
+
 function validatePromptFile(
   tasksDir: string,
   id: string,
@@ -563,8 +572,8 @@ export function validateTodoFile(
   let content: string;
   try {
     content = readFileSync(todoPath, "utf8");
-  } catch {
-    return [`missing todo file: ${todoPath}`];
+  } catch (error) {
+    return [todoFileReadError(todoPath, error)];
   }
 
   const parsedAll = parseAllLines(content);

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -112,6 +112,25 @@ describe(composeAgentLaunch, () => {
     expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
   });
 
+  it("adds task source write paths only to the Safehouse agent wrap", () => {
+    const launchCommand = compose({
+      prepareWorktreeCommand: "npm ci",
+      taskSourceWritePaths: ["/Users/dev/v", "/Users/dev/v/.tasks"],
+    });
+
+    const prepareWrapIndex = launchCommand.indexOf("safehouse-clearance' --add-dirs=");
+    const prepareCommandIndex = launchCommand.indexOf("npm ci");
+    const agentWrapIndex = launchCommand.indexOf('"$_safehouse_shim" -c');
+    const prepareWrap = launchCommand.slice(prepareWrapIndex, prepareCommandIndex);
+    const agentWrap = launchCommand.slice(prepareCommandIndex, agentWrapIndex + 200);
+
+    expect(prepareWrap).toContain("--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git'");
+    expect(prepareWrap).not.toContain("/Users/dev/v");
+    expect(agentWrap).toContain(
+      "--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git:/Users/dev/v:/Users/dev/v/.tasks'",
+    );
+  });
+
   it("warns when clearance reports unreviewed cmux Claude wrapper env names", () => {
     safehouseCmuxIntegrationWarningLinesMock.mockReturnValue([
       "groundcrew: clearance-owned warning one",

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -44,6 +44,7 @@ export function composeAgentLaunch(input: {
   sandboxName?: string | undefined;
   workspaceKind: WorkspaceKind;
   workerEnvironment?: WorkerEnvironment | undefined;
+  taskSourceWritePaths?: readonly string[] | undefined;
 }): { launchCommand: string; srtSettingsDir: string | undefined } {
   const staged =
     input.runner === "srt"
@@ -51,6 +52,7 @@ export function composeAgentLaunch(input: {
           task: input.task,
           worktreeDir: input.worktreeDir,
           definition: input.definition,
+          taskSourceWritePaths: input.taskSourceWritePaths,
         })
       : undefined;
   const safehouseAgentIntegration =
@@ -73,6 +75,8 @@ export function composeAgentLaunch(input: {
     workerEnvironment: input.workerEnvironment,
     safehouseAddDirs:
       input.runner === "safehouse" ? resolveSafehouseAddDirs(input.worktreeDir) : undefined,
+    safehouseAgentAddDirs:
+      input.runner === "safehouse" ? (input.taskSourceWritePaths ?? []) : undefined,
     safehouseAgentIntegration,
   });
   return { launchCommand, srtSettingsDir: staged?.directory };

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -430,6 +430,11 @@ interface LaunchCommandArguments {
    */
   safehouseAddDirs?: readonly string[] | undefined;
   /**
+   * Extra read/write paths granted only to the Safehouse agent wrap. These are
+   * intentionally withheld from the repo-controlled prepareWorktree wrap.
+   */
+  safehouseAgentAddDirs?: readonly string[] | undefined;
+  /**
    * Extra host-terminal integration surface granted only to the Safehouse agent
    * wrap. The agent may need to execute host shims and reach their sockets
    * while repo-controlled prepareWorktree hooks should not inherit those paths
@@ -597,10 +602,13 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
   // Quote the whole value so shell-special chars survive; the trailing space
   // separates it from the next argv token. See `resolveSafehouseAddDirs` for
   // which paths these are and why.
-  const safehouseAddDirsFlag = safehousePathListFlag(
-    "--add-dirs",
-    arguments_.safehouseAddDirs ?? [],
-  );
+  const safehousePrepareAddDirs = arguments_.safehouseAddDirs ?? [];
+  const safehouseAgentAddDirs = uniqueStrings([
+    ...safehousePrepareAddDirs,
+    ...(arguments_.safehouseAgentAddDirs ?? []),
+  ]);
+  const safehouseAddDirsFlag = safehousePathListFlag("--add-dirs", safehousePrepareAddDirs);
+  const safehouseAgentAddDirsFlag = safehousePathListFlag("--add-dirs", safehouseAgentAddDirs);
   const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
     "--add-dirs-ro",
     safehouseAgentIntegration?.addDirsReadOnly ?? [],
@@ -645,7 +653,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     // Running the real launch chain as `sh -c` would make it see `sh`, so use
     // an agent-named symlink to /bin/sh. This preserves per-agent profile
     // selection without enabling every agent profile.
-    `{ ${safehouseWrapper} ${safehouseAddDirsFlag}${safehouseAgentAddDirsReadOnlyFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
+    `{ ${safehouseWrapper} ${safehouseAgentAddDirsFlag}${safehouseAgentAddDirsReadOnlyFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh "$_p"; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
   );
   return lines.join(" && ");
 }
@@ -655,6 +663,10 @@ function safehousePathListFlag(
   paths: readonly string[],
 ): string {
   return paths.length === 0 ? "" : `${flagName}=${shellSingleQuote(paths.join(":"))} `;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
 }
 
 /**

--- a/src/lib/srtLaunch.test.ts
+++ b/src/lib/srtLaunch.test.ts
@@ -133,6 +133,24 @@ describe(buildAndStageSrtLaunch, () => {
     expect(reads).not.toContain(path.join(workspaceRoot, "billing", ".git"));
   });
 
+  it("adds task source write paths to the agent settings only", () => {
+    const result = buildAndStageSrtLaunch({
+      task: "team-1",
+      worktreeDir: initWorktree("repo-a-team-1"),
+      definition: definition("claude --permission-mode auto"),
+      homeDir: fakeHome,
+      taskSourceWritePaths: ["/Users/dev/v"],
+    });
+    staged.push(result.directory);
+
+    const agent = readSettings(result.agentFile);
+    const prepare = readSettings(result.prepareFile);
+    expect(agent.filesystem.allowRead).toContain("/Users/dev/v");
+    expect(agent.filesystem.allowWrite).toContain("/Users/dev/v");
+    expect(prepare.filesystem.allowRead).not.toContain("/Users/dev/v");
+    expect(prepare.filesystem.allowWrite).not.toContain("/Users/dev/v");
+  });
+
   it("uses groundcrew's shipped clearance allowlist for network policy when no env files are exported", () => {
     vi.stubEnv("CLEARANCE_ALLOW_HOSTS", "");
     vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");

--- a/src/lib/srtLaunch.ts
+++ b/src/lib/srtLaunch.ts
@@ -69,6 +69,8 @@ export function buildAndStageSrtLaunch(input: {
   task: string;
   worktreeDir: string;
   definition: AgentDefinition;
+  /** Local task-source directories the agent needs for self-completion writeback. */
+  taskSourceWritePaths?: readonly string[] | undefined;
   /** Defaults to `os.homedir()`. Injected in tests to seed from a fixture home. */
   homeDir?: string;
 }): StagedSrtLaunch {
@@ -103,6 +105,7 @@ export function buildAndStageSrtLaunch(input: {
   const agentSettings = buildSrtSettings({
     ...base,
     agent,
+    taskSourceWritePaths: input.taskSourceWritePaths ?? [],
     ...(relocatedConfigDir === undefined ? {} : { relocatedConfigDir }),
   });
   const prepareFile = path.join(directory, "prepare-settings.json");

--- a/src/lib/srtPolicy.test.ts
+++ b/src/lib/srtPolicy.test.ts
@@ -51,6 +51,13 @@ describe(buildSrtSettings, () => {
     expect(actual.filesystem.allowRead).not.toContain("/home/dev/.local");
   });
 
+  it("grants task source write paths for worker self-completion", () => {
+    const actual = buildSrtSettings(input({ taskSourceWritePaths: ["/Users/dev/v"] }));
+
+    expect(actual.filesystem.allowRead).toContain("/Users/dev/v");
+    expect(actual.filesystem.allowWrite).toContain("/Users/dev/v");
+  });
+
   describe("agent state isolation (work item 1)", () => {
     it("gives claude a writable home but denies every fixed-path executable surface (incl .claude.json + chrome)", () => {
       const actual = buildSrtSettings(input({ agent: "claude" }));

--- a/src/lib/srtPolicy.ts
+++ b/src/lib/srtPolicy.ts
@@ -73,6 +73,11 @@ export interface BuildSrtSettingsInput {
    * to the default config dir), so this is omitted for it.
    */
   relocatedConfigDir?: string;
+  /**
+   * Local task-source directories the worker needs for self-completion
+   * writeback, such as a todo-txt file's parent directory and task prompt dir.
+   */
+  taskSourceWritePaths?: readonly string[];
   /** Defaults to `process.platform`. Injected in tests to exercise both deny-read roots. */
   platform?: NodeJS.Platform;
   /** Defaults to `os.homedir()`. Injected in tests. */
@@ -355,6 +360,7 @@ export function buildSrtSettings(input: BuildSrtSettingsInput): SandboxRuntimeCo
     ...profile.readPaths.map(underHome),
     ...keychainRead,
     ...(input.relocatedConfigDir === undefined ? [] : [input.relocatedConfigDir]),
+    ...(input.taskSourceWritePaths ?? []),
   ]);
 
   const allowWrite = unique([
@@ -367,6 +373,7 @@ export function buildSrtSettings(input: BuildSrtSettingsInput): SandboxRuntimeCo
     // The agent's relocated, writable config home (codex). Absent for agents
     // that write their real home behind a deny-list (claude).
     ...(input.relocatedConfigDir === undefined ? [] : [input.relocatedConfigDir]),
+    ...(input.taskSourceWritePaths ?? []),
   ]);
 
   const denyWrite = unique([

--- a/src/lib/taskSourceFilesystem.test.ts
+++ b/src/lib/taskSourceFilesystem.test.ts
@@ -1,0 +1,91 @@
+import { taskSourceWritePathsForCompletion } from "./taskSourceFilesystem.ts";
+import type { TodoTxtAdapterConfig } from "./adapters/todo-txt/schema.ts";
+import type { ResolvedConfig } from "./config.ts";
+
+function configWithSources(sources: ResolvedConfig["sources"]): Pick<ResolvedConfig, "sources"> {
+  return { sources };
+}
+
+function todoSource(overrides: Partial<TodoTxtAdapterConfig> = {}): TodoTxtAdapterConfig {
+  return {
+    kind: "todo-txt",
+    name: "todo",
+    todoPath: "todo.txt",
+    tasksDir: ".tasks",
+    idPrefix: "GC",
+    timezone: "UTC",
+    ...overrides,
+  };
+}
+
+describe(taskSourceWritePathsForCompletion, () => {
+  it("grants the todo file directory and tasks dir for the matching canonical todo source", () => {
+    const actual = taskSourceWritePathsForCompletion({
+      config: configWithSources([
+        todoSource({
+          name: "todo",
+          todoPath: "/Users/rocky/v/todo.md",
+          tasksDir: "/Users/rocky/v/.tasks",
+        }),
+        todoSource({
+          name: "later",
+          todoPath: "/Users/rocky/later/todo.md",
+          tasksDir: "/Users/rocky/later/.tasks",
+        }),
+      ]),
+      taskId: "todo:gc-1",
+      workingDir: "/work/repo-a-team-1",
+    });
+
+    expect(actual).toStrictEqual(["/Users/rocky/v", "/Users/rocky/v/.tasks"]);
+  });
+
+  it("resolves relative todo paths against the worker cwd", () => {
+    const actual = taskSourceWritePathsForCompletion({
+      config: configWithSources([todoSource({ name: "todo" })]),
+      taskId: "todo:gc-1",
+      workingDir: "/work/repo-a-team-1",
+    });
+
+    expect(actual).toStrictEqual(["/work/repo-a-team-1", "/work/repo-a-team-1/.tasks"]);
+  });
+
+  it("uses the default todo source name when filtering before full parsing", () => {
+    const source = todoSource({
+      todoPath: "/Users/rocky/v/todo.md",
+      tasksDir: "/Users/rocky/v/.tasks",
+    });
+    Reflect.deleteProperty(source, "name");
+
+    const actual = taskSourceWritePathsForCompletion({
+      config: configWithSources([source]),
+      taskId: "todo:gc-1",
+      workingDir: "/work/repo-a-team-1",
+    });
+
+    expect(actual).toStrictEqual(["/Users/rocky/v", "/Users/rocky/v/.tasks"]);
+  });
+
+  it("grants all todo sources when the completion task id is not source-qualified", () => {
+    const actual = taskSourceWritePathsForCompletion({
+      config: configWithSources([
+        todoSource({ name: "todo", todoPath: "/tasks/a/todo.txt", tasksDir: "/tasks/a" }),
+        todoSource({ name: "other", todoPath: "/tasks/b/todo.txt", tasksDir: "/tasks/b" }),
+      ]),
+      taskId: "gc-1",
+      workingDir: "/work/repo-a-team-1",
+    });
+
+    expect(actual).toStrictEqual(["/tasks/a", "/tasks/b"]);
+  });
+
+  it("ignores disabled and non-todo sources", () => {
+    const actual = taskSourceWritePathsForCompletion({
+      config: configWithSources([{ kind: "linear", enabled: false }]),
+      taskId: "gc-1",
+      workingDir: "/work/repo-a-team-1",
+    });
+
+    expect(actual).toStrictEqual([]);
+  });
+});

--- a/src/lib/taskSourceFilesystem.ts
+++ b/src/lib/taskSourceFilesystem.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+
+import { z } from "zod";
+
+import { todoTxtAdapterConfigSchema } from "./adapters/todo-txt/schema.ts";
+import type { ResolvedConfig } from "./config.ts";
+
+const sourceSelectorShape = z.looseObject({
+  kind: z.string().optional(),
+  name: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
+const DEFAULT_TODO_SOURCE_NAME = "todo";
+
+export function taskSourceWritePathsForCompletion(input: {
+  config: Pick<ResolvedConfig, "sources">;
+  taskId: string;
+  workingDir: string;
+}): readonly string[] {
+  const targetSourceName = sourceNameFromTaskId(input.taskId);
+  const paths: string[] = [];
+
+  for (const rawSource of input.config.sources) {
+    const selector = sourceSelectorShape.parse(rawSource);
+    if (selector.enabled === false || selector.kind !== "todo-txt") {
+      continue;
+    }
+
+    const sourceName = selector.name ?? DEFAULT_TODO_SOURCE_NAME;
+    if (targetSourceName !== undefined && sourceName !== targetSourceName) {
+      continue;
+    }
+
+    const source = todoTxtAdapterConfigSchema.parse(rawSource);
+
+    // Completion writeback writes the todo file plus lock/tmp siblings, so the
+    // sandbox grant must cover the todo file's parent directory.
+    paths.push(resolveForWorker(input.workingDir, path.dirname(source.todoPath)));
+    paths.push(resolveForWorker(input.workingDir, source.tasksDir));
+  }
+
+  return [...new Set(paths)];
+}
+
+function sourceNameFromTaskId(taskId: string): string | undefined {
+  const colonIndex = taskId.indexOf(":");
+  if (colonIndex <= 0) {
+    return undefined;
+  }
+  return taskId.slice(0, colonIndex);
+}
+
+function resolveForWorker(workingDir: string, filePath: string): string {
+  return path.resolve(workingDir, filePath);
+}


### PR DESCRIPTION
## Summary

Fixes todo-txt task completion for sandboxed local agents by granting the worker agent access to the configured todo source paths during setup and resume.

The change grants the todo file parent directory and tasks directory to Safehouse and srt agent wraps only, leaving the prepare-worktree phase unchanged. It also improves todo-txt diagnostics so unreadable files report the filesystem error instead of being mislabeled as missing.

Markdown lint now ignores local `.worktrees/**` checkouts so generated worktree contents do not break repository verification.

## Validation

- `node --run verify`
- Pre-push `node --run verify`

## Notes

Safehouse grants are directory-based, so the todo file parent directory is required for the todo file plus lock/tmp siblings. This does not widen cmux outer app-sandbox access; the todo source still needs to live somewhere the selected workspace backend can access.

Agent session: `codex resume 019ec11a-6e4f-71b0-a278-652f320d6566`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>
