### PR TITLE
fix: show "provisioning" while the worktree is being created

### DIFF
--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -104,6 +104,8 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
       ...actual.worktrees,
       create: vi.fn<typeof actual.worktrees.create>(),
       teardown: vi.fn<typeof actual.worktrees.teardown>(),
+      findByTask: vi.fn<typeof actual.worktrees.findByTask>(),
+      predictedEntry: vi.fn<typeof actual.worktrees.predictedEntry>(),
     },
   };
 });
@@ -146,6 +148,8 @@ const debugMock = vi.mocked(debug);
 const recordRunStateMock = vi.mocked(recordRunState);
 const createMock = vi.mocked(worktrees.create);
 const teardownMock = vi.mocked(worktrees.teardown);
+const findByTaskMock = vi.mocked(worktrees.findByTask);
+const predictedEntryMock = vi.mocked(worktrees.predictedEntry);
 
 type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
 
@@ -296,6 +300,10 @@ function mockTmuxWindows(names: readonly string[]): void {
 }
 
 function mockExistingWorktree(): void {
+  // The hoisted duplicate check in setupWorkspace runs before worktrees.create
+  // is called, so make findByTask report the entry. createMock still rejects as
+  // a belt-and-suspenders for the (vanishingly rare) parallel-dispatcher race.
+  findByTaskMock.mockReturnValue([hostEntry()]);
   createMock.mockRejectedValue(new WorktreeAlreadyExistsError("/work/repo-a-team-1"));
 }
 
