### PR TITLE
fix: make shell adapter timeouts uniform and stabilize subprocess tests

### DIFF
--- a/config/vitestShared.ts
+++ b/config/vitestShared.ts
@@ -48,6 +48,15 @@ export function createVitestConfig(
       include: ["{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
       name,
       reporters: ["default"],
+      // Subprocess-spawning tests (adapters/shell/*, orchestrator) spawn a
+      // child process that races the shell adapter's per-call timeout (up to
+      // 30s). With one worker thread per core plus v8 coverage, the pool
+      // saturates every core and a spawned child can't be scheduled in time.
+      // Cap the pool to leave CPU headroom for those children, and keep the
+      // harness timeout above the adapter ceiling so the real outcome wins.
+      testTimeout: 60_000,
+      hookTimeout: 60_000,
+      maxWorkers: 4,
       watch: false,
     },
   });

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -54,12 +54,12 @@ interface ResolvedShellTimeouts {
 }
 
 const DEFAULT_TIMEOUTS: ResolvedShellTimeouts = {
-  verify: 10_000,
+  verify: 30_000,
   listTasks: 30_000,
-  getTask: 10_000,
-  markInProgress: 10_000,
-  markInReview: 10_000,
-  markDone: 10_000,
+  getTask: 30_000,
+  markInProgress: 30_000,
+  markInReview: 30_000,
+  markDone: 30_000,
   createTask: 30_000,
   validate: 30_000,
 };

--- a/src/lib/adapters/shell/invoke.test.ts
+++ b/src/lib/adapters/shell/invoke.test.ts
@@ -66,7 +66,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("ok.sh", 'echo "hello"');
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
     });
     expect(result.stdout.trim()).toBe("hello");
@@ -76,14 +76,14 @@ describe(invokeShellCommand, () => {
   it("throws on nonzero exit with stderr content in the error message", async () => {
     const script = dir.writeScript("bad.sh", 'echo "err message" >&2; exit 1');
     await expect(
-      invokeShellCommand({ command: script, timeoutMs: 5000, sourceName: "test" }),
+      invokeShellCommand({ command: script, timeoutMs: 30_000, sourceName: "test" }),
     ).rejects.toThrow(/err message/);
   });
 
   it("falls back to the command when stderr is empty on nonzero exit", async () => {
     const script = dir.writeScript("silent.sh", "exit 2");
     await expect(
-      invokeShellCommand({ command: script, timeoutMs: 5000, sourceName: "test" }),
+      invokeShellCommand({ command: script, timeoutMs: 30_000, sourceName: "test" }),
     ).rejects.toThrow(/exit 2/);
   });
 
@@ -91,7 +91,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("nf.sh", "exit 3");
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
     });
     expect(result.exitCode).toBe(3);
@@ -108,7 +108,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("stdin.sh", "cat");
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       stdin: "hello stdin",
       sourceName: "test",
     });
@@ -119,7 +119,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("show.sh", 'echo "$1"');
     const result = await invokeShellCommand({
       command: `${script} \${id}`,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       substitutions: { id: "'; rm -rf /; echo '" },
       sourceName: "test",
     });
@@ -132,7 +132,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("env.sh", 'echo "$MY_VAR"');
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       env: { MY_VAR: "passed through" },
       sourceName: "test",
     });
@@ -143,7 +143,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("warn.sh", 'echo "warning text" >&2; echo "ok"');
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
     });
     expect(result.stderr).toContain("warning text");
@@ -154,7 +154,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("small.sh", 'echo "ok"');
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
     });
     expect(result.truncated).toBe(false);
@@ -166,7 +166,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("yes.sh", "yes a | head -c 500");
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
       maxOutputBytes: 100,
     });
@@ -180,7 +180,7 @@ describe(invokeShellCommand, () => {
     const script = dir.writeScript("yes-err.sh", "yes a | head -c 500 >&2; echo ok");
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
       maxOutputBytes: 100,
     });
@@ -199,7 +199,7 @@ describe(invokeShellCommand, () => {
     );
     const result = await invokeShellCommand({
       command: script,
-      timeoutMs: 5000,
+      timeoutMs: 30_000,
       sourceName: "test",
       maxOutputBytes: 100,
     });


### PR DESCRIPTION
## Summary

Subprocess-spawning shell-adapter and orchestrator tests spawn real child processes that race the shell adapter's per-call timeouts. Running the full coverage suite spins one worker thread per core, saturating CPU so a spawned child can't be scheduled before its timeout fires — even though the work finishes in ~150ms once scheduled. The failures are pure scheduling starvation (not logic) and surface differently per run: a Vitest harness timeout, a `ShellAdapterTimeoutError`, or a swallowed `markInReview` that leaves an assertion `false`.

**Production change:** make `ShellAdapter` `DEFAULT_TIMEOUTS` uniform at 30s. `verify`/`getTask`/`markInProgress`/`markInReview`/`markDone` were 10s while `listTasks`/`createTask`/`validate` were already 30s — the split had no rationale, and 30s is the more tolerant default for shell status commands on a slow network. This also gives the subprocess tests enough headroom.

**Test-harness changes** (`config/vitestShared.ts`):
- `maxWorkers: 4` — leave CPU headroom so spawned children get scheduled.
- `testTimeout`/`hookTimeout: 60s` — backstop kept above the 30s adapter ceiling so the real outcome wins.
- `invoke.test.ts`: the direct `invokeShellCommand` calls pass 30s (the dedicated 200ms timeout test is unchanged).

## Validation

- Full suite green **3× consecutively at load avg ~24** (the conditions that previously flaked): 1919/1919 each.
- The branch's own pre-push hook (`node --run verify`) passed — self-unblocking proof that the fix resolves the flake it targets.
- No test asserts the old 10s defaults, and no shell test relies on a default timeout firing, so the uniform bump changes no expected behavior.

## Notes

- Discovered while the flaky pre-push hook blocked unrelated PRs (#260, #265, and a workspace-title change). Root cause is the developer machine being CPU-saturated (load avg 24+), which the full-suite thread pool compounds. CI on dedicated runners was unaffected, but the local pre-push hook was effectively unusable.