### PR TITLE
fix: surface unavailable usage reasons

### DIFF
--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -949,18 +949,28 @@ describe(createDispatcher, () => {
     it("does not double-gate when weekly is Infinity (session gate handles EXHAUSTED_USAGE)", async () => {
       const board = makeBoard();
       const dispatcher = createDispatcher({ config: makeConfig(), board });
+      const usageByAgent = {
+        claude: {
+          ...EXHAUSTED_USAGE,
+          unavailableReason: "codexbar returned no usage for provider=claude, source=oauth",
+        },
+      };
 
       await dispatcher.runOnce({
         state: boardOf([todoIssue()]),
         worktreeEntries: [],
-        usage: async () => ({ claude: EXHAUSTED_USAGE }),
+        usage: async () => usageByAgent,
         dryRun: false,
       });
 
       expect(setupMock).not.toHaveBeenCalled();
-      // Session gate's log fires; weekly gate's "paced budget" log doesn't.
+      // Fail-closed usage logs the diagnostic reason instead of formatting the
+      // sentinel as a real percentage; weekly gate's "paced budget" log doesn't.
       const output = consoleLog.output();
-      expect(output).toContain("session at Infinity%");
+      expect(output).toContain(
+        "claude usage unavailable: codexbar returned no usage for provider=claude, source=oauth",
+      );
+      expect(output).not.toContain("session at Infinity%");
       expect(output).not.toContain("paced budget");
     });
   });

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -334,6 +334,9 @@ function hasRecoverableCandidate(
 }
 
 function formatUsageExhaustion(exhaustion: AgentUsageExhaustion): string {
+  if (exhaustion.kind === "unavailable") {
+    return `${exhaustion.agent} usage unavailable: ${exhaustion.reason} — skipping its tasks`;
+  }
   if (exhaustion.kind === "session") {
     const mins = exhaustion.resetMinutes ?? "?";
     return `${exhaustion.agent} session at ${exhaustion.usedPercentage.toFixed(0)}% (> ${exhaustion.limitPercentage}%), resets in ${mins}m — skipping its tasks`;

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -56,6 +56,11 @@ type Verdict = StartVerdict | SkipVerdict;
 
 export type AgentUsageExhaustion =
   | {
+      kind: "unavailable";
+      agent: string;
+      reason: string;
+    }
+  | {
       kind: "session";
       agent: string;
       usedPercentage: number;
@@ -171,6 +176,14 @@ export function classifyUsageExhaustion(
   const exhausted: AgentUsageExhaustion[] = [];
   const sessionLimit = config.orchestrator.sessionLimitPercentage;
   for (const [agent, snapshot] of Object.entries(usage)) {
+    if (snapshot.unavailableReason !== undefined) {
+      exhausted.push({
+        kind: "unavailable",
+        agent,
+        reason: snapshot.unavailableReason,
+      });
+      continue;
+    }
     if (snapshot.session !== null && snapshot.session * PERCENT_FRACTION_DIVISOR > sessionLimit) {
       exhausted.push({
         kind: "session",

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -251,7 +251,10 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject({
+      ...EXHAUSTED_USAGE,
+      unavailableReason: "codexbar exploded",
+    });
     expect(consoleCapture.output()).toContain(
       "Usage check failed for codex (treating as exhausted): codexbar exploded",
     );
@@ -288,7 +291,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
     expect(consoleCapture.output()).toContain("codex app-server closed stdout");
   });
 
@@ -334,7 +337,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
     expect(consoleCapture.output()).toContain("codex app-server closed stdout");
   });
 
@@ -351,7 +354,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
   });
 
   it("fails closed when the command error carries no captured output", async () => {
@@ -364,7 +367,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
   });
 
   it("fails closed when codexbar returns an entry with neither usage nor error", async () => {
@@ -373,7 +376,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
     expect(consoleCapture.output()).toContain("no usage data");
   });
 
@@ -468,7 +471,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
     expect(consoleCapture.output()).toContain(
       "codexbar returned no matching entry for provider=codex",
     );
@@ -493,7 +496,7 @@ describe(getUsageByAgent, () => {
 
     const actual = await getUsageByAgent(makeConfig());
 
-    expect(actual["codex"]).toStrictEqual(EXHAUSTED_USAGE);
+    expect(actual["codex"]).toMatchObject(EXHAUSTED_USAGE);
     expect(consoleCapture.output()).toContain(
       "codexbar returned no matching entry for provider=codex",
     );

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -43,6 +43,8 @@ interface NormalizedUsage {
   sessionEndDuration: number | null;
   weekly: number | null;
   weekEndDuration: number | null;
+  /** Set when the snapshot is fail-closed because codexbar could not be read. */
+  unavailableReason?: string;
 }
 
 export type UsageByAgent = Record<string, NormalizedUsage>;
@@ -157,7 +159,9 @@ async function codexbarUsage(definition: AgentDefinition, signal?: AbortSignal):
     // exhausted entry; surface codexbar's error message so the operator
     // can fix the underlying CLI.
     const detail = match.error?.message ?? "no usage data";
-    throw new Error(`codexbar returned no usage for provider=${provider}: ${detail}`);
+    throw new Error(
+      `codexbar returned no usage for provider=${provider}, source=${source}: ${detail}`,
+    );
   }
   return match.usage;
 }
@@ -253,8 +257,9 @@ export async function getUsageByAgent(
       // --verbose) so operators can fix the underlying CLI, and return a
       // fully-exhausted snapshot so the dispatcher gates the agent. The
       // gate itself surfaces a visible skip line via formatUsageExhaustion.
-      debug(`Usage check failed for ${agent} (treating as exhausted): ${errorMessage(error)}`);
-      out[agent] = EXHAUSTED_USAGE;
+      const reason = errorMessage(error);
+      debug(`Usage check failed for ${agent} (treating as exhausted): ${reason}`);
+      out[agent] = { ...EXHAUSTED_USAGE, unavailableReason: reason };
     }
   }
   return out;


### PR DESCRIPTION
## Summary

Preserve the real codexbar failure reason when usage probing fails closed, then render that reason in dispatcher skip logs instead of showing the synthetic `Infinity%` sentinel as if it were real usage.

## Validation

- `npx vitest run src/lib/usage.test.ts src/commands/dispatcher.test.ts src/commands/eligibility.test.ts`
- `node --run verify`
- Push hook ran `node --run verify`

## Notes

Agent session: `codex resume 019f04eb-fb64-7360-98b5-970940176848`

<sub>🤖 <code>cb-ship:created v1 core@3.8.0</code></sub>