### PR TITLE
feat: report live cmux agent activity via injected Claude hooks (TG-3891)

### DIFF
--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -814,7 +814,8 @@ describe(setupWorkspace, () => {
     );
     expect(launchScript).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
     expect(launchScript).not.toContain("--enable=all-agents");
-    expect(launchScript).toContain('exec claude --permission-mode auto "$@"');
+    expect(launchScript).toContain("exec claude --permission-mode auto --settings ");
+    expect(launchScript).toContain('"$@"');
     expect(launchScript).toContain('sh "$_p"');
     // prepareWorktree status guard so a failed install still launches the agent
     expect(launchScript).toContain('"$prepare_status" -ne 0');

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -110,7 +110,24 @@ describe(composeAgentLaunch, () => {
     expect(launchCommand).toContain("CMUX_SOCKET_PATH");
     expect(launchCommand).toContain("CMUX_CUSTOM_CLAUDE_PATH");
     expect(launchCommand).toContain("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
-    expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
+    expect(launchCommand).toContain("exec claude --permission-mode auto --settings ");
+    expect(launchCommand).toContain('"$@"');
+  });
+
+  it("injects cmux activity-reporting hooks for a cmux-hosted Claude agent", () => {
+    const launchCommand = compose();
+
+    expect(launchCommand).toContain("--settings ");
+    expect(launchCommand).toContain("set-progress");
+    expect(launchCommand).toContain("running · claude");
+    expect(launchCommand).toContain("SessionStart");
+  });
+
+  it("does not inject Claude activity hooks for a non-Claude cmux agent", () => {
+    const launchCommand = compose({ definition: definition({ cmd: "codex", color: "#000" }) });
+
+    expect(launchCommand).toContain('exec codex "$@"');
+    expect(launchCommand).not.toContain("set-progress");
   });
 
   it("adds task source write paths only to the Safehouse agent wrap", () => {

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -5,6 +5,8 @@ import {
 } from "@clipboard-health/clearance";
 
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
+import { cmuxAgentHookSettingsJson } from "./cmuxAgentHooks.ts";
+import { shellSingleQuote } from "./shell.ts";
 import {
   hasPreLaunchEnv,
   type LocalRunner,
@@ -114,7 +116,8 @@ function safehouseAgentIntegrationFor(
   if (workspaceKind !== "cmux") {
     return undefined;
   }
-  const isClaudeAgent = inferAgentCommandName(definition.cmd) === "claude";
+  const agentCommandName = inferAgentCommandName(definition.cmd);
+  const isClaudeAgent = agentCommandName === "claude";
   const cmuxIntegration = resolveSafehouseCmuxIntegration();
   if (isClaudeAgent) {
     warnOnCmuxIntegrationDrift({ unreviewedEnvNames: cmuxIntegration.unreviewedEnvNames });
@@ -124,6 +127,14 @@ function safehouseAgentIntegrationFor(
     addDirsReadOnly: cmuxIntegration.addDirsReadOnly,
     envPass: cmuxIntegration.envPass,
     commandPreludes: isClaudeAgent ? [cmuxIntegration.claudeCommandPrelude] : [],
+    ...(isClaudeAgent
+      ? {
+          agentArgs: [
+            "--settings",
+            shellSingleQuote(cmuxAgentHookSettingsJson({ agent: agentCommandName })),
+          ],
+        }
+      : {}),
   };
 }
 

--- a/src/lib/cmuxAgentHooks.test.ts
+++ b/src/lib/cmuxAgentHooks.test.ts
@@ -1,0 +1,73 @@
+import {
+  buildCmuxAgentHookSettings,
+  type CmuxAgentHookSettings,
+  cmuxAgentHookSettingsJson,
+} from "./cmuxAgentHooks.ts";
+
+function commandFor(settings: CmuxAgentHookSettings, event: string): string {
+  const command = settings.hooks[event]?.[0]?.hooks[0]?.command;
+  if (command === undefined) {
+    throw new Error(`No hook command for event ${event}`);
+  }
+
+  return command;
+}
+
+describe(buildCmuxAgentHookSettings, () => {
+  it("emits one command hook for each lifecycle event", () => {
+    const actual = buildCmuxAgentHookSettings({ agent: "claude" });
+
+    expect(Object.keys(actual.hooks)).toStrictEqual([
+      "SessionStart",
+      "UserPromptSubmit",
+      "Notification",
+      "Stop",
+      "SessionEnd",
+    ]);
+    for (const groups of Object.values(actual.hooks)) {
+      expect(groups).toHaveLength(1);
+      expect(groups[0]?.hooks[0]?.type).toBe("command");
+    }
+  });
+
+  it("labels SessionStart with the agent and maps the other lifecycle phases", () => {
+    const actual = buildCmuxAgentHookSettings({ agent: "claude" });
+
+    expect(commandFor(actual, "SessionStart")).toContain("running · claude");
+    expect(commandFor(actual, "UserPromptSubmit")).toContain("working");
+    expect(commandFor(actual, "Notification")).toContain("needs input");
+    expect(commandFor(actual, "Stop")).toContain("idle");
+    expect(commandFor(actual, "SessionEnd")).toContain("done");
+  });
+
+  it("guards on the workspace id and stays best-effort so a hook never breaks the agent", () => {
+    const actual = commandFor(buildCmuxAgentHookSettings({ agent: "claude" }), "SessionStart");
+
+    expect(actual).toContain('if [ -n "$CMUX_WORKSPACE_ID" ]');
+    expect(actual).toContain('--workspace "$CMUX_WORKSPACE_ID"');
+    expect(actual).toContain("|| true");
+  });
+
+  it("resolves the cmux CLI from the bundled path with a PATH fallback", () => {
+    const actual = commandFor(buildCmuxAgentHookSettings({ agent: "claude" }), "Stop");
+
+    // eslint-disable-next-line no-template-curly-in-string -- shell parameter expansion, not a JS template
+    expect(actual).toContain('"${CMUX_BUNDLED_CLI_PATH:-cmux}" set-progress');
+  });
+
+  it("flows a non-default agent name into the running label", () => {
+    const actual = commandFor(buildCmuxAgentHookSettings({ agent: "codex" }), "SessionStart");
+
+    expect(actual).toContain("running · codex");
+  });
+});
+
+describe(cmuxAgentHookSettingsJson, () => {
+  it("serializes to valid JSON that round-trips to the settings object", () => {
+    const expected = buildCmuxAgentHookSettings({ agent: "claude" });
+
+    const actual: unknown = JSON.parse(cmuxAgentHookSettingsJson({ agent: "claude" }));
+
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/src/lib/cmuxAgentHooks.ts
+++ b/src/lib/cmuxAgentHooks.ts
@@ -1,0 +1,60 @@
+import { shellSingleQuote } from "./shell.ts";
+
+interface CmuxAgentHookCommand {
+  type: "command";
+  command: string;
+}
+
+interface CmuxAgentHookGroup {
+  hooks: readonly CmuxAgentHookCommand[];
+}
+
+export interface CmuxAgentHookSettings {
+  hooks: Record<string, readonly CmuxAgentHookGroup[]>;
+}
+
+/**
+ * Claude Code hook settings that report the agent's own lifecycle to the cmux
+ * sidebar. Passed to the agent as `--settings <json>` (Layer A of the live
+ * activity bridge), so the panel reflects what the agent is doing within a
+ * session rather than the single coarse milestone the orchestrator can paint.
+ *
+ * Each hook calls `cmux set-progress` against `$CMUX_WORKSPACE_ID` — present in
+ * the safehouse cmux env-pass allowlist, so the call reaches cmux from inside
+ * the sandbox and resolves identity by id rather than the brittle title match.
+ * The call is guarded and best-effort: a missing workspace id or a cmux failure
+ * is swallowed so a hook never breaks the agent.
+ */
+export function buildCmuxAgentHookSettings(input: { agent: string }): CmuxAgentHookSettings {
+  const { agent } = input;
+  const phases: readonly CmuxAgentHookPhase[] = [
+    { event: "SessionStart", value: 0.05, label: `running · ${agent}` },
+    { event: "UserPromptSubmit", value: 0.5, label: "working" },
+    { event: "Notification", value: 0.5, label: "needs input" },
+    { event: "Stop", value: 0.9, label: "idle" },
+    { event: "SessionEnd", value: 1, label: "done" },
+  ];
+
+  const hooks: Record<string, readonly CmuxAgentHookGroup[]> = {};
+  for (const phase of phases) {
+    hooks[phase.event] = [{ hooks: [{ type: "command", command: setProgressCommand(phase) }] }];
+  }
+
+  return { hooks };
+}
+
+export function cmuxAgentHookSettingsJson(input: { agent: string }): string {
+  return JSON.stringify(buildCmuxAgentHookSettings(input));
+}
+
+interface CmuxAgentHookPhase {
+  event: string;
+  value: number;
+  label: string;
+}
+
+function setProgressCommand(phase: CmuxAgentHookPhase): string {
+  const setProgress = `"\${CMUX_BUNDLED_CLI_PATH:-cmux}" set-progress ${phase.value} --label ${shellSingleQuote(phase.label)} --workspace "$CMUX_WORKSPACE_ID" >/dev/null 2>&1 || true`;
+
+  return `if [ -n "$CMUX_WORKSPACE_ID" ]; then ${setProgress}; fi`;
+}

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -210,8 +210,10 @@ function renderPrepareAndAgentCommand(arguments_: LaunchCommandArguments): {
     worktreeDir: arguments_.worktreeDir,
     sandboxName: arguments_.sandboxName ?? "",
   });
+  const agentArgs = arguments_.safehouseAgentIntegration?.agentArgs ?? [];
+  const agentInvocation = agentArgs.length === 0 ? agentCmd : `${agentCmd} ${agentArgs.join(" ")}`;
   return {
-    agentCommand: `exec ${agentCmd} "$@"`,
+    agentCommand: `exec ${agentInvocation} "$@"`,
     prepareWorktreeCommand:
       arguments_.prepareWorktreeCommand === undefined
         ? undefined
@@ -392,6 +394,12 @@ export interface SafehouseAgentIntegration {
   addDirsReadOnly: readonly string[];
   envPass: readonly string[];
   commandPreludes: readonly string[];
+  /**
+   * Extra, already-shell-safe argv tokens appended to the agent invocation
+   * before the prompt positional (e.g. `--settings <quoted-json>` to inject
+   * cmux activity-reporting hooks for a Claude agent).
+   */
+  agentArgs?: readonly string[];
 }
 
 interface LaunchCommandArguments {


### PR DESCRIPTION
## Summary

Groundcrew runs each task as a cmux workspace, but a launched agent's panel only ever showed a single static `running · claude` label and never reflected what the agent was actually doing. cmux's own Claude integration can't fill the gap — crew launches agents hermetically (safehouse, `env -i`), and cmux only captures generic notifications for them, not live conversation/lifecycle; the custom-sidebar interpreter doesn't expose that signal anyway.

This is **Layer A** of a layered live-activity design: crew injects a Claude Code `hooks` block (via `--settings <inline-json>`) so the agent reports its own lifecycle to the cmux sidebar through the existing `set-progress` channel:

- `SessionStart` → `running · claude`
- `UserPromptSubmit` → `working`
- `Notification` → `needs input`
- `Stop` → `idle`
- `SessionEnd` → `done`

Scoped to Claude agents on the cmux + safehouse path; tmux/zellij, non-cmux backends, and non-Claude agents are untouched. Each hook resolves the workspace by `$CMUX_WORKSPACE_ID` (already in the safehouse cmux env-pass allowlist), so it reaches cmux from inside the sandbox and identifies the workspace by id rather than the brittle title match. Calls are guarded (`if [ -n "$CMUX_WORKSPACE_ID" ]`) and best-effort (`>/dev/null 2>&1 || true`) so a hook can never break the agent or its launch.

`--settings` takes inline JSON, so no settings file is staged — this sidesteps the safehouse read mask entirely (the same reason crew already host-reads the prompt into `$_p`).

## Validation

- `node --run verify` green: architecture, build, lint, spell, format, knip, cpd, markdown, syncpack, and **1887 tests** pass on node 24.14.1.
- New `cmuxAgentHooks.test.ts` (label/event mapping, workspace-id guard, best-effort, bundled-CLI fallback, JSON round-trip) at 100% coverage; `agentLaunch.test.ts` and `setupWorkspace.test.ts` updated for the injected `--settings`.
- Shell-quoting round-trip verified: the inline hook JSON survives all `sh -c` / safehouse wrap layers intact (parsed back to the settings object after `sh` unwrapping).
- cmux side verified live: the verbatim `SessionStart` hook command resolved `$CMUX_BUNDLED_CLI_PATH` and returned `OK` against the running cmux daemon (`set-progress` signature confirmed; `--workspace` defaults to `$CMUX_WORKSPACE_ID`).
- Not run: a full end-to-end crew launch painting the panel through every lifecycle transition (host at capacity). The set-progress channel itself was already verified live in #260.

## Notes

- Layered design: this Layer A (within-session liveness) composes with Layer B (orchestrator milestones, #260) and the sidebar display work — they write different interpreter fields and don't conflict.
- Relates to #260 (the set-progress channel; this calls the `cmux set-progress` CLI directly from hooks, so no dependency on its TypeScript) and TG-3891 / TG-3890 (#261, workspace identity hardening).
- Reviewer focus: the `--settings` injection threads through the security-sensitive safehouse launch wrap — `agentArgs` are appended only for Claude on cmux+safehouse, and the JSON is `shellSingleQuote`-quoted before entering the command.

Agent session: `claude --resume 68ed4686-eaa6-4583-b81d-1a78a1c2de46`

<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>
