### PR TITLE
feat: show log file path in crew doctor

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -239,6 +239,14 @@ describe(doctor, () => {
     expect(output).toContain("[ok] config loaded — /work/crew.config.ts (GROUNDCREW_CONFIG)");
   });
 
+  it("reports the resolved log file path", async () => {
+    loadConfigWithSourceMock.mockResolvedValue(makeLoadedConfig(makeConfig()));
+
+    await doctor();
+
+    expect(consoleLog.output()).toContain("log file: /tmp/groundcrew-test.log");
+  });
+
   it("returns false when config loading fails", async () => {
     loadConfigMock.mockRejectedValue(new Error("GROUNDCREW_CONFIG=/missing.ts not found"));
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -274,6 +274,10 @@ export async function doctor(): Promise<boolean> {
     config = loadedConfig;
     const sourceLabel = CONFIG_SOURCE_LABELS[source.kind];
     writeOutput(`[ok] config loaded — ${source.filepath} (${sourceLabel})`);
+    // Sibling "where things live" line: the resolved log file, so a user
+    // investigating a problem knows where to look. Shown as a full path to
+    // match the config filepath above (doctor favors exact, copyable paths).
+    writeOutput(`     log file: ${config.logging.file}`);
   } catch (error) {
     writeOutput(`[--] config: ${errorMessage(error)}`);
     return false;


### PR DESCRIPTION
## Why

When something goes wrong, a common question is "where are the logs?" `crew doctor` is the natural place to answer it: it's the diagnostic command you reach for when investigating, and it already reports the resolved config file path. The log file path is the sibling fact ("config lives here, logs live there"), so it belongs right next to it.

## What

`crew doctor` now prints the resolved log file path on its own line, directly beneath the existing "config loaded" line:

```
[ok] config loaded — /Users/me/.config/groundcrew/crew.config.json (global XDG)
     log file: /Users/me/.local/state/groundcrew/groundcrew.log
```

- Value is `config.logging.file`, the same file the per-task `crew status <task>` "Recent logs" section reads from.
- Shown as a full absolute path to match the config filepath above. `doctor` favors exact, copy-pasteable paths over abbreviated ones, so no `~` collapsing.
- Printed inside the config-load `try`, so it only appears once the config resolved successfully.

## Decisions

- **`doctor`, not `status`.** Earlier drafting put this in `crew status`, but the log file path is reference/config metadata, not operational state. `status` is an operational dashboard (worktrees, sessions, slots) that deliberately stays free of static chrome; a constant, unchanging path line fights that. `doctor` already owns the sibling fact (config path) and is the "investigate" command, so it's the better home.
- **Full path, not `~`-collapsed.** Matches the adjacent config-path line and `doctor`'s exact-paths convention.
- **Placement: under "config loaded".** Groups the two "where do groundcrew's files live" facts together.

## Validation

- `node --run verify` passes (1779 tests, lint, types, cpd, format, knip, spell, architecture).
- Manual: `crew doctor` prints the `log file:` line beneath `config loaded`.