### PR TITLE
fix(cmux): close leaked workspace by id when new-workspace fails after creating it

### DIFF
--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -261,19 +261,21 @@ async function closeWorkspaceLeakedByFailedOpen(
 }
 
 /**
- * The captured stdout/stderr is folded into the command error's message (see
- * `normalizeCommandError`), so parse the id back out of it. cmux `--json`
- * failures emit a `workspace_id`/`id` JSON field; older builds print a bare
- * `workspace:N` ref that the success extractor already recognizes.
+ * Recover the created workspace id from a failed `new-workspace`. Parse only
+ * the captured stdout slice of the command error's message (see
+ * `normalizeCommandError`), never the whole message — matching against stderr
+ * or the echoed command line risks grabbing an unrelated `workspace:N` and
+ * closing the wrong workspace. The slice is the same shape the success path
+ * sees, so `extractCmuxOpenId` handles both the `--json` id object and a bare
+ * `workspace:N` ref.
  */
 function extractCmuxOpenIdFromFailure(error: unknown): string | undefined {
-  const message = errorMessage(error);
-  const refId = extractCmuxOpenId(message);
-  if (refId !== undefined) {
-    return refId;
-  }
-  const jsonIdMatch = /"(?:workspace_id|id)"\s*:\s*"([^"]+)"/.exec(message);
-  return jsonIdMatch?.[1];
+  const stdout = cmuxStdoutFromFailureMessage(errorMessage(error));
+  return stdout === undefined ? undefined : extractCmuxOpenId(stdout);
+}
+
+function cmuxStdoutFromFailureMessage(message: string): string | undefined {
+  return /\nStdout:\n([\s\S]*?)(?:\nCause: |$)/.exec(message)?.[1];
 }
 
 function isCmuxSetStatusUnsupported(error: unknown): boolean {

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -14,22 +14,28 @@ import { debug, errorMessage, log } from "./util.ts";
 
 export const cmuxAdapter: Adapter = {
   async open(spec, signal) {
-    const output = await runWorkspaceCommand(
-      "cmux",
-      [
-        "--json",
-        "new-workspace",
-        "--name",
-        spec.name,
-        "--cwd",
-        spec.cwd,
-        "--command",
-        spec.command,
-        "--description",
-        cmuxDescriptionFor(spec.name),
-      ],
-      signal,
-    );
+    let output: string;
+    try {
+      output = await runWorkspaceCommand(
+        "cmux",
+        [
+          "--json",
+          "new-workspace",
+          "--name",
+          spec.name,
+          "--cwd",
+          spec.cwd,
+          "--command",
+          spec.command,
+          "--description",
+          cmuxDescriptionFor(spec.name),
+        ],
+        signal,
+      );
+    } catch (error) {
+      await closeWorkspaceLeakedByFailedOpen(error, spec.name, signal);
+      throw error;
+    }
     const workspaceId = extractCmuxOpenId(output);
     if (workspaceId === undefined) {
       log(
@@ -218,6 +224,56 @@ async function applyCmuxStatus(
 
 async function closeCmuxWorkspace(workspaceId: string, signal?: AbortSignal): Promise<void> {
   await runWorkspaceCommand("cmux", ["close-workspace", "--workspace", workspaceId], signal);
+}
+
+/**
+ * cmux occasionally exits non-zero from `new-workspace` while still having
+ * created the workspace (a known flake where it also lands in the wrong `--cwd`).
+ * The id rides along in the failed command's captured output, so recover it and
+ * close that exact workspace by id — a failed launch must not strand an orphan
+ * tagged with the task's `groundcrew:<taskId>` marker. Closing by the recovered
+ * id needs no `list-workspaces`, so it survives a concurrent list failure that
+ * would defeat re-enumeration. Re-enumeration close is unsafe here anyway; we
+ * hold the precise id cmux returned, so there is no same-named-sibling risk.
+ */
+async function closeWorkspaceLeakedByFailedOpen(
+  error: unknown,
+  name: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (isSignalAborted(signal)) {
+    return;
+  }
+  const workspaceId = extractCmuxOpenIdFromFailure(error);
+  if (workspaceId === undefined) {
+    return;
+  }
+  try {
+    await closeCmuxWorkspace(workspaceId, signal);
+    debug(
+      `cmux new-workspace for ${name} exited non-zero but had created ${workspaceId}; closed the leaked workspace.`,
+    );
+  } catch (closeError) {
+    log(
+      `cmux new-workspace for ${name} exited non-zero and left workspace ${workspaceId}; automatic close failed (${errorMessage(closeError)}). Run \`cmux close-workspace --workspace ${workspaceId}\` by hand.`,
+    );
+  }
+}
+
+/**
+ * The captured stdout/stderr is folded into the command error's message (see
+ * `normalizeCommandError`), so parse the id back out of it. cmux `--json`
+ * failures emit a `workspace_id`/`id` JSON field; older builds print a bare
+ * `workspace:N` ref that the success extractor already recognizes.
+ */
+function extractCmuxOpenIdFromFailure(error: unknown): string | undefined {
+  const message = errorMessage(error);
+  const refId = extractCmuxOpenId(message);
+  if (refId !== undefined) {
+    return refId;
+  }
+  const jsonIdMatch = /"(?:workspace_id|id)"\s*:\s*"([^"]+)"/.exec(message);
+  return jsonIdMatch?.[1];
 }
 
 function isCmuxSetStatusUnsupported(error: unknown): boolean {

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -115,12 +115,20 @@ function commonAfterEach(): void {
 }
 
 // Mirrors the error `runCommandAsync` rejects with on a non-zero exit: the
-// message embeds the captured stdout and the original error (carrying the raw
-// `stdout`) rides along as `cause`.
+// normalized message embeds the captured stdout under a `Stdout:` section,
+// which is what the adapter parses the leaked workspace id back out of.
 function cmuxNewWorkspaceFailure(stdout: string): Error {
   return new Error(
     `Command failed: cmux --json new-workspace\nExit status: 1\nStdout:\n${stdout}\nCause: Command exited unsuccessfully`,
-    { cause: Object.assign(new Error("Command exited unsuccessfully"), { stdout }) },
+  );
+}
+
+// Signature-agnostic: matches a close-workspace invocation regardless of how
+// many arguments (e.g. a trailing signal) accompany it.
+function closeWorkspaceWasCalled(): boolean {
+  return runMock.mock.calls.some(
+    ([command, arguments_]) =>
+      command === "cmux" && Array.isArray(arguments_) && arguments_.includes("close-workspace"),
   );
 }
 
@@ -328,7 +336,7 @@ describe("workspaces.open (cmux)", () => {
     ]);
   });
 
-  it("rethrows without attempting a close when the failed new-workspace output carries no id", async () => {
+  it("rethrows without attempting a close when the failed new-workspace stdout carries no id", async () => {
     runMock.mockImplementationOnce(() => {
       throw cmuxNewWorkspaceFailure("no recognizable id here");
     });
@@ -337,7 +345,23 @@ describe("workspaces.open (cmux)", () => {
       workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
     ).rejects.toThrow(/Command failed: cmux/);
 
-    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
+    expect(closeWorkspaceWasCalled()).toBe(false);
+  });
+
+  it("does not let a stray workspace id in stderr trigger a close", async () => {
+    // The real workspace id lives in stdout; an unrelated `workspace:7` in
+    // stderr must not be parsed as the leaked workspace.
+    runMock.mockImplementationOnce(() => {
+      throw new Error(
+        "Command failed: cmux --json new-workspace\nExit status: 1\nStderr:\nconflict with workspace:7\nCause: Command exited unsuccessfully",
+      );
+    });
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(closeWorkspaceWasCalled()).toBe(false);
   });
 
   it("does not fight an already-aborted signal by trying to close the leaked workspace", async () => {
@@ -355,11 +379,7 @@ describe("workspaces.open (cmux)", () => {
       ),
     ).rejects.toThrow(/Command failed: cmux/);
 
-    expect(runMock).not.toHaveBeenCalledWith(
-      "cmux",
-      expect.arrayContaining(["close-workspace"]),
-      expect.anything(),
-    );
+    expect(closeWorkspaceWasCalled()).toBe(false);
   });
 
   it("logs a manual-close hint when closing the leaked workspace itself fails", async () => {

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -8,7 +8,7 @@ import type { RunCommandOptions } from "./commandRunner.ts";
 import type { ResolvedConfig, WorkspaceKindSetting } from "./config.ts";
 import type * as hostModule from "./host.ts";
 import { detectHostCapabilities, type HostCapabilities } from "./host.ts";
-import { debug, writeError } from "./util.ts";
+import { debug, log, writeError } from "./util.ts";
 import type * as utilModule from "./util.ts";
 import {
   resolveWorkspaceKind,
@@ -18,6 +18,7 @@ import {
 } from "./workspaces.ts";
 
 const debugMock = vi.mocked(debug);
+const logMock = vi.mocked(log);
 const writeErrorMock = vi.mocked(writeError);
 
 type RunCommandMock = (
@@ -111,6 +112,16 @@ function commonAfterEach(): void {
   deleteEnvironmentVariable("GROUNDCREW_KEEP_DEAD_WINDOWS");
   deleteEnvironmentVariable("GROUNDCREW_TMUX_SESSION_PER_TASK");
   vi.resetAllMocks();
+}
+
+// Mirrors the error `runCommandAsync` rejects with on a non-zero exit: the
+// message embeds the captured stdout and the original error (carrying the raw
+// `stdout`) rides along as `cause`.
+function cmuxNewWorkspaceFailure(stdout: string): Error {
+  return new Error(
+    `Command failed: cmux --json new-workspace\nExit status: 1\nStdout:\n${stdout}\nCause: Command exited unsuccessfully`,
+    { cause: Object.assign(new Error("Command exited unsuccessfully"), { stdout }) },
+  );
 }
 
 function workspaceInterruptError(result: WorkspaceInterruptResult): unknown {
@@ -283,6 +294,90 @@ describe("workspaces.open (cmux)", () => {
 
     expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
     expect(debugMock).not.toHaveBeenCalledWith(expect.stringContaining("set-status"));
+  });
+
+  it("closes the leaked workspace by id when new-workspace exits non-zero but emitted an id, without re-enumerating", async () => {
+    // new-workspace fails carrying an id; the follow-up close-workspace succeeds
+    // (the default ""). A re-enumeration via list-workspaces is never attempted,
+    // so a concurrent list failure can't strand the orphan.
+    runMock.mockImplementationOnce(() => {
+      throw cmuxNewWorkspaceFailure(JSON.stringify({ workspace_id: "leaked-id" }));
+    });
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(runMock).toHaveBeenCalledWith("cmux", ["close-workspace", "--workspace", "leaked-id"]);
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["list-workspaces"]));
+  });
+
+  it("closes the leaked workspace by the workspace:N ref parsed from a non-JSON failure", async () => {
+    runMock.mockImplementationOnce(() => {
+      throw cmuxNewWorkspaceFailure("Created workspace:99 then failed");
+    });
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "close-workspace",
+      "--workspace",
+      "workspace:99",
+    ]);
+  });
+
+  it("rethrows without attempting a close when the failed new-workspace output carries no id", async () => {
+    runMock.mockImplementationOnce(() => {
+      throw cmuxNewWorkspaceFailure("no recognizable id here");
+    });
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(runMock).not.toHaveBeenCalledWith("cmux", expect.arrayContaining(["close-workspace"]));
+  });
+
+  it("does not fight an already-aborted signal by trying to close the leaked workspace", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    runMock.mockImplementationOnce(() => {
+      throw cmuxNewWorkspaceFailure(JSON.stringify({ workspace_id: "leaked-id" }));
+    });
+
+    await expect(
+      workspaces.open(
+        makeConfig(),
+        { name: "TEAM-1", cwd: "/cwd", command: "x" },
+        controller.signal,
+      ),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(runMock).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["close-workspace"]),
+      expect.anything(),
+    );
+  });
+
+  it("logs a manual-close hint when closing the leaked workspace itself fails", async () => {
+    runMock
+      .mockImplementationOnce(() => {
+        throw cmuxNewWorkspaceFailure(JSON.stringify({ workspace_id: "leaked-id" }));
+      })
+      .mockImplementationOnce(() => {
+        throw new Error("close refused");
+      });
+
+    await expect(
+      workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
+    ).rejects.toThrow(/Command failed: cmux/);
+
+    expect(logMock).toHaveBeenCalledWith(
+      expect.stringContaining("cmux close-workspace --workspace leaked-id"),
+    );
   });
 
   it("caches the resolved adapter per config so detectHostCapabilities is not re-run", async () => {


### PR DESCRIPTION
Closes tg-3919

## Problem

When a workspace launch fails *after* cmux has already created the workspace, the workspace is orphaned: it survives pointing at the wrong working directory and, after a cmux restart, re-runs a now-deleted `launch.sh` (`No such file or directory`).

Observed in production: the watcher tried to start one task three times. The first two `cmux new-workspace` invocations exited non-zero but cmux still created a workspace, each landing in the *previously active* worktree's directory instead of the requested `--cwd`. crew treated the launch as failed and rolled back, but the rollback could not close the leaked workspace, leaving two orphans tagged with the task's `groundcrew:<taskId>` marker in the wrong worktree.

## Root cause

Two gaps combined:

1. `cmuxAdapter.open()` parsed the created workspace id from `cmux new-workspace` output **only on success**. On a non-zero exit, `runWorkspaceCommand` threw before the id was read, so the id of a workspace cmux *did* create was lost.
2. The rollback closed the just-created workspace by **re-enumerating** workspaces (`list-workspaces`). When that probe was transiently `unavailable`, it couldn't find or close the workspace and only logged "close by hand". The orphan persisted.

## Fix

`cmuxAdapter.open()` now wraps the `new-workspace` call. On failure it recovers the workspace id from the failed command's captured output (`workspace_id`/`id` JSON field, or a bare `workspace:N` ref for older builds) and closes **that exact workspace by id** on the failure path.

Closing by the recovered id needs no `list-workspaces`, so it survives a concurrent list failure that would defeat re-enumeration — the orphan is prevented at the source. There's no same-named-sibling risk because we hold the precise id cmux returned (unlike a title-based close).

The id is parsed back out of the command error message, consistent with how this file already inspects cmux errors (e.g. `isCmuxSetStatusUnsupported`). The existing worktree-teardown rollback remains as defense-in-depth: if the by-id close itself fails, a manual-close hint is logged and the later teardown can still recover once `list-workspaces` succeeds.

## Design note

The close happens at open-failure time rather than being threaded through the generic worktree-teardown rollback. This keeps the fix localized to the adapter that created the workspace and closes both gaps in one place: the id is captured (gap 1) and closed by id without re-enumeration (gap 2). Under a still-failing `list-workspaces` at teardown time the generic rollback may still log its hedged "close by hand if it's still open" line, but the workspace is already closed — no orphan.

## Acceptance criteria

- [x] Non-zero `new-workspace` exit with an id in output → id captured and workspace closed without re-enumeration.
- [x] Rollback closes by captured id even when `list-workspaces` fails — no "close by hand" orphan under a transient list failure.
- [x] A failed launch never leaves a workspace whose `groundcrew:<taskId>` marker is orphaned.
- [x] Unit test reproduces the path: open fails with an id in output, no re-enumeration, workspace closed by id.
- [x] `node --run verify` green (1945 tests, 100% coverage, lint/format/typecheck pass).

## Validation

`node --run verify` → exit 0, 74 test files / 1945 tests passing.

New tests in `src/lib/workspaces.test.ts`:
- closes the leaked workspace by id (JSON `workspace_id`) without calling `list-workspaces`
- closes by `workspace:N` ref parsed from a non-JSON failure
- rethrows without a close when the failure output carries no id
- does not fight an already-aborted signal
- logs a manual-close hint when the by-id close itself fails

## Notes

The underlying cmux behavior — `new-workspace` ignoring `--cwd` and exiting non-zero while still creating the workspace — is a cmux-side flake worth reporting upstream, but crew is now resilient to it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjRCxdFFMTfjQqLUoHM63b