### PR TITLE
fix(provisioning): handle gate->create race and flag stranded rows

### DIFF
--- a/config/oxlint.config.ts
+++ b/config/oxlint.config.ts
@@ -40,12 +40,13 @@ export default defineConfig(
         },
         {
           // setupWorkspace.test.ts covers launch composition across cmux,
-          // tmux, safehouse, srt, sdx, rollback, and CLI source-resolution
-          // paths. Keep those shared mocks together; splitting the file causes
-          // duplicate module mocks to race under Vitest's parallel runner.
+          // tmux, safehouse, srt, sdx, rollback, CLI source-resolution, and
+          // the preflight provisioning gate / create() race. Keep those shared
+          // mocks together; splitting the file causes duplicate module mocks
+          // to race under Vitest's parallel runner.
           files: ["**/setupWorkspace.test.ts"],
           rules: {
-            "max-lines": ["error", 2200],
+            "max-lines": ["error", 2250],
           },
         },
       ],

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1586,6 +1586,33 @@ describe(setupWorkspace, () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
+  it("does not clobber a parallel dispatcher's 'provisioning' row when create() loses the race", async () => {
+    // The preflight gate sees no existing worktree (findByTask default: []),
+    // but worktrees.create() throws WorktreeAlreadyExistsError because a
+    // parallel dispatcher beat us to provisionWorktree's internal duplicate
+    // check. The live `provisioning` row belongs to that other dispatcher
+    // now — overwriting it with `failed-to-launch` would lie about their
+    // state. Surface the attach hint instead.
+    mockTmuxHost();
+    mockTmuxWindows(["team-1"]);
+    createMock.mockRejectedValue(new WorktreeAlreadyExistsError("/work/repo-a-team-1"));
+
+    await expect(
+      setupWorkspace(makeConfig(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      }),
+    ).rejects.toThrow(/Worktree already exists/);
+
+    const failedToLaunch = recordRunStateMock.mock.calls.filter(
+      ([input]) => input.state.state === "failed-to-launch",
+    );
+    expect(failedToLaunch).toHaveLength(0);
+    expect(debugMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
+  });
+
   it("logs the tmux access hint when the worktree already exists and the previous workspace is still live", async () => {
     mockTmuxHost();
     mockExistingWorktree();

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -97,6 +97,16 @@ export async function setupWorkspace(
   try {
     created = await createdPromise;
   } catch (error) {
+    if (error instanceof WorktreeAlreadyExistsError) {
+      // The preflight gate was clean, so a parallel dispatcher beat us to
+      // provisionWorktree's internal duplicate check. The live `provisioning`
+      // row belongs to that dispatcher now — clobbering it with
+      // `failed-to-launch` would lie about their state. Per-host dispatcher
+      // serialization makes this race vanishingly rare; surface the attach
+      // hint so the operator can find the in-flight session.
+      await logAccessHintForExistingWorkspace({ config, task, signal });
+      throw error;
+    }
     // Roll the pre-flight `provisioning` row forward; the outer catch only
     // fires post-create and the dispatcher just logs and moves on.
     recordFailedToLaunch({
@@ -344,6 +354,8 @@ function recordRunStateBestEffort(arguments_: {
   worktreeDir: string;
   branchName: string;
   workspaceName: string;
+  // Narrowed to the states this helper writes: interrupted/resumed go through
+  // updateRunState elsewhere.
   state: "provisioning" | "running" | "failed-to-launch";
   title: string;
   detail?: string;

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -411,7 +411,11 @@ describe(status, () => {
     // Provisioning runs before worktrees.create() resolves, so there is no
     // live workspace yet — make sure the status view doesn't decorate the
     // line with `session dead` (running/resumed only) or any duration token.
-    readRunStateMock.mockReturnValue(runState({ state: "provisioning" }));
+    // The explicit fresh updatedAt keeps this row inside the 5m stranded
+    // threshold (clock is pinned 1m30s later).
+    readRunStateMock.mockReturnValue(
+      runState({ state: "provisioning", updatedAt: "2026-05-26T02:13:00.000Z" }),
+    );
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
 
     await status(makeConfig(), { task: "team-1" });
@@ -421,6 +425,21 @@ describe(status, () => {
     expect(output).not.toContain("idle");
     expect(output).not.toContain("session dead");
     expect(output).not.toContain("session exited");
+    expect(output).not.toContain("provisioning stalled");
+  });
+
+  it("flags the per-task run: line as `provisioning stalled` when the row is older than 5 minutes", async () => {
+    // A `provisioning` row whose updatedAt is past the threshold means the
+    // dispatcher died between preflightProvisioningGate and create()'s catch
+    // block — `crew cleanup` is the operator's recourse.
+    readRunStateMock.mockReturnValue(
+      runState({ state: "provisioning", updatedAt: "2026-05-26T02:00:00.000Z" }),
+    );
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig(), { task: "team-1" });
+
+    expect(consoleLog.output()).toContain("run: provisioning (provisioning stalled);");
   });
 
   it("leaves the per-task run: line as bare `running` when the session is live", async () => {
@@ -770,6 +789,37 @@ describe(status, () => {
     expect(output).toContain(
       "  hint:      run 'crew cleanup team-1' to clear this stray exited session",
     );
+  });
+
+  it("flags inventory rows as `provisioning stalled` and suggests `crew cleanup` when the row is older than 5 minutes", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ task: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReturnValue(
+      runState({ state: "provisioning", updatedAt: "2026-05-26T02:00:00.000Z" }),
+    );
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  state:     provisioning (provisioning stalled)");
+    expect(output).toContain(
+      "  hint:      provisioning stalled — run 'crew cleanup team-1' to clear and retry",
+    );
+  });
+
+  it("leaves inventory rows bare when the provisioning row is fresh", async () => {
+    listWorktreesMock.mockReturnValue([worktree({ task: "team-1", repository: "repo-a" })]);
+    readRunStateMock.mockReturnValue(
+      runState({ state: "provisioning", updatedAt: "2026-05-26T02:13:00.000Z" }),
+    );
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("  state:     provisioning\n");
+    expect(output).not.toContain("provisioning stalled");
+    expect(output).not.toContain("  hint:");
   });
 
   it("omits the `hint:` line on healthy rows", async () => {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -228,9 +228,12 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
     readTaskSourceStatus(config, task),
   ]);
   const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
+  const now = new Date();
   writeOutput(formatTaskLine(task, runState, sourceStatus));
   writeTaskTitle(runState, sourceStatus);
-  writeOutput(`run: ${formatRunState(runState, runProbeFlags(runState, workspaceProbe, task))}`);
+  writeOutput(
+    `run: ${formatRunState(runState, runProbeFlags(runState, workspaceProbe, task, now))}`,
+  );
   writeOutput(`workspace: ${taskWorkspaceText(workspaceProbe, task)}`);
   if (accessHint !== undefined) {
     writeOutput(`attach: ${accessHint.command}`);
@@ -263,6 +266,22 @@ function runStateDurationMs(runState: RunState | undefined, now: Date): number |
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 60 * MS_PER_MINUTE;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
+const PROVISIONING_STALLED_THRESHOLD_MS = 5 * MS_PER_MINUTE;
+
+/**
+ * A `provisioning` row whose updatedAt is past the threshold means the
+ * dispatcher died between `preflightProvisioningGate` and create()'s catch
+ * block — without this, `crew status` would render the stale row indistinguishably
+ * from a live in-flight provision. `crew cleanup` is the operator's recourse.
+ */
+function isProvisioningStalled(runState: RunState | undefined, now: Date): boolean {
+  if (runState?.state !== "provisioning") {
+    return false;
+  }
+  // A malformed `updatedAt` parses to NaN; `now - NaN > THRESHOLD` is false,
+  // so the row stays un-flagged — the safe default for unparseable state.
+  return now.getTime() - Date.parse(runState.updatedAt) > PROVISIONING_STALLED_THRESHOLD_MS;
+}
 
 function formatDuration(ms: number): string {
   if (ms < MS_PER_MINUTE) {
@@ -286,21 +305,28 @@ function formatDuration(ms: number): string {
  * `run:` line. Flags the two interesting disagreements between the recorded
  * RunState lifecycle and the live workspace probe: a running/resumed dispatch
  * with a missing or exited session, and an idle row with a stray live or
- * exited session. `probe.kind === "unavailable"` is "we don't know" and yields
- * no flags. Excludes the duration token, which only the inventory row appends.
+ * exited session. Also flags a `provisioning` row whose updatedAt is past the
+ * stranded threshold (probe-independent, since provisioning predates the
+ * workspace). `probe.kind === "unavailable"` is "we don't know" for the
+ * probe-dependent flags but does not suppress the time-based stranded flag.
+ * Excludes the duration token, which only the inventory row appends.
  */
 function runProbeFlags(
   runState: RunState | undefined,
   probe: WorkspaceProbe,
   task: string,
+  now: Date,
 ): string[] {
+  const flags: string[] = [];
+  if (isProvisioningStalled(runState, now)) {
+    flags.push("provisioning stalled");
+  }
   if (probe.kind !== "ok") {
-    return [];
+    return flags;
   }
   const lifecycle = runState?.state ?? "idle";
   const sessionPresent = probe.names.has(task);
   const sessionExited = isWorkspaceExited(probe, task);
-  const flags: string[] = [];
   if (lifecycle === "idle" && sessionPresent) {
     flags.push(sessionExited ? "stray exited session" : "stray session");
   }
@@ -325,7 +351,7 @@ function inventoryStateText(
   now: Date,
 ): string {
   const lifecycle = runState?.state ?? "idle";
-  const flags = runProbeFlags(runState, probe, task);
+  const flags = runProbeFlags(runState, probe, task, now);
   const duration = runStateDurationMs(runState, now);
   if (duration !== undefined) {
     flags.push(formatDuration(duration));
@@ -338,6 +364,9 @@ function inventoryStateText(
  * probe disagree. Returned commands are safe defaults; the user is free to
  * ignore them and use `attach:` + `pr:` to investigate first.
  *
+ * - Stalled provisioning (row stuck past the threshold, dispatcher died
+ *   between preflight and create()'s catch) -> `crew cleanup` clears the
+ *   row whether or not the partial worktree landed on disk.
  * - Stray session (session present, no run-state record) -> `crew cleanup`
  *   to tear down the orphaned worktree and close the session.
  * - Session exited (run-state says running/resumed, kept dead tmux window)
@@ -345,14 +374,19 @@ function inventoryStateText(
  * - Session dead (run-state says running/resumed, no session present) ->
  *   `crew resume` to bring the agent back; the worktree is preserved.
  *
- * No hint when the probe is unavailable (we genuinely don't know whether
- * there's a disagreement) or when the row is healthy.
+ * No hint when the probe is unavailable (we don't know whether the session
+ * disagreement is real); the time-based stalled flag is independent of the
+ * probe and still fires. No hint when the row is healthy.
  */
 function inventoryHint(
   runState: RunState | undefined,
   probe: WorkspaceProbe,
   task: string,
+  now: Date,
 ): string | undefined {
+  if (isProvisioningStalled(runState, now)) {
+    return `provisioning stalled — run 'crew cleanup ${task}' to clear and retry`;
+  }
   if (probe.kind === "unavailable") {
     return undefined;
   }
@@ -454,7 +488,7 @@ async function writeInventoryWorktrees(
     if (prs.length > 0) {
       writeOutput(inventoryField("pr", formatPullRequests(prs)));
     }
-    const hint = inventoryHint(runState, probe, entry.task);
+    const hint = inventoryHint(runState, probe, entry.task, now);
     if (hint !== undefined) {
       writeOutput(inventoryField("hint", hint));
     }

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -750,14 +750,16 @@ function findByTask(config: ResolvedConfig, task: string): WorktreeEntry[] {
   return list(config).filter((entry) => entry.task === task);
 }
 
+/**
+ * Deterministic preview of where worktree create() would land. Lets callers
+ * record run state (e.g. "provisioning") before the worktree exists on disk,
+ * without duplicating the path-derivation rules in basePaths().
+ */
 export interface PredictedWorktreeEntry {
   branchName: string;
   worktreeDir: string;
 }
 
-// Deterministic preview of where worktree create() would land. Lets callers
-// record run state (e.g. "provisioning") before the worktree exists on disk,
-// without duplicating the path-derivation rules in basePaths().
 function predictedEntry(
   config: ResolvedConfig,
   repository: string,


### PR DESCRIPTION
## Summary

Follow-up to #252 addressing the multi-model PR review findings (Claude, Gemini, Codex, Cursor — 5 verified findings):

- **Race fix in `setupWorkspace`**: `create()`'s catch unconditionally wrote `failed-to-launch`. When the preflight gate is clean but a parallel dispatcher beats us to `provisionWorktree`'s internal duplicate check (`WorktreeAlreadyExistsError`), the live `provisioning` row belongs to that other dispatcher — clobbering it would mislead the operator. Skip the write and surface the `tmux attach` hint instead.
- **Stranded `provisioning` rows in `crew status`**: rows older than 5 minutes are flagged `provisioning stalled` in the per-task `run:` line and the inventory view, with a `crew cleanup ${task}` hint. 5 min chosen because `worktrees.create()` typically completes sub-second; clone+hooks rarely exceed 1 min.
- **New race test** locks the `setupWorkspace` fix in.
- **Doc nits**: `predictedEntry` rationale moved onto the exported `PredictedWorktreeEntry` JSDoc; `recordRunStateBestEffort` state-union comment added.
- **Test-file `max-lines` cap**: bumped `setupWorkspace.test.ts` override from 2200 → 2250. The file already has a documented per-file override because splitting it causes duplicate module mocks to race under Vitest's parallel runner.

## Test plan

- [x] `node --run verify` (architecture:check, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint, test) all green
- [x] New `setupWorkspace.test.ts` test asserts `failed-to-launch` is never recorded when `create()` throws `WorktreeAlreadyExistsError` and that the tmux attach hint is logged
- [x] New `status.test.ts` tests cover stranded (>5 min) and fresh (<5 min) `provisioning` rows in both the per-task and inventory paths
- [x] Coverage stays at 100% (the `Number.isNaN` defensive branch was restructured away — `now - NaN > THRESHOLD` is `false` in JS, so the explicit guard was redundant)