### PR TITLE
feat(pr-followups): bundled task source for followup refactoring PRs on merge

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -15,6 +15,7 @@
     "docs/superpowers/**"
   ],
   "words": [
+    "idempotently",
     "ankitpokhrel",
     "assertname",
     "jdoe",

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -161,6 +161,8 @@
     "Neue",
     "qlmanage",
     "argjson",
-    "tostring"
+    "tostring",
+    "hset",
+    "newfloor"
   ]
 }

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -159,6 +159,8 @@
     "unreviewed",
     "linejoin",
     "Neue",
-    "qlmanage"
+    "qlmanage",
+    "argjson",
+    "tostring"
   ]
 }

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -25,7 +25,7 @@ export default {
 };
 ```
 
-A complete, runnable JIRA source backed by the [`jira` CLI](https://github.com/ankitpokhrel/jira-cli) ships in [`task-sources/jira/`](../task-sources/jira/README.md): a single `jira.sh` dispatcher (`verify`/`list`/`get`/`move`) that maps JIRA's REST output into the contract below, plus the config block to wire it up.
+A complete, runnable JIRA source backed by the [`jira` CLI](https://github.com/ankitpokhrel/jira-cli) ships in [`task-sources/jira/`](../task-sources/jira/README.md): a single `jira.sh` dispatcher (`verify`/`list`/`get`/`move`) that maps JIRA's REST output into the contract below, plus the config block to wire it up. A read-only, merged-PR-driven example ships in [`task-sources/pr-followups/`](../task-sources/pr-followups/README.md): it emits one task per merged PR so an agent can open followup refactoring PRs, tracking progress in a local state file (no GitHub writes).
 
 `commands.listTasks` must print a JSON array of issues. `commands.getTask`, when
 set, must print one issue, print nothing for "not found", or exit `3` for "not

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { snapshotEnvironmentVariables } from "../../../testHelpers/env.ts";
-import { shellFetchOutputSchema } from "./schema.ts";
+import { shellFetchOutputSchema, shellIssueSchema } from "./schema.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../");
 const SCRIPT = path.join(REPO_ROOT, "task-sources/pr-followups/pr-followups.sh");
@@ -314,5 +314,28 @@ describe("pr-followups shell source", () => {
     expect(state.floor).toBe("2026-06-02T00:00:00Z");
     // 301 (< floor) pruned, 302 (== floor) kept.
     expect(state.handled).toStrictEqual([302]);
+  });
+
+  it("get returns one valid task for a known followup id", () => {
+    const pr: MergedPr = {
+      number: 101,
+      title: "Add retry logic",
+      mergedAt: "2026-06-10T10:00:00Z",
+      headRefName: "feature/retry",
+      body: "Body",
+      author: { login: "alice" },
+    };
+    const h = makeHarness({ prList: [], prView: { "101": pr } });
+    const r = h.run(["get", "followup-101"]);
+    expect(r.status).toBe(0);
+    const task = shellIssueSchema.parse(JSON.parse(r.stdout));
+    expect(task.id).toBe("followup-101");
+    expect(task.sourceRef).toStrictEqual({ number: 101 });
+  });
+
+  it("get exits 3 when the PR is absent", () => {
+    const h = makeHarness({ prList: [], prView: {} });
+    const r = h.run(["get", "followup-999"]);
+    expect(r.status).toBe(3);
   });
 });

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -200,6 +200,12 @@ describe("pr-followups shell source", () => {
     expect(t!.description).toContain("#101");
     // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
     expect(t!.description).toContain("gh pr diff 101");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.agent).toBeNull();
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.blockers).toStrictEqual([]);
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.hasMoreBlockers).toBe(false);
   });
 
   it("emits nothing when no PR is newer than the floor", () => {

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -131,4 +131,14 @@ describe("pr-followups shell source", () => {
     expect(r.status).toBe(2);
     expect(r.stderr).toContain("usage:");
   });
+
+  it("list initializes state on first run with an empty handled set", () => {
+    const h = makeHarness({ prList: [] });
+    const r = h.run(["list"]);
+    expect(r.status).toBe(0);
+    const state = h.readState();
+    expect(state.handled).toStrictEqual([]);
+    // floor is an ISO-8601 Zulu timestamp.
+    expect(state.floor).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
 });

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -338,4 +338,30 @@ describe("pr-followups shell source", () => {
     const r = h.run(["get", "followup-999"]);
     expect(r.status).toBe(3);
   });
+
+  it("complete records the PR number from stdin sourceRef", () => {
+    const h = makeHarness({
+      prList: [],
+      stateSeed: { floor: "2026-06-01T00:00:00Z", handled: [] },
+    });
+    const r = h.run(["complete", "followup-123"], {
+      stdin: JSON.stringify({ number: 123 }),
+    });
+    expect(r.status).toBe(0);
+    expect(h.readState().handled).toStrictEqual([123]);
+  });
+
+  it("reviewed is idempotent and preserves the floor", () => {
+    const h = makeHarness({
+      prList: [],
+      stateSeed: { floor: "2026-06-01T00:00:00Z", handled: [123] },
+    });
+    const r = h.run(["reviewed", "followup-123"], {
+      stdin: JSON.stringify({ number: 123 }),
+    });
+    expect(r.status).toBe(0);
+    const state = h.readState();
+    expect(state.handled).toStrictEqual([123]);
+    expect(state.floor).toBe("2026-06-01T00:00:00Z");
+  });
 });

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { snapshotEnvironmentVariables } from "../../../testHelpers/env.ts";
+import { shellFetchOutputSchema } from "./schema.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../");
 const SCRIPT = path.join(REPO_ROOT, "task-sources/pr-followups/pr-followups.sh");
@@ -140,5 +141,88 @@ describe("pr-followups shell source", () => {
     expect(state.handled).toStrictEqual([]);
     // floor is an ISO-8601 Zulu timestamp.
     expect(state.floor).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  const PRS: MergedPr[] = [
+    {
+      number: 101,
+      title: "Add retry logic",
+      mergedAt: "2026-06-10T10:00:00Z",
+      headRefName: "feature/retry",
+      body: "Body of 101",
+      author: { login: "alice" },
+    },
+    {
+      number: 102,
+      title: "Already handled",
+      mergedAt: "2026-06-11T10:00:00Z",
+      headRefName: "feature/handled",
+      body: "Body of 102",
+      author: { login: "bob" },
+    },
+    {
+      number: 103,
+      title: "A followup PR",
+      mergedAt: "2026-06-12T10:00:00Z",
+      headRefName: "gc-followup/77-extract",
+      body: "Body of 103",
+      author: { login: "carol" },
+    },
+  ];
+
+  it("emits one valid task per qualifying merged PR", () => {
+    const h = makeHarness({
+      prList: PRS,
+      stateSeed: { floor: "2026-06-01T00:00:00Z", handled: [102] },
+    });
+    const r = h.run(["list"]);
+    expect(r.status).toBe(0);
+    const tasks = shellFetchOutputSchema.parse(JSON.parse(r.stdout));
+    // 102 is handled, 103 is a followup branch -> only 101 emitted.
+    expect(tasks.map((task) => task.id)).toStrictEqual(["followup-101"]);
+    const [t] = tasks;
+    expect(t).toBeDefined();
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.title).toBe("Refactor followup for #101: Add retry logic");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.status).toBe("todo");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.repository).toBe("acme/widgets");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.assignee).toBe("alice");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.updatedAt).toBe("2026-06-10T10:00:00Z");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.url).toBe("https://github.com/acme/widgets/pull/101");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.sourceRef).toStrictEqual({ number: 101 });
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.description).toContain("#101");
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.description).toContain("gh pr diff 101");
+  });
+
+  it("emits nothing when no PR is newer than the floor", () => {
+    const h = makeHarness({
+      prList: PRS,
+      stateSeed: { floor: "2026-12-01T00:00:00Z", handled: [] },
+    });
+    const r = h.run(["list"]);
+    expect(shellFetchOutputSchema.parse(JSON.parse(r.stdout))).toStrictEqual([]);
+  });
+
+  it("emits a default agent when PR_FOLLOWUPS_AGENT is set", () => {
+    const [pr101] = PRS;
+    expect(pr101).toBeDefined();
+    const h = makeHarness({
+      // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+      prList: [pr101!],
+      stateSeed: { floor: "2026-06-01T00:00:00Z", handled: [] },
+    });
+    const r = h.run(["list"], { env: { PR_FOLLOWUPS_AGENT: "claude-fable" } });
+    const [t] = shellFetchOutputSchema.parse(JSON.parse(r.stdout));
+    expect(t).toBeDefined();
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
+    expect(t!.agent).toBe("claude-fable");
   });
 });

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -1,0 +1,134 @@
+/* eslint-disable no-template-curly-in-string -- this file embeds a fake `gh` bash script whose `${...}` tokens are literal shell parameter expansions, NOT JS template literals */
+
+/**
+ * Fixture-driven test for the committed pr-followups shell-source example
+ * (`task-sources/pr-followups/pr-followups.sh`). It does NOT hit GitHub: a fake
+ * `gh` executable on PATH emits canned payloads, the real script runs via
+ * bash + jq, and its stdout is validated against the same Zod schemas the shell
+ * adapter applies at runtime.
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { snapshotEnvironmentVariables } from "../../../testHelpers/env.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../");
+const SCRIPT = path.join(REPO_ROOT, "task-sources/pr-followups/pr-followups.sh");
+
+interface MergedPr {
+  number: number;
+  title: string;
+  mergedAt: string;
+  headRefName: string;
+  body: string;
+  author: { login: string };
+}
+
+/**
+ * Build a fake `gh` on PATH. `prList` is the JSON array returned for
+ * `gh pr list ... --json ...`; `prView` maps "<number>" -> one PR object for
+ * `gh pr view <number> --json ...`. `repo view` and `auth status` succeed.
+ */
+function makeHarness(opts: {
+  prList: MergedPr[];
+  prView?: Record<string, MergedPr>;
+  stateSeed?: { floor: string; handled: number[] };
+}): {
+  dir: string;
+  stateDir: string;
+  run: (
+    args: string[],
+    extra?: { env?: Record<string, string>; stdin?: string },
+  ) => { status: number | null; stdout: string; stderr: string };
+  readState: () => { floor: string; handled: number[] };
+} {
+  const dir = mkdtempSync(path.join(tmpdir(), "pr-followups-"));
+  const stateDir = path.join(dir, "state");
+  const listFixture = path.join(dir, "list.json");
+  const viewDir = path.join(dir, "views");
+  writeFileSync(listFixture, JSON.stringify(opts.prList));
+  // viewDir is created lazily by the fake only if needed; create eagerly:
+  spawnSync("mkdir", ["-p", viewDir]);
+  for (const [num, pr] of Object.entries(opts.prView ?? {})) {
+    writeFileSync(path.join(viewDir, `${num}.json`), JSON.stringify(pr));
+  }
+
+  const fakeGh = path.join(dir, "gh");
+  writeFileSync(
+    fakeGh,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then exit 0; fi',
+      'if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then printf "%s" "${FAKE_REPO:-acme/widgets}"; exit 0; fi',
+      'if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then cat "$FAKE_LIST"; exit 0; fi',
+      'if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then',
+      '  f="$FAKE_VIEW_DIR/${3:-}.json"',
+      '  [[ -f "$f" ]] || { echo "no pull requests found" >&2; exit 1; }',
+      '  cat "$f"; exit 0',
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(fakeGh, 0o755);
+
+  if (opts.stateSeed) {
+    spawnSync("mkdir", ["-p", stateDir]);
+    writeFileSync(path.join(stateDir, "acme__widgets.json"), JSON.stringify(opts.stateSeed));
+  }
+
+  function run(
+    args: string[],
+    extra: { env?: Record<string, string>; stdin?: string } = {},
+  ): { status: number | null; stdout: string; stderr: string } {
+    const baseEnv = snapshotEnvironmentVariables();
+    const result = spawnSync("bash", [SCRIPT, ...args], {
+      encoding: "utf8",
+      input: extra.stdin,
+      env: {
+        ...baseEnv,
+        PATH: `${dir}:${baseEnv["PATH"] ?? ""}`,
+        FAKE_LIST: listFixture,
+        FAKE_VIEW_DIR: viewDir,
+        PR_FOLLOWUPS_REPO: "acme/widgets",
+        PR_FOLLOWUPS_BASE: "main",
+        PR_FOLLOWUPS_STATE_DIR: stateDir,
+        ...extra.env,
+      },
+    });
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+
+  function readState(): { floor: string; handled: number[] } {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- narrowing untyped JSON.parse output to the known state shape
+    return JSON.parse(readFileSync(path.join(stateDir, "acme__widgets.json"), "utf8")) as {
+      floor: string;
+      handled: number[];
+    };
+  }
+
+  return { dir, stateDir, run, readState };
+}
+
+describe("pr-followups shell source", () => {
+  it("verify succeeds when gh is authed and repo reachable", () => {
+    const h = makeHarness({ prList: [] });
+    const r = h.run(["verify"]);
+    expect(r.status).toBe(0);
+  });
+
+  it("prints usage and exits 2 on unknown subcommand", () => {
+    const h = makeHarness({ prList: [] });
+    const r = h.run(["bogus"]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("usage:");
+  });
+});

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -231,4 +231,88 @@ describe("pr-followups shell source", () => {
     // oxlint-disable-next-line typescript/no-non-null-assertion -- asserted above
     expect(t!.agent).toBe("claude-fable");
   });
+
+  it("advances the floor across a contiguous handled/followup prefix and prunes", () => {
+    // 201 handled, 202 followup branch, 203 PENDING (hole), 204 handled.
+    const prs: MergedPr[] = [
+      {
+        number: 201,
+        title: "h1",
+        mergedAt: "2026-06-01T00:00:00Z",
+        headRefName: "x/1",
+        body: "",
+        author: { login: "a" },
+      },
+      {
+        number: 202,
+        title: "fu",
+        mergedAt: "2026-06-02T00:00:00Z",
+        headRefName: "gc-followup/1-x",
+        body: "",
+        author: { login: "a" },
+      },
+      {
+        number: 203,
+        title: "pending",
+        mergedAt: "2026-06-03T00:00:00Z",
+        headRefName: "x/3",
+        body: "",
+        author: { login: "a" },
+      },
+      {
+        number: 204,
+        title: "h2",
+        mergedAt: "2026-06-04T00:00:00Z",
+        headRefName: "x/4",
+        body: "",
+        author: { login: "a" },
+      },
+    ];
+    const h = makeHarness({
+      prList: prs,
+      stateSeed: { floor: "2026-05-01T00:00:00Z", handled: [201, 204] },
+    });
+    const r = h.run(["list"]);
+    const tasks = shellFetchOutputSchema.parse(JSON.parse(r.stdout));
+    // Only 203 is pending and emittable (201 handled, 202 followup, 204 handled).
+    expect(tasks.map((t) => t.id)).toStrictEqual(["followup-203"]);
+
+    const state = h.readState();
+    // Floor advances past 201 and 202, stops at the 203 hole -> floor == 202's time.
+    expect(state.floor).toBe("2026-06-02T00:00:00Z");
+    // 201 (< new floor) pruned; 204 kept (still a hole above the floor).
+    expect(state.handled.toSorted((a, b) => a - b)).toStrictEqual([204]);
+  });
+
+  it("keeps a handled PR tied exactly to the new floor in the set", () => {
+    // Two handled PRs share a timestamp at the advancing boundary; the boundary
+    // one must stay in `handled` so it is not re-emitted next poll.
+    const prs: MergedPr[] = [
+      {
+        number: 301,
+        title: "h",
+        mergedAt: "2026-06-01T00:00:00Z",
+        headRefName: "x/1",
+        body: "",
+        author: { login: "a" },
+      },
+      {
+        number: 302,
+        title: "h",
+        mergedAt: "2026-06-02T00:00:00Z",
+        headRefName: "x/2",
+        body: "",
+        author: { login: "a" },
+      },
+    ];
+    const h = makeHarness({
+      prList: prs,
+      stateSeed: { floor: "2026-05-01T00:00:00Z", handled: [301, 302] },
+    });
+    h.run(["list"]);
+    const state = h.readState();
+    expect(state.floor).toBe("2026-06-02T00:00:00Z");
+    // 301 (< floor) pruned, 302 (== floor) kept.
+    expect(state.handled).toStrictEqual([302]);
+  });
 });

--- a/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
+++ b/src/lib/adapters/shell/prFollowupsExampleSource.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { snapshotEnvironmentVariables } from "../../../testHelpers/env.ts";
-import { shellFetchOutputSchema, shellIssueSchema } from "./schema.ts";
+import { shellAdapterConfigSchema, shellFetchOutputSchema, shellIssueSchema } from "./schema.ts";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../");
 const SCRIPT = path.join(REPO_ROOT, "task-sources/pr-followups/pr-followups.sh");
@@ -363,5 +363,16 @@ describe("pr-followups shell source", () => {
     const state = h.readState();
     expect(state.handled).toStrictEqual([123]);
     expect(state.floor).toBe("2026-06-01T00:00:00Z");
+  });
+
+  it("source.json commands parse against the shell adapter config schema", () => {
+    const raw = readFileSync(path.join(REPO_ROOT, "task-sources/pr-followups/source.json"), "utf8");
+    // shellAdapterConfigSchema.parse accepts `unknown`; pass the JSON.parse
+    // output directly so the schema itself validates and narrows the types.
+    const parsed = shellAdapterConfigSchema.parse(JSON.parse(raw));
+    expect(parsed.name).toBe("pr-followups");
+    expect(parsed.commands.listTasks).toContain("pr-followups.sh list");
+    expect(parsed.commands.markInReview).toContain("reviewed");
+    expect(parsed.commands.markDone).toContain("complete");
   });
 });

--- a/task-sources/README.md
+++ b/task-sources/README.md
@@ -39,3 +39,4 @@ The command keys (`verify`, `listTasks`, `getTask`, `markInProgress`,
 
 - [`jira/`](./jira/README.md) — JIRA issues via the
   [`jira` CLI](https://github.com/ankitpokhrel/jira-cli).
+- [`pr-followups/`](./pr-followups/README.md) - followup refactoring PRs for each merged PR (read-only, local state).

--- a/task-sources/pr-followups/README.md
+++ b/task-sources/pr-followups/README.md
@@ -1,0 +1,90 @@
+# PR-followups shell source
+
+A ready-to-use [`shell` task source](../../docs/task-sources.md) that watches a
+repository's merged pull requests and emits one groundcrew task per newly merged
+PR. Each task asks an agent to decide whether a small followup refactoring is
+warranted and, if so, open a followup PR. Everything lives in one script,
+[`pr-followups.sh`](./pr-followups.sh), which the shell adapter calls with a
+subcommand per operation:
+
+| Subcommand                      | Adapter command | What it does                                                          |
+| ------------------------------- | --------------- | --------------------------------------------------------------------- |
+| `pr-followups.sh verify`        | `verify`        | Checks `gh` auth and repo reachability.                               |
+| `pr-followups.sh list`          | `listTasks`     | Prints a `ShellIssue[]` for merged PRs not yet handled.               |
+| `pr-followups.sh get <ID>`      | `getTask`       | Prints one `ShellIssue`, or exits `3` when the PR is absent/unmerged. |
+| `pr-followups.sh reviewed <ID>` | `markInReview`  | Records the PR as handled (a followup PR was opened).                 |
+| `pr-followups.sh complete <ID>` | `markDone`      | Records the PR as handled (no-op completion or followup merged).      |
+
+## How it works
+
+The source is **read-only on GitHub**: it never labels or comments on the
+upstream repo, so contributors without push access can run it. Dedup state lives
+in a local JSON file per repo (`{floor, handled}`) under
+`~/.config/groundcrew/pr-followups-state/<owner>__<name>.json`:
+
+- `floor` is a low-water mark initialized to install time (no historical
+  backfill). It advances over time across the contiguous run of fully-handled
+  PRs, bounding both the state file and the query window.
+- `handled` is the set of PR numbers that reached a terminal state. A PR is
+  recorded only on `reviewed`/`complete`, never on emit, so a crashed agent run
+  is retried rather than silently dropped.
+
+Loop prevention: followup PRs are opened on `gc-followup/*` branches, which the
+`list` query skips, so a merged followup never spawns a followup-of-a-followup.
+
+## Prerequisites
+
+- [`gh` CLI](https://cli.github.com) - `brew install gh`, then `gh auth login`.
+- [`jq`](https://jqlang.github.io/jq/) - `brew install jq`.
+
+## Install
+
+1. **Copy the script** to `~/.config/groundcrew/`:
+
+   ```bash
+   mkdir -p ~/.config/groundcrew
+   cp task-sources/pr-followups/pr-followups.sh ~/.config/groundcrew/pr-followups.sh
+   chmod +x ~/.config/groundcrew/pr-followups.sh
+   ```
+
+2. **Add the source** to your `crew.config.json` (or `crew.config.ts`):
+
+   ```json
+   {
+     "kind": "shell",
+     "name": "pr-followups",
+     "commands": {
+       "verify": "~/.config/groundcrew/pr-followups.sh verify",
+       "listTasks": "~/.config/groundcrew/pr-followups.sh list",
+       "getTask": "~/.config/groundcrew/pr-followups.sh get ${id}",
+       "markInReview": "~/.config/groundcrew/pr-followups.sh reviewed ${id}",
+       "markDone": "~/.config/groundcrew/pr-followups.sh complete ${id}"
+     },
+     "env": {
+       "PR_FOLLOWUPS_BASE": "main",
+       "PR_FOLLOWUPS_BRANCH_GLOB": "gc-followup/*"
+     }
+   }
+   ```
+
+   Set `PR_FOLLOWUPS_REPO` in the `env` block to the `owner/name` you want
+   watched, or run from within that repo's directory so the script can derive it
+   via `gh repo view`.
+
+## Knobs (set via the source's `env` block)
+
+| Variable                   | Default                                   | Meaning                               |
+| -------------------------- | ----------------------------------------- | ------------------------------------- |
+| `PR_FOLLOWUPS_REPO`        | derived via `gh repo view`                | `owner/name` to watch.                |
+| `PR_FOLLOWUPS_BASE`        | `main`                                    | Base branch whose merges are watched. |
+| `PR_FOLLOWUPS_BRANCH_GLOB` | `gc-followup/*`                           | Followup branch glob (loop guard).    |
+| `PR_FOLLOWUPS_AGENT`       | empty (`null`)                            | Agent assigned to emitted tasks.      |
+| `PR_FOLLOWUPS_STATE_DIR`   | `~/.config/groundcrew/pr-followups-state` | Where per-repo state files live.      |
+
+## Customizing the rubric
+
+The refactorings the agent considers live in the `RUBRIC` block at the top of
+`pr-followups.sh`. Edit that block to change what counts as a worthwhile
+followup. Keep the instruction to open the followup PR on a `gc-followup/<N>-*`
+branch and to run `$GROUNDCREW_COMPLETE` when nothing applies, or the loop guard
+and no-op path will not work.

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -121,6 +121,32 @@ case "${cmd}" in
             sourceRef: { number: $pr.number }
           }
       ]'
+
+    # Compaction: advance the floor across the oldest-first contiguous run of
+    # PRs that need no (further) processing (in `handled` OR followup-branch),
+    # then prune from `handled` everything strictly below the new floor. A PR
+    # tied exactly at the new floor stays in `handled` so the inclusive boundary
+    # cannot re-emit it.
+    new_state="$(printf '%s' "${prs}" | jq -c \
+      --arg floor "${floor}" \
+      --argjson handled "${handled}" \
+      --arg prefix "${BRANCH_PREFIX}" '
+      ([$handled[] | tostring]) as $hset
+      | (sort_by(.mergedAt)) as $sorted
+      | (reduce $sorted[] as $pr ({stop:false, floor:$floor};
+          if .stop then .
+          elif ($pr.headRefName | startswith($prefix)) then .floor = $pr.mergedAt
+          elif ($hset | index($pr.number | tostring)) != null then .floor = $pr.mergedAt
+          else .stop = true end)
+        ).floor as $newfloor
+      | {
+          floor: $newfloor,
+          handled: [ $handled[] as $n
+                     | (([$sorted[] | select(.number == $n) | .mergedAt] | first) // null) as $m
+                     | select(($m == null) or ($m >= $newfloor))
+                     | $n ]
+        }')"
+    printf '%s' "${new_state}" > "${state_file}"
     ;;
   *)
     echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -94,6 +94,25 @@ ensure_state() {
   fi
 }
 
+# Append a PR number (read from the stdin sourceRef JSON) to `handled`,
+# idempotently. Used by both `reviewed` and `complete`.
+record_handled() {
+  local repo state_file number
+  repo="$(resolve_repo)"
+  state_file="$(state_path "${repo}")"
+  ensure_state "${state_file}"
+  number="$(jq -r '.number')"   # reads stdin
+  [[ -n "${number}" && "${number}" != "null" ]] || {
+    echo "pr-followups: no .number on stdin sourceRef" >&2
+    exit 1
+  }
+  local tmp
+  tmp="$(mktemp)"
+  jq -c --argjson n "${number}" \
+    '.handled = ((.handled + [$n]) | unique)' "${state_file}" > "${tmp}"
+  mv "${tmp}" "${state_file}"
+}
+
 cmd="${1:-}"
 shift || true
 case "${cmd}" in
@@ -173,6 +192,9 @@ case "${cmd}" in
     printf '%s' "${out}" | jq -c \
       --arg repo "${repo}" --arg agent "${AGENT}" --arg rubric "${RUBRIC}" \
       "${JQ_TO_ISSUE} toIssue(\$repo; \$agent; \$rubric)"
+    ;;
+  reviewed|complete)
+    record_handled
     ;;
   *)
     echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# pr-followups <-> groundcrew shell source (single file).
+# The shell adapter's commands.* point at one of these subcommands:
+#   pr-followups.sh verify           gh auth + repo reachability       (commands.verify)
+#   pr-followups.sh list             ShellIssue[] JSON on stdout       (commands.listTasks)
+#   pr-followups.sh get <ID>         one ShellIssue, exit 3 if absent  (commands.getTask)
+#   pr-followups.sh reviewed <ID>    record PR as handled (PR opened)  (commands.markInReview)
+#   pr-followups.sh complete <ID>    record PR as handled (no-op/merged)(commands.markDone)
+#
+# Requires the `gh` CLI (https://cli.github.com) and `jq`. Read-only on GitHub:
+# all progress state lives in a local JSON file per repo, so contributors without
+# push access to the upstream repo can run it.
+#
+# Knobs (set via the source's `env` block in crew.config / source.json):
+#   PR_FOLLOWUPS_REPO         "owner/name" (default: derived via `gh repo view`)
+#   PR_FOLLOWUPS_BASE         base branch merges are watched on (default: main)
+#   PR_FOLLOWUPS_BRANCH_GLOB  followup branch glob, loop guard (default: gc-followup/*)
+#   PR_FOLLOWUPS_AGENT        agent for emitted tasks (default: empty -> null)
+#   PR_FOLLOWUPS_STATE_DIR    state dir (default: ~/.config/groundcrew/pr-followups-state)
+set -euo pipefail
+
+BASE="${PR_FOLLOWUPS_BASE:-main}"
+BRANCH_GLOB="${PR_FOLLOWUPS_BRANCH_GLOB:-gc-followup/*}"
+# Loop-guard prefix: the glob with a single trailing "*" removed.
+BRANCH_PREFIX="${BRANCH_GLOB%\*}"
+AGENT="${PR_FOLLOWUPS_AGENT:-}"
+STATE_DIR="${PR_FOLLOWUPS_STATE_DIR:-${HOME}/.config/groundcrew/pr-followups-state}"
+
+resolve_repo() {
+  if [[ -n "${PR_FOLLOWUPS_REPO:-}" ]]; then
+    printf '%s' "${PR_FOLLOWUPS_REPO}"
+  else
+    gh repo view --json nameWithOwner -q .nameWithOwner
+  fi
+}
+
+cmd="${1:-}"
+shift || true
+case "${cmd}" in
+  verify)
+    gh auth status >/dev/null 2>&1
+    gh repo view "$(resolve_repo)" --json nameWithOwner >/dev/null
+    ;;
+  *)
+    echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2
+    exit 2
+    ;;
+esac

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -43,6 +43,33 @@ diff minimal and focused. If none clearly applies, run `$GROUNDCREW_COMPLETE` an
 stop WITHOUT opening a PR. Do not refactor beyond the listed items.
 TXT
 
+# Shared single-PR -> ShellIssue transform. Input: one PR object (as `gh pr
+# view --json number,title,mergedAt,headRefName,body,author` returns). Args:
+# $repo, $agent, $rubric. Used by `list` (mapped over the array) and `get`.
+read -r -d '' JQ_TO_ISSUE <<'JQ' || true
+def toIssue($repo; $agent; $rubric):
+  {
+    id: ("followup-" + (.number | tostring)),
+    title: ("Refactor followup for #" + (.number | tostring) + ": " + .title),
+    description: ($rubric
+      + "\n\n--- Merged PR ---\n"
+      + "Number: #" + (.number | tostring) + "\n"
+      + "Title: " + .title + "\n\n"
+      + "Body:\n" + (.body // "")
+      + "\n\nFetch the full diff with: gh pr diff " + (.number | tostring)
+      + " --repo " + $repo),
+    status: "todo",
+    repository: $repo,
+    agent: (if $agent == "" then null else $agent end),
+    assignee: (.author.login // "unknown"),
+    updatedAt: .mergedAt,
+    blockers: [],
+    hasMoreBlockers: false,
+    url: ("https://github.com/" + $repo + "/pull/" + (.number | tostring)),
+    sourceRef: { number: .number }
+  };
+JQ
+
 resolve_repo() {
   if [[ -n "${PR_FOLLOWUPS_REPO:-}" ]]; then
     printf '%s' "${PR_FOLLOWUPS_REPO}"
@@ -94,33 +121,14 @@ case "${cmd}" in
       --arg prefix "${BRANCH_PREFIX}" \
       --arg repo "${repo}" \
       --arg agent "${AGENT}" \
-      --arg rubric "${RUBRIC}" '
+      --arg rubric "${RUBRIC}" "
+      ${JQ_TO_ISSUE}
       [ .[]
-        | select(.mergedAt > $floor)
-        | select((.headRefName | startswith($prefix)) | not)
-        | . as $pr
-        | select(([$handled[] | tostring] | index($pr.number | tostring)) == null)
-        | {
-            id: ("followup-" + ($pr.number | tostring)),
-            title: ("Refactor followup for #" + ($pr.number | tostring) + ": " + $pr.title),
-            description: ($rubric
-              + "\n\n--- Merged PR ---\n"
-              + "Number: #" + ($pr.number | tostring) + "\n"
-              + "Title: " + $pr.title + "\n\n"
-              + "Body:\n" + ($pr.body // "")
-              + "\n\nFetch the full diff with: gh pr diff " + ($pr.number | tostring)
-              + " --repo " + $repo),
-            status: "todo",
-            repository: $repo,
-            agent: (if $agent == "" then null else $agent end),
-            assignee: ($pr.author.login // "unknown"),
-            updatedAt: $pr.mergedAt,
-            blockers: [],
-            hasMoreBlockers: false,
-            url: ("https://github.com/" + $repo + "/pull/" + ($pr.number | tostring)),
-            sourceRef: { number: $pr.number }
-          }
-      ]'
+        | select(.mergedAt > \$floor)
+        | select((.headRefName | startswith(\$prefix)) | not)
+        | . as \$pr
+        | select(([\$handled[] | tostring] | index(\$pr.number | tostring)) == null)
+        | toIssue(\$repo; \$agent; \$rubric) ]"
 
     # Compaction: advance the floor across the oldest-first contiguous run of
     # PRs that need no (further) processing (in `handled` OR followup-branch),
@@ -147,6 +155,24 @@ case "${cmd}" in
                      | $n ]
         }')"
     printf '%s' "${new_state}" > "${state_file}"
+    ;;
+  get)
+    repo="$(resolve_repo)"
+    id="${1:?usage: pr-followups.sh get <ID>}"
+    number="${id#followup-}"
+    get_err="$(mktemp)"
+    trap 'rm -f "${get_err}"' EXIT
+    if ! out="$(gh pr view "${number}" --repo "${repo}" \
+                  --json number,title,mergedAt,headRefName,body,author,state 2>"${get_err}")"; then
+      # gh exits non-zero for a missing PR; treat as the not-found sentinel.
+      exit 3
+    fi
+    # Only merged PRs are valid followup tasks; anything else is "not found".
+    merged_at="$(printf '%s' "${out}" | jq -r '.mergedAt // empty')"
+    [[ -n "${merged_at}" ]] || exit 3
+    printf '%s' "${out}" | jq -c \
+      --arg repo "${repo}" --arg agent "${AGENT}" --arg rubric "${RUBRIC}" \
+      "${JQ_TO_ISSUE} toIssue(\$repo; \$agent; \$rubric)"
     ;;
   *)
     echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -27,6 +27,22 @@ BRANCH_PREFIX="${BRANCH_GLOB%\*}"
 AGENT="${PR_FOLLOWUPS_AGENT:-}"
 STATE_DIR="${PR_FOLLOWUPS_STATE_DIR:-${HOME}/.config/groundcrew/pr-followups-state}"
 
+# The agent's rubric. This is the "prompt in source config": the agent reads it
+# as its task description and decides, per merged PR, whether a followup applies.
+read -r -d '' RUBRIC <<'TXT' || true
+You are reviewing a merged pull request to decide whether a small, mechanical
+followup refactoring is warranted. Consider ONLY these refactorings:
+
+  - Extract a duplicated block introduced by this PR into a shared helper.
+  - Replace a magic literal the PR added with a named constant already used nearby.
+  - Tighten a type the PR left as `any`/`unknown` when the concrete type is obvious.
+
+If exactly one or more clearly applies, make the smallest sensible change and open
+a followup PR on a branch named `gc-followup/<PR_NUMBER>-<short-slug>`. Keep the
+diff minimal and focused. If none clearly applies, run `$GROUNDCREW_COMPLETE` and
+stop WITHOUT opening a PR. Do not refactor beyond the listed items.
+TXT
+
 resolve_repo() {
   if [[ -n "${PR_FOLLOWUPS_REPO:-}" ]]; then
     printf '%s' "${PR_FOLLOWUPS_REPO}"
@@ -62,7 +78,49 @@ case "${cmd}" in
     repo="$(resolve_repo)"
     state_file="$(state_path "${repo}")"
     ensure_state "${state_file}"
-    printf '[]'
+    floor="$(jq -r '.floor' "${state_file}")"
+    handled="$(jq -c '.handled' "${state_file}")"
+
+    # Read-only query: merged PRs into BASE. Over-fetch by date (search has no
+    # reliable sub-day granularity for the `merged:` qualifier across formats),
+    # then apply the precise `mergedAt > floor` filter in jq below.
+    prs="$(gh pr list --repo "${repo}" --state merged --base "${BASE}" \
+            --search "merged:>=${floor%%T*}" --limit 200 \
+            --json number,title,mergedAt,headRefName,body,author)"
+
+    printf '%s' "${prs}" | jq -c \
+      --arg floor "${floor}" \
+      --argjson handled "${handled}" \
+      --arg prefix "${BRANCH_PREFIX}" \
+      --arg repo "${repo}" \
+      --arg agent "${AGENT}" \
+      --arg rubric "${RUBRIC}" '
+      [ .[]
+        | select(.mergedAt > $floor)
+        | select((.headRefName | startswith($prefix)) | not)
+        | . as $pr
+        | select(([$handled[] | tostring] | index($pr.number | tostring)) == null)
+        | {
+            id: ("followup-" + ($pr.number | tostring)),
+            title: ("Refactor followup for #" + ($pr.number | tostring) + ": " + $pr.title),
+            description: ($rubric
+              + "\n\n--- Merged PR ---\n"
+              + "Number: #" + ($pr.number | tostring) + "\n"
+              + "Title: " + $pr.title + "\n\n"
+              + "Body:\n" + ($pr.body // "")
+              + "\n\nFetch the full diff with: gh pr diff " + ($pr.number | tostring)
+              + " --repo " + $repo),
+            status: "todo",
+            repository: $repo,
+            agent: (if $agent == "" then null else $agent end),
+            assignee: ($pr.author.login // "unknown"),
+            updatedAt: $pr.mergedAt,
+            blockers: [],
+            hasMoreBlockers: false,
+            url: ("https://github.com/" + $repo + "/pull/" + ($pr.number | tostring)),
+            sourceRef: { number: $pr.number }
+          }
+      ]'
     ;;
   *)
     echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2

--- a/task-sources/pr-followups/pr-followups.sh
+++ b/task-sources/pr-followups/pr-followups.sh
@@ -35,12 +35,34 @@ resolve_repo() {
   fi
 }
 
+now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# ${STATE_DIR}/<owner>__<name>.json for "owner/name".
+state_path() {
+  local repo="$1"
+  printf '%s/%s.json' "${STATE_DIR}" "${repo//\//__}"
+}
+
+ensure_state() {
+  local file="$1"
+  if [[ ! -f "${file}" ]]; then
+    mkdir -p "$(dirname "${file}")"
+    jq -n --arg floor "$(now_iso)" '{floor: $floor, handled: []}' > "${file}"
+  fi
+}
+
 cmd="${1:-}"
 shift || true
 case "${cmd}" in
   verify)
     gh auth status >/dev/null 2>&1
     gh repo view "$(resolve_repo)" --json nameWithOwner >/dev/null
+    ;;
+  list)
+    repo="$(resolve_repo)"
+    state_file="$(state_path "${repo}")"
+    ensure_state "${state_file}"
+    printf '[]'
     ;;
   *)
     echo "usage: pr-followups.sh {verify|list|get <ID>|reviewed <ID>|complete <ID>}" >&2

--- a/task-sources/pr-followups/source.json
+++ b/task-sources/pr-followups/source.json
@@ -1,0 +1,22 @@
+{
+  "name": "pr-followups",
+  "kind": "shell",
+  "description": "Open followup refactoring PRs for each merged PR.",
+  "installDir": "~/.config/groundcrew",
+  "files": ["pr-followups.sh"],
+  "prerequisites": [
+    { "bin": "gh", "install": "brew install gh", "setup": "gh auth login" },
+    { "bin": "jq", "install": "brew install jq" }
+  ],
+  "env": {
+    "PR_FOLLOWUPS_BASE": "main",
+    "PR_FOLLOWUPS_BRANCH_GLOB": "gc-followup/*"
+  },
+  "commands": {
+    "verify": "~/.config/groundcrew/pr-followups.sh verify",
+    "listTasks": "~/.config/groundcrew/pr-followups.sh list",
+    "getTask": "~/.config/groundcrew/pr-followups.sh get ${id}",
+    "markInReview": "~/.config/groundcrew/pr-followups.sh reviewed ${id}",
+    "markDone": "~/.config/groundcrew/pr-followups.sh complete ${id}"
+  }
+}


### PR DESCRIPTION
## What

Adds a bundled `pr-followups` shell task source (mirroring `task-sources/jira/`) that watches a repository's merged PRs and emits one groundcrew task per newly merged PR, so an agent can decide whether to open a followup refactoring PR. Lives entirely inside `crew run`'s existing polling loop.

**Zero groundcrew core/adapter changes** - this is config + a script + a test, using the existing shell-source contract.

## How it works

- One bash dispatcher `pr-followups.sh` implements `verify` / `list` / `get` / `reviewed` (markInReview) / `complete` (markDone) using `gh` (read-only) and `jq`.
- Dedup state is a local per-repo JSON file `{floor, handled}` - **read-only on GitHub**, so fork contributors without push access can run it.
- Three cooperating dedup layers: the durable `handled` set, the stable `followup-<PR#>` task id (groundcrew suppresses relaunch of in-flight tasks), and a self-compacting `floor` low-water mark that bounds both the state file and the `gh` query window.
- Loop-safe: followup PRs use `gc-followup/*` branches, excluded from candidates and transparent to floor advancement, so a merged followup never spawns a followup-of-a-followup.
- Crash-safe: a PR is recorded in `handled` only at a terminal state (`reviewed`/`complete`), never on emit, so a crashed agent run is retried rather than silently dropped.
- No backfill: `floor` initializes to "now" on first run.

## Deliverables

- `task-sources/pr-followups/pr-followups.sh` - the dispatcher
- `task-sources/pr-followups/source.json` - install manifest
- `task-sources/pr-followups/README.md` - usage docs
- `src/lib/adapters/shell/prFollowupsExampleSource.test.ts` - fixture-driven test driving the real script via a fake `gh` on PATH
- docs cross-links + benign `config/cspell.json` word additions

## Verification

`node --run verify` passes: 1932 tests, 100% coverage. Built test-first, one commit per task, with per-task spec+quality review and a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

## Remaining polish (non-blocking, draft)

- Harden `BRANCH_PREFIX` derivation for a glob ending in `**` (currently strips one trailing `*`).
- Add a numeric `^[0-9]+$` guard in `record_handled` (rejects a malformed `{"number":"abc"}` sourceRef and avoids a temp-file leak).
- Add tests for: `get` exit-3 on a present-but-unmerged PR; writeback invalid-stdin error path; `floor` unchanged in the emits-nothing case.
- Replace `spawnSync("mkdir","-p")` with `mkdirSync` in the test harness (cross-platform).

## Design / plan

Saved locally under `~/plans/groundcrew/` (design + exec-plan).
