### PR TITLE
fix: relabel Notification hook from "needs input" to "idle"

### DIFF
--- a/src/lib/cmuxAgentHooks.test.ts
+++ b/src/lib/cmuxAgentHooks.test.ts
@@ -35,7 +35,7 @@ describe(buildCmuxAgentHookSettings, () => {
 
     expect(commandFor(actual, "SessionStart")).toContain("running · claude");
     expect(commandFor(actual, "UserPromptSubmit")).toContain("working");
-    expect(commandFor(actual, "Notification")).toContain("needs input");
+    expect(commandFor(actual, "Notification")).toContain("idle");
     expect(commandFor(actual, "Stop")).toContain("idle");
     expect(commandFor(actual, "SessionEnd")).toContain("done");
   });

--- a/src/lib/cmuxAgentHooks.ts
+++ b/src/lib/cmuxAgentHooks.ts
@@ -30,7 +30,7 @@ export function buildCmuxAgentHookSettings(input: { agent: string }): CmuxAgentH
   const phases: readonly CmuxAgentHookPhase[] = [
     { event: "SessionStart", value: 0.05, label: `running · ${agent}` },
     { event: "UserPromptSubmit", value: 0.5, label: "working" },
-    { event: "Notification", value: 0.5, label: "needs input" },
+    { event: "Notification", value: 0.5, label: "idle" },
     { event: "Stop", value: 0.9, label: "idle" },
     { event: "SessionEnd", value: 1, label: "done" },
   ];


### PR DESCRIPTION
## Summary

The Claude Code `Notification` lifecycle event fires when the agent is done or idle, not only when it is blocked waiting for user input. The Layer A cmux hook was mapping `Notification` to the label `"needs input"`, causing the cmux sidebar panel to falsely claim the agent needs the user's attention. This change aligns `Notification` with the `Stop` event, both now showing `"idle"`.

## Validation

- `npx vitest run src/lib/cmuxAgentHooks.test.ts` — 6/6 tests pass
- `node --run verify` — all tests green except the documented known-flaky subprocess-spawning tests (`npmGlobal`, `verifyRunner`, `orchestrator`, `adapters/shell/invoke`) that time out under concurrent load; these are pre-existing and pass in isolation and on CI

<sub>🤖 `commit-push-pr:created v1 core@3.9.0`</sub>