### PR TITLE
feat(safehouse): add local.safehouse.enable to opt agents into sandbox integrations

### DIFF
--- a/crew.config.example.ts
+++ b/crew.config.example.ts
@@ -166,6 +166,15 @@ export default {
   // // macOS when you need an agent to use Docker safely.
   // local: { runner: "auto" },
   //
+  // // Safehouse optional integrations, turned on for every agent launched
+  // // under the safehouse runner (forwarded to `safehouse --enable=<list>`).
+  // // Each name layers the matching optional sandbox profile on top of the
+  // // deny-by-default policy. Examples: `agent-browser` so the
+  // // chrome-devtools MCP server can drive a headless Chrome;
+  // // `browser-native-messaging` for `claude --chrome`. Ignored by the
+  // // srt/sdx/none runners.
+  // local: { safehouse: { enable: ["agent-browser"] } },
+  //
   // // Groundcrew does not create or authenticate sdx sandboxes. For an sdx
   // // agent, create the matching sandbox yourself before first launch:
   // //   sbx create --name groundcrew-claude claude ~/dev/groundcrew

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -50,7 +50,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -89,7 +89,7 @@ const config: ResolvedConfig = {
   },
   prompts: { initial: "x" },
   workspaceKind: "auto",
-  local: { runner: "auto", networkEgress: "allowlisted" },
+  local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
   logging: { file: "/tmp/groundcrew-test.log" },
 };
 

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -58,7 +58,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -123,7 +123,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
@@ -654,7 +654,7 @@ describe(doctor, () => {
     detectHostMock.mockResolvedValue(host());
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "srt", networkEgress: "allowlisted" },
+      local: { runner: "srt", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();
@@ -679,7 +679,7 @@ describe(doctor, () => {
     );
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "srt", networkEgress: "allowlisted" },
+      local: { runner: "srt", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();
@@ -705,7 +705,7 @@ describe(doctor, () => {
     );
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "srt", networkEgress: "allowlisted" },
+      local: { runner: "srt", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();
@@ -727,7 +727,7 @@ describe(doctor, () => {
     );
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "srt", networkEgress: "allowlisted" },
+      local: { runner: "srt", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();
@@ -740,7 +740,7 @@ describe(doctor, () => {
     detectHostMock.mockResolvedValue(host());
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "none", networkEgress: "allowlisted" },
+      local: { runner: "none", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();
@@ -755,7 +755,7 @@ describe(doctor, () => {
     detectHostMock.mockResolvedValue(host({ hasSbx: true }));
     loadConfigMock.mockResolvedValue({
       ...makeConfig(),
-      local: { runner: "sdx", networkEgress: "allowlisted" },
+      local: { runner: "sdx", networkEgress: "allowlisted", safehouse: { enable: [] } },
     });
 
     const actual = await doctor();

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -47,7 +47,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -77,7 +77,7 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -180,7 +180,7 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -122,7 +122,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted", ...overrides.local },
+    local: {
+      runner: "auto",
+      networkEgress: "allowlisted",
+      safehouse: { enable: [] },
+      ...overrides.local,
+    },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -191,7 +191,7 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
@@ -510,7 +510,11 @@ describe(resumeWorkspace, () => {
   it("stages neutral prepare + agent srt settings and wraps the resumed agent under srt", async () => {
     const srtConfig = {
       ...makeConfig(),
-      local: { runner: "srt" as const, networkEgress: "allowlisted" as const },
+      local: {
+        runner: "srt" as const,
+        networkEgress: "allowlisted" as const,
+        safehouse: { enable: [] },
+      },
     };
 
     await resumeWorkspace(srtConfig, { task: "team-1" });
@@ -531,7 +535,11 @@ describe(resumeWorkspace, () => {
   it("wraps with bare safehouse and skips the clearance daemon when networkEgress is open", async () => {
     const openEgress = {
       ...makeConfig(),
-      local: { runner: "safehouse" as const, networkEgress: "open" as const },
+      local: {
+        runner: "safehouse" as const,
+        networkEgress: "open" as const,
+        safehouse: { enable: [] },
+      },
     };
 
     await resumeWorkspace(openEgress, { task: "team-1" });
@@ -552,7 +560,7 @@ describe(resumeWorkspace, () => {
     // has no effect: it is rejected by the same worker-env guard as allowlisted.
     const cmdOwned: ResolvedConfig = {
       ...makeConfig(),
-      local: { runner: "safehouse", networkEgress: "open" },
+      local: { runner: "safehouse", networkEgress: "open", safehouse: { enable: [] } },
       agents: {
         default: "claude",
         definitions: { claude: { cmd: "safehouse claude --auto", color: "#fff" } },
@@ -567,7 +575,7 @@ describe(resumeWorkspace, () => {
   it("does not add task source sandbox grants for unsandboxed resume runners", async () => {
     const noneConfig: ResolvedConfig = {
       ...makeConfig(),
-      local: { runner: "none", networkEgress: "allowlisted" },
+      local: { runner: "none", networkEgress: "allowlisted", safehouse: { enable: [] } },
       sources: [
         { kind: "linear" },
         {
@@ -605,7 +613,11 @@ describe(resumeWorkspace, () => {
   it("cleans up the staged srt settings dir when the resumed launch fails to open", async () => {
     const srtConfig = {
       ...makeConfig(),
-      local: { runner: "srt" as const, networkEgress: "allowlisted" as const },
+      local: {
+        runner: "srt" as const,
+        networkEgress: "allowlisted" as const,
+        safehouse: { enable: [] },
+      },
     };
     workspacesOpenMock.mockRejectedValue(new Error("cmux down"));
 

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -261,6 +261,7 @@ export async function resumeWorkspace(
         markDoneSupported: context.completionMarkDoneSupported,
       }),
       taskSourceWritePaths,
+      safehouseEnableFeatures: config.local.safehouse.enable,
     }));
     const launchCmd = stageWorkspaceLaunchCommand(stagedPrompt.directory, launchCommand);
     await openAgentWorkspace({

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -72,7 +72,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: path.join(stateRoot, "groundcrew.log") },
   };
 }

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -216,7 +216,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
       initial: "Begin {{task}} ({{title}}) in {{worktree}}\n{{description}}",
     },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }
@@ -571,7 +571,7 @@ describe(setupWorkspace, () => {
 
   it("stages neutral prepare + full agent srt settings and wraps the agent under the agent policy when runner=srt", async () => {
     const config = makeConfig();
-    config.local = { runner: "srt", networkEgress: "allowlisted" };
+    config.local = { runner: "srt", networkEgress: "allowlisted", safehouse: { enable: [] } };
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
     await setupWorkspace(config, {
@@ -940,7 +940,7 @@ describe(setupWorkspace, () => {
 
   it("wraps with bare safehouse and skips the clearance daemon when networkEgress is open", async () => {
     const config = makeConfig();
-    config.local = { runner: "safehouse", networkEgress: "open" };
+    config.local = { runner: "safehouse", networkEgress: "open", safehouse: { enable: [] } };
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
 
     await setupWorkspace(config, {
@@ -1301,7 +1301,7 @@ describe(setupWorkspace, () => {
       }),
     );
     const config = makeConfig();
-    config.local = { runner: "safehouse", networkEgress: "allowlisted" };
+    config.local = { runner: "safehouse", networkEgress: "allowlisted", safehouse: { enable: [] } };
 
     await expect(
       setupWorkspace(config, {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -175,6 +175,7 @@ export async function setupWorkspace(
         markDoneSupported: completionMarkDoneSupported,
       }),
       taskSourceWritePaths,
+      safehouseEnableFeatures: config.local.safehouse.enable,
     });
     srtSettingsDir = stagedSrtSettingsDir;
     const launchCmd = stageWorkspaceLaunchCommand(promptDir, launchCommand);

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -51,7 +51,7 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -158,7 +158,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted", ...overrides.local },
+    local: {
+      runner: "auto",
+      networkEgress: "allowlisted",
+      safehouse: { enable: [] },
+      ...overrides.local,
+    },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -83,7 +83,7 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -47,7 +47,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -74,7 +74,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -39,7 +39,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
     },
     prompts: { initial: "x", ...overrides.prompts },
     workspaceKind: overrides.workspaceKind ?? "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log", ...overrides.logging },
   };
 }

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -50,6 +50,7 @@ export function composeAgentLaunch(input: {
   workerEnvironment?: WorkerEnvironment | undefined;
   omitPromptArgument?: boolean | undefined;
   taskSourceWritePaths?: readonly string[] | undefined;
+  safehouseEnableFeatures?: readonly string[] | undefined;
 }): { launchCommand: string; srtSettingsDir: string | undefined } {
   const staged =
     input.runner === "srt"
@@ -84,6 +85,8 @@ export function composeAgentLaunch(input: {
       input.runner === "safehouse" ? resolveSafehouseAddDirs(input.worktreeDir) : undefined,
     safehouseAgentAddDirs:
       input.runner === "safehouse" ? (input.taskSourceWritePaths ?? []) : undefined,
+    safehouseEnableFeatures:
+      input.runner === "safehouse" ? input.safehouseEnableFeatures : undefined,
     safehouseAgentIntegration,
   });
   return { launchCommand, srtSettingsDir: staged?.directory };

--- a/src/lib/config.paths.test.ts
+++ b/src/lib/config.paths.test.ts
@@ -24,7 +24,7 @@ function resolvedConfigWithWorkspace(
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/x.log" },
   };
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1023,6 +1023,100 @@ describe("loadConfig", () => {
     expect(actual.local.runner).toBe("safehouse");
   });
 
+  it("defaults local.safehouse.enable to an empty list when omitted", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.local.safehouse.enable).toStrictEqual([]);
+  });
+
+  it("preserves and de-duplicates local.safehouse.enable feature names", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        local: {
+          safehouse: { enable: ["agent-browser", "browser-native-messaging", "agent-browser"] },
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.local.safehouse.enable).toStrictEqual([
+      "agent-browser",
+      "browser-native-messaging",
+    ]);
+  });
+
+  it("defaults local.safehouse.enable to an empty list when safehouse is set without enable", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        local: { safehouse: {} },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+    expect(actual.local.safehouse.enable).toStrictEqual([]);
+  });
+
+  it("rejects a non-object local.safehouse", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        `  agents: { definitions: { claude: {} } },`,
+        `  local: { safehouse: 5 },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(/local\.safehouse must be an object/);
+  });
+
+  it("rejects a non-array local.safehouse.enable", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        `  agents: { definitions: { claude: {} } },`,
+        `  local: { safehouse: { enable: 'agent-browser' } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(/local\.safehouse\.enable must be an array/);
+  });
+
+  it("rejects an invalid local.safehouse.enable feature slug", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      [
+        "export default {",
+        `  workspace: ${JSON.stringify(VALID_WORKSPACE(temporary))},`,
+        `  agents: { definitions: { claude: {} } },`,
+        `  local: { safehouse: { enable: ['Agent Browser'] } },`,
+        "};",
+      ].join("\n"),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /local\.safehouse\.enable\[0\] must be a safehouse feature slug/,
+    );
+  });
+
   it("defaults local.networkEgress to allowlisted when omitted", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -311,6 +311,24 @@ export interface Config {
      * unrestricted network egress. `srt`/`sdx`/`none` ignore this setting.
      */
     networkEgress?: NetworkEgressSetting;
+    /**
+     * Safehouse sandbox tuning. Consumed only by the `safehouse` runner; other
+     * runners ignore it.
+     */
+    safehouse?: {
+      /**
+       * Optional Safehouse integrations turned on for every agent launched
+       * under the safehouse runner, forwarded verbatim to
+       * `safehouse --enable=<comma-list>` on the agent wrap. Each name layers
+       * the matching optional sandbox profile on top of the deny-by-default
+       * policy — e.g. `agent-browser` for the chrome-devtools MCP server's
+       * Puppeteer/CDP browser, or `browser-native-messaging` for
+       * `claude --chrome`. Names are safehouse feature slugs
+       * (`[a-z0-9][a-z0-9-]*`); unknown names are rejected by safehouse at
+       * launch. Defaults to none.
+       */
+      enable?: string[];
+    };
   };
   logging?: {
     /**
@@ -382,6 +400,13 @@ export interface ResolvedConfig {
      * `"allowlisted"`. Only the safehouse runner consumes this today.
      */
     networkEgress: NetworkEgressSetting;
+    /**
+     * Resolved Safehouse tuning. Always present; `enable` defaults to `[]`.
+     * Only the safehouse runner consumes it.
+     */
+    safehouse: {
+      enable: readonly string[];
+    };
   };
   logging: {
     file: string;
@@ -714,6 +739,36 @@ function normalizeNetworkEgress(
     );
   }
   return value;
+}
+
+const SAFEHOUSE_FEATURE_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+function normalizeSafehouseEnable(value: unknown, configKey: string): readonly string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!isPlainObject(value)) {
+    fail(`${configKey} must be an object`);
+  }
+  const { enable } = value;
+  if (enable === undefined) {
+    return [];
+  }
+  if (!Array.isArray(enable)) {
+    fail(
+      `${configKey}.enable must be an array of safehouse feature names (got ${JSON.stringify(enable)})`,
+    );
+  }
+  const features: string[] = [];
+  for (const [index, entry] of enable.entries()) {
+    if (typeof entry !== "string" || !SAFEHOUSE_FEATURE_PATTERN.test(entry)) {
+      fail(
+        `${configKey}.enable[${index}] must be a safehouse feature slug matching ${SAFEHOUSE_FEATURE_PATTERN.source} (got ${JSON.stringify(entry)})`,
+      );
+    }
+    features.push(entry);
+  }
+  return [...new Set(features)];
 }
 
 function normalizeResumeArgs(value: unknown, configKey: string): string {
@@ -1130,7 +1185,9 @@ function applyDefaults(user: Config, configDir: string): ResolvedConfig {
       "remote is no longer supported: groundcrew runs locally via safehouse/sdx/none; remove the remote block from your config",
     );
   }
-  const userLocal = (user as { local?: { runner?: unknown; networkEgress?: unknown } }).local;
+  const userLocal = (
+    user as { local?: { runner?: unknown; networkEgress?: unknown; safehouse?: unknown } }
+  ).local;
   if (userLocal !== undefined && !isPlainObject(userLocal)) {
     fail("local must be an object");
   }
@@ -1161,6 +1218,9 @@ function applyDefaults(user: Config, configDir: string): ResolvedConfig {
       runner: normalizeLocalRunner(userLocal?.runner, "local.runner") ?? "auto",
       networkEgress:
         normalizeNetworkEgress(userLocal?.networkEgress, "local.networkEgress") ?? "allowlisted",
+      safehouse: {
+        enable: normalizeSafehouseEnable(userLocal?.safehouse, "local.safehouse"),
+      },
     },
     logging: {
       file: expandHome(

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -343,6 +343,30 @@ describe(buildLaunchCommand, () => {
     expect(out).not.toContain("--add-dirs");
   });
 
+  it("turns on requested Safehouse features on the agent wrap only via --enable", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        prepareWorktreeCommand: "npm ci",
+        safehouseEnableFeatures: ["browser-native-messaging", "agent-browser"],
+      }),
+    );
+
+    const enableFlag = "--enable='browser-native-messaging,agent-browser'";
+    // The shim-dir line splits the prepareWorktree wrap (before) from the agent
+    // wrap (after); browser features belong only to the latter.
+    const agentWrapStart = out.indexOf("_safehouse_shim_dir=$(mktemp");
+
+    expect(out.split(enableFlag).length - 1).toBe(1);
+    expect(out).toContain(`${enableFlag} "$_safehouse_shim" -c`);
+    expect(out.slice(0, agentWrapStart)).not.toContain("--enable");
+  });
+
+  it("omits --enable when no Safehouse features are requested", () => {
+    const out = buildLaunchCommand(arguments_({ prepareWorktreeCommand: "npm ci" }));
+
+    expect(out).not.toContain("--enable");
+  });
+
   it("uses an agent-named shell shim so Safehouse applies only the matching agent profile", () => {
     const out = buildLaunchCommand(arguments_());
 

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -497,6 +497,15 @@ interface LaunchCommandArguments {
    */
   safehouseAgentAddDirs?: readonly string[] | undefined;
   /**
+   * Optional Safehouse integrations turned on for the agent wrap, emitted as
+   * `--enable=<comma-list>` before the profile shim. Each name layers the
+   * matching optional sandbox profile (e.g. `agent-browser`) on top of the
+   * agent's deny-by-default policy. Withheld from the repo-controlled
+   * prepareWorktree wrap, which never needs them. Empty/undefined → no
+   * `--enable` flag.
+   */
+  safehouseEnableFeatures?: readonly string[] | undefined;
+  /**
    * Extra host-terminal integration surface granted only to the Safehouse agent
    * wrap. The agent may need to execute host shims and reach their sockets
    * while repo-controlled prepareWorktree hooks should not inherit those paths
@@ -683,6 +692,9 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     "--add-dirs-ro",
     safehouseAgentIntegration?.addDirsReadOnly ?? [],
   );
+  // Optional sandbox integrations (e.g. `agent-browser`) layered onto the agent
+  // profile only — the repo-controlled prepareWorktree hook never needs them.
+  const safehouseEnableFlag = safehouseEnableFeaturesFlag(arguments_.safehouseEnableFeatures ?? []);
   const safehouseWrapper = safehouseWrapperCommand(arguments_.networkEgress);
 
   // Defensive shim+promptDir trap: by the time we arm it, `rm -rf <promptDir>`
@@ -723,7 +735,7 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     // Running the real launch chain as `sh -c` would make it see `sh`, so use
     // an agent-named symlink to /bin/sh. This preserves per-agent profile
     // selection without enabling every agent profile.
-    `{ ${safehouseWrapper} ${safehouseAgentAddDirsFlag}${safehouseAgentAddDirsReadOnlyFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh${promptPositional(arguments_.omitPromptArgument)}; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
+    `{ ${safehouseWrapper} ${safehouseAgentAddDirsFlag}${safehouseAgentAddDirsReadOnlyFlag}${safehouseEnableFlag}${agentEnvPassFlag}"$_safehouse_shim" -c ${shellSingleQuote(agentCommand)} sh${promptPositional(arguments_.omitPromptArgument)}; _safehouse_status=$?; rm -rf "$_safehouse_shim_dir"; trap - EXIT; exit "$_safehouse_status"; }`,
   );
   return lines.join(" && ");
 }
@@ -733,6 +745,10 @@ function safehousePathListFlag(
   paths: readonly string[],
 ): string {
   return paths.length === 0 ? "" : `${flagName}=${shellSingleQuote(paths.join(":"))} `;
+}
+
+function safehouseEnableFeaturesFlag(features: readonly string[]): string {
+  return features.length === 0 ? "" : `--enable=${shellSingleQuote(features.join(","))} `;
 }
 
 function uniqueStrings(values: readonly string[]): string[] {

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -34,7 +34,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: path.join(stateRoot, "groundcrew.log") },
   };
 }

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -74,7 +74,7 @@ function makeConfig(
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -97,7 +97,7 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
     },
     prompts: { initial: "x" },
     workspaceKind,
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/worktrees.create.test.ts
+++ b/src/lib/worktrees.create.test.ts
@@ -75,7 +75,7 @@ function makeConfig(overrides: {
     agents: { default: "claude", definitions: agents },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/worktrees.open.test.ts
+++ b/src/lib/worktrees.open.test.ts
@@ -65,7 +65,7 @@ function makeConfig(overrides: {
     agents: { default: "claude", definitions: { claude: { cmd: "claude", color: "#fff" } } },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -91,7 +91,7 @@ function makeConfig(overrides: {
     agents: { default: "claude", definitions: agents },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: { runner: "auto", networkEgress: "allowlisted", safehouse: { enable: [] } },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }


### PR DESCRIPTION
## Why

Groundcrew launches every safehouse agent as bare `claude`, inheriting the user's MCP/plugin config. But some MCP tools need Safehouse **optional integrations** that the baseline `claude-code` profile doesn't grant:

- **chrome-devtools-mcp** (`npx chrome-devtools-mcp`) launches a Puppeteer/CDP Chrome — needs `agent-browser` / `chromium-headless`, which are **not** in the baseline profile.
- **`claude --chrome`** needs `browser-native-messaging` (this one *is* implicitly injected by the claude profile today, but being able to name it explicitly is useful).

Safehouse exposes these via `safehouse --enable=<features>`, and that is **CLI-flag-only** — there is no `SAFEHOUSE_ENABLE` env var, unlike `SAFEHOUSE_ADD_DIRS`. So today there's no way to turn them on for groundcrew-launched agents short of rewriting `cmd` to `safehouse … -- claude …`, which gives up the clearance wrap (egress allowlisting, the profile-shim, env sanitization, the prepareWorktree wrap). This PR adds a first-class, config-driven seam instead.

## What

- New optional config: `local.safehouse.enable: string[]`. Resolves to `[]` by default; consumed only by the safehouse runner (srt/sdx/none ignore it).
- Threaded through `composeAgentLaunch` → `buildSafehouseLaunchCommand`, emitted as `--enable=<comma-list>` on the **agent wrap only** (the repo-controlled prepareWorktree wrap never needs browser features, mirroring how `safehouseAgentAddDirs` is withheld from it).
- Feature names are validated as safehouse slugs (`[a-z0-9][a-z0-9-]*`) at config-load time and de-duplicated; genuinely unknown names are still rejected by safehouse itself at launch.
- Documented in `crew.config.example.ts`.

```ts
// crew.config.ts
local: { safehouse: { enable: ["agent-browser"] } },
```

## Areas of concern / follow-ups

- This grants the **sandbox permission** to use the browser. For chrome-devtools-mcp to actually function end-to-end, two runtime prerequisites remain (out of scope here, flagged for the operator): `npx` must be able to fetch the package through the clearance proxy (registry allowlisting or a warm cache), and the headless Chrome needs a writable user-data dir. `agent-browser` grants `~/.agent-browser`; a custom user-data-dir would need a matching `--add-dirs`.
- Scope is intentionally global (`local.safehouse.enable`) rather than per-agent, matching the "all agents" intent. Per-agent could layer on later if needed.

## Validation

`node --run verify` passes: build, lint/typecheck, oxfmt, `architecture:check`, markdownlint, syncpack, and the full test suite at the repo's enforced **100% coverage**. New unit tests cover the flag composition (agent-wrap-only placement, omitted when empty) and config parsing (default `[]`, dedup, non-object/non-array/invalid-slug rejection).