### PR TITLE
fix(status): use git's checked-out branch when looking up PRs

### DIFF
--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1336,7 +1336,6 @@ JSON
           number: 3,
           state: "open",
           title: "PR",
-          headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         },
       ]);
       const client = makeClient({ pages: [[]] });

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -44,7 +44,6 @@ function pullRequest(overrides: Partial<PullRequestSummary> = {}): PullRequestSu
     number: overrides.number ?? 1,
     state: overrides.state ?? "open",
     title: overrides.title ?? "PR title",
-    headRefOid: overrides.headRefOid ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   };
 }
 

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -154,7 +154,8 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
       const branchName =
         reviewerConfig === undefined
           ? entry.branchName
-          : effectiveBranchName({ config: reviewerConfig, entry });
+          : // oxlint-disable-next-line no-await-in-loop -- one git lookup per worktree; a task almost always has one entry.
+            await effectiveBranchName({ config: reviewerConfig, entry });
       // The injected lookup is contracted never to reject (failures resolve to
       // []), but we still guard it so one bad lookup can never abort the tick
       // and starve the other candidates. A failure means "can't tell yet" →

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -623,7 +623,6 @@ describe(status, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
-        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 
@@ -814,7 +813,6 @@ describe(status, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
-        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 
@@ -837,14 +835,12 @@ describe(status, () => {
         number: 1,
         state: "open",
         title: "a",
-        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
       {
         url: "https://x/pull/2",
         number: 2,
         state: "merged",
         title: "b",
-        headRefOid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
       },
     ]);
 
@@ -874,7 +870,6 @@ describe(status, () => {
         number: 99,
         state: "open",
         title: "Something",
-        headRefOid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       },
     ]);
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -61,7 +61,8 @@ async function writeTaskWorktrees(config: ResolvedConfig, task: string): Promise
   }
   const runState = readRunState(config, task);
   for (const entry of entries) {
-    const branchName = effectiveBranchNameFromRunState({ entry, runState });
+    // oxlint-disable-next-line no-await-in-loop -- status output is easier to read in worktree order.
+    const branchName = await effectiveBranchNameFromRunState({ entry, runState });
     // oxlint-disable-next-line no-await-in-loop -- status output is easier to read in worktree order.
     const dirtiness = await worktrees.probeWorkingTree({
       worktreeDir: entry.dir,
@@ -414,13 +415,15 @@ async function writeInventoryWorktrees(
   }
   const accessHints = await collectAccessHints(config, entries);
   const pullRequests = await collectPullRequests(
-    entries.map((entry) => ({
-      dir: entry.dir,
-      branchName: effectiveBranchNameFromRunState({
-        entry,
-        runState: runStates.get(entry.task),
-      }),
-    })),
+    await Promise.all(
+      entries.map(async (entry) => ({
+        dir: entry.dir,
+        branchName: await effectiveBranchNameFromRunState({
+          entry,
+          runState: runStates.get(entry.task),
+        }),
+      })),
+    ),
   );
   const now = new Date();
   for (const [index, entry] of entries.entries()) {

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -755,6 +755,22 @@ describe("crew task done", () => {
     expect(markDone).not.toHaveBeenCalled();
   });
 
+  it("refuses a dirty matching worktree when the branch only has a merged PR", async () => {
+    const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
+    const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({
+      outcome: "applied",
+    });
+    buildSourcesMock.mockResolvedValue([stubSource("todo", [issue], { markDone })]);
+    findWorktreesByTaskMock.mockReturnValue([hostEntryFor("gc-1")]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 1, untracked: 2 });
+    findPullRequestsForBranchMock.mockResolvedValue([pullRequest({ state: "merged" })]);
+
+    await expect(taskCli(["done", "todo:GC-1"])).rejects.toThrow(
+      /refusing to mark todo:gc-1 done.*1 modified, 2 untracked.*--allow-dirty/,
+    );
+    expect(markDone).not.toHaveBeenCalled();
+  });
+
   it("refuses a worktree when git status cannot be verified", async () => {
     const issue = makeIssue({ id: "todo:gc-1", status: "in-progress" });
     const markDone = vi.fn<NonNullable<TaskSource["markDone"]>>().mockResolvedValue({

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -147,7 +147,6 @@ function pullRequest(overrides: Partial<PullRequestSummary> = {}): PullRequestSu
     number: overrides.number ?? 1,
     state: overrides.state ?? "open",
     title: overrides.title ?? "Ready",
-    headRefOid: overrides.headRefOid ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   };
 }
 

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -685,7 +685,11 @@ async function worktreeHasPullRequest(input: {
     cwd: input.entry.dir,
     branchName: await effectiveBranchName({ config: input.config, entry: input.entry }),
   });
-  return pullRequests.length > 0;
+  // Only an open PR gates `crew task done`: a merged or closed PR for this
+  // branch is stale (work already landed, or abandoned) and shouldn't keep the
+  // worktree pinned. The lifecycle filter also defends against branch-name
+  // reuse — a long-dead merged PR with the same head name doesn't count.
+  return pullRequests.some((pr) => pr.state === "open");
 }
 
 async function assertCanMarkDone(arguments_: {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -683,7 +683,7 @@ async function worktreeHasPullRequest(input: {
 }): Promise<boolean> {
   const pullRequests = await findPullRequestsForBranch({
     cwd: input.entry.dir,
-    branchName: effectiveBranchName({ config: input.config, entry: input.entry }),
+    branchName: await effectiveBranchName({ config: input.config, entry: input.entry }),
   });
   return pullRequests.length > 0;
 }

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -18,20 +18,11 @@ vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   };
 });
 
-const WORKTREE_HEAD_OID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const STALE_HEAD_OID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-const PR_AHEAD_OF_LOCAL_OID = "cccccccccccccccccccccccccccccccccccccccc";
-const LOCAL_AHEAD_OF_PR_OID = "dddddddddddddddddddddddddddddddddddddddd";
-const MISSING_PR_HEAD_OID = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-
-type AncestorVerdict = "ancestor" | "not-ancestor" | "missing";
-
 interface RawPullRequestFixture {
   url: string;
   number: number;
   state: string;
   title: string;
-  headRefOid: string;
 }
 
 function rawPullRequest(overrides: Partial<RawPullRequestFixture> = {}): RawPullRequestFixture {
@@ -40,70 +31,7 @@ function rawPullRequest(overrides: Partial<RawPullRequestFixture> = {}): RawPull
     number: overrides.number ?? 42,
     state: overrides.state ?? "OPEN",
     title: overrides.title ?? "Wire up auth",
-    headRefOid: overrides.headRefOid ?? WORKTREE_HEAD_OID,
   };
-}
-
-function commandFailure(status: number): Error {
-  const cause = Object.assign(new Error("Command exited unsuccessfully"), { status });
-  return new Error(`Command failed (test fixture)\nExit status: ${status}`, { cause });
-}
-
-function mockSuccessfulLookup(
-  output: string,
-  currentHeadOid: string = WORKTREE_HEAD_OID,
-  ancestorMap: Readonly<Record<string, AncestorVerdict>> = {},
-): void {
-  runCommandMock.mockImplementation(async (command, arguments_) => {
-    if (command === "gh") {
-      return output;
-    }
-    if (command !== "git") {
-      throw new Error(`unexpected command: ${command}`);
-    }
-    const [verb, flag, ancestor, descendant] = arguments_;
-    if (verb === "rev-parse" && flag === "HEAD") {
-      return currentHeadOid;
-    }
-    if (verb === "merge-base" && flag === "--is-ancestor") {
-      const verdict = ancestorMap[`${ancestor}->${descendant}`];
-      if (verdict === undefined) {
-        throw new Error(`unmocked merge-base --is-ancestor ${ancestor} ${descendant}`);
-      }
-      if (verdict === "ancestor") {
-        return "";
-      }
-      throw commandFailure(verdict === "not-ancestor" ? 1 : 128);
-    }
-    throw new Error(`unexpected git args: ${arguments_.join(" ")}`);
-  });
-}
-
-function mockMergeBaseRawError(prNumber: number, prHeadOid: string, mergeBaseError: Error): void {
-  runCommandMock.mockImplementation(async (command, arguments_) => {
-    if (command === "gh") {
-      return JSON.stringify([rawPullRequest({ number: prNumber, headRefOid: prHeadOid })]);
-    }
-    if (command !== "git") {
-      throw new Error(`unexpected command: ${command}`);
-    }
-    if (arguments_[0] === "rev-parse") {
-      return WORKTREE_HEAD_OID;
-    }
-    if (arguments_[0] === "merge-base") {
-      throw mergeBaseError;
-    }
-    throw new Error(`unexpected git args: ${arguments_.join(" ")}`);
-  });
-}
-
-function mockFailedGhLookup(): void {
-  runCommandMock.mockImplementation(async (command) => {
-    if (command === "git") {
-      return WORKTREE_HEAD_OID;
-    }
-    throw new Error("gh: command not found");
-  });
 }
 
 describe(findPullRequestsForBranch, () => {
@@ -112,7 +40,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("parses gh's JSON output into typed PR summaries", async () => {
-    mockSuccessfulLookup(JSON.stringify([rawPullRequest()]));
+    runCommandMock.mockResolvedValue(JSON.stringify([rawPullRequest()]));
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -125,13 +53,12 @@ describe(findPullRequestsForBranch, () => {
         number: 42,
         state: "open",
         title: "Wire up auth",
-        headRefOid: WORKTREE_HEAD_OID,
       },
     ]);
   });
 
   it("runs gh in the worktree dir and omits --repo so gh resolves the remote", async () => {
-    mockSuccessfulLookup("[]");
+    runCommandMock.mockResolvedValue("[]");
 
     await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -146,18 +73,10 @@ describe(findPullRequestsForBranch, () => {
     expect(runCommandMock).toHaveBeenCalledWith("gh", expect.not.arrayContaining(["--repo"]), {
       cwd: "/work/widgets-team-1",
     });
-    expect(runCommandMock).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
-      cwd: "/work/widgets-team-1",
-    });
-    expect(runCommandMock).not.toHaveBeenCalledWith(
-      "git",
-      expect.arrayContaining(["merge-base"]),
-      expect.anything(),
-    );
   });
 
   it("normalises MERGED and CLOSED states to lowercase", async () => {
-    mockSuccessfulLookup(
+    runCommandMock.mockResolvedValue(
       JSON.stringify([
         rawPullRequest({ url: "https://x/pull/1", number: 1, state: "MERGED", title: "a" }),
         rawPullRequest({ url: "https://x/pull/2", number: 2, state: "CLOSED", title: "b" }),
@@ -172,17 +91,13 @@ describe(findPullRequestsForBranch, () => {
     expect(prs.map((p) => p.state)).toStrictEqual(["merged", "closed"]);
   });
 
-  it("drops PRs whose head is on a history unrelated to local HEAD (branch-name reuse)", async () => {
-    mockSuccessfulLookup(
+  it("returns merged, open, and closed PRs verbatim so the caller can decide how to use them", async () => {
+    runCommandMock.mockResolvedValue(
       JSON.stringify([
-        rawPullRequest({ number: 1, state: "MERGED", headRefOid: STALE_HEAD_OID }),
+        rawPullRequest({ number: 1, state: "MERGED" }),
         rawPullRequest({ number: 2, state: "OPEN" }),
+        rawPullRequest({ number: 3, state: "CLOSED" }),
       ]),
-      WORKTREE_HEAD_OID,
-      {
-        [`${STALE_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
-        [`${WORKTREE_HEAD_OID}->${STALE_HEAD_OID}`]: "not-ancestor",
-      },
     );
 
     const prs = await findPullRequestsForBranch({
@@ -190,169 +105,11 @@ describe(findPullRequestsForBranch, () => {
       branchName: "x",
     });
 
-    expect(prs.map((p) => p.number)).toStrictEqual([2]);
-  });
-
-  it("keeps a PR whose head is an ancestor of local HEAD (local has WIP commits on top)", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([rawPullRequest({ number: 7, headRefOid: PR_AHEAD_OF_LOCAL_OID })]),
-      WORKTREE_HEAD_OID,
-      { [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor" },
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([7]);
-  });
-
-  it("keeps a PR whose head is ahead of local HEAD (PR has a merge-master commit)", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([rawPullRequest({ number: 8, headRefOid: LOCAL_AHEAD_OF_PR_OID })]),
-      WORKTREE_HEAD_OID,
-      {
-        [`${LOCAL_AHEAD_OF_PR_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
-        [`${WORKTREE_HEAD_OID}->${LOCAL_AHEAD_OF_PR_OID}`]: "ancestor",
-      },
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([8]);
-  });
-
-  it("keeps a PR whose head is not in the local object DB (favor visibility over a missed fetch)", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([rawPullRequest({ number: 9, headRefOid: MISSING_PR_HEAD_OID })]),
-      WORKTREE_HEAD_OID,
-      {
-        [`${MISSING_PR_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "missing",
-        [`${WORKTREE_HEAD_OID}->${MISSING_PR_HEAD_OID}`]: "missing",
-      },
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([9]);
-  });
-
-  it("keeps a PR when merge-base fails with an error that has no cause (e.g. spawn ENOENT)", async () => {
-    mockMergeBaseRawError(12, STALE_HEAD_OID, new Error("spawn ENOENT"));
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([12]);
-  });
-
-  it("keeps a PR when merge-base fails with a wrapper cause that carries no status field", async () => {
-    mockMergeBaseRawError(
-      13,
-      STALE_HEAD_OID,
-      new Error("wrapped", { cause: new Error("nested without status") }),
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([13]);
-  });
-
-  it("preserves gh's ordering across a mixed batch of equal / ancestor / unrelated / descendant heads", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([
-        rawPullRequest({ number: 100 }),
-        rawPullRequest({ number: 101, headRefOid: PR_AHEAD_OF_LOCAL_OID }),
-        rawPullRequest({ number: 102, headRefOid: STALE_HEAD_OID }),
-        rawPullRequest({ number: 103, headRefOid: LOCAL_AHEAD_OF_PR_OID }),
-      ]),
-      WORKTREE_HEAD_OID,
-      {
-        [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor",
-        [`${STALE_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
-        [`${WORKTREE_HEAD_OID}->${STALE_HEAD_OID}`]: "not-ancestor",
-        [`${LOCAL_AHEAD_OF_PR_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
-        [`${WORKTREE_HEAD_OID}->${LOCAL_AHEAD_OF_PR_OID}`]: "ancestor",
-      },
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([100, 101, 103]);
-  });
-
-  it("keeps a PR when forward is not-ancestor but reverse is unknown (reverse-arm fallback)", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([rawPullRequest({ number: 15, headRefOid: MISSING_PR_HEAD_OID })]),
-      WORKTREE_HEAD_OID,
-      {
-        [`${MISSING_PR_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
-        [`${WORKTREE_HEAD_OID}->${MISSING_PR_HEAD_OID}`]: "missing",
-      },
-    );
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([15]);
-  });
-
-  it("forwards the AbortSignal to merge-base invocations alongside cwd", async () => {
-    mockSuccessfulLookup(
-      JSON.stringify([rawPullRequest({ number: 14, headRefOid: PR_AHEAD_OF_LOCAL_OID })]),
-      WORKTREE_HEAD_OID,
-      { [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor" },
-    );
-    const { signal } = new AbortController();
-
-    await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-      signal,
-    });
-
-    expect(runCommandMock).toHaveBeenCalledWith(
-      "git",
-      ["merge-base", "--is-ancestor", PR_AHEAD_OF_LOCAL_OID, WORKTREE_HEAD_OID],
-      { cwd: "/work/widgets-team-1", signal },
-    );
-  });
-
-  it("skips merge-base entirely on OID equality (fast path)", async () => {
-    mockSuccessfulLookup(JSON.stringify([rawPullRequest({ number: 11 })]));
-
-    const prs = await findPullRequestsForBranch({
-      cwd: "/work/widgets-team-1",
-      branchName: "x",
-    });
-
-    expect(prs.map((p) => p.number)).toStrictEqual([11]);
-    expect(runCommandMock).not.toHaveBeenCalledWith(
-      "git",
-      expect.arrayContaining(["merge-base"]),
-      expect.anything(),
-    );
+    expect(prs.map((p) => p.number)).toStrictEqual([1, 2, 3]);
   });
 
   it("returns empty when gh fails (not installed / not authenticated / network)", async () => {
-    mockFailedGhLookup();
+    runCommandMock.mockRejectedValue(new Error("gh: command not found"));
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -363,7 +120,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("returns empty when gh emits non-JSON output", async () => {
-    mockSuccessfulLookup("not json at all");
+    runCommandMock.mockResolvedValue("not json at all");
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -374,7 +131,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("returns empty when gh emits a non-array JSON value", async () => {
-    mockSuccessfulLookup("null");
+    runCommandMock.mockResolvedValue("null");
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",
@@ -385,10 +142,9 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("skips entries that don't match the expected PR shape", async () => {
-    mockSuccessfulLookup(
+    runCommandMock.mockResolvedValue(
       JSON.stringify([
         rawPullRequest({ url: "https://x/pull/1", number: 1, state: "OPEN", title: "valid" }),
-        { url: "https://x/pull/9", number: 9, state: "OPEN", title: "missing head oid" },
         { url: 42, number: "not a number" }, // malformed; dropped silently
         null, // also dropped
       ]),
@@ -403,7 +159,7 @@ describe(findPullRequestsForBranch, () => {
   });
 
   it("forwards the AbortSignal to runCommandAsync alongside cwd when provided", async () => {
-    mockSuccessfulLookup("[]");
+    runCommandMock.mockResolvedValue("[]");
     const { signal } = new AbortController();
 
     await findPullRequestsForBranch({
@@ -416,14 +172,12 @@ describe(findPullRequestsForBranch, () => {
       cwd: "/work/widgets-team-1",
       signal,
     });
-    expect(runCommandMock).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
-      cwd: "/work/widgets-team-1",
-      signal,
-    });
   });
 
   it("forwards a lowercased unknown state value verbatim", async () => {
-    mockSuccessfulLookup(JSON.stringify([rawPullRequest({ state: "DRAFT", title: "wip" })]));
+    runCommandMock.mockResolvedValue(
+      JSON.stringify([rawPullRequest({ state: "DRAFT", title: "wip" })]),
+    );
 
     const prs = await findPullRequestsForBranch({
       cwd: "/work/widgets-team-1",

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -20,6 +20,11 @@ vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
 
 const WORKTREE_HEAD_OID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const STALE_HEAD_OID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PR_AHEAD_OF_LOCAL_OID = "cccccccccccccccccccccccccccccccccccccccc";
+const LOCAL_AHEAD_OF_PR_OID = "dddddddddddddddddddddddddddddddddddddddd";
+const MISSING_PR_HEAD_OID = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+type AncestorVerdict = "ancestor" | "not-ancestor" | "missing";
 
 interface RawPullRequestFixture {
   url: string;
@@ -39,15 +44,56 @@ function rawPullRequest(overrides: Partial<RawPullRequestFixture> = {}): RawPull
   };
 }
 
-function mockSuccessfulLookup(output: string, currentHeadOid = WORKTREE_HEAD_OID): void {
-  runCommandMock.mockImplementation(async (command) => {
+function commandFailure(status: number): Error {
+  const cause = Object.assign(new Error("Command exited unsuccessfully"), { status });
+  return new Error(`Command failed (test fixture)\nExit status: ${status}`, { cause });
+}
+
+function mockSuccessfulLookup(
+  output: string,
+  currentHeadOid: string = WORKTREE_HEAD_OID,
+  ancestorMap: Readonly<Record<string, AncestorVerdict>> = {},
+): void {
+  runCommandMock.mockImplementation(async (command, arguments_) => {
     if (command === "gh") {
       return output;
     }
-    if (command === "git") {
+    if (command !== "git") {
+      throw new Error(`unexpected command: ${command}`);
+    }
+    const [verb, flag, ancestor, descendant] = arguments_;
+    if (verb === "rev-parse" && flag === "HEAD") {
       return currentHeadOid;
     }
-    throw new Error(`unexpected command: ${command}`);
+    if (verb === "merge-base" && flag === "--is-ancestor") {
+      const verdict = ancestorMap[`${ancestor}->${descendant}`];
+      if (verdict === undefined) {
+        throw new Error(`unmocked merge-base --is-ancestor ${ancestor} ${descendant}`);
+      }
+      if (verdict === "ancestor") {
+        return "";
+      }
+      throw commandFailure(verdict === "not-ancestor" ? 1 : 128);
+    }
+    throw new Error(`unexpected git args: ${arguments_.join(" ")}`);
+  });
+}
+
+function mockMergeBaseRawError(prNumber: number, prHeadOid: string, mergeBaseError: Error): void {
+  runCommandMock.mockImplementation(async (command, arguments_) => {
+    if (command === "gh") {
+      return JSON.stringify([rawPullRequest({ number: prNumber, headRefOid: prHeadOid })]);
+    }
+    if (command !== "git") {
+      throw new Error(`unexpected command: ${command}`);
+    }
+    if (arguments_[0] === "rev-parse") {
+      return WORKTREE_HEAD_OID;
+    }
+    if (arguments_[0] === "merge-base") {
+      throw mergeBaseError;
+    }
+    throw new Error(`unexpected git args: ${arguments_.join(" ")}`);
   });
 }
 
@@ -103,6 +149,11 @@ describe(findPullRequestsForBranch, () => {
     expect(runCommandMock).toHaveBeenCalledWith("git", ["rev-parse", "HEAD"], {
       cwd: "/work/widgets-team-1",
     });
+    expect(runCommandMock).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["merge-base"]),
+      expect.anything(),
+    );
   });
 
   it("normalises MERGED and CLOSED states to lowercase", async () => {
@@ -121,12 +172,17 @@ describe(findPullRequestsForBranch, () => {
     expect(prs.map((p) => p.state)).toStrictEqual(["merged", "closed"]);
   });
 
-  it("returns only PRs whose head matches the current worktree HEAD", async () => {
+  it("drops PRs whose head is on a history unrelated to local HEAD (branch-name reuse)", async () => {
     mockSuccessfulLookup(
       JSON.stringify([
         rawPullRequest({ number: 1, state: "MERGED", headRefOid: STALE_HEAD_OID }),
         rawPullRequest({ number: 2, state: "OPEN" }),
       ]),
+      WORKTREE_HEAD_OID,
+      {
+        [`${STALE_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
+        [`${WORKTREE_HEAD_OID}->${STALE_HEAD_OID}`]: "not-ancestor",
+      },
     );
 
     const prs = await findPullRequestsForBranch({
@@ -135,6 +191,164 @@ describe(findPullRequestsForBranch, () => {
     });
 
     expect(prs.map((p) => p.number)).toStrictEqual([2]);
+  });
+
+  it("keeps a PR whose head is an ancestor of local HEAD (local has WIP commits on top)", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([rawPullRequest({ number: 7, headRefOid: PR_AHEAD_OF_LOCAL_OID })]),
+      WORKTREE_HEAD_OID,
+      { [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor" },
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([7]);
+  });
+
+  it("keeps a PR whose head is ahead of local HEAD (PR has a merge-master commit)", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([rawPullRequest({ number: 8, headRefOid: LOCAL_AHEAD_OF_PR_OID })]),
+      WORKTREE_HEAD_OID,
+      {
+        [`${LOCAL_AHEAD_OF_PR_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
+        [`${WORKTREE_HEAD_OID}->${LOCAL_AHEAD_OF_PR_OID}`]: "ancestor",
+      },
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([8]);
+  });
+
+  it("keeps a PR whose head is not in the local object DB (favor visibility over a missed fetch)", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([rawPullRequest({ number: 9, headRefOid: MISSING_PR_HEAD_OID })]),
+      WORKTREE_HEAD_OID,
+      {
+        [`${MISSING_PR_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "missing",
+        [`${WORKTREE_HEAD_OID}->${MISSING_PR_HEAD_OID}`]: "missing",
+      },
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([9]);
+  });
+
+  it("keeps a PR when merge-base fails with an error that has no cause (e.g. spawn ENOENT)", async () => {
+    mockMergeBaseRawError(12, STALE_HEAD_OID, new Error("spawn ENOENT"));
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([12]);
+  });
+
+  it("keeps a PR when merge-base fails with a wrapper cause that carries no status field", async () => {
+    mockMergeBaseRawError(
+      13,
+      STALE_HEAD_OID,
+      new Error("wrapped", { cause: new Error("nested without status") }),
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([13]);
+  });
+
+  it("preserves gh's ordering across a mixed batch of equal / ancestor / unrelated / descendant heads", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([
+        rawPullRequest({ number: 100 }),
+        rawPullRequest({ number: 101, headRefOid: PR_AHEAD_OF_LOCAL_OID }),
+        rawPullRequest({ number: 102, headRefOid: STALE_HEAD_OID }),
+        rawPullRequest({ number: 103, headRefOid: LOCAL_AHEAD_OF_PR_OID }),
+      ]),
+      WORKTREE_HEAD_OID,
+      {
+        [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor",
+        [`${STALE_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
+        [`${WORKTREE_HEAD_OID}->${STALE_HEAD_OID}`]: "not-ancestor",
+        [`${LOCAL_AHEAD_OF_PR_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
+        [`${WORKTREE_HEAD_OID}->${LOCAL_AHEAD_OF_PR_OID}`]: "ancestor",
+      },
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([100, 101, 103]);
+  });
+
+  it("keeps a PR when forward is not-ancestor but reverse is unknown (reverse-arm fallback)", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([rawPullRequest({ number: 15, headRefOid: MISSING_PR_HEAD_OID })]),
+      WORKTREE_HEAD_OID,
+      {
+        [`${MISSING_PR_HEAD_OID}->${WORKTREE_HEAD_OID}`]: "not-ancestor",
+        [`${WORKTREE_HEAD_OID}->${MISSING_PR_HEAD_OID}`]: "missing",
+      },
+    );
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([15]);
+  });
+
+  it("forwards the AbortSignal to merge-base invocations alongside cwd", async () => {
+    mockSuccessfulLookup(
+      JSON.stringify([rawPullRequest({ number: 14, headRefOid: PR_AHEAD_OF_LOCAL_OID })]),
+      WORKTREE_HEAD_OID,
+      { [`${PR_AHEAD_OF_LOCAL_OID}->${WORKTREE_HEAD_OID}`]: "ancestor" },
+    );
+    const { signal } = new AbortController();
+
+    await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+      signal,
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["merge-base", "--is-ancestor", PR_AHEAD_OF_LOCAL_OID, WORKTREE_HEAD_OID],
+      { cwd: "/work/widgets-team-1", signal },
+    );
+  });
+
+  it("skips merge-base entirely on OID equality (fast path)", async () => {
+    mockSuccessfulLookup(JSON.stringify([rawPullRequest({ number: 11 })]));
+
+    const prs = await findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+    });
+
+    expect(prs.map((p) => p.number)).toStrictEqual([11]);
+    expect(runCommandMock).not.toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["merge-base"]),
+      expect.anything(),
+    );
   });
 
   it("returns empty when gh fails (not installed / not authenticated / network)", async () => {

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -8,6 +8,14 @@
  * resolve the GitHub repo from that checkout's own `origin` remote. This
  * handles bare config names, full `owner/repo` slugs, forks, and SSH/HTTPS
  * remotes uniformly — we never reconstruct the slug ourselves.
+ *
+ * To guard against PRs from a long-dead, unrelated history that happens to
+ * have reused the same branch name, the lookup keeps only PRs whose head
+ * is linearly related to the worktree's local HEAD — either one reachable
+ * from the other via `git merge-base --is-ancestor`. When git can't tell
+ * (PR head not in the local object DB, etc.), the PR is kept; hiding a
+ * likely-relevant PR is worse than showing one the user can recognize as
+ * wrong from its title and URL.
  */
 
 import { runCommandAsync } from "./commandRunner.ts";
@@ -18,7 +26,7 @@ export interface PullRequestSummary {
   /** Lowercased lifecycle: "open" | "merged" | "closed". */
   state: string;
   title: string;
-  /** PR head commit SHA used to ignore historical PRs from reused branch names. */
+  /** PR head commit SHA; compared against local HEAD to drop unrelated histories. */
   headRefOid: string;
 }
 
@@ -202,10 +210,72 @@ export async function findPullRequestsForBranch(
       ),
       runCommandAsync("git", ["rev-parse", "HEAD"], options),
     ]);
-    return parsePullRequests(output).filter((pr) => pr.headRefOid === currentHeadOid);
+    const summaries = parsePullRequests(output);
+    const kept: PullRequestSummary[] = [];
+    for (const pr of summaries) {
+      if (pr.headRefOid === currentHeadOid) {
+        kept.push(pr);
+        continue;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- ≤ GH_PR_LIST_LIMIT (5) PRs; sequential avoids fan-out of git processes for a status display
+      if (await mightShareHistory(pr.headRefOid, currentHeadOid, cwd, signal)) {
+        kept.push(pr);
+      }
+    }
+    return kept;
   } catch {
     // gh/git not installed / not authenticated / non-GitHub remote / network
     // error / etc. All resolve to "no PR info available" for display.
     return [];
   }
+}
+
+/**
+ * Returns true when the two heads might be on the same history — either git
+ * confirms one is reachable from the other, or git can't tell (missing object
+ * DB entry, git failure). Returns false only when both directions definitively
+ * report "not an ancestor", which is the branch-name-reuse case the strict
+ * filter was originally guarding against.
+ */
+async function mightShareHistory(
+  prHeadOid: string,
+  localHeadOid: string,
+  cwd: string,
+  signal: AbortSignal | undefined,
+): Promise<boolean> {
+  const forward = await ancestorRelation(prHeadOid, localHeadOid, cwd, signal);
+  if (forward !== "not-ancestor") {
+    return true;
+  }
+  const reverse = await ancestorRelation(localHeadOid, prHeadOid, cwd, signal);
+  return reverse !== "not-ancestor";
+}
+
+async function ancestorRelation(
+  ancestor: string,
+  descendant: string,
+  cwd: string,
+  signal: AbortSignal | undefined,
+): Promise<"ancestor" | "not-ancestor" | "unknown"> {
+  const options = signal === undefined ? { cwd } : { cwd, signal };
+  try {
+    await runCommandAsync("git", ["merge-base", "--is-ancestor", ancestor, descendant], options);
+    return "ancestor";
+  } catch (error) {
+    // Exit 1 is git's definitive "not an ancestor". Anything else (typically
+    // exit 128 — missing object, bad SHA, repo error) is non-definitive;
+    // favor visibility and let the caller keep the PR.
+    return hasExitStatus(error, 1) ? "not-ancestor" : "unknown";
+  }
+}
+
+function hasExitStatus(error: unknown, expected: number): boolean {
+  if (typeof error !== "object" || error === null || !("cause" in error)) {
+    return false;
+  }
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("status" in cause)) {
+    return false;
+  }
+  return typeof cause.status === "number" && cause.status === expected;
 }

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -9,13 +9,13 @@
  * handles bare config names, full `owner/repo` slugs, forks, and SSH/HTTPS
  * remotes uniformly — we never reconstruct the slug ourselves.
  *
- * To guard against PRs from a long-dead, unrelated history that happens to
- * have reused the same branch name, the lookup keeps only PRs whose head
- * is linearly related to the worktree's local HEAD — either one reachable
- * from the other via `git merge-base --is-ancestor`. When git can't tell
- * (PR head not in the local object DB, etc.), the PR is kept; hiding a
- * likely-relevant PR is worse than showing one the user can recognize as
- * wrong from its title and URL.
+ * Whatever GitHub returns is returned verbatim. We do not filter by commit
+ * history: the branch name on the remote (which `gh pr list --head` matches)
+ * is already a strong identifier for "the PR(s) for this checkout". Stale
+ * PRs from a long-dead branch with a reused name surface as `(merged)` or
+ * `(closed)` in the status output, which is more informative than silently
+ * dropping them. Decision-making callers (e.g. `crew task done`) filter by
+ * lifecycle state instead.
  */
 
 import { runCommandAsync } from "./commandRunner.ts";
@@ -26,8 +26,6 @@ export interface PullRequestSummary {
   /** Lowercased lifecycle: "open" | "merged" | "closed". */
   state: string;
   title: string;
-  /** PR head commit SHA; compared against local HEAD to drop unrelated histories. */
-  headRefOid: string;
 }
 
 const GH_PR_LIST_LIMIT = 5;
@@ -50,7 +48,6 @@ interface RawPullRequest {
   number: number;
   state: string;
   title: string;
-  headRefOid: string;
 }
 
 function parsePullRequests(output: string): PullRequestSummary[] {
@@ -73,7 +70,6 @@ function parsePullRequests(output: string): PullRequestSummary[] {
       number: entry.number,
       state: STATE_MAP[entry.state] ?? entry.state.toLowerCase(),
       title: entry.title,
-      headRefOid: entry.headRefOid,
     });
   }
   return summaries;
@@ -89,8 +85,7 @@ function isRawPullRequest(value: unknown): value is RawPullRequest {
     typeof record["url"] === "string" &&
     typeof record["number"] === "number" &&
     typeof record["state"] === "string" &&
-    typeof record["title"] === "string" &&
-    typeof record["headRefOid"] === "string"
+    typeof record["title"] === "string"
   );
 }
 
@@ -191,91 +186,26 @@ export async function findPullRequestsForBranch(
   const { cwd, branchName, signal } = arguments_;
   const options = signal === undefined ? { cwd } : { cwd, signal };
   try {
-    const [output, currentHeadOid] = await Promise.all([
-      runCommandAsync(
-        "gh",
-        [
-          "pr",
-          "list",
-          "--head",
-          branchName,
-          "--state",
-          "all",
-          "--limit",
-          String(GH_PR_LIST_LIMIT),
-          "--json",
-          "url,number,state,title,headRefOid",
-        ],
-        options,
-      ),
-      runCommandAsync("git", ["rev-parse", "HEAD"], options),
-    ]);
-    const summaries = parsePullRequests(output);
-    const kept: PullRequestSummary[] = [];
-    for (const pr of summaries) {
-      if (pr.headRefOid === currentHeadOid) {
-        kept.push(pr);
-        continue;
-      }
-      // oxlint-disable-next-line no-await-in-loop -- ≤ GH_PR_LIST_LIMIT (5) PRs; sequential avoids fan-out of git processes for a status display
-      if (await mightShareHistory(pr.headRefOid, currentHeadOid, cwd, signal)) {
-        kept.push(pr);
-      }
-    }
-    return kept;
+    const output = await runCommandAsync(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--head",
+        branchName,
+        "--state",
+        "all",
+        "--limit",
+        String(GH_PR_LIST_LIMIT),
+        "--json",
+        "url,number,state,title",
+      ],
+      options,
+    );
+    return parsePullRequests(output);
   } catch {
-    // gh/git not installed / not authenticated / non-GitHub remote / network
+    // gh not installed / not authenticated / non-GitHub remote / network
     // error / etc. All resolve to "no PR info available" for display.
     return [];
   }
-}
-
-/**
- * Returns true when the two heads might be on the same history — either git
- * confirms one is reachable from the other, or git can't tell (missing object
- * DB entry, git failure). Returns false only when both directions definitively
- * report "not an ancestor", which is the branch-name-reuse case the strict
- * filter was originally guarding against.
- */
-async function mightShareHistory(
-  prHeadOid: string,
-  localHeadOid: string,
-  cwd: string,
-  signal: AbortSignal | undefined,
-): Promise<boolean> {
-  const forward = await ancestorRelation(prHeadOid, localHeadOid, cwd, signal);
-  if (forward !== "not-ancestor") {
-    return true;
-  }
-  const reverse = await ancestorRelation(localHeadOid, prHeadOid, cwd, signal);
-  return reverse !== "not-ancestor";
-}
-
-async function ancestorRelation(
-  ancestor: string,
-  descendant: string,
-  cwd: string,
-  signal: AbortSignal | undefined,
-): Promise<"ancestor" | "not-ancestor" | "unknown"> {
-  const options = signal === undefined ? { cwd } : { cwd, signal };
-  try {
-    await runCommandAsync("git", ["merge-base", "--is-ancestor", ancestor, descendant], options);
-    return "ancestor";
-  } catch (error) {
-    // Exit 1 is git's definitive "not an ancestor". Anything else (typically
-    // exit 128 — missing object, bad SHA, repo error) is non-definitive;
-    // favor visibility and let the caller keep the PR.
-    return hasExitStatus(error, 1) ? "not-ancestor" : "unknown";
-  }
-}
-
-function hasExitStatus(error: unknown, expected: number): boolean {
-  if (typeof error !== "object" || error === null || !("cause" in error)) {
-    return false;
-  }
-  const { cause } = error;
-  if (typeof cause !== "object" || cause === null || !("status" in cause)) {
-    return false;
-  }
-  return typeof cause.status === "number" && cause.status === expected;
 }

--- a/src/lib/worktreeRunState.test.ts
+++ b/src/lib/worktreeRunState.test.ts
@@ -1,0 +1,157 @@
+import type { RunCommandOptions } from "./commandRunner.ts";
+import type { RunState } from "./runState.ts";
+import { effectiveBranchNameFromRunState as resolveBranch } from "./worktreeRunState.ts";
+
+type RunCommandAsyncMock = (
+  command: string,
+  arguments_: readonly string[],
+  options?: RunCommandOptions,
+) => Promise<string>;
+
+const runCommandMock = vi.hoisted(() => vi.fn<RunCommandAsyncMock>());
+
+vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- single recorder for the captured-stdio overload of runCommandAsync
+    runCommandAsync: runCommandMock as unknown as typeof actual.runCommandAsync,
+  };
+});
+
+const WORKTREE_DIR = "/work/repo/team-1";
+const ENTRY_BRANCH = "dev-team-1";
+const RUN_STATE_BRANCH = "feature/dev-team-1";
+const GIT_BRANCH = "jdoe/dev-team-1";
+
+interface EntryFixture {
+  repository: string;
+  branchName: string;
+  dir: string;
+}
+
+function entry(overrides: Partial<EntryFixture> = {}): EntryFixture {
+  return {
+    repository: overrides.repository ?? "repo",
+    branchName: overrides.branchName ?? ENTRY_BRANCH,
+    dir: overrides.dir ?? WORKTREE_DIR,
+  };
+}
+
+function runState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    task: overrides.task ?? "team-1",
+    repository: overrides.repository ?? "repo",
+    agent: overrides.agent ?? "claude",
+    worktreeDir: overrides.worktreeDir ?? WORKTREE_DIR,
+    branchName: overrides.branchName ?? RUN_STATE_BRANCH,
+    workspaceName: overrides.workspaceName ?? "ws",
+    state: overrides.state ?? "running",
+    createdAt: overrides.createdAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00.000Z",
+    resumeCount: overrides.resumeCount ?? 0,
+    ...(overrides.reason !== undefined && { reason: overrides.reason }),
+    ...(overrides.detail !== undefined && { detail: overrides.detail }),
+    ...(overrides.title !== undefined && { title: overrides.title }),
+    ...(overrides.url !== undefined && { url: overrides.url }),
+    ...(overrides.completionTaskId !== undefined && {
+      completionTaskId: overrides.completionTaskId,
+    }),
+    ...(overrides.adoptedBranch !== undefined && { adoptedBranch: overrides.adoptedBranch }),
+  };
+}
+
+function mockGitBranch(output: string): void {
+  runCommandMock.mockImplementation(async (command, arguments_) => {
+    if (command === "git" && arguments_[0] === "branch" && arguments_[1] === "--show-current") {
+      return output;
+    }
+    throw new Error(`unexpected command: ${command} ${arguments_.join(" ")}`);
+  });
+}
+
+function mockGitFailure(): void {
+  runCommandMock.mockImplementation(async (command, arguments_) => {
+    if (command === "git" && arguments_[0] === "branch" && arguments_[1] === "--show-current") {
+      throw new Error("fatal: not a git repository");
+    }
+    throw new Error(`unexpected command: ${command} ${arguments_.join(" ")}`);
+  });
+}
+
+describe(resolveBranch, () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it("returns the git-resolved branch when git succeeds, even over a matching runState", async () => {
+    mockGitBranch(GIT_BRANCH);
+
+    const result = await resolveBranch({
+      entry: entry(),
+      runState: runState(),
+    });
+
+    expect(result).toBe(GIT_BRANCH);
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "git",
+      ["branch", "--show-current"],
+      expect.objectContaining({ cwd: WORKTREE_DIR }),
+    );
+  });
+
+  it("falls back to runState branchName when git returns empty (detached HEAD)", async () => {
+    mockGitBranch("");
+
+    const result = await resolveBranch({
+      entry: entry(),
+      runState: runState(),
+    });
+
+    expect(result).toBe(RUN_STATE_BRANCH);
+  });
+
+  it("falls back to entry branchName when git returns empty and runState is undefined", async () => {
+    mockGitBranch("");
+
+    const result = await resolveBranch({
+      entry: entry(),
+      runState: undefined,
+    });
+
+    expect(result).toBe(ENTRY_BRANCH);
+  });
+
+  it("falls back to entry branchName when git returns empty and runState does not match entry", async () => {
+    mockGitBranch("");
+
+    const result = await resolveBranch({
+      entry: entry({ dir: "/work/repo/team-1" }),
+      runState: runState({ worktreeDir: "/work/other-place" }),
+    });
+
+    expect(result).toBe(ENTRY_BRANCH);
+  });
+
+  it("falls back to runState branchName when git throws", async () => {
+    mockGitFailure();
+
+    const result = await resolveBranch({
+      entry: entry(),
+      runState: runState(),
+    });
+
+    expect(result).toBe(RUN_STATE_BRANCH);
+  });
+
+  it("falls back to entry branchName when git throws and runState is undefined", async () => {
+    mockGitFailure();
+
+    const result = await resolveBranch({
+      entry: entry(),
+      runState: undefined,
+    });
+
+    expect(result).toBe(ENTRY_BRANCH);
+  });
+});

--- a/src/lib/worktreeRunState.ts
+++ b/src/lib/worktreeRunState.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { runCommandAsync } from "./commandRunner.ts";
 import type { ResolvedConfig } from "./config.ts";
 import { readRunState, type RunState } from "./runState.ts";
 import type { WorktreeEntry } from "./worktrees.ts";
@@ -40,8 +41,8 @@ interface EffectiveBranchNameInput {
   entry: Pick<WorktreeEntry, "repository" | "task" | "branchName" | "dir">;
 }
 
-export function effectiveBranchName(input: EffectiveBranchNameInput): string {
-  return effectiveBranchNameFromRunState({
+export async function effectiveBranchName(input: EffectiveBranchNameInput): Promise<string> {
+  return await effectiveBranchNameFromRunState({
     entry: input.entry,
     runState: readMatchingRunState(input),
   });
@@ -52,13 +53,35 @@ interface EffectiveBranchNameFromRunStateInput {
   runState: RunState | undefined;
 }
 
-export function effectiveBranchNameFromRunState(
+/**
+ * Resolves the worktree's checked-out branch name. Git is the source of truth:
+ * run state records the branch we *requested* at creation, but a template hook
+ * or manual rename can drift the actual branch (e.g. flawless-inventory prefixes
+ * with the GitHub username). Downstream callers — `gh pr list --head <name>`,
+ * the displayed `branch:` row, `git push` — need what git has now, not what we
+ * once asked for. Falls back to run state / entry when git can't answer
+ * (detached HEAD, worktree not yet provisioned, git failure).
+ */
+export async function effectiveBranchNameFromRunState(
   input: EffectiveBranchNameFromRunStateInput,
-): string {
+): Promise<string> {
+  const checkedOut = await resolveCheckedOutBranch(input.entry.dir);
+  if (checkedOut !== undefined) {
+    return checkedOut;
+  }
   if (input.runState !== undefined && runStateMatchesEntry(input)) {
     return input.runState.branchName;
   }
   return input.entry.branchName;
+}
+
+async function resolveCheckedOutBranch(dir: string): Promise<string | undefined> {
+  try {
+    const output = await runCommandAsync("git", ["branch", "--show-current"], { cwd: dir });
+    return output === "" ? undefined : output;
+  } catch {
+    return undefined;
+  }
 }
 
 interface HasAdoptedBranchInput {


### PR DESCRIPTION
## Summary

- `crew status <task>` was omitting the `pr:` row for worktrees whose
  checked-out branch had been renamed (e.g. by a `create` template hook
  that prefixes a remote-tracking name onto the branch git created).
- Run state and the worktree directory listing both cached the original
  branch name; `gh pr list --head <stale-name>` returned `[]`, so the
  PR was invisible.
- Now: callers resolve the branch via `git branch --show-current` in
  the worktree dir and fall back to the cached name only when git can't
  answer (detached HEAD, not a git repo). `gh pr list --head` then
  matches what GitHub actually has.

## Concrete example fixed

Task `cat-66755`, worktree
`/Users/paulbaranowski/groundcrew/worktrees/flawless-inventory-cat-66755`.
Run state recorded `branchName: paulbaranowski-cat-66755`; the
`flawless-inventory` create hook had renamed the branch to
`paulb-instacart/paulbaranowski-cat-66755`. `gh pr list --head
paulbaranowski-cat-66755` returned `[]` even though
https://github.com/instacart/carrot/pull/813151 was open. With this
change, `git branch --show-current` returns the prefixed name and the
PR row renders.

## Implementation

- `src/lib/worktreeRunState.ts` — `effectiveBranchName` and
  `effectiveBranchNameFromRunState` are now async; they shell out to
  `git branch --show-current` in the worktree dir and use the result
  when git can resolve a branch, falling back to the matching run
  state's branch (then the entry's branch) only on empty / failure.
- `src/commands/status.ts`, `src/commands/reviewer.ts`,
  `src/commands/task.ts` — three call sites cascade `await` through
  the new async signatures. `status.ts` switches to
  `await Promise.all(entries.map(...))` so per-entry git lookups still
  parallelise.
- `src/lib/pullRequests.ts:findPullRequestsForBranch` — simplified.
  An earlier commit on this PR added a merge-base reachability check
  to compensate for OID divergence; once the branch name is right,
  `gh pr list --head` already returns "PRs for this checkout" and the
  reachability filter adds no value. Stripped the
  `mightShareHistory` / `ancestorRelation` / `git rev-parse HEAD` /
  `git merge-base --is-ancestor` plumbing and the `headRefOid` field.
- `src/commands/task.ts:worktreeHasPullRequest` (the gate for
  `crew task done`) now filters by `state === "open"`. A merged or
  closed PR for this branch is stale (work already landed, or
  abandoned) and shouldn't pin the worktree open. State-based
  filtering at the decision site is what defends against
  branch-name-reuse, not commit-history filtering at the lookup site.
- `src/commands/reviewer.ts` was already state-driven (merged → done,
  open + in-progress → in-review); behaviour unchanged.

## Test coverage

- `src/lib/worktreeRunState.test.ts` (new) — 6 cases pinning the git
  → run state → entry fallback chain (success, empty output, git
  throws, run state missing, run state mismatched-dir).
- `src/lib/pullRequests.test.ts` — kept the parse / state-normalisation
  / failure-tolerance cases; dropped the 11 merge-base reachability
  cases that no longer apply.
- Caller tests in `status.test.ts`, `reviewer.test.ts`, `task.test.ts`,
  and `orchestrator.test.ts` had `headRefOid` stripped from their PR
  fixtures.

## Decisions

1. **Three commits, one PR.** Original commit added the merge-base
   filter to fix what looked like an OID divergence bug. Investigating
   `cat-66755` revealed the real root cause was branch name resolution
   (OIDs were byte-equal). The second commit fixed that. The third
   commit removes the now-unused merge-base filter rather than leaving
   dead code in the lookup path.
2. **`git branch --show-current` over `git rev-parse --abbrev-ref HEAD`.**
   Cleaner contract: `--show-current` returns empty for detached HEAD
   instead of the literal string `"HEAD"`, so the empty-string fallback
   in `resolveCheckedOutBranch` doesn't need to special-case it.
3. **Run state fallback still requires a worktree-dir match.** When
   git can't answer and we fall back to run state, we still require
   `runStateMatchesEntry` — a run state for a different worktree dir
   doesn't authoritatively name this entry's branch.

## Test plan

- [x] `node --run verify` passes (1885 tests, 100% coverage on a clean run)
- [x] Sanity: `node --run crew -- status cat-66755` shows
      `pr: https://github.com/instacart/carrot/pull/813151 (open)` with
      the prefixed branch name