@@ -384,6 +392,11 @@ describe(setupWorkspace, () => {
     existsMock.mockReturnValue(true);
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
+    findByTaskMock.mockReturnValue([]);
+    predictedEntryMock.mockReturnValue({
+      branchName: "dev-team-1",
+      worktreeDir: "/work/repo-a-team-1",
+    });
     ensureClearanceMock.mockResolvedValue(clearanceResult());
     resolveSafehouseCmuxIntegrationMock.mockReturnValue(safehouseCmuxIntegrationFixture());
     mkdtempMock.mockReturnValue("/tmp/groundcrew-team-1-x");
@@ -1510,7 +1523,7 @@ describe(setupWorkspace, () => {
     expect(ensureClearanceMock).not.toHaveBeenCalled();
   });
 
-  it("propagates worktree-creation errors without launching cmux", async () => {
+  it("propagates worktree-creation errors, skips cmux, and records 'failed-to-launch'", async () => {
     createMock.mockRejectedValue(new Error("git fetch failed"));
 
     await expect(
@@ -1518,13 +1531,59 @@ describe(setupWorkspace, () => {
         task: "team-1",
         repository: "repo-a",
         agent: "claude",
-        details: { title: "Test Title", description: "Body" },
+        details: { title: "Test Title", description: "Body", url: "https://example/TEAM-1" },
       }),
     ).rejects.toThrow(/git fetch failed/);
     expect(runCommandMock).not.toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["new-workspace"]),
     );
+    // Without this row the pre-flight `provisioning` would strand forever.
+    const last = lastRecordedRunState();
+    expect(last.state).toBe("failed-to-launch");
+    expect(last.url).toBe("https://example/TEAM-1");
+  });
+
+  it("records a 'provisioning' run state with the predicted paths before worktrees.create starts", async () => {
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+    createMock.mockResolvedValue(hostEntry());
+    await setupWorkspace(makeConfig(), {
+      task: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      details: { title: "Long", description: "Body", url: "https://example/TEAM-1" },
+    });
+    const provisioning = recordRunStateMock.mock.calls.find(
+      ([input]) => input.state.state === "provisioning",
+    )?.[0].state;
+    expect(provisioning).toMatchObject({
+      state: "provisioning",
+      task: "team-1",
+      branchName: "dev-team-1",
+      worktreeDir: "/work/repo-a-team-1",
+      title: "Long",
+      url: "https://example/TEAM-1",
+    });
+    // The row must hit disk BEFORE create() starts, else `crew status` races.
+    expect(firstInvocationOrder(recordRunStateMock)).toBeLessThan(firstInvocationOrder(createMock));
+    expect(lastRecordedRunState().state).toBe("running");
+  });
+
+  it("does not record a 'provisioning' run state when the worktree already exists", async () => {
+    mockExistingWorktree();
+    await expect(
+      setupWorkspace(makeConfig(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
+    ).rejects.toThrow(/Worktree already exists/);
+    const provisioned = recordRunStateMock.mock.calls.filter(
+      ([input]) => input.state.state === "provisioning",
+    );
+    expect(provisioned).toHaveLength(0);
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   it("logs the tmux access hint when the worktree already exists and the previous workspace is still live", async () => {
@@ -1915,6 +1974,11 @@ describe(setupWorkspaceCli, () => {
     existsMock.mockReturnValue(true);
     detectHostMock.mockResolvedValue(host());
     createMock.mockImplementation(async () => hostEntry());
+    findByTaskMock.mockReturnValue([]);
+    predictedEntryMock.mockReturnValue({
+      branchName: "dev-team-1",
+      worktreeDir: "/work/repo-a-team-1",
+    });
     mkdtempMock.mockReturnValue("/tmp/groundcrew-team-1-x");
     runCommandMock.mockReturnValue(JSON.stringify({ ref: "workspace:1" }));
     loadConfigMock.mockResolvedValue(makeConfig());

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -18,8 +18,8 @@ import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import {
-  isWorktreeAlreadyExistsError,
   resolveLaunchDir,
+  WorktreeAlreadyExistsError,
   type WorktreeEntry,
   worktrees,
 } from "../lib/worktrees.ts";
@@ -87,17 +87,24 @@ export async function setupWorkspace(
       ...(signal === undefined ? {} : { signal }),
     });
 
+  await preflightProvisioningGate({ config, options, signal });
+
   const spec = { repository, task };
-  let created: WorktreeEntry;
   const createdPromise =
     signal === undefined ? worktrees.create(config, spec) : worktrees.create(config, spec, signal);
   const readinessPromise = startLaunchReadiness(ensureReady);
+  let created: WorktreeEntry;
   try {
     created = await createdPromise;
   } catch (error) {
-    if (isWorktreeAlreadyExistsError(error)) {
-      await logAccessHintForExistingWorkspace({ config, task, signal });
-    }
+    // Roll the pre-flight `provisioning` row forward; the outer catch only
+    // fires post-create and the dispatcher just logs and moves on.
+    recordFailedToLaunch({
+      config,
+      options,
+      paths: worktrees.predictedEntry(config, repository, task),
+      error,
+    });
     throw error;
   }
   const { branchName, dir: worktreeDir } = created;
@@ -204,22 +211,71 @@ export async function setupWorkspace(
     }
   } catch (error) {
     await rollbackWorktree({ config, entry: created, promptDir, srtSettingsDir });
-    recordRunStateBestEffort({
-      config,
-      task,
-      repository,
-      agent,
-      worktreeDir,
-      branchName,
-      workspaceName: task,
-      state: "failed-to-launch",
-      detail: errorMessage(error),
-      title: options.details.title,
-      completionTaskId: options.completionTaskId ?? task,
-      ...(options.details.url === undefined ? {} : { url: options.details.url }),
-    });
+    recordFailedToLaunch({ config, options, paths: { worktreeDir, branchName }, error });
     throw error;
   }
+}
+
+/**
+ * Bail out before any state-write when the worktree already exists, then
+ * record a "provisioning" row so `crew status` can surface the in-flight
+ * worktree create instead of falling back to "idle". The dispatcher
+ * serializes setupWorkspace calls per host, so the race against a parallel
+ * worktrees.create() can't realistically fire here — `worktrees.create()`
+ * still defends against it internally.
+ */
+async function preflightProvisioningGate(arguments_: {
+  config: ResolvedConfig;
+  options: SetupWorkspaceOptions;
+  signal: AbortSignal | undefined;
+}): Promise<void> {
+  const { config, options, signal } = arguments_;
+  const { task, repository, agent } = options;
+  const existing = worktrees
+    .findByTask(config, task)
+    .find((entry) => entry.repository === repository);
+  if (existing !== undefined) {
+    await logAccessHintForExistingWorkspace({ config, task, signal });
+    throw new WorktreeAlreadyExistsError(existing.dir);
+  }
+  const predicted = worktrees.predictedEntry(config, repository, task);
+  recordRunStateBestEffort({
+    config,
+    task,
+    repository,
+    agent,
+    worktreeDir: predicted.worktreeDir,
+    branchName: predicted.branchName,
+    workspaceName: task,
+    state: "provisioning",
+    title: options.details.title,
+    completionTaskId: options.completionTaskId ?? task,
+    ...(options.details.url === undefined ? {} : { url: options.details.url }),
+  });
+}
+
+function recordFailedToLaunch(arguments_: {
+  config: ResolvedConfig;
+  options: SetupWorkspaceOptions;
+  paths: { worktreeDir: string; branchName: string };
+  error: unknown;
+}): void {
+  const { config, options, paths, error } = arguments_;
+  const { task, repository, agent } = options;
+  recordRunStateBestEffort({
+    config,
+    task,
+    repository,
+    agent,
+    worktreeDir: paths.worktreeDir,
+    branchName: paths.branchName,
+    workspaceName: task,
+    state: "failed-to-launch",
+    detail: errorMessage(error),
+    title: options.details.title,
+    completionTaskId: options.completionTaskId ?? task,
+    ...(options.details.url === undefined ? {} : { url: options.details.url }),
+  });
 }
 
 type LaunchReadinessResult = { kind: "ready" } | { kind: "failed"; error: unknown };
@@ -288,7 +344,7 @@ function recordRunStateBestEffort(arguments_: {
   worktreeDir: string;
   branchName: string;
   workspaceName: string;
-  state: "running" | "failed-to-launch";
+  state: "provisioning" | "running" | "failed-to-launch";
   title: string;
   detail?: string;
   url?: string;

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -407,6 +407,22 @@ describe(status, () => {
     );
   });
 
+  it("renders the per-task run: line as bare `provisioning` while the worktree is being created", async () => {
+    // Provisioning runs before worktrees.create() resolves, so there is no
+    // live workspace yet — make sure the status view doesn't decorate the
+    // line with `session dead` (running/resumed only) or any duration token.
+    readRunStateMock.mockReturnValue(runState({ state: "provisioning" }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig(), { task: "team-1" });
+
+    const output = consoleLog.output();
+    expect(output).toContain("run: provisioning;");
+    expect(output).not.toContain("idle");
+    expect(output).not.toContain("session dead");
+    expect(output).not.toContain("session exited");
+  });
+
   it("leaves the per-task run: line as bare `running` when the session is live", async () => {
     readRunStateMock.mockReturnValue(runState({ state: "running" }));
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -313,7 +313,13 @@ describe("run state store", () => {
   });
 
   it("round-trips every lifecycle state", () => {
-    const states: RunLifecycleState[] = ["running", "interrupted", "resumed", "failed-to-launch"];
+    const states: RunLifecycleState[] = [
+      "provisioning",
+      "running",
+      "interrupted",
+      "resumed",
+      "failed-to-launch",
+    ];
 
     for (const state of states) {
       recordRunState({

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import type { ResolvedConfig } from "./config.ts";
 import { normalizePlainTaskId } from "./taskId.ts";
 
-export type RunLifecycleState = "running" | "interrupted" | "resumed" | "failed-to-launch";
+export type RunLifecycleState =
+  | "provisioning"
+  | "running"
+  | "interrupted"
+  | "resumed"
+  | "failed-to-launch";
 
 export interface RunState {
   task: string;
@@ -103,6 +108,7 @@ function stringField(value: Record<string, unknown>, key: string): string | unde
 
 function isRunLifecycleState(value: unknown): value is RunLifecycleState {
   return (
+    value === "provisioning" ||
     value === "running" ||
     value === "interrupted" ||
     value === "resumed" ||

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1314,6 +1314,23 @@ describe("worktrees.branchNameForTask", () => {
   });
 });
 
+describe("worktrees.predictedEntry", () => {
+  setupTempProjectDir();
+
+  it("returns the branch name and host worktree dir for a task that has not been created yet", () => {
+    userInfoMock.mockReturnValue(makeUserInfo("dev"));
+    mkdirSync(path.join(projectDir, "repo-a"), { recursive: true });
+    const config = makeConfig({ projectDir });
+
+    const actual = worktrees.predictedEntry(config, "repo-a", "team-1");
+
+    expect(actual).toStrictEqual({
+      branchName: "dev-team-1",
+      worktreeDir: path.join(projectDir, "repo-a-team-1"),
+    });
+  });
+});
+
 describe("worktrees.probeWorkingTree", () => {
   beforeEach(async () => {
     // Strip inherited GIT_* env vars so probe tests run against the temp repo,

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -41,10 +41,6 @@ export class WorktreeAlreadyExistsError extends Error {
   }
 }
 
-export function isWorktreeAlreadyExistsError(error: unknown): error is WorktreeAlreadyExistsError {
-  return error instanceof WorktreeAlreadyExistsError;
-}
-
 export interface WorktreeEntry {
   repository: string;
   /** Source task id, lowercased — e.g. "team-220" or "gc-20260608-001". */
@@ -754,6 +750,23 @@ function findByTask(config: ResolvedConfig, task: string): WorktreeEntry[] {
   return list(config).filter((entry) => entry.task === task);
 }
 
+export interface PredictedWorktreeEntry {
+  branchName: string;
+  worktreeDir: string;
+}
+
+// Deterministic preview of where worktree create() would land. Lets callers
+// record run state (e.g. "provisioning") before the worktree exists on disk,
+// without duplicating the path-derivation rules in basePaths().
+function predictedEntry(
+  config: ResolvedConfig,
+  repository: string,
+  task: string,
+): PredictedWorktreeEntry {
+  const { branchName, hostWorktreeDir } = basePaths(config, repository, task);
+  return { branchName, worktreeDir: hostWorktreeDir };
+}
+
 // Shared by create() and open(): reject a duplicate worktree for the same
 // task+repo before building, then assert the configured workdir materialized,
 // rolling the worktree back if it did not. The build callback owns the git
@@ -924,6 +937,7 @@ export const worktrees = {
   open,
   list,
   findByTask,
+  predictedEntry,
   remove,
   teardown,
   branchNameForTask,


### PR DESCRIPTION
## Summary

`crew status` reported `idle` while a worktree create was in flight, masking
long-running provisioning steps (clones, fetches, hook templates) as a frozen
task. This adds a `provisioning` lifecycle state and writes a run-state row
before `worktrees.create()` starts, so status reflects the in-flight work
instead of falling back to `idle`.

- Extend `RunLifecycleState` with `provisioning` and round-trip it in
  `runState.ts` (parser + writer).
- Add a `worktrees.predictedEntry(config, repo, task)` helper that returns the
  deterministic branch name + host worktree dir before the worktree exists, so
  the pre-flight `provisioning` row can be written without duplicating the
  path-derivation rules.
- In `setupWorkspace`, add `preflightProvisioningGate` that fast-fails on a
  duplicate worktree (with the access hint) and otherwise records the
  `provisioning` row before `worktrees.create()` is called.
- Roll the `provisioning` row forward to `failed-to-launch` if `create()`
  rejects — the dispatcher just logs and moves on, so without this the row
  would strand on disk and pin the task forever.
- `status` already had a bare-state branch for unknown lifecycles; add a test
  pinning the `provisioning` rendering so it stays bare (no `session dead`,
  no duration token) while the workspace is not yet open.

## Validation

- `node --run verify` (architecture:check, build, cpd, format:check, knip,
  lint, markdown:lint, spell:check, syncpack:lint, tests with 100% coverage)
  — all green.

Agent session: `claude --resume c58da27a-ad00-47a9-b9fe-82eca691d343`

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>