### PR TITLE
feat: support unique task id prefixes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,7 @@ crew task list --source todo --status todo --unblocked
 crew task list --agent claude-fable --repo ClipboardHealth/api --json
 ```
 
-`crew task get <task-id>` prints one normalized task. Canonical IDs such as `todo:GC-20260608-001` route directly to the named source. Natural IDs can be resolved with `--source <name>` or, when unique, by searching all configured sources. If more than one source matches, the command fails and asks for a canonical ID or `--source`.
+`crew task get <task-id>` prints one normalized task. Canonical IDs such as `todo:GC-20260608-001` route directly to the named source. Natural IDs can be resolved with `--source <name>` or, when unique, by searching all configured sources. Exact IDs are tried first; if none match, Groundcrew accepts a unique prefix of a current listed task ID. If more than one task matches, the command fails and prints the matching canonical IDs.
 
 ```bash
 crew task get todo:GC-20260608-001
@@ -44,8 +44,9 @@ crew task create "Fix cancellation retry race" \
 `crew task done <task-id>` marks one task done through its source adapter. Use
 it for completed work that intentionally does not produce a PR. The command
 resolves canonical IDs such as `todo:flaky-triage-1` directly, or natural IDs
-when they match exactly one configured source. Sources without a done writeback
-return an unsupported error.
+when they match exactly one configured source. Exact IDs are tried first; if
+none match, Groundcrew accepts a unique prefix of a current listed task ID.
+Sources without a done writeback return an unsupported error.
 
 Groundcrew checks matching local worktrees before marking a task done. Clean
 worktrees, and tasks with no local worktree, are allowed. A dirty worktree with

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -382,6 +382,58 @@ describe("crew task get", () => {
     expect(log.output()).toBe("Investigate cancellation retries.");
   });
 
