### PR TITLE
fix: treat codexbar 'no rate limit events' as available

### DIFF
--- a/src/commands/teardownReporter.test.ts
+++ b/src/commands/teardownReporter.test.ts
@@ -226,7 +226,12 @@ function makeConfig(): ResolvedConfig {
     },
     prompts: { initial: "x" },
     workspaceKind: "auto",
-    local: { runner: "auto", networkEgress: "allowlisted" },
+    local: {
+      runner: "auto",
+      networkEgress: "allowlisted",
+      safehouse: { enable: [] },
+      readOnlyDirs: [],
+    },
     logging: { file: "/tmp/groundcrew-test.log" },
   };
 }

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -96,6 +96,20 @@ function makeCursorConfig(): ResolvedConfig {
   });
 }
 
+/**
+ * Mirrors `normalizeCommandError`: codexbar exits non-zero but still writes its
+ * JSON payload to stdout, which `runCommandAsync` attaches to the thrown
+ * error's `cause`.
+ */
+function codexbarCommandFailure(status: number, payload: unknown): Error {
+  return new Error(`Command failed: codexbar\nExit status: ${status}`, {
+    cause: Object.assign(new Error("Command exited unsuccessfully"), {
+      status,
+      stdout: Buffer.from(JSON.stringify(payload)),
+    }),
+  });
+}
+
 function mockCodexbarResponse(source: string, provider = "codex"): string {
   return JSON.stringify([
     {
@@ -278,10 +292,12 @@ describe(getUsageByAgent, () => {
     expect(consoleCapture.output()).toContain("codex app-server closed stdout");
   });
 
-  it("treats codexbar's 'no rate limit events yet' as available, not exhausted", async () => {
+  it("treats codexbar's non-zero-exit 'no rate limit events yet' as available, not exhausted", async () => {
     stubPlatform("darwin");
-    runCommandMock.mockReturnValue(
-      JSON.stringify([
+    // codexbar exits 3 for this handled provider condition, still emitting its
+    // JSON payload on stdout — exactly how runCommandAsync surfaces it.
+    runCommandMock.mockImplementation(() => {
+      throw codexbarCommandFailure(3, [
         {
           provider: "codex",
           source: "oauth",
@@ -291,8 +307,8 @@ describe(getUsageByAgent, () => {
             message: "Found sessions, but no rate limit events yet.",
           },
         },
-      ]),
-    );
+      ]);
+    });
 
     const actual = await getUsageByAgent(makeConfig());
 
@@ -302,6 +318,53 @@ describe(getUsageByAgent, () => {
       weekly: null,
       weekEndDuration: null,
     });
+  });
+
+  it("fails closed when codexbar exits non-zero with a genuine provider failure payload", async () => {
+    stubPlatform("darwin");
+    runCommandMock.mockImplementation(() => {
+      throw codexbarCommandFailure(1, [
+        {
+          provider: "codex",
+          source: "oauth",
+          error: { kind: "provider", code: 1, message: "codex app-server closed stdout" },
+        },
+      ]);
+    });
+
+    const actual = await getUsageByAgent(makeConfig());
+
+    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(consoleCapture.output()).toContain("codex app-server closed stdout");
+  });
+
+  it("fails closed when codexbar exits non-zero with no stdout payload to recover", async () => {
+    stubPlatform("darwin");
+    runCommandMock.mockImplementation(() => {
+      throw new Error("Command failed: codexbar\nExit status: 1", {
+        cause: Object.assign(new Error("Command exited unsuccessfully"), {
+          status: 1,
+          stdout: undefined,
+        }),
+      });
+    });
+
+    const actual = await getUsageByAgent(makeConfig());
+
+    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+  });
+
+  it("fails closed when the command error carries no captured output", async () => {
+    stubPlatform("darwin");
+    runCommandMock.mockImplementation(() => {
+      throw new Error("Command failed: codexbar", {
+        cause: new Error("spawn codexbar ENOENT"),
+      });
+    });
+
+    const actual = await getUsageByAgent(makeConfig());
+
+    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
   });
 
   it("fails closed when codexbar returns an entry with neither usage nor error", async () => {

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -278,6 +278,32 @@ describe(getUsageByAgent, () => {
     expect(consoleCapture.output()).toContain("codex app-server closed stdout");
   });
 
+  it("treats codexbar's 'no rate limit events yet' as available, not exhausted", async () => {
+    stubPlatform("darwin");
+    runCommandMock.mockReturnValue(
+      JSON.stringify([
+        {
+          provider: "codex",
+          source: "oauth",
+          error: {
+            kind: "provider",
+            code: 3,
+            message: "Found sessions, but no rate limit events yet.",
+          },
+        },
+      ]),
+    );
+
+    const actual = await getUsageByAgent(makeConfig());
+
+    expect(actual["codex"]).toStrictEqual({
+      session: null,
+      sessionEndDuration: null,
+      weekly: null,
+      weekEndDuration: null,
+    });
+  });
+
   it("fails closed when codexbar returns an entry with neither usage nor error", async () => {
     stubPlatform("darwin");
     runCommandMock.mockReturnValue(JSON.stringify([{ provider: "codex", source: "auto" }]));

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -97,16 +97,30 @@ async function codexbarUsage(definition: AgentDefinition, signal?: AbortSignal):
     "json",
   ];
 
-  const out = await runCommandAsync(
-    "codexbar",
-    arguments_,
+  const options =
     signal === undefined
       ? { timeoutMs: CODEXBAR_TIMEOUT_MS }
-      : {
-          signal,
-          timeoutMs: CODEXBAR_TIMEOUT_MS,
-        },
-  );
+      : { signal, timeoutMs: CODEXBAR_TIMEOUT_MS };
+  let out: string;
+  try {
+    out = await runCommandAsync("codexbar", arguments_, options);
+  } catch (error) {
+    if (signal?.aborted === true) {
+      throw error;
+    }
+    // codexbar exits non-zero (e.g. status 3 for "no rate limit events yet")
+    // for handled provider conditions while still writing its JSON payload to
+    // stdout. runCommandAsync rejects on the exit code, so recover that payload
+    // and parse it like a success — its per-entry `error` field, not the exit
+    // code, distinguishes "available" from a genuine failure below. A missing
+    // or unparseable payload is a real failure: rethrow so the caller fails
+    // closed.
+    const recovered = recoverStdout(error);
+    if (recovered === undefined) {
+      throw error;
+    }
+    out = recovered;
+  }
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON.parse returns any; codexbar's --format json output matches CodexbarEntry[]
   const parsed = JSON.parse(out) as CodexbarEntry[];
   // codexbar can return multiple entries when a provider has several
@@ -155,6 +169,26 @@ async function codexbarUsage(definition: AgentDefinition, signal?: AbortSignal):
  */
 function isNoRateLimitEvents(error: CodexbarEntry["error"]): boolean {
   return /no rate limit events/i.test(error?.message ?? "");
+}
+
+/**
+ * runCommandAsync rejects on a non-zero exit, attaching the captured stdout
+ * Buffer to the thrown error's `cause`. codexbar uses non-zero exits for handled
+ * provider conditions while still emitting its JSON payload, so pull that stdout
+ * back out to parse like a success. Returns undefined when no stdout was
+ * captured (a real failure with nothing to parse).
+ */
+function recoverStdout(error: unknown): string | undefined {
+  /* v8 ignore next 3 @preserve -- runCommandAsync always rejects with an Error */
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  // A plain command failure with no captured output carries no cause/stdout.
+  if (!(error.cause instanceof Error) || !("stdout" in error.cause)) {
+    return undefined;
+  }
+  const { stdout } = error.cause;
+  return Buffer.isBuffer(stdout) ? stdout.toString("utf8") : undefined;
 }
 
 function toFraction(value: number | undefined | null): number | null {

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -129,8 +129,16 @@ async function codexbarUsage(definition: AgentDefinition, signal?: AbortSignal):
     );
   }
   if (!match.usage) {
-    // codexbar can return `{error: ...}` instead of `{usage: ...}` when
-    // the underlying provider failed (e.g. codex app-server crashed). The
+    // codexbar reports a valid session that simply has no rate-limit events
+    // recorded yet — a fresh, low-traffic, or unlimited-quota account that has
+    // consumed nothing the windows can measure. That is the *least* exhausted
+    // state, not an unreadable one: return empty windows so it normalizes to
+    // `session: null` (available) instead of fail-closing to exhausted.
+    if (isNoRateLimitEvents(match.error)) {
+      return {};
+    }
+    // codexbar can otherwise return `{error: ...}` instead of `{usage: ...}`
+    // when the underlying provider failed (e.g. codex app-server crashed). The
     // outer catch in getUsageByAgent turns this into a fail-closed
     // exhausted entry; surface codexbar's error message so the operator
     // can fix the underlying CLI.
@@ -138,6 +146,15 @@ async function codexbarUsage(definition: AgentDefinition, signal?: AbortSignal):
     throw new Error(`codexbar returned no usage for provider=${provider}: ${detail}`);
   }
   return match.usage;
+}
+
+/**
+ * codexbar signals an authenticated account with zero recorded rate-limit
+ * events via this provider error (e.g. "Found sessions, but no rate limit
+ * events yet."). It means no quota consumed — available — not a probe failure.
+ */
+function isNoRateLimitEvents(error: CodexbarEntry["error"]): boolean {
+  return /no rate limit events/i.test(error?.message ?? "");
 }
 
 function toFraction(value: number | undefined | null): number | null {


### PR DESCRIPTION
## Summary

We were granted unlimited tokens, so the codex account has no rate-limit events — and codexbar exits non-zero ("no rate limit events yet") instead of returning usage. The usage probe treated that exit as a failure and fail-closed to exhausted, so **no codex task gets picked up** (`codex session at Infinity% — skipping its tasks`).

codexbar still writes its JSON payload to stdout on that non-zero exit. The probe now recovers and parses it: "no rate limit events" → available; a genuine failure with no payload still fails closed.


### Before/after

<img width="911" height="513" alt="image" src="https://github.com/user-attachments/assets/eb07705c-4897-42ed-8b88-44d093fdbd58" />



<sub>🤖 <code>commit-push-pr:created v1 core@3.9.0</code></sub>