### PR TITLE
fix(reviewer): tear down worktree when a merged PR's task is marked done

### DIFF
--- a/src/commands/cleaner.ts
+++ b/src/commands/cleaner.ts
@@ -5,11 +5,10 @@
  */
 
 import type { ResolvedConfig } from "../lib/config.ts";
-import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { naturalIdFromCanonical, type BoardState } from "../lib/taskSource.ts";
 import { log, logEvent } from "../lib/util.ts";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
-import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
+import type { WorktreeEntry } from "../lib/worktrees.ts";
+import { reapWorktrees } from "./teardownReporter.ts";
 
 interface CleanerDeps {
   config: ResolvedConfig;
@@ -66,13 +65,7 @@ export function createCleaner(deps: CleanerDeps): Cleaner {
     }
 
     log(`Cleaning up ${stale.length} terminal worktree(s)`);
-    const result =
-      signal === undefined
-        ? await worktrees.teardown(config, stale)
-        : await worktrees.teardown(config, stale, { signal });
-    recordCleanedUpRuns(config, result.removed);
-    logTeardown(result);
-    recordTeardownEvents(result);
+    await reapWorktrees(config, stale, signal);
   }
 
   return { runOnce };

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -693,6 +693,32 @@ describe(createReviewer, () => {
 
     const out = consoleLog.output();
     expect(out).toContain("Advanced team-1 to done");
-    expect(out).toContain("worktree remove failed");
+    expect(out).toContain("Teardown failed for team-1: worktree remove failed");
+    expect(out).not.toContain("Failed to advance team-1 to done");
+  });
+
+  it("threads the abort signal into teardown on a successful markDone (supported source)", async () => {
+    const { signal } = new AbortController();
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-signal-"));
+    const config = makeConfig(stateRoot);
+    const entry = hostEntryFor("team-1");
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+      config,
+    });
+
+    try {
+      await reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [entry],
+        dryRun: false,
+        signal,
+      });
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry], { signal });
   });
 });

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -9,10 +9,24 @@ import type { ResolvedConfig } from "../lib/config.ts";
 import type { PullRequestSummary } from "../lib/pullRequests.ts";
 import { recordRunState } from "../lib/runState.ts";
 import type { BoardState, Issue, MarkDoneResult, MarkInReviewResult } from "../lib/taskSource.ts";
