### PR TITLE
feat(cmux): identify workspaces by description marker, not title (tg-3890)

### DIFF
--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -307,10 +307,12 @@ function mockExistingWorktree(): void {
   createMock.mockRejectedValue(new WorktreeAlreadyExistsError("/work/repo-a-team-1"));
 }
 
-function lastRunArgumentFromCallWithArgument(argument: string): string {
+function launchCommandFromRunCall(argument: string): string {
   const call = runCommandMock.mock.calls.find((candidate) => candidate[1].includes(argument));
-  const lastArgument = call?.[1].at(-1);
-  return typeof lastArgument === "string" ? lastArgument : "";
+  const arguments_ = call?.[1] ?? [];
+  const commandIndex = arguments_.indexOf("--command");
+  const commandValue = commandIndex === -1 ? undefined : arguments_[commandIndex + 1];
+  return typeof commandValue === "string" ? commandValue : "";
 }
 
 function writtenFileContent(filePath: string): string {
@@ -534,7 +536,7 @@ describe(setupWorkspace, () => {
       details: { title: "Test Title", description: "Body" },
     });
 
-    const command = lastRunArgumentFromCallWithArgument("new-workspace");
+    const command = launchCommandFromRunCall("new-workspace");
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
 
     expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
@@ -796,7 +798,7 @@ describe(setupWorkspace, () => {
     expect(firstInvocationOrder(createMock)).toBeLessThan(
       firstInvocationOrder(ensureClearanceMock),
     );
-    const command = lastRunArgumentFromCallWithArgument("new-workspace");
+    const command = launchCommandFromRunCall("new-workspace");
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
     expect(launchScript).toContain("cd '/work/repo-a-team-1'");
@@ -1151,7 +1153,7 @@ describe(setupWorkspace, () => {
         "NPM_TOKEN='npm_test_token'\n",
         { mode: 0o600 },
       );
-      const command = lastRunArgumentFromCallWithArgument("new-workspace");
+      const command = launchCommandFromRunCall("new-workspace");
       const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
       expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
       expect(launchScript).toContain(". '/tmp/groundcrew-team-1-x/secrets.env'");
@@ -1213,7 +1215,7 @@ describe(setupWorkspace, () => {
         expect.anything(),
         expect.anything(),
       );
-      const command = lastRunArgumentFromCallWithArgument("new-workspace");
+      const command = launchCommandFromRunCall("new-workspace");
       const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
       expect(command).not.toContain("secrets.env");
       expect(command).not.toContain("unset NPM_TOKEN");
@@ -1931,7 +1933,7 @@ describe(setupWorkspace, () => {
       details: { title: "Test Title", description: "Body" },
     });
 
-    const cmd = lastRunArgumentFromCallWithArgument("new-workspace");
+    const cmd = launchCommandFromRunCall("new-workspace");
     const launchScript = writtenFileContent("/tmp/with'quote-1/launch.sh");
     expect(cmd).toContain(String.raw`'\''`);
     expect(launchScript).toContain(String.raw`_p=$(cat '/tmp/with'\''quote-1/prompt.txt')`);

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -25,6 +25,8 @@ export const cmuxAdapter: Adapter = {
         spec.cwd,
         "--command",
         spec.command,
+        "--description",
+        cmuxDescriptionFor(spec.name),
       ],
       signal,
     );
@@ -50,7 +52,7 @@ export const cmuxAdapter: Adapter = {
   },
   async list(signal) {
     const raw = await listCmuxRaw(signal);
-    return raw?.map((ws) => ({ name: ws.title }));
+    return raw?.map((ws) => ({ name: cmuxTaskId(ws) }));
   },
   async close(name, signal) {
     const raw = await listCmuxRaw(signal);
@@ -61,7 +63,7 @@ export const cmuxAdapter: Adapter = {
       debug(`cmux close-workspace skipped for ${name}: list-workspaces failed, no usable id`);
       return { kind: "unavailable" };
     }
-    const match = raw.find((ws) => ws.title === name);
+    const match = raw.find((ws) => cmuxTaskId(ws) === name);
     if (match === undefined) {
       return { kind: "missing" };
     }
@@ -76,7 +78,7 @@ export const cmuxAdapter: Adapter = {
       if (remaining === undefined) {
         return { kind: "unavailable", error };
       }
-      const isStillPresent = remaining.some((ws) => ws.title === name);
+      const isStillPresent = remaining.some((ws) => cmuxTaskId(ws) === name);
       if (!isStillPresent) {
         return { kind: "closed" };
       }
@@ -91,16 +93,41 @@ export const cmuxAdapter: Adapter = {
   },
 };
 
+/**
+ * Stable per-workspace task-id marker stamped into cmux's `description` at
+ * creation. Identity keys on this, not the title — a user renaming a panel
+ * must not make crew lose track of the workspace. cmux exposes no
+ * set-description RPC (settable only at creation), so legacy workspaces carry
+ * `description: null`; `cmuxTaskId` falls back to the title for those.
+ */
+const CMUX_DESCRIPTION_MARKER_PREFIX = "groundcrew:";
+
+function cmuxDescriptionFor(taskId: string): string {
+  return `${CMUX_DESCRIPTION_MARKER_PREFIX}${taskId}`;
+}
+
+function cmuxTaskId(ws: CmuxRawWorkspace): string {
+  if (ws.description !== null && ws.description.startsWith(CMUX_DESCRIPTION_MARKER_PREFIX)) {
+    const marked = ws.description.slice(CMUX_DESCRIPTION_MARKER_PREFIX.length);
+    if (marked.length > 0) {
+      return marked;
+    }
+  }
+  return ws.title;
+}
+
 interface CmuxRawWorkspace {
   title: string;
   /** Stable UUID handle. v2 RPC requires this for workspace.close / etc. */
   id: string;
+  /** cmux per-workspace description; carries the task-id marker, or null for legacy workspaces. */
+  description: string | null;
 }
 
 function parseCmuxList(output: string): CmuxRawWorkspace[] {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- cmux --json list-workspaces always emits this shape
   const parsed = JSON.parse(output) as {
-    workspaces?: { title?: string; ref?: string; id?: string }[];
+    workspaces?: { title?: string; ref?: string; id?: string; description?: string | null }[];
   };
   const items: CmuxRawWorkspace[] = [];
   /* v8 ignore next @preserve -- cmux always emits a workspaces field; default keeps the loop safe */
@@ -115,7 +142,7 @@ function parseCmuxList(output: string): CmuxRawWorkspace[] {
       );
       continue;
     }
-    items.push({ title: ws.title, id });
+    items.push({ title: ws.title, id, description: ws.description ?? null });
   }
   return items;
 }

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -150,6 +150,8 @@ describe("workspaces.open (cmux)", () => {
       "/work/repo-a-TEAM-1",
       "--command",
       "exec claude",
+      "--description",
+      "groundcrew:TEAM-1",
     ]);
   });
 
@@ -300,12 +302,12 @@ describe("workspaces.probe (cmux)", () => {
   beforeEach(commonBeforeEach);
   afterEach(commonAfterEach);
 
-  it("returns kind=ok with the workspaces' titles as names", async () => {
+  it("returns kind=ok with names resolved from the groundcrew description marker", async () => {
     runMock.mockReturnValue(
       JSON.stringify({
         workspaces: [
-          { title: "TEAM-1", id: "id-1" },
-          { title: "TEAM-2", id: "id-2" },
+          { title: "TEAM-1", id: "id-1", description: "groundcrew:TEAM-1" },
+          { title: "TEAM-2", id: "id-2", description: "groundcrew:TEAM-2" },
         ],
       }),
     );
@@ -315,6 +317,48 @@ describe("workspaces.probe (cmux)", () => {
       names: new Set(["TEAM-1", "TEAM-2"]),
     });
     expect(runMock).toHaveBeenCalledWith("cmux", ["--json", "list-workspaces"]);
+  });
+
+  it("tracks a workspace by its marker even when the title has been renamed", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({
+        workspaces: [{ title: "Fix the login bug", id: "id-1", description: "groundcrew:TEAM-1" }],
+      }),
+    );
+
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1"]),
+    });
+  });
+
+  it("falls back to the title when the marker is present but carries no task id", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({
+        workspaces: [{ title: "TEAM-1", id: "id-1", description: "groundcrew:" }],
+      }),
+    );
+
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1"]),
+    });
+  });
+
+  it("falls back to the title for legacy workspaces without a marker", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({
+        workspaces: [
+          { title: "TEAM-1", id: "id-1", description: null },
+          { title: "TEAM-2", id: "id-2" },
+        ],
+      }),
+    );
+
+    await expect(workspaces.probe(makeConfig())).resolves.toStrictEqual({
+      kind: "ok",
+      names: new Set(["TEAM-1", "TEAM-2"]),
+    });
   });
 
   it("returns kind=ok with an empty name set when cmux reports no workspaces", async () => {
@@ -387,6 +431,58 @@ describe("workspaces.close (cmux)", () => {
       "--workspace",
       "workspace:42",
     ]);
+  });
+
+  it("closes by the description marker even when the title was renamed", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({
+        workspaces: [
+          { title: "Fix the login bug", ref: "workspace:42", description: "groundcrew:TEAM-1" },
+        ],
+      }),
+    );
+
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "close-workspace",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("closes a legacy workspace by title when no marker is present", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({ workspaces: [{ title: "TEAM-1", ref: "workspace:42", description: null }] }),
+    );
+
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "closed",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "close-workspace",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("is missing when neither a marker nor the title matches the requested name", async () => {
+    runMock.mockReturnValue(
+      JSON.stringify({
+        workspaces: [
+          { title: "Fix the login bug", ref: "workspace:42", description: "groundcrew:TEAM-2" },
+        ],
+      }),
+    );
+
+    await expect(workspaces.close(makeConfig(), "TEAM-1")).resolves.toStrictEqual({
+      kind: "missing",
+    });
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
   });
 
   it("falls back to the workspace id when ref is omitted", async () => {


### PR DESCRIPTION
## Why

crew identified cmux workspaces by an exact title match (`ws.title === <taskId>`) in `src/lib/cmuxAdapter.ts`, relied on by `list()`, `close()`, and the capacity probe in `workspaces.ts`. Any title drift — e.g. a user manually renaming a cmux panel — made crew lose track of a live workspace: capacity miscounts, close/interrupt couldn't find it, and resume spawned a duplicate panel.

## What

Stamp a stable `groundcrew:<taskId>` marker into cmux's per-workspace `description` at creation, and resolve workspace identity from it instead of the title.

- **Creation** (`open`): pass `--description groundcrew:<taskId>` to `cmux new-workspace`.
- **Identity** (`cmuxTaskId`): parse the `description` from `cmux list-workspaces --json` and extract the task id from the marker. `list`, `close`, and the close re-check route through this helper, so the capacity probe (which keys on the names `list` returns) tracks by marker too.
- **Backward compat**: legacy workspaces created before this change have `description: null` and `title === taskId`. `cmuxTaskId` falls back to the title when no marker is present (or the marker carries no id), so in-flight tasks are not orphaned. cmux has no set-description RPC (settable only at creation), so there is no backfill — the fallback covers running tasks until they are recreated.
- **tmux/zellij**: unchanged (no description concept).

## Notes

- **PR #260 (`reportProgress` bridge)** is not present on this branch, so there was nothing to update for that path here. It shares the title-matching weakness and should adopt `cmuxTaskId` when it lands — the helper is structured for reuse.
- **Follow-up (out of scope):** now that identity no longer depends on the title, `--name` can be set to the human ticket title for display.

## Testing

`node --run verify` passes (1885 tests, 100% coverage thresholds met). New/updated coverage:
- `open` emits the `--description groundcrew:<taskId>` marker.
- probe/close match by the description marker even when the title is renamed.
- legacy (no marker) and empty-marker (`groundcrew:`) workspaces fall back to title.
- close returns `missing` when neither marker nor title matches.

Closes tg-3890

🤖 Generated with [Claude Code](https://claude.com/claude-code)