+  it("resolves a unique source-native id prefix from listed current tasks", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({
+        id: "todo:flaky-critic-1-20260613-002",
+        description: "Run flaky critic.",
+      }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "flaky-critic-1", "--prompt"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.getTask).toHaveBeenCalledWith("flaky-critic-1");
+    expect(todo.listTasks).toHaveBeenCalledTimes(1);
+    expect(log.output()).toBe("Run flaky critic.");
+  });
+
+  it("keeps exact source-native id matches ahead of prefix matches", async () => {
+    const exact = makeIssue({ id: "todo:flaky-critic-1", title: "Exact" });
+    const todo = stubSource("todo", [
+      exact,
+      makeIssue({ id: "todo:flaky-critic-1-20260613-002", title: "Prefix" }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["get", "flaky-critic-1"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.listTasks).not.toHaveBeenCalled();
+    expect(log.output()).toContain("title: Exact");
+  });
+
+  it("fails prefix lookup when multiple current tasks match", async () => {
+    const todo = stubSource("todo", [
+      makeIssue({ id: "todo:flaky-critic-1-20260613-002" }),
+      makeIssue({ id: "todo:flaky-critic-10-20260613" }),
+    ]);
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    await expect(taskCli(["get", "flaky-critic-1"])).rejects.toThrow(
+      /matched multiple tasks.*todo:flaky-critic-1-20260613-002.*todo:flaky-critic-10-20260613/i,
+    );
+  });
+
   it("fails natural id lookup when multiple sources match", async () => {
     const todo = stubSource("todo", [makeIssue()]);
     const linear = stubSource("linear", [makeIssue({ id: "linear:gc-1", source: "linear" })]);
@@ -619,6 +671,31 @@ describe("crew task done", () => {
     expect(findWorktreesByTaskMock).toHaveBeenCalledWith(expect.anything(), "gc-1");
     expect(markDone).toHaveBeenCalledWith(issue);
     expect(log.output()).toBe("Marked todo:gc-1 done.");
+  });
+
+  it("marks a task done through a unique source-native id prefix", async () => {
+    const issue = makeIssue({ id: "todo:flaky-critic-1-20260613-002", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    const todo = stubSource("todo", [issue], { markDone });
+    buildSourcesMock.mockResolvedValue([todo]);
+
+    const log = captureConsoleLog();
+    try {
+      await taskCli(["done", "flaky-critic-1"]);
+    } finally {
+      log.restore();
+    }
+
+    expect(todo.getTask).toHaveBeenCalledWith("flaky-critic-1");
+    expect(todo.listTasks).toHaveBeenCalledTimes(1);
+    expect(findWorktreesByTaskMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "flaky-critic-1-20260613-002",
+    );
+    expect(markDone).toHaveBeenCalledWith(issue);
+    expect(log.output()).toBe("Marked todo:flaky-critic-1-20260613-002 done.");
   });
 
   it("allows a clean matching worktree without checking PRs", async () => {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -2,6 +2,7 @@ import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { AGENT_ANY, loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
+import { resolveTaskIdMatches, type TaskResolutionMatches } from "../lib/taskResolution.ts";
 import {
   type CanonicalStatus,
   type CreateTaskInput,
@@ -511,8 +512,38 @@ function canonicalParts(taskId: string): { sourceName: string; naturalId: string
   return { sourceName, naturalId };
 }
 
-async function taskFromSource(source: TaskSource, naturalId: string): Promise<Task | null> {
-  return await source.getTask(naturalId);
+interface TaskFromResolutionArguments {
+  taskId: string;
+  resolution: TaskResolutionMatches;
+  sourceName?: string;
+}
+
+function taskFromResolution({ taskId, resolution, sourceName }: TaskFromResolutionArguments): Task {
+  if (resolution.matches.length === 0) {
+    if (resolution.rejections.length > 0) {
+      throw resolution.rejections[0];
+    }
+    if (sourceName !== undefined) {
+      throw new Error(`Task ${taskId} not found in source "${sourceName}".`);
+    }
+    throw new Error(`Task ${taskId} not found across configured sources.`);
+  }
+  if (resolution.matches.length > 1) {
+    if (resolution.matchKind === "exact" && sourceName === undefined) {
+      throw new Error(
+        `Task id "${taskId}" matched multiple sources: ${resolution.matches.map((task) => task.id).join(", ")}. Re-run with a canonical id or --source <name>.`,
+      );
+    }
+    throw new Error(
+      `Task id "${taskId}" matched multiple tasks: ${resolution.matches.map((task) => task.id).join(", ")}. Re-run with a longer prefix or canonical id.`,
+    );
+  }
+  const [match] = resolution.matches;
+  /* v8 ignore next 3 @preserve -- matches.length was checked above; guard exists for noUncheckedIndexedAccess */
+  if (match === undefined) {
+    throw new Error(`Task ${taskId} not found across configured sources.`);
+  }
+  return match;
 }
 
 async function resolveTask(
@@ -528,53 +559,26 @@ async function resolveTask(
       );
     }
     const source = findSource(sources, canonical.sourceName);
-    const task = await taskFromSource(source, canonical.naturalId);
-    if (task === null) {
-      throw new Error(`Task ${taskId} not found in source "${source.name}".`);
-    }
-    return task;
+    return taskFromResolution({
+      taskId,
+      sourceName: source.name,
+      resolution: await resolveTaskIdMatches({ sources: [source], naturalId: canonical.naturalId }),
+    });
   }
 
   if (sourceName !== undefined) {
     const source = findSource(sources, sourceName);
-    const task = await taskFromSource(source, taskId);
-    if (task === null) {
-      throw new Error(`Task ${taskId} not found in source "${source.name}".`);
-    }
-    return task;
+    return taskFromResolution({
+      taskId,
+      sourceName: source.name,
+      resolution: await resolveTaskIdMatches({ sources: [source], naturalId: taskId }),
+    });
   }
 
-  const results = await Promise.allSettled(
-    sources.map(async (source) => await taskFromSource(source, taskId)),
-  );
-  const matches: Task[] = [];
-  const rejections: unknown[] = [];
-  for (const result of results) {
-    if (result.status === "fulfilled") {
-      if (result.value !== null) {
-        matches.push(result.value);
-      }
-      continue;
-    }
-    rejections.push(result.reason);
-  }
-  if (matches.length === 0) {
-    if (rejections.length > 0) {
-      throw rejections[0];
-    }
-    throw new Error(`Task ${taskId} not found across configured sources.`);
-  }
-  if (matches.length > 1) {
-    throw new Error(
-      `Task id "${taskId}" matched multiple sources: ${matches.map((task) => task.id).join(", ")}. Re-run with a canonical id or --source <name>.`,
-    );
-  }
-  const [match] = matches;
-  /* v8 ignore next 3 @preserve -- matches.length was checked above; guard exists for noUncheckedIndexedAccess */
-  if (match === undefined) {
-    throw new Error(`Task ${taskId} not found across configured sources.`);
-  }
-  return match;
+  return taskFromResolution({
+    taskId,
+    resolution: await resolveTaskIdMatches({ sources, naturalId: taskId }),
+  });
 }
 
 function writeTaskDetails(task: Task): void {

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -410,6 +410,23 @@ describe(toCanonicalIssue, () => {
     ]);
   });
 
+  it("omits nativeStatus for an unmapped blocker that has no native status name", () => {
+    const issue = linearIssue({
+      blockers: [{ id: "team-2", title: "Block A", status: undefined, stateType: "backlog" }],
+    });
+
+    const result = toCanonicalIssue(issue, "linear");
+
+    expect(result.blockers).toStrictEqual([
+      {
+        id: "linear:team-2",
+        title: "Block A",
+        status: "other",
+        statusReason: "unmapped",
+      },
+    ]);
+  });
+
   it("uses a custom source name when provided", () => {
     const result = toCanonicalIssue(linearIssue(), "work-linear");
     expect(result.id).toBe("work-linear:team-1");
@@ -659,6 +676,15 @@ describe(createLinearTaskSource, () => {
     } satisfies AdapterContext);
 
     await expect(source.getTask("team-1")).rejects.toThrow("lookup failed");
+  });
+
+  it("preserves non-Error Linear lookup rejections", async () => {
+    vi.spyOn(boardSource, "fetchResolvedIssue").mockRejectedValue("offline");
+    const source = createLinearTaskSource({ kind: "linear" }, {
+      globalConfig: makeConfig(),
+    } satisfies AdapterContext);
+
+    await expect(source.getTask("team-1")).rejects.toBe("offline");
   });
 
   it("createTask() creates a Groundcrew-eligible Linear issue and blocked-by relation", async () => {

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -67,17 +67,16 @@ function canonicalBlockerStatus(
     stateType: blocker.stateType,
     statusNames,
   });
-  if (status !== "other") {
-    return {
-      status,
-      ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
-    };
-  }
-  return {
-    status,
-    statusReason: blocker.stateType === undefined ? "missing" : "unmapped",
-    ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
-  };
+  return status === "other"
+    ? {
+        status,
+        statusReason: blocker.stateType === undefined ? "missing" : "unmapped",
+        ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+      }
+    : {
+        status,
+        ...(blocker.status !== undefined && { nativeStatus: blocker.status }),
+      };
 }
 
 function toCanonicalBlocker(
@@ -109,6 +108,10 @@ function isLinearNotFoundError(error: unknown, naturalId: string): boolean {
     error.message.startsWith(`Task ${naturalId.toUpperCase()} `) &&
     error.message.includes("not found")
   );
+}
+
+function throwLinearLookupError(error: unknown): never {
+  throw error;
 }
 
 export function toCanonicalIssue(
@@ -195,10 +198,7 @@ export function createLinearTaskSource(
         task: naturalId,
       });
     } catch (error: unknown) {
-      if (isLinearNotFoundError(error, naturalId)) {
-        return null;
-      }
-      throw error;
+      return isLinearNotFoundError(error, naturalId) ? null : throwLinearLookupError(error);
     }
     const sourceRef: LinearSourceRef = {
       uuid: resolved.uuid,

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -161,6 +161,72 @@ describe("Board.resolveOne", () => {
     expect(result?.id).toBe("b:x");
   });
 
+  it("resolves a unique natural id prefix from listed current tasks when exact lookup misses", async () => {
+    const listTasks = vi
+      .fn<() => Promise<Issue[]>>()
+      .mockResolvedValue([fakeIssue("todo:flaky-critic-1-20260613-002", "todo")]);
+    const board = createBoard([fakeSource("todo", { listTasks })]);
+
+    const result = await board.resolveOne("flaky-critic-1");
+
+    expect(result?.id).toBe("todo:flaky-critic-1-20260613-002");
+    expect(listTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps exact natural id matches ahead of listed prefix matches", async () => {
+    const getTask = vi
+      .fn<(id: string) => Promise<Issue | null>>()
+      .mockResolvedValue(fakeIssue("todo:flaky-critic-1", "todo"));
+    const listTasks = vi
+      .fn<() => Promise<Issue[]>>()
+      .mockRejectedValue(new Error("prefix lookup should not run"));
+    const board = createBoard([fakeSource("todo", { getTask, listTasks })]);
+
+    const result = await board.resolveOne("flaky-critic-1");
+
+    expect(result?.id).toBe("todo:flaky-critic-1");
+    expect(listTasks).not.toHaveBeenCalled();
+  });
+
+  it("throws AmbiguousTaskError when a natural id prefix matches multiple listed current tasks", async () => {
+    const board = createBoard([
+      fakeSource("todo", {
+        listTasks: vi
+          .fn<() => Promise<Issue[]>>()
+          .mockResolvedValue([
+            fakeIssue("todo:flaky-critic-1-20260613-002", "todo"),
+            fakeIssue("todo:flaky-critic-10-20260613", "todo"),
+          ]),
+      }),
+    ]);
+
+    await expect(board.resolveOne("flaky-critic-1")).rejects.toThrow(
+      /ambiguous.*todo:flaky-critic-1-20260613-002.*todo:flaky-critic-10-20260613/i,
+    );
+  });
+
+  it("surfaces a source rejection from prefix lookup when no source matched", async () => {
+    const board = createBoard([
+      fakeSource("todo", {
+        listTasks: vi.fn<() => Promise<Issue[]>>().mockRejectedValue(new Error("source offline")),
+      }),
+    ]);
+
+    await expect(board.resolveOne("flaky-critic-1")).rejects.toThrow(/source offline/);
+  });
+
+  it("does not treat an empty canonical natural id as a prefix for every listed task", async () => {
+    const board = createBoard([
+      fakeSource("todo", {
+        listTasks: vi
+          .fn<() => Promise<Issue[]>>()
+          .mockResolvedValue([fakeIssue("todo:flaky-critic-1-20260613-002", "todo")]),
+      }),
+    ]);
+
+    await expect(board.resolveOne("todo:")).resolves.toBeUndefined();
+  });
+
   it("returns undefined when no source matches", async () => {
     const board = createBoard([fakeSource("a"), fakeSource("b")]);
     await expect(board.resolveOne("missing")).resolves.toBeUndefined();

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -14,13 +14,15 @@ import {
   type ParentSkip,
   type TaskSource,
 } from "./taskSource.ts";
+import { resolveTaskIdMatches, type TaskResolutionMatches } from "./taskResolution.ts";
 
 export interface Board {
   verify: () => Promise<void>;
   fetch: () => Promise<BoardState>;
   /**
-   * Accepts either canonical (`linear:eng-220`) or natural (`eng-220`) ids.
-   * Natural ids fan out across sources; ambiguous matches throw.
+   * Accepts either canonical (`linear:eng-220`) or natural (`eng-220`) ids,
+   * plus unique prefixes of current listed tasks. Natural ids fan out across
+   * sources; ambiguous matches throw.
    */
   resolveOne: (canonicalOrNaturalId: string) => Promise<Issue | undefined>;
   /** Routes to the adapter whose `name` matches `issue.source`. Unknown source throws. */
@@ -54,8 +56,29 @@ async function callFetchParentSkips(source: TaskSource): Promise<readonly Parent
   return [];
 }
 
-async function callResolveOne(source: TaskSource, naturalId: string): Promise<Issue | undefined> {
-  return (await source.getTask(naturalId)) ?? undefined;
+interface UniqueResolvedIssueArguments {
+  idArgument: string;
+  resolution: TaskResolutionMatches;
+}
+
+function uniqueResolvedIssue({
+  idArgument,
+  resolution,
+}: UniqueResolvedIssueArguments): Issue | undefined {
+  if (resolution.matches.length === 0) {
+    if (resolution.rejections.length > 0) {
+      throw resolution.rejections[0];
+    }
+    return undefined;
+  }
+  if (resolution.matches.length === 1) {
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- length checked above
+    return resolution.matches[0]!;
+  }
+  throw new AmbiguousTaskError({
+    naturalId: idArgument,
+    matches: resolution.matches.map((match) => match.id),
+  });
 }
 
 export function createBoard(sources: readonly TaskSource[]): Board {
@@ -115,7 +138,10 @@ export function createBoard(sources: readonly TaskSource[]): Board {
         if (!source) {
           throw new Error(`unknown source "${sourceName}" in canonical id "${idArgument}"`);
         }
-        return await callResolveOne(source, naturalId);
+        return uniqueResolvedIssue({
+          idArgument,
+          resolution: await resolveTaskIdMatches({ sources: [source], naturalId }),
+        });
       }
       // Per-source resolveOne errors must not poison sibling resolutions.
       // A source that rejects on a natural-id lookup is treated as "I don't
@@ -124,33 +150,9 @@ export function createBoard(sources: readonly TaskSource[]): Board {
       // the rejection — so the user sees a real Linear/network error when
       // there's no fallback, but a stray "not found" from one source doesn't
       // mask a successful match from another.
-      const results = await Promise.allSettled(
-        sources.map(async (s) => await callResolveOne(s, idArgument)),
-      );
-      const matches: Issue[] = [];
-      const rejections: unknown[] = [];
-      for (const result of results) {
-        if (result.status === "rejected") {
-          rejections.push(result.reason);
-          continue;
-        }
-        if (result.value !== undefined) {
-          matches.push(result.value);
-        }
-      }
-      if (matches.length === 0) {
-        if (rejections.length > 0) {
-          throw rejections[0];
-        }
-        return undefined;
-      }
-      if (matches.length === 1) {
-        // oxlint-disable-next-line typescript/no-non-null-assertion -- length checked above
-        return matches[0]!;
-      }
-      throw new AmbiguousTaskError({
-        naturalId: idArgument,
-        matches: matches.map((m) => m.id),
+      return uniqueResolvedIssue({
+        idArgument,
+        resolution: await resolveTaskIdMatches({ sources, naturalId: idArgument }),
       });
     },
 

--- a/src/lib/taskResolution.ts
+++ b/src/lib/taskResolution.ts
@@ -1,0 +1,96 @@
+import { naturalIdFromCanonical, type Task, type TaskSource } from "./taskSource.ts";
+
+type TaskMatchKind = "exact" | "prefix" | "none";
+
+export interface TaskResolutionMatches {
+  matches: Task[];
+  rejections: unknown[];
+  matchKind: TaskMatchKind;
+}
+
+interface CollectExactTaskMatchesArguments {
+  sources: readonly TaskSource[];
+  naturalId: string;
+}
+
+interface CollectPrefixTaskMatchesArguments {
+  sources: readonly TaskSource[];
+  naturalIdPrefix: string;
+}
+
+interface TaskMatchesNaturalIdPrefixArguments {
+  task: Task;
+  naturalIdPrefix: string;
+}
+
+export async function resolveTaskIdMatches(
+  arguments_: CollectExactTaskMatchesArguments,
+): Promise<TaskResolutionMatches> {
+  const exact = await collectExactTaskMatches(arguments_);
+  if (exact.matches.length > 0) {
+    return { ...exact, matchKind: "exact" };
+  }
+
+  const prefix = await collectPrefixTaskMatches({
+    sources: arguments_.sources,
+    naturalIdPrefix: arguments_.naturalId,
+  });
+  const rejections = [...exact.rejections, ...prefix.rejections];
+  if (prefix.matches.length > 0) {
+    return { matches: prefix.matches, rejections, matchKind: "prefix" };
+  }
+  return { matches: [], rejections, matchKind: "none" };
+}
+
+async function collectExactTaskMatches({
+  sources,
+  naturalId,
+}: CollectExactTaskMatchesArguments): Promise<Omit<TaskResolutionMatches, "matchKind">> {
+  const results = await Promise.allSettled(
+    sources.map(async (source) => await source.getTask(naturalId)),
+  );
+  const matches: Task[] = [];
+  const rejections: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      if (result.value !== null) {
+        matches.push(result.value);
+      }
+      continue;
+    }
+    rejections.push(result.reason);
+  }
+  return { matches, rejections };
+}
+
+async function collectPrefixTaskMatches({
+  sources,
+  naturalIdPrefix,
+}: CollectPrefixTaskMatchesArguments): Promise<Omit<TaskResolutionMatches, "matchKind">> {
+  const results = await Promise.allSettled(
+    sources.map(async (source) => {
+      const tasks = await source.listTasks();
+      return tasks.filter((task) => taskMatchesNaturalIdPrefix({ task, naturalIdPrefix }));
+    }),
+  );
+  const matches: Task[] = [];
+  const rejections: unknown[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      matches.push(...result.value);
+      continue;
+    }
+    rejections.push(result.reason);
+  }
+  return { matches, rejections };
+}
+
+function taskMatchesNaturalIdPrefix({
+  task,
+  naturalIdPrefix,
+}: TaskMatchesNaturalIdPrefixArguments): boolean {
+  if (naturalIdPrefix.length === 0) {
+    return false;
+  }
+  return naturalIdFromCanonical(task.id).toLowerCase().startsWith(naturalIdPrefix.toLowerCase());
+}

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -242,7 +242,7 @@ export class AmbiguousTaskError extends Error {
   public constructor(arguments_: { naturalId: string; matches: readonly string[] }) {
     const { naturalId, matches } = arguments_;
     super(
-      `Task id "${naturalId}" is ambiguous; matched in multiple sources: ${matches.join(", ")}. Re-invoke with one of those canonical ids.`,
+      `Task id "${naturalId}" is ambiguous; matched multiple tasks: ${matches.join(", ")}. Re-invoke with a longer prefix or one of those canonical ids.`,
     );
     this.name = "AmbiguousTaskError";
   }


### PR DESCRIPTION
## Summary

Adds Docker-style unique prefix resolution for task IDs. Exact task IDs still win first; when exact lookup misses, `crew task get`, `crew task done`, and board resolution accept a unique prefix of the current listed task natural ID and fail with matching canonical IDs when ambiguous.

Also documents the new behavior and keeps coverage-complete Linear lookup branches after the shared resolver change.

## Validation

- `node --run verify`
- pre-push hook: `node --run verify`

## Notes

Agent session: `codex resume 019ec131-d55f-7e53-8344-f9547d7bedd6`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>