### PR TITLE
fix(stop): close orphaned workspaces with no run-state or worktree

### DIFF
--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -161,13 +161,26 @@ describe(interruptWorkspace, () => {
     });
   });
 
-  it("fails when there is no run state or worktree", async () => {
+  it("closes the live workspace when there is no run state or worktree", async () => {
     readRunStateMock.mockReset();
     findByTaskMock.mockReturnValue([]);
+
+    await interruptWorkspace(config, { task: "orphan-1" });
+
+    expect(interruptMock).toHaveBeenCalledWith(config, "orphan-1");
+    expect(recordRunStateMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("Closed orphaned workspace orphan-1");
+  });
+
+  it("fails when there is no run state, no worktree, and no live workspace", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockResolvedValue({ kind: "missing" });
 
     await expect(interruptWorkspace(config, { task: "team-1" })).rejects.toThrow(
       /nothing to interrupt/,
     );
+    expect(recordRunStateMock).not.toHaveBeenCalled();
   });
 
   it("fails when the workspace backend is unavailable", async () => {

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -82,14 +82,14 @@ function resolveInterruptSource(arguments_: {
   task: string;
   state: RunState | undefined;
   entry: WorktreeEntry | undefined;
-}): InterruptSource {
+}): InterruptSource | undefined {
   if (arguments_.state !== undefined) {
     return sourceFromState(arguments_.state);
   }
   if (arguments_.entry !== undefined) {
     return sourceFromWorktree(arguments_.config, arguments_.task, arguments_.entry);
   }
-  throw new Error(`No run state or worktree found for ${arguments_.task}; nothing to interrupt.`);
+  return undefined;
 }
 
 function interruptDetail(result: WorkspaceInterruptResult): string | undefined {
@@ -116,6 +116,10 @@ export async function interruptWorkspace(
   const state = readRunState(config, task);
   const [entry] = worktrees.findByTask(config, task);
   const source = resolveInterruptSource({ config, task, state, entry });
+  if (source === undefined) {
+    await interruptOrphanWorkspace(config, task);
+    return;
+  }
   const result = await workspaces.interrupt(config, source.workspaceName);
   failOnUnavailable(result);
   const detail = interruptDetail(result);
@@ -136,6 +140,21 @@ export async function interruptWorkspace(
   });
   log(`Interrupted ${task}; worktree preserved at ${source.worktreeDir}`);
   log(`Next: crew status ${task}`);
+}
+
+// Orphan path: a tmux session/window for `task` exists but neither a run-state
+// record nor a worktree does, so there's no lifecycle to record `interrupted`
+// against — just close the workspace. Reported in `crew status` under
+// "Orphaned sessions" and pointed at `crew stop`.
+async function interruptOrphanWorkspace(config: ResolvedConfig, task: string): Promise<void> {
+  const result = await workspaces.interrupt(config, task);
+  failOnUnavailable(result);
+  if (result.kind === "missing") {
+    throw new Error(
+      `No run state, worktree, or live workspace found for ${task}; nothing to interrupt.`,
+    );
+  }
+  log(`Closed orphaned workspace ${task}`);
 }
 
 export async function interruptWorkspaceCli(argv: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

`crew status` lists live tmux entities under "Orphaned sessions (no matching worktree)" and tells the user to run `crew stop <task>` to close them. For a true orphan (live tmux entity, no `.runstate` record, no worktree on disk), `crew stop` bailed early with `No run state or worktree found for ...; nothing to interrupt.` — so the documented action did nothing, and the user had no working `crew` command for the orphan it had just surfaced.

This splits `interruptWorkspace()` into two paths:

- **Managed path** (RunState or worktree exists): unchanged — close the workspace, record an `interrupted` RunState for later inspection.
- **Orphan path** (neither exists): call `workspaces.interrupt(config, task)` directly and log `Closed orphaned workspace <task>`. No `RunState` is written (there's no lifecycle to update). If the workspace probe also reports the entity as missing, throw `No run state, worktree, or live workspace found for <task>; nothing to interrupt.` so a mistyped task still surfaces.

`crew cleanup` is unchanged — it still defers to leave the run-state intact when a workspace is present.

## Note on the orphan section's tmux fallback hint

`status.ts:506` still suggests `tmux kill-session -t <task>` as a fallback. That's only correct in session-per-task mode (`GROUNDCREW_TMUX_SESSION_PER_TASK=1`); in the default window mode the correct command is `tmux kill-window -t groundcrew:<task>`. Intentionally left for a follow-up — this PR just makes `crew stop` honor the first half of its own hint.

## Test plan

- [x] `node --run verify` (full suite green)
- [x] New unit tests in `interruptWorkspace.test.ts`: orphan-with-live-workspace closes via `workspaces.interrupt` and writes no RunState; orphan-with-no-live-workspace throws "nothing to interrupt".
- [ ] Manual: in a session with an orphaned tmux entity (no run-state, no worktree), `crew stop <task>` closes the entity and no longer errors.