-import type { WorktreeEntry } from "../lib/worktrees.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { makeBoard } from "../testHelpers/boardFixtures.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import { createReviewer, type FindPullRequests } from "./reviewer.ts";
+
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      teardown: vi.fn<typeof actual.worktrees.teardown>(),
+    },
+  };
+});
+
+const teardownMock = vi.mocked(worktrees.teardown);
 
 function boardOf(issues: BoardState["issues"]): BoardState {
   return { timestamp: "2025-01-01T00:00:00.000Z", issues, parentSkips: [] };
@@ -92,6 +106,7 @@ describe(createReviewer, () => {
       .fn<(issue: Issue) => Promise<MarkDoneResult>>()
       .mockResolvedValue({ outcome: "applied" });
     board = makeBoard({ markInReview: markInReviewMock, markDone: markDoneMock });
+    teardownMock.mockResolvedValue(emptyTeardownResult());
     // review telemetry (event= lines) is diagnostic — verbose echoes it to the
     // console so these cases can assert the wording.
     setVerbose(true);
@@ -556,5 +571,128 @@ describe(createReviewer, () => {
       branchName: "dev-team-1",
       signal,
     });
+  });
+
+  it("tears down the worktree after a successful markDone (merged PR, supported source)", async () => {
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-teardown-"));
+    const config = makeConfig(stateRoot);
+    const entry = hostEntryFor("team-1");
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+      config,
+    });
+
+    try {
+      await reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [entry],
+        dryRun: false,
+      });
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    expect(markDoneMock).toHaveBeenCalledTimes(1);
+    expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry]);
+  });
+
+  it("does not tear down when markDone returns unsupported", async () => {
+    markDoneMock.mockResolvedValueOnce({
+      outcome: "unsupported",
+      reason: "source has no done transition",
+    });
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-teardown-"));
+    const config = makeConfig(stateRoot);
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+      config,
+    });
+
+    try {
+      await reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [hostEntryFor("team-1")],
+        dryRun: false,
+      });
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    expect(teardownMock).not.toHaveBeenCalled();
+  });
+
+  it("does not tear down on a markInReview transition (open PR)", async () => {
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-teardown-"));
+    const config = makeConfig(stateRoot);
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "open" })]),
+      config,
+    });
+
+    try {
+      await reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [hostEntryFor("team-1")],
+        dryRun: false,
+      });
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    expect(markInReviewMock).toHaveBeenCalledTimes(1);
+    expect(teardownMock).not.toHaveBeenCalled();
+  });
+
+  it("does not tear down on --dry-run even with a merged PR", async () => {
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-teardown-"));
+    const config = makeConfig(stateRoot);
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged" })]),
+      config,
+    });
+
+    try {
+      await reviewer.runOnce({
+        state: boardOf([inProgressIssue("team-1")]),
+        worktreeEntries: [hostEntryFor("team-1")],
+        dryRun: true,
+      });
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    expect(markDoneMock).not.toHaveBeenCalled();
+    expect(teardownMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows a teardown failure after a successful markDone", async () => {
+    teardownMock.mockRejectedValue(new Error("worktree remove failed"));
+    const stateRoot = mkdtempSync(path.join(tmpdir(), "groundcrew-reviewer-teardown-"));
+    const config = makeConfig(stateRoot);
+    const reviewer = createReviewer({
+      board,
+      findPullRequests: findReturning([pullRequest({ state: "merged", url: "https://gh/pr/9" })]),
+      config,
+    });
+
+    try {
+      await expect(
+        reviewer.runOnce({
+          state: boardOf([inProgressIssue("team-1")]),
+          worktreeEntries: [hostEntryFor("team-1")],
+          dryRun: false,
+        }),
+      ).resolves.toBeUndefined();
+    } finally {
+      rmSync(stateRoot, { recursive: true, force: true });
+    }
+
+    const out = consoleLog.output();
+    expect(out).toContain("Advanced team-1 to done");
+    expect(out).toContain("worktree remove failed");
   });
 });

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -7,8 +7,11 @@
  *   dispatch slot (slot math counts only in-progress) while leaving the
  *   worktree intact for review, since the cleaner only tears down `done`.
  * - A **merged** PR (on an in-progress or in-review task) → `markDone`:
- *   the work has landed, so the task is terminal and the cleaner tears the
- *   worktree down on a later tick. `merged` never routes to `in-review`.
+ *   the work has landed, so the task is terminal. On a successful `markDone`
+ *   the reviewer tears the worktree down immediately (same step). The cleaner
+ *   remains the level-triggered backstop for sources where `markDone` is
+ *   unsupported or that keep reporting `done`. `merged` never routes to
+ *   `in-review`.
  *
  * Sources that don't implement `markDone` (e.g. Linear) return `unsupported`;
  * the reviewer logs the skip and does nothing — there is no in-review
