### PR TITLE
feat(cmux): deliver Claude activity hooks via a project settings file (tg-3925)

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -58,6 +58,8 @@
     "gitdirs",
     "gitfile",
     "groundcrew",
+    "idempotently",
+    "unmatch",
     "defence",
     "discriminable",
     "initialised",

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -818,8 +818,8 @@ describe(setupWorkspace, () => {
     );
     expect(launchScript).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
     expect(launchScript).not.toContain("--enable=all-agents");
-    expect(launchScript).toContain("exec claude --permission-mode auto --settings ");
-    expect(launchScript).toContain('"$@"');
+    expect(launchScript).toContain('exec claude --permission-mode auto "$@"');
+    expect(launchScript).not.toContain("--settings ");
     expect(launchScript).toContain('sh "$_p"');
     // prepareWorktree status guard so a failed install still launches the agent
     expect(launchScript).toContain('"$prepare_status" -ne 0');

--- a/src/commands/teardownReporter.test.ts
+++ b/src/commands/teardownReporter.test.ts
@@ -226,7 +226,12 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: {
+      runner: "auto",
+      networkEgress: "allowlisted",
+      safehouse: { enable: [] },
+      readOnlyDirs: [],
+    },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -22,6 +22,9 @@ const safehouseCmuxIntegrationWarningLinesMock = vi.hoisted(() =>
   >(),
 );
 const writeErrorMock = vi.hoisted(() => vi.fn<(message: string) => void>());
+const writeCmuxAgentProjectSettingsMock = vi.hoisted(() =>
+  vi.fn<(input: { worktreeDir: string; agentCommandName: string }) => void>(),
+);
 
 vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -30,6 +33,9 @@ vi.mock(import("./commandRunner.ts"), async (importOriginal) => {
     runCommand: runCommandMock,
   };
 });
