### PR TITLE
feat: sync run-state lifecycle to the cmux sidebar

### DIFF
--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -24,6 +24,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       close: vi.fn<typeof actual.workspaces.close>(),
       interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
+      reportProgress: vi.fn<typeof actual.workspaces.reportProgress>(),
     },
   };
 });

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -48,6 +48,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
       close: vi.fn<typeof actual.workspaces.close>(),
       interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
+      reportProgress: vi.fn<typeof actual.workspaces.reportProgress>(),
     },
   };
 });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -4,6 +4,7 @@ import { isLinearEnabled, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
+import { syncWorkspaceProgress } from "../lib/progressSync.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
 import {
@@ -254,6 +255,10 @@ export async function resumeWorkspace(
     },
   });
   log(`Resumed ${task} in ${context.worktree.dir} (${context.agent})`);
+  await syncWorkspaceProgress({
+    config,
+    run: { task, workspaceName: task, agent: context.agent, state: "resumed" },
+  });
 }
 
 export async function resumeWorkspaceCli(argv: string[]): Promise<void> {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -5,6 +5,7 @@ import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
+import { syncWorkspaceProgress } from "../lib/progressSync.ts";
 import { recordRunState } from "../lib/runState.ts";
 import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
 import {
@@ -209,6 +210,11 @@ export async function setupWorkspace(
     if (accessHint !== undefined) {
       logAccessHint(accessHint);
     }
+    await syncWorkspaceProgress({
+      config,
+      run: { task, workspaceName: task, agent, state: "running" },
+      ...(signal === undefined ? {} : { signal }),
+    });
   } catch (error) {
     await rollbackWorktree({ config, entry: created, promptDir, srtSettingsDir });
     recordFailedToLaunch({ config, options, paths: { worktreeDir, branchName }, error });

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -8,6 +8,7 @@ import {
   type Adapter,
   isSignalAborted,
   runWorkspaceCommand,
+  type WorkspaceProgress,
   type WorkspaceStatus,
 } from "./workspaceAdapter.ts";
 import { debug, errorMessage, log } from "./util.ts";
@@ -90,6 +91,19 @@ export const cmuxAdapter: Adapter = {
     // not a shell command. No useful hint to emit.
     // oxlint-disable-next-line unicorn/no-useless-undefined -- explicit signal that the backend has no hint
     return undefined;
+  },
+  async reportProgress(name, progress, signal) {
+    const raw = await listCmuxRaw(signal);
+    if (raw === undefined) {
+      debug(`cmux set-progress skipped for ${name}: list-workspaces failed, no usable id`);
+      return;
+    }
+    const match = raw.find((ws) => cmuxTaskId(ws) === name);
+    if (match === undefined) {
+      debug(`cmux set-progress skipped for ${name}: no live workspace`);
+      return;
+    }
+    await applyCmuxProgress(match.id, progress, signal);
   },
 };
 
@@ -218,6 +232,32 @@ async function applyCmuxStatus(
 
 async function closeCmuxWorkspace(workspaceId: string, signal?: AbortSignal): Promise<void> {
   await runWorkspaceCommand("cmux", ["close-workspace", "--workspace", workspaceId], signal);
+}
+
+function clampProgressValue(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+async function applyCmuxProgress(
+  workspaceId: string,
+  progress: WorkspaceProgress,
+  signal?: AbortSignal,
+): Promise<void> {
+  await runWorkspaceCommand(
+    "cmux",
+    [
+      "set-progress",
+      String(clampProgressValue(progress.value)),
+      "--label",
+      progress.label,
+      "--workspace",
+      workspaceId,
+    ],
+    signal,
+  );
 }
 
 function isCmuxSetStatusUnsupported(error: unknown): boolean {

--- a/src/lib/progressSync.test.ts
+++ b/src/lib/progressSync.test.ts
@@ -1,0 +1,107 @@
+import type { ResolvedConfig } from "./config.ts";
+import { logEvent } from "./util.ts";
+import type * as utilModule from "./util.ts";
+import { syncWorkspaceProgress } from "./progressSync.ts";
+import type { workspaces } from "./workspaces.ts";
+
+const reportProgressMock = vi.hoisted(() => vi.fn<typeof workspaces.reportProgress>());
+
+vi.mock(import("./workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: { ...actual.workspaces, reportProgress: reportProgressMock },
+  };
+});
+vi.mock(import("./util.ts"), async (importOriginal) => {
+  const actual = await importOriginal<typeof utilModule>();
+  return { ...actual, logEvent: vi.fn<typeof actual.logEvent>() };
+});
+
+const logEventMock = vi.mocked(logEvent);
+
+function makeConfig(): ResolvedConfig {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the helper only forwards config to workspaces.reportProgress, which is mocked.
+  return { logging: { file: "/tmp/groundcrew-test.log" } } as unknown as ResolvedConfig;
+}
+
+describe("syncWorkspaceProgress (cmux bridge)", () => {
+  beforeEach(() => {
+    reportProgressMock.mockResolvedValue();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("paints the workspace with a lifecycle label and logs the synced outcome", async () => {
+    const config = makeConfig();
+
+    await syncWorkspaceProgress({
+      config,
+      run: { task: "team-1", workspaceName: "TEAM-1", agent: "claude", state: "running" },
+    });
+
+    expect(reportProgressMock).toHaveBeenCalledWith(
+      config,
+      "TEAM-1",
+      { value: 0.5, label: "running · claude" },
+      undefined,
+    );
+    expect(logEventMock).toHaveBeenCalledWith("cmux-progress-sync", {
+      outcome: "synced",
+      task: "team-1",
+      workspace: "TEAM-1",
+      state: "running",
+    });
+  });
+
+  it("uses the resumed label for a resumed run", async () => {
+    await syncWorkspaceProgress({
+      config: makeConfig(),
+      run: { task: "team-2", workspaceName: "TEAM-2", agent: "codex", state: "resumed" },
+    });
+
+    expect(reportProgressMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "TEAM-2",
+      { value: 0.5, label: "resumed · codex" },
+      undefined,
+    );
+  });
+
+  it("forwards the abort signal", async () => {
+    const controller = new AbortController();
+
+    await syncWorkspaceProgress({
+      config: makeConfig(),
+      run: { task: "team-3", workspaceName: "TEAM-3", agent: "claude", state: "running" },
+      signal: controller.signal,
+    });
+
+    expect(reportProgressMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "TEAM-3",
+      expect.anything(),
+      controller.signal,
+    );
+  });
+
+  it("swallows reporting failures and logs an error outcome", async () => {
+    reportProgressMock.mockRejectedValueOnce(new Error("cmux down"));
+
+    await expect(
+      syncWorkspaceProgress({
+        config: makeConfig(),
+        run: { task: "team-4", workspaceName: "TEAM-4", agent: "claude", state: "running" },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logEventMock).toHaveBeenCalledWith("cmux-progress-sync", {
+      outcome: "error",
+      task: "team-4",
+      workspace: "TEAM-4",
+      state: "running",
+      error: "cmux down",
+    });
+  });
+});

--- a/src/lib/progressSync.ts
+++ b/src/lib/progressSync.ts
@@ -1,0 +1,63 @@
+/**
+ * Bridges run-state lifecycle transitions to the cmux sidebar: when a task
+ * launches or resumes, paint its workspace row with the current lifecycle
+ * status so a sidebar can show live agent activity. Best-effort and cosmetic —
+ * a failure here must never break a launch, so it is swallowed and logged.
+ *
+ * Only `running` and `resumed` reach a live workspace: `interrupt` closes the
+ * cmux workspace before recording state, and `provisioning`/`failed-to-launch`
+ * precede a workspace existing. The phase value is a coarse carrier for cmux
+ * `set-progress`, not context-window usage; sidebars render the label.
+ */
+
+import type { ResolvedConfig } from "./config.ts";
+import type { RunLifecycleState } from "./runState.ts";
+import { errorMessage, logEvent } from "./util.ts";
+import { workspaces } from "./workspaces.ts";
+
+const PROGRESS_SYNC_FLOW = "cmux-progress-sync";
+
+const LIFECYCLE_PHASE_VALUE: Record<RunLifecycleState, number> = {
+  provisioning: 0.1,
+  running: 0.5,
+  resumed: 0.5,
+  interrupted: 0.25,
+  "failed-to-launch": 1,
+};
+
+interface SyncWorkspaceProgressInput {
+  config: ResolvedConfig;
+  run: {
+    task: string;
+    workspaceName: string;
+    agent: string;
+    state: RunLifecycleState;
+  };
+  signal?: AbortSignal;
+}
+
+export async function syncWorkspaceProgress(input: SyncWorkspaceProgressInput): Promise<void> {
+  const { config, run, signal } = input;
+  try {
+    await workspaces.reportProgress(
+      config,
+      run.workspaceName,
+      { value: LIFECYCLE_PHASE_VALUE[run.state], label: `${run.state} · ${run.agent}` },
+      signal,
+    );
+    logEvent(PROGRESS_SYNC_FLOW, {
+      outcome: "synced",
+      task: run.task,
+      workspace: run.workspaceName,
+      state: run.state,
+    });
+  } catch (error) {
+    logEvent(PROGRESS_SYNC_FLOW, {
+      outcome: "error",
+      task: run.task,
+      workspace: run.workspaceName,
+      state: run.state,
+      error: errorMessage(error),
+    });
+  }
+}

--- a/src/lib/workspaceAdapter.ts
+++ b/src/lib/workspaceAdapter.ts
@@ -24,6 +24,18 @@ export interface WorkspaceStatus {
   icon?: string;
 }
 
+export interface WorkspaceProgress {
+  /**
+   * 0..1 carrier for the cmux `set-progress` value argument. A coarse
+   * lifecycle-phase number, NOT context-window usage; the Groundcrew sidebar
+   * renders `label` and hides the bar, so views that don't show the raw value
+   * ignore it.
+   */
+  value: number;
+  /** Human status painted on the workspace row (e.g. "running · claude"). */
+  label: string;
+}
+
 export interface WorkspaceAccessHint {
   kind: "attachCommand";
   command: string;
@@ -74,6 +86,16 @@ export interface Adapter {
    * has no concise external hint.
    */
   accessHint: (name: string) => WorkspaceAccessHint | undefined;
+  /**
+   * Paint a live status onto the workspace row, best-effort. Optional: a
+   * backend with no sidebar channel (tmux, zellij) omits it and callers skip
+   * the sync. cmux implements it via `set-progress`.
+   */
+  reportProgress?: (
+    name: string,
+    progress: WorkspaceProgress,
+    signal?: AbortSignal,
+  ) => Promise<void>;
 }
 
 export async function runWorkspaceCommand(

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -582,6 +582,100 @@ describe("workspaces.close (cmux)", () => {
   });
 });
 
+describe("workspaces.reportProgress (cmux)", () => {
+  beforeEach(commonBeforeEach);
+  afterEach(commonAfterEach);
+
+  it("looks up the id by name and calls set-progress with the value and label", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({ workspaces: [{ title: "TEAM-1", ref: "workspace:42" }] }),
+    );
+
+    await workspaces.reportProgress(makeConfig(), "TEAM-1", {
+      value: 0.5,
+      label: "running · claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-progress",
+      "0.5",
+      "--label",
+      "running · claude",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("clamps an out-of-range value into 0..1", async () => {
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "abc123" }] }));
+
+    await workspaces.reportProgress(makeConfig(), "TEAM-1", { value: 1.7, label: "running" });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-progress",
+      "1",
+      "--label",
+      "running",
+      "--workspace",
+      "abc123",
+    ]);
+  });
+
+  it("coerces a non-finite value to 0", async () => {
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [{ title: "TEAM-1", id: "abc123" }] }));
+
+    await workspaces.reportProgress(makeConfig(), "TEAM-1", {
+      value: Number.NaN,
+      label: "running",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-progress",
+      "0",
+      "--label",
+      "running",
+      "--workspace",
+      "abc123",
+    ]);
+  });
+
+  it("is a no-op when no workspace exists for the name", async () => {
+    runMock.mockReturnValue(JSON.stringify({ workspaces: [] }));
+
+    await workspaces.reportProgress(makeConfig(), "TEAM-1", { value: 0.5, label: "running" });
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["set-progress"]));
+  });
+
+  it("is a no-op when the cmux list itself fails", async () => {
+    runMock.mockImplementationOnce(() => {
+      throw new Error("cmux down");
+    });
+
+    await workspaces.reportProgress(makeConfig(), "TEAM-1", { value: 0.5, label: "running" });
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["set-progress"]));
+  });
+});
+
+describe("workspaces.reportProgress (tmux)", () => {
+  beforeEach(() => {
+    commonBeforeEach();
+    detectHostMock.mockResolvedValue(makeHost({ hasCmux: false, hasTmux: true }));
+  });
+  afterEach(commonAfterEach);
+
+  it("is a no-op because tmux has no sidebar channel", async () => {
+    await workspaces.reportProgress(makeConfig("tmux"), "TEAM-1", {
+      value: 0.5,
+      label: "running",
+    });
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["set-progress"]));
+    expect(runMock).not.toHaveBeenCalledWith("tmux", expect.arrayContaining(["set-progress"]));
+  });
+});
+
 describe("workspaces.open (tmux)", () => {
   beforeEach(() => {
     commonBeforeEach();

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -19,6 +19,7 @@ import {
   type WorkspaceInterruptResult,
   type WorkspaceKind,
   type WorkspaceProbe,
+  type WorkspaceProgress,
 } from "./workspaceAdapter.ts";
 
 export type {
@@ -29,6 +30,7 @@ export type {
   WorkspaceInterruptResult,
   WorkspaceKind,
   WorkspaceProbe,
+  WorkspaceProgress,
   WorkspaceStatus,
 } from "./workspaceAdapter.ts";
 
@@ -208,4 +210,16 @@ export const workspaces = {
   },
   interrupt: interruptWorkspace,
   accessHint: accessHintForWorkspace,
+  async reportProgress(
+    config: ResolvedConfig,
+    name: string,
+    progress: WorkspaceProgress,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const adapter = await adapterFor(config, signal);
+    if (adapter.reportProgress === undefined) {
+      return;
+    }
+    await adapter.reportProgress(name, progress, signal);
+  },
 };

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -45,6 +45,7 @@ vi.mock(import("./workspaces.ts"), async (importOriginal) => {
       close: vi.fn<typeof actual.workspaces.close>(),
       interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
       accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
+      reportProgress: vi.fn<typeof actual.workspaces.reportProgress>(),
     },
   };
 });


### PR DESCRIPTION
## Summary

This is in support of a custom cmux sidebar configuration to surface more information on what each workspace is for:
<img width="325" height="670" alt="image" src="https://github.com/user-attachments/assets/6dbaa6f5-a127-42ed-825e-bfa5c6bcb0bd" />

Groundcrew runs each task as a cmux workspace, but the sidebar carried no signal of where a task sits in its lifecycle. This bridges run-state transitions to the cmux sidebar so a monitor can show live agent activity per workspace.

It adds an optional `reportProgress` to the workspace `Adapter` contract. cmux implements it via `set-progress`; tmux and zellij omit it and the facade skips the sync. A new `progressSync` helper paints the lifecycle status (e.g. `running · claude`) at the `running` and `resumed` transitions — best-effort and logged under the `cmux-progress-sync` flow, so a sidebar failure never breaks a launch.

Only `running` and `resumed` reach a live workspace: `interrupt` closes the cmux workspace before recording state, and `provisioning` / `failed-to-launch` precede the workspace existing. The progress value is a coarse lifecycle-phase carrier, not context-window usage — the paired custom sidebar renders the status label and hides the bar.

Rebased onto `main` after #261 merged: `reportProgress` now resolves the workspace by the `cmuxTaskId` description marker (`groundcrew:<task>`), matching `list` / `close`, so a renamed panel no longer orphans the progress sync.

## Validation

- `node --run verify` green on node 24.14.1. (A handful of subprocess-spawning, timing-sensitive tests — `srtLaunch`, `launchCommand`, shell-adapter, orchestrator signal/retry — flake under heavy concurrent CPU load with ~5s timeouts; they pass in isolation and on clean `main`, and CI runs the authoritative suite in a clean environment.)
- New tests: `progressSync.test.ts` (label/value mapping, abort-signal forwarding, swallow-and-log on failure) and `workspaces.test.ts` cmux/tmux `reportProgress` cases (id lookup, value clamp, non-finite coercion, no-op when the workspace is missing or the cmux list fails).
- Verified live end-to-end against a fresh `crew start tg-3502`: the rebased `syncWorkspaceProgress(running)` resolved the workspace by its `groundcrew:tg-3502` marker and painted `progress=0.50 running · claude` (confirmed via `cmux sidebar-state`; note `cmux workspace list --json` does not expose the progress field).

## Notes

- Live context-window usage was the original idea for the bar, but it isn't sourceable from these discrete lifecycle hooks — the orchestrator never sees the agent's running session. That bar was dropped; the `value` field stays as a documented lifecycle-phase carrier in case a future continuous poller wants the channel.
- Composes with #262 (Layer A — injected Claude hooks reporting within-session lifecycle through the same `set-progress` channel) and #261 (workspace identity by description marker).

Agent session: `claude --resume 68ed4686-eaa6-4583-b81d-1a78a1c2de46`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>