@@ -238,7 +241,11 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         to: transition,
       });
       if (transition === "done" && reviewerConfig !== undefined) {
-        await reapWorktrees(reviewerConfig, [entry], signal);
+        try {
+          await reapWorktrees(reviewerConfig, [entry], signal);
+        } catch (teardownError) {
+          log(`Teardown failed for ${task}: ${errorMessage(teardownError)}`);
+        }
       }
     } catch (error) {
       log(`Failed to advance ${task} to ${transition}: ${errorMessage(error)}`);

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -34,6 +34,7 @@ import {
 import { debug, errorMessage, log, logEvent } from "../lib/util.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { effectiveBranchName } from "../lib/worktreeRunState.ts";
+import { reapWorktrees } from "./teardownReporter.ts";
 
 /**
  * Injected PR lookup. Matches `findPullRequestsForBranch`'s shape: best-effort,
@@ -189,7 +190,15 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         return;
       }
       // oxlint-disable-next-line no-await-in-loop -- single write-back then return; never iterates past the first actionable worktree.
-      await advance({ issue, task, pullRequest, transition });
+      await advance({
+        issue,
+        task,
+        pullRequest,
+        transition,
+        entry,
+        reviewerConfig,
+        signal,
+      });
       return;
     }
   }
@@ -202,8 +211,11 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
     task: string;
     pullRequest: PullRequestSummary;
     transition: Transition;
+    entry: WorktreeEntry;
+    reviewerConfig: ResolvedConfig | undefined;
+    signal: AbortSignal | undefined;
   }): Promise<void> {
-    const { issue, task, pullRequest, transition } = arguments_;
+    const { issue, task, pullRequest, transition, entry, reviewerConfig, signal } = arguments_;
     try {
       const result =
         transition === "done" ? await board.markDone(issue) : await board.markInReview(issue);
@@ -225,6 +237,9 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
         state: pullRequest.state,
         to: transition,
       });
+      if (transition === "done" && reviewerConfig !== undefined) {
+        await reapWorktrees(reviewerConfig, [entry], signal);
+      }
     } catch (error) {
       log(`Failed to advance ${task} to ${transition}: ${errorMessage(error)}`);
       logEvent("review", {

--- a/src/commands/teardownReporter.test.ts
+++ b/src/commands/teardownReporter.test.ts
@@ -1,8 +1,28 @@
+import type { ResolvedConfig } from "../lib/config.ts";
+import { removeRunState } from "../lib/runState.ts";
 import { setVerbose } from "../lib/util.ts";
-import type { TeardownResult, WorktreeEntry } from "../lib/worktrees.ts";
+import { type TeardownResult, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
-import { logTeardown, recordTeardownEvents } from "./teardownReporter.ts";
+import { logTeardown, reapWorktrees, recordTeardownEvents } from "./teardownReporter.ts";
+
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      teardown: vi.fn<typeof actual.worktrees.teardown>(),
+    },
+  };
+});
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, removeRunState: vi.fn<typeof removeRunState>() };
+});
+
+const teardownMock = vi.mocked(worktrees.teardown);
+const removeRunStateMock = vi.mocked(removeRunState);
 
 // The teardown reporter's telemetry (logEvent) and sub-step lines (debug) are
 // diagnostic, so they only reach the console under verbose. These cases assert
@@ -182,5 +202,92 @@ describe(recordTeardownEvents, () => {
     expect(out).toContain("repository=repo-a");
     expect(out).toContain("kind=host");
     expect(out).toContain("busy");
+  });
+});
+
+function makeConfig(): ResolvedConfig {
+  return {
+    sources: [],
+    defaults: { hooks: {} },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["repo-a"],
+      repositories: [{ name: "repo-a" }],
+    },
+    orchestrator: {
+      maximumInProgress: 2,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    agents: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: { runner: "auto", networkEgress: "allowlisted" },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+describe(reapWorktrees, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+    teardownMock.mockResolvedValue(emptyTeardownResult());
+    setVerbose(true);
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    setVerbose(false);
+    vi.clearAllMocks();
+  });
+
+  it("calls worktrees.teardown with the given entries", async () => {
+    const entry = hostEntry("team-1");
+
+    await reapWorktrees(makeConfig(), [entry]);
+
+    expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry]);
+  });
+
+  it("passes the signal into worktrees.teardown when provided", async () => {
+    const { signal } = new AbortController();
+    const entry = hostEntry("team-1");
+
+    await reapWorktrees(makeConfig(), [entry], signal);
+
+    expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry], { signal });
+  });
+
+  it("calls removeRunState for each removed entry", async () => {
+    const entry = hostEntry("team-1");
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [entry] }));
+
+    await reapWorktrees(makeConfig(), [entry]);
+
+    expect(removeRunStateMock).toHaveBeenCalledWith(expect.anything(), "team-1");
+  });
+
+  it("logs cleanup complete for a removed entry", async () => {
+    const entry = hostEntry("team-1");
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [entry] }));
+
+    await reapWorktrees(makeConfig(), [entry]);
+
+    expect(consoleLog.output()).toContain("event=cleanup outcome=cleaned task=team-1");
+  });
+
+  it("returns the TeardownResult from worktrees.teardown", async () => {
+    const entry = hostEntry("team-1");
+    const expected = emptyTeardownResult({ removed: [entry] });
+    teardownMock.mockResolvedValue(expected);
+
+    const actual = await reapWorktrees(makeConfig(), [entry]);
+
+    expect(actual).toBe(expected);
   });
 });

--- a/src/commands/teardownReporter.ts
+++ b/src/commands/teardownReporter.ts
@@ -1,5 +1,7 @@
+import type { ResolvedConfig } from "../lib/config.ts";
+import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { debug, errorMessage, log, logEvent, okMark } from "../lib/util.ts";
-import type { TeardownResult } from "../lib/worktrees.ts";
+import { type TeardownResult, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 export function logTeardown(result: TeardownResult): void {
   if (result.workspaceProbe.kind === "unavailable" && result.workspaceProbe.error !== undefined) {
@@ -20,6 +22,26 @@ export function logTeardown(result: TeardownResult): void {
       log(`Cleanup failed for ${failure.entry.task} (${failure.entry.kind}): ${message}`);
     }
   }
+}
+
+/**
+ * Shared helper: runs `worktrees.teardown` then records run-state cleanup,
+ * logs the result, and emits telemetry events. Used by both the cleaner and
+ * the reviewer fast-path so the sequence is never duplicated.
+ */
+export async function reapWorktrees(
+  config: ResolvedConfig,
+  entries: readonly WorktreeEntry[],
+  signal?: AbortSignal,
+): Promise<TeardownResult> {
+  const result =
+    signal === undefined
+      ? await worktrees.teardown(config, entries)
+      : await worktrees.teardown(config, entries, { signal });
+  recordCleanedUpRuns(config, result.removed);
+  logTeardown(result);
+  recordTeardownEvents(result);
+  return result;
 }
 
 export function recordTeardownEvents(result: TeardownResult): void {


### PR DESCRIPTION
## Why

Teardown is driven entirely by the cleaner observing a task with `status: "done"` in a `board.fetch()`. The reviewer marks a merged PR's task done via `markDone` but does not tear down itself; it relies on a later tick re-fetching that task and seeing `done`.

That design imposes a hidden requirement on every source: it must keep surfacing completed tickets indefinitely, because teardown can only happen on some future tick that re-observes the ticket as `done`. A source that stops listing a ticket once it is finished never gives the cleaner its trigger, so the worktree is never torn down and lingers forever (observed: a worktree stranded 10+ days after its PR merged).

There is no good reason to force sources to report finished work forever. The reviewer already learns the work is done the moment `markDone` succeeds, so it can tear the worktree down right then instead of deferring to a re-observation that may never come.

## What

The reviewer now tears the worktree down immediately when it advances a task to `done` via a **successful** `markDone`.

- Extracted `reapWorktrees(config, entries, signal?)` in `teardownReporter.ts` as the single home for the teardown + bookkeeping sequence (`worktrees.teardown` then `recordCleanedUpRuns` + `logTeardown` + `recordTeardownEvents`). Both `cleaner.ts` and `reviewer.ts` call it - no duplication.
- `cleaner.ts` now calls `reapWorktrees` (pure refactor, behavior unchanged).
- `reviewer.ts` calls `reapWorktrees(config, [entry], signal)` after a successful `markDone` for a `done` transition. The teardown is wrapped in its own try/catch so a teardown failure logs a distinct `Teardown failed for <task>` and is swallowed, without mislabeling the (successful) board write-back as a failed advance.

### Unchanged by design

- Sources where `markDone` returns `unsupported` (e.g. Linear) get no fast-path teardown; the cleaner reaps them on a later tick exactly as before.
- `markInReview` transitions never trigger teardown.
- `--dry-run` performs no teardown.
- The cleaner remains the level-triggered backstop.

## Tests

TDD, red-green-refactor. New coverage:

- Reviewer tears down on a merged PR (supported source); does **not** on `unsupported` / `markInReview` / `--dry-run`.
- Teardown failure is logged (distinct message) and swallowed; the success log and `advanced` event still fire; `Failed to advance` is **not** logged.
- The abort signal is forwarded into `worktrees.teardown`.
- `reapWorktrees` unit tests in `teardownReporter.test.ts`.
- Existing cleaner tests pass unchanged (refactor is behavior-preserving).

`node --run verify` passes clean (full suite, 1943 tests).

## Areas of concern / follow-up

- This is the fast path. A failed teardown under a source that has already retired the ticket has no automatic cross-tick retry (the cleaner is the retry backstop only for sources that keep reporting `done`).
- No groundcrew-side orphan reaper was added (explicitly out of scope).
