### PR TITLE
fix(packaging): ship task-sources in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "crew.config.example.ts",
     "dist",
     "docs",
-    "static"
+    "static",
+    "task-sources"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/src/packaging.test.ts
+++ b/src/packaging.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+interface PackageJson {
+  files: string[];
+}
+
+function readPackageJson(): PackageJson {
+  const raw = readFileSync(path.join(REPO_ROOT, "package.json"), "utf8");
+  return JSON.parse(raw) as PackageJson;
+}
+
+describe("npm package contents", () => {
+  it("ships the task-sources directory", () => {
+    const { files } = readPackageJson();
+
+    expect(files).toContain("task-sources");
+  });
+
+  it("has the packaged jira source manifest on disk", () => {
+    const manifestPath = path.join(REPO_ROOT, "task-sources/jira/source.json");
+
+    expect(() => readFileSync(manifestPath, "utf8")).not.toThrow();
+  });
+});

--- a/src/packaging.test.ts
+++ b/src/packaging.test.ts
@@ -19,9 +19,11 @@ describe("npm package contents", () => {
     expect(files).toContain("task-sources");
   });
 
-  it("has the packaged jira source manifest on disk", () => {
+  it("has the packaged jira source files on disk", () => {
     const manifestPath = path.join(REPO_ROOT, "task-sources/jira/source.json");
+    const scriptPath = path.join(REPO_ROOT, "task-sources/jira/jira.sh");
 
     expect(() => readFileSync(manifestPath, "utf8")).not.toThrow();
+    expect(() => readFileSync(scriptPath, "utf8")).not.toThrow();
   });
 });


### PR DESCRIPTION
## Why

`package.json#files` omitted `task-sources`, so `npm install @clipboard-health/groundcrew` did not include `task-sources/jira/source.json` or its `jira.sh` script. The bundled JIRA task source was therefore absent from the published tarball, and downstream consumers (the `crew-config` TUI, which installs packaged sources) cannot resolve it. This is the blocking packaging bug underneath the broader "enable task sources by kind" work.

## What

- Add `"task-sources"` to `package.json#files` (alphabetical order, after `static`).
- Add `src/packaging.test.ts` as a regression guard: asserts `files` includes `task-sources` and that `task-sources/jira/source.json` is present on disk.

## Validation

- `npx vitest run src/packaging.test.ts` -> 2 passed.
- `npm pack --dry-run` now ships `task-sources/jira/{source.json,jira.sh,README.md}` and `task-sources/README.md`.
- `node --run verify` -> all checks pass (architecture:check, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint, test: 1979 tests).

## Decisions

- Guarded the fix with a `files`-array + on-disk assertion rather than invoking `npm pack` inside the test suite: the packaging entry plus the manifest's presence is the regression we care about, and shelling out to `npm pack` in a unit test is slow and environment-sensitive. The `npm pack --dry-run` proof is recorded above.
- Scoped this PR to packaging only. It is the first slice of a larger plan; the manifest schema, open registry, and unified catalog land in follow-up PRs.

## Source

plan-keeper slice `plan-412548639` (parent `plan-2478160323`).