+vi.mock(import("./cmuxProjectSettings.ts"), () => ({
+  writeCmuxAgentProjectSettings: writeCmuxAgentProjectSettingsMock,
+}));
 vi.mock(import("@clipboard-health/clearance"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -95,6 +101,7 @@ describe(composeAgentLaunch, () => {
     );
     safehouseCmuxIntegrationWarningLinesMock.mockReturnValue([]);
     writeErrorMock.mockReset();
+    writeCmuxAgentProjectSettingsMock.mockReset();
     deleteEnvironmentVariable("CMUX_SOCKET_PATH");
   });
 
@@ -115,24 +122,45 @@ describe(composeAgentLaunch, () => {
     expect(launchCommand).toContain("CMUX_SOCKET_PATH");
     expect(launchCommand).toContain("CMUX_CUSTOM_CLAUDE_PATH");
     expect(launchCommand).toContain("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
-    expect(launchCommand).toContain("exec claude --permission-mode auto --settings ");
-    expect(launchCommand).toContain('"$@"');
+    expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
   });
 
-  it("injects cmux activity-reporting hooks for a cmux-hosted Claude agent", () => {
+  it("delivers cmux activity hooks via the project settings file, not inline --settings", () => {
     const launchCommand = compose();
 
-    expect(launchCommand).toContain("--settings ");
-    expect(launchCommand).toContain("set-progress");
-    expect(launchCommand).toContain("running · claude");
-    expect(launchCommand).toContain("SessionStart");
+    expect(launchCommand).not.toContain("--settings ");
+    expect(launchCommand).not.toContain("set-progress");
+    expect(writeCmuxAgentProjectSettingsMock).toHaveBeenCalledWith({
+      worktreeDir: "/work/repo-a-team-1",
+      agentCommandName: "claude",
+    });
   });
 
-  it("does not inject Claude activity hooks for a non-Claude cmux agent", () => {
+  it("writes no hooks for a non-Claude cmux agent", () => {
     const launchCommand = compose({ definition: definition({ cmd: "codex", color: "#000" }) });
 
     expect(launchCommand).toContain('exec codex "$@"');
     expect(launchCommand).not.toContain("set-progress");
+    expect(writeCmuxAgentProjectSettingsMock).toHaveBeenCalledWith({
+      worktreeDir: "/work/repo-a-team-1",
+      agentCommandName: "codex",
+    });
+  });
+
+  it("does not write project hooks for non-cmux workspace backends", () => {
+    compose({ workspaceKind: "tmux" });
+
+    expect(writeCmuxAgentProjectSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("still builds the launch command when the project-hooks write fails", () => {
+    writeCmuxAgentProjectSettingsMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    const launchCommand = compose();
+
+    expect(launchCommand).toContain('exec claude --permission-mode auto "$@"');
   });
 
   it("adds task source write paths only to the Safehouse agent wrap", () => {

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -7,8 +7,7 @@ import {
 } from "@clipboard-health/clearance";
 
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
-import { cmuxAgentHookSettingsJson } from "./cmuxAgentHooks.ts";
-import { shellSingleQuote } from "./shell.ts";
+import { writeCmuxAgentProjectSettings } from "./cmuxProjectSettings.ts";
 import {
   hasPreLaunchEnv,
   type LocalRunner,
@@ -26,7 +25,7 @@ import {
 import { assertLocalRunnerRequirements, resolveLocalRunner } from "./localRunner.ts";
 import { sandboxNameFor } from "./sandboxName.ts";
 import { buildAndStageSrtLaunch, resolveGitCommonDir } from "./srtLaunch.ts";
-import { debug, sleep, writeError } from "./util.ts";
+import { debug, errorMessage, sleep, writeError } from "./util.ts";
 import { resolveWorkspaceKind, workspaces } from "./workspaces.ts";
 import type { WorkspaceKind } from "./workspaceAdapter.ts";
 
@@ -96,7 +95,30 @@ export function composeAgentLaunch(input: {
       input.runner === "safehouse" ? (input.readOnlyDirs ?? []).filter(existsSync) : undefined,
     safehouseAgentIntegration,
   });
+  if (input.workspaceKind === "cmux") {
+    deliverCmuxAgentProjectHooks({
+      worktreeDir: input.worktreeDir,
+      agentCommandName: inferAgentCommandName(input.definition.cmd),
+    });
+  }
   return { launchCommand, srtSettingsDir: staged?.directory };
+}
+
+/**
+ * Best-effort write of the agent's cmux activity hooks into its project settings
+ * file in the worktree. The hooks are live-progress observability, not required
+ * functionality, so a failure here is logged and swallowed rather than allowed
+ * to strand the launch.
+ */
+function deliverCmuxAgentProjectHooks(input: {
+  worktreeDir: string;
+  agentCommandName: string;
+}): void {
+  try {
+    writeCmuxAgentProjectSettings(input);
+  } catch (error) {
+    debug(`cmux agent project hooks not written: ${errorMessage(error)}`);
+  }
 }
 
 /**
@@ -137,14 +159,6 @@ function safehouseAgentIntegrationFor(
     addDirsReadOnly: cmuxIntegration.addDirsReadOnly,
     envPass: cmuxIntegration.envPass,
     commandPreludes: isClaudeAgent ? [cmuxIntegration.claudeCommandPrelude] : [],
-    ...(isClaudeAgent
-      ? {
-          agentArgs: [
-            "--settings",
-            shellSingleQuote(cmuxAgentHookSettingsJson({ agent: agentCommandName })),
-          ],
-        }
-      : {}),
   };
 }
 

--- a/src/lib/cmuxAgentHooks.test.ts
+++ b/src/lib/cmuxAgentHooks.test.ts
@@ -1,7 +1,8 @@
 import {
   buildCmuxAgentHookSettings,
   type CmuxAgentHookSettings,
-  cmuxAgentHookSettingsJson,
+  cmuxAgentHookDelivery,
+  isCmuxAgentHookCommand,
 } from "./cmuxAgentHooks.ts";
 
 function commandFor(settings: CmuxAgentHookSettings, event: string): string {
@@ -60,14 +61,37 @@ describe(buildCmuxAgentHookSettings, () => {
 
     expect(actual).toContain("running · codex");
   });
+
+  it("stamps every command with the groundcrew marker so a later merge can find it", () => {
+    const settings = buildCmuxAgentHookSettings({ agent: "claude" });
+
+    for (const event of Object.keys(settings.hooks)) {
+      expect(isCmuxAgentHookCommand(commandFor(settings, event))).toBe(true);
+    }
+  });
 });
 
-describe(cmuxAgentHookSettingsJson, () => {
-  it("serializes to valid JSON that round-trips to the settings object", () => {
-    const expected = buildCmuxAgentHookSettings({ agent: "claude" });
+describe(isCmuxAgentHookCommand, () => {
+  it("recognizes groundcrew-authored hook commands", () => {
+    const command = commandFor(buildCmuxAgentHookSettings({ agent: "claude" }), "Stop");
 
-    const actual: unknown = JSON.parse(cmuxAgentHookSettingsJson({ agent: "claude" }));
+    expect(isCmuxAgentHookCommand(command)).toBe(true);
+  });
 
-    expect(actual).toStrictEqual(expected);
+  it("does not claim an unrelated user hook command", () => {
+    expect(isCmuxAgentHookCommand("npm run lint")).toBe(false);
+  });
+});
+
+describe(cmuxAgentHookDelivery, () => {
+  it("delivers Claude hooks via the project settings.local.json file", () => {
+    expect(cmuxAgentHookDelivery("claude")).toStrictEqual({
+      projectSettingsPath: ".claude/settings.local.json",
+    });
+  });
+
+  it("returns no delivery for agents without a hook integration", () => {
+    expect(cmuxAgentHookDelivery("codex")).toBeUndefined();
+    expect(cmuxAgentHookDelivery("cursor-agent")).toBeUndefined();
   });
 });

--- a/src/lib/cmuxAgentHooks.ts
+++ b/src/lib/cmuxAgentHooks.ts
@@ -14,10 +14,19 @@ export interface CmuxAgentHookSettings {
 }
 
 /**
+ * Trailing shell comment stamped on every groundcrew-authored hook command. It
+ * is inert at runtime but lets the project-settings merge recognize our own
+ * prior entries — so a re-launch replaces them and leaves the user's unrelated
+ * hooks untouched. See `isCmuxAgentHookCommand`.
+ */
+const CMUX_AGENT_HOOK_MARKER = "groundcrew:cmux-activity";
+
+/**
  * Claude Code hook settings that report the agent's own lifecycle to the cmux
- * sidebar. Passed to the agent as `--settings <json>` (Layer A of the live
- * activity bridge), so the panel reflects what the agent is doing within a
- * session rather than the single coarse milestone the orchestrator can paint.
+ * sidebar. Written to a project-level settings file in the worktree (Layer A of
+ * the live activity bridge) that the CLI auto-discovers on every startup, so the
+ * panel reflects what the agent is doing within a session — and keeps updating
+ * across manual restarts (`claude --resume`) that bypass the staged launch.
  *
  * Each hook calls `cmux set-progress` against `$CMUX_WORKSPACE_ID` — present in
  * the safehouse cmux env-pass allowlist, so the call reaches cmux from inside
@@ -43,8 +52,31 @@ export function buildCmuxAgentHookSettings(input: { agent: string }): CmuxAgentH
   return { hooks };
 }
 
-export function cmuxAgentHookSettingsJson(input: { agent: string }): string {
-  return JSON.stringify(buildCmuxAgentHookSettings(input));
+/** True when `command` is a groundcrew-authored cmux activity hook command. */
+export function isCmuxAgentHookCommand(command: string): boolean {
+  return command.includes(CMUX_AGENT_HOOK_MARKER);
+}
+
+export interface CmuxAgentHookDelivery {
+  /**
+   * Worktree-relative path of the project settings file the agent auto-loads on
+   * every startup. Written at launch so the activity hooks survive manual
+   * restarts that bypass the staged launch.
+   */
+  projectSettingsPath: string;
+}
+
+/**
+ * Per-agent map of how the agent receives its cmux activity hooks. Only agents
+ * with a project-level settings file the CLI auto-discovers are listed; agents
+ * without a hook integration (e.g. codex) return `undefined` and receive none.
+ */
+const CMUX_AGENT_HOOK_DELIVERY: Readonly<Record<string, CmuxAgentHookDelivery>> = {
+  claude: { projectSettingsPath: ".claude/settings.local.json" },
+};
+
+export function cmuxAgentHookDelivery(agentCommandName: string): CmuxAgentHookDelivery | undefined {
+  return CMUX_AGENT_HOOK_DELIVERY[agentCommandName];
 }
 
 interface CmuxAgentHookPhase {
@@ -56,5 +88,5 @@ interface CmuxAgentHookPhase {
 function setProgressCommand(phase: CmuxAgentHookPhase): string {
   const setProgress = `"\${CMUX_BUNDLED_CLI_PATH:-cmux}" set-progress ${phase.value} --label ${shellSingleQuote(phase.label)} --workspace "$CMUX_WORKSPACE_ID" >/dev/null 2>&1 || true`;
 
-  return `if [ -n "$CMUX_WORKSPACE_ID" ]; then ${setProgress}; fi`;
+  return `if [ -n "$CMUX_WORKSPACE_ID" ]; then ${setProgress}; fi # ${CMUX_AGENT_HOOK_MARKER}`;
 }

--- a/src/lib/cmuxProjectSettings.test.ts
+++ b/src/lib/cmuxProjectSettings.test.ts
@@ -44,6 +44,15 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 beforeEach(() => {
+  // Strip inherited GIT_* env vars so the temp-repo git calls run against the
+  // temp worktree, not whatever repo invoked vitest (e.g. a `git push` pre-push
+  // hook that exports GIT_DIR, which would override the `git -C <tempdir>` flag).
+  // oxlint-disable-next-line unicorn/no-useless-undefined -- undefined is the unset signal here
+  vi.stubEnv("GIT_DIR", undefined);
+  // oxlint-disable-next-line unicorn/no-useless-undefined
+  vi.stubEnv("GIT_WORK_TREE", undefined);
+  // oxlint-disable-next-line unicorn/no-useless-undefined
+  vi.stubEnv("GIT_INDEX_FILE", undefined);
   worktreeDir = mkdtempSync(path.join(os.tmpdir(), "gc-project-hooks-"));
   runCommand("git", ["-C", worktreeDir, "init", "-q"]);
   runCommand("git", ["-C", worktreeDir, "config", "user.email", "test@example.com"]);
@@ -51,6 +60,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   rmSync(worktreeDir, { recursive: true, force: true });
 });
 

--- a/src/lib/cmuxProjectSettings.test.ts
+++ b/src/lib/cmuxProjectSettings.test.ts
@@ -1,0 +1,189 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runCommand } from "./commandRunner.ts";
+import { writeCmuxAgentProjectSettings } from "./cmuxProjectSettings.ts";
+
+let worktreeDir: string;
+
+function settingsPath(): string {
+  return path.join(worktreeDir, ".claude", "settings.local.json");
+}
+
+function readSettingsRaw(): string {
+  return readFileSync(settingsPath(), "utf8");
+}
+
+function readSettings(): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(readSettingsRaw());
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("settings.local.json is not a JSON object");
+  }
+  return { ...parsed };
+}
+
+function excludeFile(): string {
+  return runCommand("git", [
+    "-C",
+    worktreeDir,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-path",
+    "info/exclude",
+  ]);
+}
+
+function excludeContents(): string {
+  const file = excludeFile();
+  return existsSync(file) ? readFileSync(file, "utf8") : "";
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+beforeEach(() => {
+  worktreeDir = mkdtempSync(path.join(os.tmpdir(), "gc-project-hooks-"));
+  runCommand("git", ["-C", worktreeDir, "init", "-q"]);
+  runCommand("git", ["-C", worktreeDir, "config", "user.email", "test@example.com"]);
+  runCommand("git", ["-C", worktreeDir, "config", "user.name", "Test"]);
+});
+
+afterEach(() => {
+  rmSync(worktreeDir, { recursive: true, force: true });
+});
+
+describe(writeCmuxAgentProjectSettings, () => {
+  it("writes the Claude activity hooks to .claude/settings.local.json", () => {
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(readSettings()["hooks"]).toMatchObject({ SessionStart: expect.any(Array) });
+    expect(readSettingsRaw()).toContain("set-progress");
+  });
+
+  it("git-excludes the settings file so it is never committed", () => {
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(excludeContents()).toContain("/.claude/settings.local.json");
+    const status = runCommand("git", ["-C", worktreeDir, "status", "--porcelain"]);
+    expect(status).not.toContain("settings.local.json");
+  });
+
+  it("creates the git exclude file when the repo has none", () => {
+    rmSync(excludeFile());
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(excludeContents()).toBe("/.claude/settings.local.json\n");
+  });
+
+  it("appends the exclude pattern after content that lacks a trailing newline", () => {
+    writeFileSync(excludeFile(), "*.log");
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(excludeContents()).toBe("*.log\n/.claude/settings.local.json\n");
+  });
+
+  it("does not duplicate the git-exclude pattern across launches", () => {
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(countOccurrences(excludeContents(), "/.claude/settings.local.json")).toBe(1);
+  });
+
+  it("writes nothing for an agent without a hook integration", () => {
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "codex" });
+
+    expect(existsSync(settingsPath())).toBe(false);
+  });
+
+  it("skips the write when the repo already tracks the settings file", () => {
+    mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    const tracked = '{ "committed": true }\n';
+    writeFileSync(settingsPath(), tracked);
+    runCommand("git", ["-C", worktreeDir, "add", "-f", ".claude/settings.local.json"]);
+    runCommand("git", ["-C", worktreeDir, "commit", "-q", "-m", "track settings"]);
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(readSettingsRaw()).toBe(tracked);
+  });
+
+  it("merges into a pre-existing file, preserving unrelated user settings", () => {
+    mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        permissions: { allow: ["Bash(npm run test)"] },
+        hooks: {
+          SessionStart: [{ hooks: [{ type: "command", command: "echo user-owned" }] }],
+        },
+      }),
+    );
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    const settings = readSettings();
+    expect(settings["permissions"]).toStrictEqual({ allow: ["Bash(npm run test)"] });
+    const serialized = JSON.stringify(settings["hooks"]);
+    expect(serialized).toContain("echo user-owned");
+    expect(serialized).toContain("set-progress");
+  });
+
+  it("preserves prior hook groups it does not recognize as its own", () => {
+    mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            "not-an-object",
+            { notHooks: 1 },
+            { hooks: [] },
+            { hooks: ["bare-string-hook"] },
+            { hooks: [{ command: 42 }] },
+            { hooks: [{ type: "command", command: "echo user-owned" }] },
+          ],
+        },
+      }),
+    );
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    const serialized = JSON.stringify(readSettings()["hooks"]);
+    expect(serialized).toContain("not-an-object");
+    expect(serialized).toContain("bare-string-hook");
+    expect(serialized).toContain("echo user-owned");
+    expect(serialized).toContain("set-progress");
+  });
+
+  it("ignores a settings file whose JSON is not an object", () => {
+    mkdirSync(path.dirname(settingsPath()), { recursive: true });
+    writeFileSync(settingsPath(), "[1, 2, 3]");
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+
+    expect(readSettings()["hooks"]).toMatchObject({ SessionStart: expect.any(Array) });
+  });
+
+  it("propagates a read error that is not a missing file", () => {
+    mkdirSync(settingsPath(), { recursive: true });
+
+    expect(() => {
+      writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+    }).toThrow(/EISDIR/);
+  });
+
+  it("replaces prior groundcrew hook entries instead of stacking them", () => {
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+    const firstWrite = readSettingsRaw();
+
+    writeCmuxAgentProjectSettings({ worktreeDir, agentCommandName: "claude" });
+    const secondWrite = readSettingsRaw();
+
+    expect(secondWrite).toBe(firstWrite);
+    expect(countOccurrences(secondWrite, "set-progress")).toBe(5);
+  });
+});

--- a/src/lib/cmuxProjectSettings.ts
+++ b/src/lib/cmuxProjectSettings.ts
@@ -1,0 +1,140 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { runCommand } from "./commandRunner.ts";
+import {
+  buildCmuxAgentHookSettings,
+  cmuxAgentHookDelivery,
+  type CmuxAgentHookSettings,
+  isCmuxAgentHookCommand,
+} from "./cmuxAgentHooks.ts";
+
+/**
+ * Write the agent's cmux activity hooks to its project-level settings file in
+ * the worktree (e.g. `<worktree>/.claude/settings.local.json` for Claude),
+ * which the CLI auto-discovers on every startup — so the hooks fire across
+ * manual restarts (`claude --resume`) that bypass the staged launch command.
+ *
+ * No-op for agents without a hook integration. The file is git-excluded (via the
+ * repo's `info/exclude`) and never committed, and the write is skipped entirely
+ * when the repo already tracks the file so a committed config is never clobbered.
+ * The hook block is merged idempotently into any pre-existing file: unrelated
+ * user settings (and user-authored hooks) are preserved, and only prior
+ * groundcrew-authored hook entries are replaced.
+ */
+export function writeCmuxAgentProjectSettings(input: {
+  worktreeDir: string;
+  agentCommandName: string;
+}): void {
+  const delivery = cmuxAgentHookDelivery(input.agentCommandName);
+  if (delivery === undefined) {
+    return;
+  }
+  const { projectSettingsPath } = delivery;
+  if (isTrackedByGit({ worktreeDir: input.worktreeDir, relativePath: projectSettingsPath })) {
+    return;
+  }
+
+  const settingsFile = path.join(input.worktreeDir, projectSettingsPath);
+  const merged = mergeHookSettings({
+    existing: readJsonObject(settingsFile),
+    settings: buildCmuxAgentHookSettings({ agent: input.agentCommandName }),
+  });
+  mkdirSync(path.dirname(settingsFile), { recursive: true });
+  writeFileSync(settingsFile, `${JSON.stringify(merged, undefined, 2)}\n`);
+
+  excludeFromGit({ worktreeDir: input.worktreeDir, relativePath: projectSettingsPath });
+}
+
+function mergeHookSettings(input: {
+  existing: Record<string, unknown>;
+  settings: CmuxAgentHookSettings;
+}): Record<string, unknown> {
+  const existingHooks = isPlainObject(input.existing["hooks"]) ? input.existing["hooks"] : {};
+  const mergedHooks: Record<string, unknown> = { ...existingHooks };
+  for (const [event, ourGroups] of Object.entries(input.settings.hooks)) {
+    const userGroups = asArray(existingHooks[event]).filter(
+      (group) => !isCmuxAgentHookGroup(group),
+    );
+    mergedHooks[event] = [...userGroups, ...ourGroups];
+  }
+  return { ...input.existing, hooks: mergedHooks };
+}
+
+function asArray(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * A hook group is ours when it carries at least one command and every command
+ * in it is a groundcrew-authored cmux activity hook (see `isCmuxAgentHookCommand`).
+ * User groups — which never carry our marker — are left untouched on re-write.
+ */
+function isCmuxAgentHookGroup(group: unknown): boolean {
+  if (!isPlainObject(group) || !Array.isArray(group["hooks"]) || group["hooks"].length === 0) {
+    return false;
+  }
+  return group["hooks"].every(
+    (hook) =>
+      isPlainObject(hook) &&
+      typeof hook["command"] === "string" &&
+      isCmuxAgentHookCommand(hook["command"]),
+  );
+}
+
+function readJsonObject(file: string): Record<string, unknown> {
+  let contents: string;
+  try {
+    contents = readFileSync(file, "utf8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return {};
+    }
+    throw error;
+  }
+  const parsed: unknown = JSON.parse(contents);
+  return isPlainObject(parsed) ? parsed : {};
+}
+
+function isTrackedByGit(input: { worktreeDir: string; relativePath: string }): boolean {
+  try {
+    runCommand("git", [
+      "-C",
+      input.worktreeDir,
+      "ls-files",
+      "--error-unmatch",
+      "--",
+      input.relativePath,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function excludeFromGit(input: { worktreeDir: string; relativePath: string }): void {
+  const excludeFile = runCommand("git", [
+    "-C",
+    input.worktreeDir,
+    "rev-parse",
+    "--path-format=absolute",
+    "--git-path",
+    "info/exclude",
+  ]);
+  const pattern = `/${input.relativePath}`;
+  const contents = existsSync(excludeFile) ? readFileSync(excludeFile, "utf8") : "";
+  if (contents.split("\n").some((line) => line.trim() === pattern)) {
+    return;
+  }
+  const separator = contents.length === 0 || contents.endsWith("\n") ? "" : "\n";
+  mkdirSync(path.dirname(excludeFile), { recursive: true });
+  writeFileSync(excludeFile, `${contents}${separator}${pattern}\n`);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -222,10 +222,8 @@ function renderPrepareAndAgentCommand(arguments_: LaunchCommandArguments): {
     worktreeDir: arguments_.worktreeDir,
     sandboxName: arguments_.sandboxName ?? "",
   });
-  const agentArgs = arguments_.safehouseAgentIntegration?.agentArgs ?? [];
-  const agentInvocation = agentArgs.length === 0 ? agentCmd : `${agentCmd} ${agentArgs.join(" ")}`;
   return {
-    agentCommand: `exec ${agentInvocation} "$@"`,
+    agentCommand: `exec ${agentCmd} "$@"`,
     prepareWorktreeCommand:
       arguments_.prepareWorktreeCommand === undefined
         ? undefined
@@ -406,12 +404,6 @@ export interface SafehouseAgentIntegration {
   addDirsReadOnly: readonly string[];
   envPass: readonly string[];
   commandPreludes: readonly string[];
-  /**
-   * Extra, already-shell-safe argv tokens appended to the agent invocation
-   * before the prompt positional (e.g. `--settings <quoted-json>` to inject
-   * cmux activity-reporting hooks for a Claude agent).
-   */
-  agentArgs?: readonly string[];
 }
 
 interface LaunchCommandArguments {


### PR DESCRIPTION
## Why

Claude's cmux activity-reporting hooks were injected inline (`claude --settings '<hooks-json>'`), baked into the staged `launch.sh` that crew builds at launch. That delivery is **ephemeral**: when a user exits the agent and restarts Claude by hand in the same worktree — e.g. `claude --resume` to recover from a broken MCP server — the relaunch bypasses `launch.sh` entirely, so the hooks are absent. The cmux sidebar then shows stale progress (frozen at the last reported phase) for the rest of that session.

The cursor agent already avoids this by writing hooks to a project-level file the CLI auto-discovers on every startup. This moves Claude to the same persistent delivery.

## What

- **`cmuxAgentHooks`** gains a per-agent hook-delivery map (`claude` → `.claude/settings.local.json`; codex/cursor → none) and stamps every hook command with an inert trailing shell-comment marker so a re-launch can recognize its own prior entries. `isCmuxAgentHookCommand` is the shared "is this one of our hook commands" check.
- **New `cmuxProjectSettings.writeCmuxAgentProjectSettings`** writes the file into the worktree at launch:
  - git-excluded via the repo's `info/exclude` (idempotently, no duplicate patterns), never committed;
  - skipped entirely when the repo already tracks the file (committed config never clobbered);
  - merged idempotently into any pre-existing `settings.local.json` — unrelated user settings and user-authored hooks are preserved; only prior groundcrew-authored hook entries are replaced.
- **`composeAgentLaunch`** calls the writer (best-effort — a failure is logged and swallowed, never strands a launch) for cmux workspaces, and the inline `--settings` hook injection is dropped so the hooks have a single source and do not double-fire.

The hook events, labels, and `set-progress` commands are unchanged — only the delivery moves. cursor delivery is unchanged; agents with no hook integration (e.g. codex) still receive none.

### Note on runner gating

The old inline injection only fired under the safehouse runner. The project file is now written for any cmux workspace regardless of runner; the file is harmless under runners where `CMUX_WORKSPACE_ID` isn't present (the existing per-hook guard makes each command a no-op), and it's what makes a manual host `claude --resume` keep reporting.

## Validation

- TDD throughout; `node --run verify` green (1979 tests, 100% coverage, lint/format/spell/arch/knip clean).
- **Manual validation still required (left as draft):** launch a Claude task, exit the agent, relaunch in the same worktree via `claude --resume`, and confirm the sidebar progress resumes updating. Per the ticket, if Claude does not load `<worktree>/.claude/settings.local.json` under the safehouse mount, fall back to `.claude/settings.json` (the delivery path is a single constant in `cmuxAgentHooks.ts`).

## Incidental

Fixes a pre-existing lint failure in `teardownReporter.test.ts` (the config `local` literal was missing the recently-added `safehouse`/`readOnlyDirs` fields) so `node --run verify` is green.

Closes tg-3925. Related: TG-3891, TG-3890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)