### PR TITLE
feat(adapters): enable shell task sources by kind (open registry)

### DIFF
--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -12,7 +12,9 @@ import {
   buildRegistry,
   buildSourceConfigSchema,
   listAdapterDirectories,
+  mergeManifestAdapters,
 } from "./registry.ts";
+import type { DiscoveredManifest } from "./shell/discovery.ts";
 
 function emptySource(name: string): TaskSource {
   return {
@@ -122,13 +124,46 @@ describe(listAdapterDirectories, () => {
   });
 });
 
+function discovered(name: string): DiscoveredManifest {
+  return {
+    manifest: {
+      name,
+      kind: "shell",
+      description: name,
+      installDir: "~/.config/groundcrew",
+      files: [],
+      commands: { listTasks: `${name} list` },
+    },
+    manifestDir: `/tmp/${name}`,
+    origin: "user",
+  };
+}
+
+describe(mergeManifestAdapters, () => {
+  it("adds a discovered manifest as an adapter keyed by its name", () => {
+    const code = { shell: fakeAdapter("shell") };
+
+    const merged = mergeManifestAdapters(code, [discovered("jira")]);
+
+    expect(Object.keys(merged).toSorted()).toStrictEqual(["jira", "shell"]);
+    expect(merged["jira"]?.kind).toBe("jira");
+  });
+
+  it("rejects a manifest whose name shadows a built-in adapter kind", () => {
+    const code = { shell: fakeAdapter("shell") };
+
+    expect(() => mergeManifestAdapters(code, [discovered("shell")])).toThrow(/collides/i);
+  });
+});
+
 describe("adapterRegistry production IIFE", () => {
-  it("loads the built-in adapters from src/lib/adapters/", async () => {
+  it("loads the built-in adapters plus discovered manifest sources", async () => {
     const registry = await adapterRegistry;
-    expect(Object.keys(registry).toSorted()).toStrictEqual(["linear", "shell", "todo-txt"]);
+    expect(Object.keys(registry).toSorted()).toStrictEqual(["jira", "linear", "shell", "todo-txt"]);
     expect(registry["linear"]?.kind).toBe("linear");
     expect(registry["shell"]?.kind).toBe("shell");
     expect(registry["todo-txt"]?.kind).toBe("todo-txt");
+    expect(registry["jira"]?.kind).toBe("jira");
   });
 
   it("each loaded adapter exposes a Zod configSchema and a create function", async () => {

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -159,7 +159,12 @@ describe(mergeManifestAdapters, () => {
 describe("adapterRegistry production IIFE", () => {
   it("loads the built-in adapters plus discovered manifest sources", async () => {
     const registry = await adapterRegistry;
-    expect(Object.keys(registry).toSorted()).toStrictEqual(["jira", "linear", "shell", "todo-txt"]);
+    // The three built-in code adapters plus the package-bundled `jira` manifest
+    // source. Asserted by presence rather than exact set so a developer's own
+    // user-installed sources under ~/.config do not break the suite.
+    expect(Object.keys(registry)).toEqual(
+      expect.arrayContaining(["jira", "linear", "shell", "todo-txt"]),
+    );
     expect(registry["linear"]?.kind).toBe("linear");
     expect(registry["shell"]?.kind).toBe("shell");
     expect(registry["todo-txt"]?.kind).toBe("todo-txt");

--- a/src/lib/adapters/registry.ts
+++ b/src/lib/adapters/registry.ts
@@ -17,6 +17,9 @@ import { z } from "zod";
 
 import type { AdapterDefinition } from "../adapterDefinition.ts";
 
+import { discoverTaskSourceManifests, type DiscoveredManifest } from "./shell/discovery.ts";
+import { manifestAdapter } from "./shell/manifestAdapter.ts";
+
 export type AdapterLoader = (directoryName: string) => Promise<AdapterDefinition>;
 
 /**
@@ -71,6 +74,29 @@ export function buildSourceConfigSchema(registry: Record<string, AdapterDefiniti
   return z.union([first, second, ...rest]);
 }
 
+/**
+ * Fold discovered manifest sources into a code-adapter registry. Each becomes
+ * an adapter keyed by its manifest name. A manifest may not shadow a built-in
+ * code-adapter kind (`linear`, `shell`, `todo-txt`) - those are reserved, so a
+ * collision is a hard error. Manifest-vs-manifest precedence (user over
+ * package) is already resolved by discovery, so `discovered` has no duplicates.
+ */
+export function mergeManifestAdapters(
+  codeRegistry: Record<string, AdapterDefinition>,
+  discovered: readonly DiscoveredManifest[],
+): Record<string, AdapterDefinition> {
+  const merged: Record<string, AdapterDefinition> = { ...codeRegistry };
+  for (const { manifest, manifestDir } of discovered) {
+    if (codeRegistry[manifest.name]) {
+      throw new Error(
+        `Task source "${manifest.name}" collides with the built-in "${manifest.name}" adapter. Rename the source manifest.`,
+      );
+    }
+    merged[manifest.name] = manifestAdapter(manifest, manifestDir);
+  }
+  return merged;
+}
+
 const here = import.meta.dirname;
 
 async function defaultImportLoader(directoryName: string): Promise<AdapterDefinition> {
@@ -93,9 +119,10 @@ export function listAdapterDirectories(baseDir: string): string[] {
 }
 
 /**
- * Production registry. Initialised at module load by scanning `src/lib/adapters/`.
+ * Production registry. Scans `src/lib/adapters/` for code adapters, then folds
+ * in the manifest sources discovered under the package + user task-sources roots.
  */
 export const adapterRegistry: Promise<Record<string, AdapterDefinition>> = buildRegistry(
   listAdapterDirectories(here),
   defaultImportLoader,
-);
+).then((codeRegistry) => mergeManifestAdapters(codeRegistry, discoverTaskSourceManifests()));

--- a/src/lib/adapters/shell/discovery.test.ts
+++ b/src/lib/adapters/shell/discovery.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { discoverFromRoots } from "./discovery.ts";
+import { discoverFromRoots, discoverTaskSourceManifests } from "./discovery.ts";
 
 function writeBundle(root: string, name: string, listTasks: string): void {
   const dir = path.join(root, name);
@@ -87,5 +87,42 @@ describe("discoverFromRoots", () => {
     const run = (): unknown => discoverFromRoots([{ dir: tooLong, origin: "user" }]);
 
     expect(run).toThrow(/ENAMETOOLONG/i);
+  });
+
+  it("skips a subdirectory that has no source.json", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "discover-no-source-"));
+    try {
+      mkdirSync(path.join(root, "not-a-source"));
+      writeBundle(root, "jira", "jira list");
+
+      const { manifests } = discoverFromRoots([{ dir: root, origin: "package" }]);
+
+      expect(manifests.map((m) => m.manifest.name)).toStrictEqual(["jira"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("discoverTaskSourceManifests", () => {
+  it("warns to stderr when a user source overrides a package source", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "discover-xdg-"));
+    const errorSpy = vi.spyOn(console, "error").mockReturnValue();
+    vi.stubEnv("XDG_CONFIG_HOME", home);
+    try {
+      // "jira" collides with the package-bundled jira source, so the user copy
+      // wins and a warning is written to stderr.
+      writeBundle(path.join(home, "groundcrew", "task-sources"), "jira", "user jira list");
+
+      const manifests = discoverTaskSourceManifests();
+
+      const jira = manifests.find((m) => m.manifest.name === "jira");
+      expect(jira?.origin).toBe("user");
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/jira/));
+    } finally {
+      vi.unstubAllEnvs();
+      errorSpy.mockRestore();
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/adapters/shell/discovery.test.ts
+++ b/src/lib/adapters/shell/discovery.test.ts
@@ -64,4 +64,28 @@ describe("discoverFromRoots", () => {
 
     expect(manifests).toStrictEqual([]);
   });
+
+  it("treats a file path root as empty rather than crashing", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "discover-file-"));
+    try {
+      const filePath = path.join(root, "not-a-dir");
+      writeFileSync(filePath, "x");
+
+      const { manifests } = discoverFromRoots([{ dir: filePath, origin: "user" }]);
+
+      expect(manifests).toStrictEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("re-raises an unexpected readdir failure rather than swallowing it", () => {
+    // An over-long path component makes readdir fail with ENAMETOOLONG (not
+    // ENOENT/ENOTDIR), which discovery must surface rather than treat as an
+    // empty root. Deterministic and independent of the running user.
+    const tooLong = `/${"a".repeat(1000)}`;
+    const run = (): unknown => discoverFromRoots([{ dir: tooLong, origin: "user" }]);
+
+    expect(run).toThrow(/ENAMETOOLONG/i);
+  });
 });

--- a/src/lib/adapters/shell/discovery.test.ts
+++ b/src/lib/adapters/shell/discovery.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { discoverFromRoots } from "./discovery.ts";
+
+function writeBundle(root: string, name: string, listTasks: string): void {
+  const dir = path.join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, "source.json"),
+    JSON.stringify({
+      name,
+      kind: "shell",
+      description: name,
+      installDir: "~/.config/groundcrew",
+      commands: { listTasks },
+    }),
+  );
+}
+
+describe("discoverFromRoots", () => {
+  it("discovers manifests from a root", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "discover-"));
+    try {
+      writeBundle(root, "jira", "jira list");
+
+      const { manifests } = discoverFromRoots([{ dir: root, origin: "package" }]);
+
+      expect(manifests.map((m) => m.manifest.name)).toStrictEqual(["jira"]);
+      expect(manifests[0]?.origin).toBe("package");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets a later root override an earlier one and records a warning", () => {
+    const pkg = mkdtempSync(path.join(tmpdir(), "discover-pkg-"));
+    const user = mkdtempSync(path.join(tmpdir(), "discover-user-"));
+    try {
+      writeBundle(pkg, "jira", "package jira");
+      writeBundle(user, "jira", "user jira");
+
+      const { manifests, warnings } = discoverFromRoots([
+        { dir: pkg, origin: "package" },
+        { dir: user, origin: "user" },
+      ]);
+
+      expect(manifests).toHaveLength(1);
+      expect(manifests[0]?.origin).toBe("user");
+      expect(manifests[0]?.manifest.commands.listTasks).toBe("user jira");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/jira/);
+    } finally {
+      rmSync(pkg, { recursive: true, force: true });
+      rmSync(user, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a root that does not exist", () => {
+    const { manifests } = discoverFromRoots([
+      { dir: path.join(tmpdir(), "does-not-exist-xyz"), origin: "user" },
+    ]);
+
+    expect(manifests).toStrictEqual([]);
+  });
+});

--- a/src/lib/adapters/shell/discovery.test.ts
+++ b/src/lib/adapters/shell/discovery.test.ts
@@ -89,6 +89,23 @@ describe("discoverFromRoots", () => {
     expect(run).toThrow(/ENAMETOOLONG/i);
   });
 
+  it("skips a manifest with invalid JSON and records a warning", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "discover-bad-"));
+    try {
+      const broken = path.join(root, "broken");
+      mkdirSync(broken, { recursive: true });
+      writeFileSync(path.join(broken, "source.json"), "{ not valid json");
+      writeBundle(root, "jira", "jira list");
+
+      const { manifests, warnings } = discoverFromRoots([{ dir: root, origin: "package" }]);
+
+      expect(manifests.map((m) => m.manifest.name)).toStrictEqual(["jira"]);
+      expect(warnings.some((w) => w.includes("broken"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("skips a subdirectory that has no source.json", () => {
     const root = mkdtempSync(path.join(tmpdir(), "discover-no-source-"));
     try {

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -7,11 +7,12 @@
  * (`../registry.ts`) turns each result into an enable-by-kind adapter.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { writeError } from "../../util.ts";
 import { xdgConfigPath } from "../../xdg.ts";
+import { isFileErrorCode } from "../todo-txt/fileErrors.ts";
 
 import { sourceManifestSchema, type SourceManifest } from "./manifest.ts";
 
@@ -41,15 +42,29 @@ export function userTaskSourcesRoot(): string {
   return xdgConfigPath("groundcrew", "task-sources");
 }
 
+/**
+ * Read a root's directory entries, treating an absent or non-directory root as
+ * empty. A task-sources root is optional (a user may never install one, and it
+ * can be torn down mid-run), so "not a readable directory" yields no sources
+ * rather than crashing discovery. Any other fault (e.g. EACCES) is re-raised.
+ */
+function readRootEntries(dir: string): Dirent[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    if (isFileErrorCode(error, "ENOENT") || isFileErrorCode(error, "ENOTDIR")) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 export function discoverFromRoots(roots: readonly ManifestRoot[]): DiscoveryResult {
   const byName = new Map<string, DiscoveredManifest>();
   const warnings: string[] = [];
 
   for (const root of roots) {
-    if (!existsSync(root.dir)) {
-      continue;
-    }
-    for (const entry of readdirSync(root.dir, { withFileTypes: true })) {
+    for (const entry of readRootEntries(root.dir)) {
       if (!entry.isDirectory()) {
         continue;
       }

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -16,7 +16,7 @@ import { isFileErrorCode } from "../todo-txt/fileErrors.ts";
 
 import { sourceManifestSchema, type SourceManifest } from "./manifest.ts";
 
-export type ManifestOrigin = "package" | "user";
+type ManifestOrigin = "package" | "user";
 
 export interface DiscoveredManifest {
   manifest: SourceManifest;
@@ -38,7 +38,7 @@ export interface DiscoveryResult {
 const PACKAGE_TASK_SOURCES_ROOT = path.resolve(import.meta.dirname, "../../../../task-sources");
 
 /** Sources any external installer drops into the groundcrew config dir. */
-export function userTaskSourcesRoot(): string {
+function userTaskSourcesRoot(): string {
   return xdgConfigPath("groundcrew", "task-sources");
 }
 

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 
 import { writeError } from "../../util.ts";
 import { xdgConfigPath } from "../../xdg.ts";
-import { isFileErrorCode } from "../todo-txt/fileErrors.ts";
+import { describeFileError, isFileErrorCode } from "../todo-txt/fileErrors.ts";
 
 import { sourceManifestSchema, type SourceManifest } from "./manifest.ts";
 
@@ -73,7 +73,17 @@ export function discoverFromRoots(roots: readonly ManifestRoot[]): DiscoveryResu
       if (!existsSync(manifestPath)) {
         continue;
       }
-      const manifest = sourceManifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
+      let manifest: SourceManifest;
+      try {
+        manifest = sourceManifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
+      } catch (error) {
+        // One malformed source.json must not take down the whole registry: skip
+        // this source and warn, so every other adapter still loads.
+        warnings.push(
+          `Ignoring invalid task source manifest at ${manifestPath}: ${describeFileError(error)}.`,
+        );
+        continue;
+      }
       const previous = byName.get(manifest.name);
       if (previous) {
         warnings.push(

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -1,0 +1,84 @@
+/**
+ * Discover task-source manifests from two roots: the sources bundled inside
+ * this package (`<pkg>/task-sources`) and the user-installed sources under
+ * `~/.config/groundcrew/task-sources`. Each `<dir>/source.json` is validated
+ * and indexed by manifest name; a later root overrides an earlier one on a
+ * name collision (user over package), recording a warning. The registry
+ * (`../registry.ts`) turns each result into an enable-by-kind adapter.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { writeError } from "../../util.ts";
+import { xdgConfigPath } from "../../xdg.ts";
+
+import { sourceManifestSchema, type SourceManifest } from "./manifest.ts";
+
+export type ManifestOrigin = "package" | "user";
+
+export interface DiscoveredManifest {
+  manifest: SourceManifest;
+  manifestDir: string;
+  origin: ManifestOrigin;
+}
+
+export interface ManifestRoot {
+  dir: string;
+  origin: ManifestOrigin;
+}
+
+export interface DiscoveryResult {
+  manifests: DiscoveredManifest[];
+  warnings: string[];
+}
+
+/** Sources bundled with this package, next to the built output in dev and prod. */
+const PACKAGE_TASK_SOURCES_ROOT = path.resolve(import.meta.dirname, "../../../../task-sources");
+
+/** Sources any external installer drops into the groundcrew config dir. */
+export function userTaskSourcesRoot(): string {
+  return xdgConfigPath("groundcrew", "task-sources");
+}
+
+export function discoverFromRoots(roots: readonly ManifestRoot[]): DiscoveryResult {
+  const byName = new Map<string, DiscoveredManifest>();
+  const warnings: string[] = [];
+
+  for (const root of roots) {
+    if (!existsSync(root.dir)) {
+      continue;
+    }
+    for (const entry of readdirSync(root.dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const manifestDir = path.join(root.dir, entry.name);
+      const manifestPath = path.join(manifestDir, "source.json");
+      if (!existsSync(manifestPath)) {
+        continue;
+      }
+      const manifest = sourceManifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
+      const previous = byName.get(manifest.name);
+      if (previous) {
+        warnings.push(
+          `Task source "${manifest.name}" from ${manifestDir} overrides the ${previous.origin} source at ${previous.manifestDir}.`,
+        );
+      }
+      byName.set(manifest.name, { manifest, manifestDir, origin: root.origin });
+    }
+  }
+
+  return { manifests: [...byName.values()], warnings };
+}
+
+export function discoverTaskSourceManifests(): DiscoveredManifest[] {
+  const { manifests, warnings } = discoverFromRoots([
+    { dir: PACKAGE_TASK_SOURCES_ROOT, origin: "package" },
+    { dir: userTaskSourcesRoot(), origin: "user" },
+  ]);
+  for (const warning of warnings) {
+    writeError(warning);
+  }
+  return manifests;
+}

--- a/src/lib/adapters/shell/enableByKind.test.ts
+++ b/src/lib/adapters/shell/enableByKind.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { AdapterContext } from "../../adapterDefinition.ts";
+import { buildSourcesWith } from "../../buildSources.ts";
+import type { ResolvedConfig } from "../../config.ts";
+import { mergeManifestAdapters } from "../registry.ts";
+
+import { discoverFromRoots } from "./discovery.ts";
+
+const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
+
+describe("enable a manifest source by kind", () => {
+  it("discovers, registers, and builds a source from { kind } alone", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "enable-by-kind-"));
+    try {
+      const bundleDir = path.join(root, "sources", "demo");
+      const installDir = path.join(root, "install");
+      mkdirSync(bundleDir, { recursive: true });
+      writeFileSync(path.join(bundleDir, "demo.sh"), "#!/bin/sh\n");
+      writeFileSync(
+        path.join(bundleDir, "source.json"),
+        JSON.stringify({
+          name: "demo",
+          kind: "shell",
+          description: "demo",
+          installDir,
+          files: ["demo.sh"],
+          commands: { listTasks: `${installDir}/demo.sh list` },
+        }),
+      );
+
+      const { manifests } = discoverFromRoots([
+        { dir: path.join(root, "sources"), origin: "user" },
+      ]);
+      const registry = mergeManifestAdapters({}, manifests);
+      const sources = buildSourcesWith(registry, [{ kind: "demo" }], fakeContext);
+
+      expect(sources).toHaveLength(1);
+      expect(sources[0]?.name).toBe("demo");
+      expect(existsSync(path.join(installDir, "demo.sh"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/adapters/shell/install.test.ts
+++ b/src/lib/adapters/shell/install.test.ts
@@ -55,6 +55,26 @@ describe("installShellSource", () => {
     }
   });
 
+  it("re-copies nothing when the installed script already matches", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(manifestDir);
+      mkdirSync(installDir);
+      writeFileSync(path.join(manifestDir, "demo.sh"), "same\n");
+      writeFileSync(path.join(installDir, "demo.sh"), "same\n");
+      const manifest = manifestWith({ installDir, files: ["demo.sh"] });
+
+      const actual = installShellSource({ manifest, manifestDir });
+
+      expect(readFileSync(path.join(installDir, "demo.sh"), "utf8")).toBe("same\n");
+      expect(actual.scriptPaths).toStrictEqual([path.join(installDir, "demo.sh")]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("installs nothing when the manifest lists no files", () => {
     const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
     try {

--- a/src/lib/adapters/shell/install.test.ts
+++ b/src/lib/adapters/shell/install.test.ts
@@ -36,6 +36,24 @@ describe("installShellSource", () => {
     }
   });
 
+  it("creates nested directories for nested bundle files", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(path.join(manifestDir, "bin"), { recursive: true });
+      writeFileSync(path.join(manifestDir, "bin", "demo.sh"), "#!/bin/sh\necho hi\n");
+      const manifest = manifestWith({ installDir, files: ["bin/demo.sh"] });
+
+      const actual = installShellSource({ manifest, manifestDir });
+
+      expect(existsSync(path.join(installDir, "bin", "demo.sh"))).toBe(true);
+      expect(actual.scriptPaths).toStrictEqual([path.join(installDir, "bin", "demo.sh")]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes an installed script when the shipped copy differs", () => {
     const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
     try {

--- a/src/lib/adapters/shell/install.test.ts
+++ b/src/lib/adapters/shell/install.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { installShellSource } from "./install.ts";
+import type { SourceManifest } from "./manifest.ts";
+
+function manifestWith(overrides: Partial<SourceManifest>): SourceManifest {
+  return {
+    name: "demo",
+    kind: "shell",
+    description: "demo",
+    installDir: "/replaced/in/test",
+    files: [],
+    commands: { listTasks: "demo list" },
+    ...overrides,
+  };
+}
+
+describe("installShellSource", () => {
+  it("copies script files into installDir and marks them executable", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(manifestDir);
+      writeFileSync(path.join(manifestDir, "demo.sh"), "#!/bin/sh\necho hi\n");
+      const manifest = manifestWith({ installDir, files: ["demo.sh"] });
+
+      const actual = installShellSource({ manifest, manifestDir });
+
+      expect(existsSync(path.join(installDir, "demo.sh"))).toBe(true);
+      expect(actual.scriptPaths).toStrictEqual([path.join(installDir, "demo.sh")]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes an installed script when the shipped copy differs", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(manifestDir);
+      mkdirSync(installDir);
+      writeFileSync(path.join(manifestDir, "demo.sh"), "new\n");
+      writeFileSync(path.join(installDir, "demo.sh"), "stale\n");
+      const manifest = manifestWith({ installDir, files: ["demo.sh"] });
+
+      installShellSource({ manifest, manifestDir });
+
+      expect(readFileSync(path.join(installDir, "demo.sh"), "utf8")).toBe("new\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("installs nothing when the manifest lists no files", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const installDir = path.join(root, "install");
+      const manifest = manifestWith({ installDir, files: [] });
+
+      const actual = installShellSource({ manifest, manifestDir: root });
+
+      expect(actual.scriptPaths).toStrictEqual([]);
+      expect(existsSync(installDir)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/adapters/shell/install.test.ts
+++ b/src/lib/adapters/shell/install.test.ts
@@ -75,6 +75,23 @@ describe("installShellSource", () => {
     }
   });
 
+  it("rejects a files entry that escapes the install directory", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(manifestDir);
+      writeFileSync(path.join(manifestDir, "evil.sh"), "#!/bin/sh\n");
+      const manifest = manifestWith({ installDir, files: ["../evil.sh"] });
+
+      const run = (): unknown => installShellSource({ manifest, manifestDir });
+
+      expect(run).toThrow(/escapes/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("installs nothing when the manifest lists no files", () => {
     const root = mkdtempSync(path.join(tmpdir(), "install-shell-"));
     try {

--- a/src/lib/adapters/shell/install.ts
+++ b/src/lib/adapters/shell/install.ts
@@ -35,6 +35,14 @@ export function installShellSource(options: InstallShellSourceOptions): Installe
   for (const file of manifest.files) {
     const source = path.join(manifestDir, file);
     const dest = path.join(installDir, file);
+    // Reject a files[] entry that escapes installDir (e.g. "../../.zshrc").
+    // Manifests are only semi-trusted, and each dest is made executable, so a
+    // traversal would let a source write over arbitrary files.
+    if (path.relative(installDir, dest).startsWith("..")) {
+      throw new Error(
+        `Task source "${manifest.name}" lists file "${file}" that escapes its install directory "${installDir}".`,
+      );
+    }
     if (!existsSync(dest) || readFileSync(dest).compare(readFileSync(source)) !== 0) {
       copyFileSync(source, dest);
     }

--- a/src/lib/adapters/shell/install.ts
+++ b/src/lib/adapters/shell/install.ts
@@ -38,11 +38,13 @@ export function installShellSource(options: InstallShellSourceOptions): Installe
     // Reject a files[] entry that escapes installDir (e.g. "../../.zshrc").
     // Manifests are only semi-trusted, and each dest is made executable, so a
     // traversal would let a source write over arbitrary files.
-    if (path.relative(installDir, dest).startsWith("..")) {
+    const relativeDest = path.relative(installDir, dest);
+    if (relativeDest === ".." || relativeDest.startsWith(`..${path.sep}`)) {
       throw new Error(
         `Task source "${manifest.name}" lists file "${file}" that escapes its install directory "${installDir}".`,
       );
     }
+    mkdirSync(path.dirname(dest), { recursive: true });
     if (!existsSync(dest) || readFileSync(dest).compare(readFileSync(source)) !== 0) {
       copyFileSync(source, dest);
     }

--- a/src/lib/adapters/shell/install.ts
+++ b/src/lib/adapters/shell/install.ts
@@ -1,0 +1,46 @@
+/**
+ * Idempotent materialization of a task source's script files. Copies each
+ * `files[]` entry from the manifest's directory into `installDir` when the destination is
+ * missing or its bytes differ, then marks it executable. A manifest with no
+ * `files` installs nothing (the source is backed by a binary already on PATH).
+ * Never writes secrets - prerequisites and secrets stay the user's job.
+ */
+
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expandHome } from "../../paths.ts";
+
+import type { SourceManifest } from "./manifest.ts";
+
+export interface InstallShellSourceOptions {
+  manifest: SourceManifest;
+  manifestDir: string;
+}
+
+export interface InstalledShellSource {
+  installDir: string;
+  scriptPaths: string[];
+}
+
+export function installShellSource(options: InstallShellSourceOptions): InstalledShellSource {
+  const { manifest, manifestDir } = options;
+  const installDir = expandHome(manifest.installDir);
+  const scriptPaths: string[] = [];
+
+  if (manifest.files.length > 0) {
+    mkdirSync(installDir, { recursive: true });
+  }
+
+  for (const file of manifest.files) {
+    const source = path.join(manifestDir, file);
+    const dest = path.join(installDir, file);
+    if (!existsSync(dest) || readFileSync(dest).compare(readFileSync(source)) !== 0) {
+      copyFileSync(source, dest);
+    }
+    chmodSync(dest, 0o755);
+    scriptPaths.push(dest);
+  }
+
+  return { installDir, scriptPaths };
+}

--- a/src/lib/adapters/shell/manifest.test.ts
+++ b/src/lib/adapters/shell/manifest.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { sourceManifestSchema } from "./manifest.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../");
+
+const validManifest = {
+  name: "jira",
+  kind: "shell",
+  description: "Feed JIRA issues into groundcrew.",
+  installDir: "~/.config/groundcrew",
+  files: ["jira.sh"],
+  commands: { listTasks: "~/.config/groundcrew/jira.sh list" },
+};
+
+describe("sourceManifestSchema", () => {
+  it("accepts a minimal valid manifest", () => {
+    const parse = (): unknown => sourceManifestSchema.parse(validManifest);
+
+    expect(parse).not.toThrow();
+  });
+
+  it("defaults files to an empty array when omitted", () => {
+    const { files: _files, ...withoutFiles } = validManifest;
+    const actual = sourceManifestSchema.parse(withoutFiles);
+
+    expect(actual.files).toStrictEqual([]);
+  });
+
+  it("requires a listTasks command", () => {
+    const input = { ...validManifest, commands: { verify: "jira me" } };
+    const parse = (): unknown => sourceManifestSchema.parse(input);
+
+    expect(parse).toThrow(/listTasks/i);
+  });
+
+  it("rejects a non-kebab-case name", () => {
+    const input = { ...validManifest, name: "Jira_Source" };
+    const parse = (): unknown => sourceManifestSchema.parse(input);
+
+    expect(parse).toThrow(/kebab-case/i);
+  });
+
+  it("rejects unknown top-level fields", () => {
+    const input = { ...validManifest, bogus: true };
+    const parse = (): unknown => sourceManifestSchema.parse(input);
+
+    expect(parse).toThrow(/unrecognized/i);
+  });
+
+  it("validates the shipped jira source manifest", () => {
+    const raw = readFileSync(path.join(REPO_ROOT, "task-sources/jira/source.json"), "utf8");
+    const input: unknown = JSON.parse(raw);
+    const parse = (): unknown => sourceManifestSchema.parse(input);
+
+    expect(parse).not.toThrow();
+  });
+});

--- a/src/lib/adapters/shell/manifest.ts
+++ b/src/lib/adapters/shell/manifest.ts
@@ -1,0 +1,71 @@
+/**
+ * `SourceManifest` describes a packaged task source's `source.json` (for
+ * example `task-sources/jira/source.json`). It is the install-time contract
+ * between whoever ships a source (groundcrew itself, or an external installer
+ * that drops a bundle into `~/.config/groundcrew/task-sources`) and groundcrew,
+ * which discovers manifests and exposes each as an enable-by-kind adapter.
+ *
+ * Deliberately separate from `ShellAdapterConfig` (the runtime config block in
+ * `./schema.ts`): the manifest carries install-only fields (`installDir`,
+ * `files`, `prerequisites`, `secrets`) and command templates whose script paths
+ * are not yet installed. `shellConfigFromManifest` (see `./manifestAdapter.ts`)
+ * bridges the two once the scripts are materialized.
+ */
+
+import { z } from "zod";
+
+const prerequisiteSchema = z.strictObject({
+  bin: z.string().min(1),
+  install: z.string().optional(),
+  setup: z.string().optional(),
+});
+
+const secretSchema = z.strictObject({
+  env: z.string().min(1),
+  file: z.string().min(1),
+  mode: z.string().optional(),
+  url: z.string().optional(),
+});
+
+const commandsSchema = z.strictObject({
+  verify: z.string().optional(),
+  listTasks: z.string(),
+  getTask: z.string().optional(),
+  markInProgress: z.string().optional(),
+  markInReview: z.string().optional(),
+  markDone: z.string().optional(),
+  createTask: z.string().optional(),
+  validate: z.string().optional(),
+});
+
+/**
+ * Per-command timeouts in milliseconds. Shared with the override schema in
+ * `./manifestAdapter.ts` so a `{ kind }` entry can override manifest timeouts.
+ */
+export const manifestTimeoutsSchema = z.strictObject({
+  verify: z.number().int().positive().optional(),
+  listTasks: z.number().int().positive().optional(),
+  getTask: z.number().int().positive().optional(),
+  markInProgress: z.number().int().positive().optional(),
+  markInReview: z.number().int().positive().optional(),
+  markDone: z.number().int().positive().optional(),
+  createTask: z.number().int().positive().optional(),
+  validate: z.number().int().positive().optional(),
+});
+
+export const sourceManifestSchema = z.strictObject({
+  name: z
+    .string()
+    .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)"),
+  kind: z.literal("shell"),
+  description: z.string(),
+  installDir: z.string().min(1),
+  files: z.array(z.string().min(1)).default([]),
+  prerequisites: z.array(prerequisiteSchema).optional(),
+  secrets: z.array(secretSchema).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  commands: commandsSchema,
+  timeouts: manifestTimeoutsSchema.optional(),
+});
+
+export type SourceManifest = z.infer<typeof sourceManifestSchema>;

--- a/src/lib/adapters/shell/manifestAdapter.test.ts
+++ b/src/lib/adapters/shell/manifestAdapter.test.ts
@@ -39,6 +39,16 @@ describe("shellConfigFromManifest", () => {
 
     expect(actual.env).toStrictEqual({ A: "1", B: "override" });
   });
+
+  it("prefers an override name and timeouts over the manifest values", () => {
+    const actual = shellConfigFromManifest(manifestWith({ name: "demo" }), {
+      name: "renamed",
+      timeouts: { listTasks: 1234 },
+    });
+
+    expect(actual.name).toBe("renamed");
+    expect(actual.timeouts).toStrictEqual({ listTasks: 1234 });
+  });
 });
 
 describe("manifestAdapter", () => {

--- a/src/lib/adapters/shell/manifestAdapter.test.ts
+++ b/src/lib/adapters/shell/manifestAdapter.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { AdapterContext } from "../../adapterDefinition.ts";
+import type { ResolvedConfig } from "../../config.ts";
+
+import { manifestAdapter, shellConfigFromManifest } from "./manifestAdapter.ts";
+import type { SourceManifest } from "./manifest.ts";
+
+const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
+
+function manifestWith(overrides: Partial<SourceManifest>): SourceManifest {
+  return {
+    name: "demo",
+    kind: "shell",
+    description: "demo",
+    installDir: "/replaced/in/test",
+    files: [],
+    env: { A: "1" },
+    commands: { listTasks: "demo list" },
+    ...overrides,
+  };
+}
+
+describe("shellConfigFromManifest", () => {
+  it("passes commands through and defaults the name to the manifest name", () => {
+    const actual = shellConfigFromManifest(manifestWith({}));
+
+    expect(actual.kind).toBe("shell");
+    expect(actual.name).toBe("demo");
+    expect(actual.commands.listTasks).toBe("demo list");
+  });
+
+  it("shallow-merges env overrides over the manifest defaults", () => {
+    const actual = shellConfigFromManifest(manifestWith({ env: { A: "1", B: "2" } }), {
+      env: { B: "override" },
+    });
+
+    expect(actual.env).toStrictEqual({ A: "1", B: "override" });
+  });
+});
+
+describe("manifestAdapter", () => {
+  it("exposes the manifest name as the adapter kind", () => {
+    const adapter = manifestAdapter(manifestWith({ name: "jira" }), "/tmp/x");
+
+    expect(adapter.kind).toBe("jira");
+    expect(() => adapter.configSchema.parse({ kind: "jira" })).not.toThrow();
+    expect(() => adapter.configSchema.parse({ kind: "jira", bogus: true })).toThrow(
+      /unrecognized/i,
+    );
+  });
+
+  it("installs scripts then builds a shell task source on create", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "manifest-adapter-"));
+    try {
+      const manifestDir = path.join(root, "manifest");
+      const installDir = path.join(root, "install");
+      mkdirSync(manifestDir);
+      writeFileSync(path.join(manifestDir, "demo.sh"), "#!/bin/sh\n");
+      const manifest = manifestWith({ installDir, files: ["demo.sh"] });
+      const adapter = manifestAdapter(manifest, manifestDir);
+
+      const source = adapter.create({ kind: "demo" }, fakeContext);
+
+      expect(source.name).toBe("demo");
+      expect(existsSync(path.join(installDir, "demo.sh"))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/adapters/shell/manifestAdapter.ts
+++ b/src/lib/adapters/shell/manifestAdapter.ts
@@ -1,0 +1,72 @@
+/**
+ * Bridges a discovered `SourceManifest` to the shell adapter runtime so a
+ * packaged/installed source is enabled with `{ kind: "<name>" }` alone. The
+ * synthetic adapter's `kind` is the manifest name; its config schema accepts
+ * light overrides (`name`, `env`, `timeouts`, `enabled`) that merge over the
+ * manifest defaults. Full command control stays with the generic `kind:"shell"`
+ * adapter. `create` materializes the scripts (idempotent) before building the
+ * TaskSource, so enabling a source is also what installs it.
+ */
+
+import { z } from "zod";
+
+import type { AdapterContext, AdapterDefinition } from "../../adapterDefinition.ts";
+import type { TaskSource } from "../../taskSource.ts";
+
+import { createShellTaskSource } from "./factory.ts";
+import { installShellSource } from "./install.ts";
+import { manifestTimeoutsSchema, type SourceManifest } from "./manifest.ts";
+import type { ShellAdapterConfig } from "./schema.ts";
+
+export interface ManifestOverrides {
+  name?: string | undefined;
+  env?: Record<string, string> | undefined;
+  timeouts?: ShellAdapterConfig["timeouts"] | undefined;
+}
+
+export function shellConfigFromManifest(
+  manifest: SourceManifest,
+  overrides: ManifestOverrides = {},
+): ShellAdapterConfig {
+  const env = { ...manifest.env, ...overrides.env };
+  const timeouts = overrides.timeouts ?? manifest.timeouts;
+  return {
+    kind: "shell",
+    name: overrides.name ?? manifest.name,
+    commands: manifest.commands,
+    ...(Object.keys(env).length > 0 ? { env } : {}),
+    ...(timeouts ? { timeouts } : {}),
+  };
+}
+
+export function manifestAdapter(manifest: SourceManifest, manifestDir: string): AdapterDefinition {
+  const configSchema = z.strictObject({
+    kind: z.literal(manifest.name),
+    name: z
+      .string()
+      .regex(/^[a-z][a-z0-9-]*$/, "name must be kebab-case (lowercase letters, digits, hyphens)")
+      .optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    timeouts: manifestTimeoutsSchema.optional(),
+    enabled: z.boolean().optional(),
+  });
+
+  return {
+    kind: manifest.name,
+    configSchema,
+    // `config` arrives already validated from buildSourcesWith; re-parse to
+    // recover the typed overrides without an unsafe cast. Cheap and idempotent.
+    create: (config: unknown, context: AdapterContext): TaskSource => {
+      const overrides = configSchema.parse(config);
+      installShellSource({ manifest, manifestDir });
+      return createShellTaskSource(
+        shellConfigFromManifest(manifest, {
+          name: overrides.name,
+          env: overrides.env,
+          timeouts: overrides.timeouts,
+        }),
+        context,
+      );
+    },
+  };
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,12 +16,30 @@ import { BUILD_SECRET_NAMES } from "./buildSecrets.ts";
 export { BUILD_SECRET_NAMES } from "./buildSecrets.ts";
 
 /**
+ * Authoring shape for a manifest-backed (discovered) task source: enable by
+ * kind, with light overrides. The concrete per-source schema is built at
+ * runtime by `manifestAdapter` and validated at `buildSources` time, so the
+ * static type here is intentionally permissive.
+ */
+export interface ManifestSourceConfig {
+  kind: string;
+  name?: string;
+  env?: Record<string, string>;
+  timeouts?: ShellAdapterConfig["timeouts"];
+  enabled?: boolean;
+}
+
+/**
  * Discriminated union of all built-in adapter config shapes. Used at
  * config-load time as the static type for `Config.sources[]` and
  * `ResolvedConfig.sources[]`. The runtime Zod validation lives in each
  * adapter's `schema.ts` and runs at `buildSources` time, not here.
  */
-export type SourceConfig = LinearAdapterConfig | ShellAdapterConfig | TodoTxtAdapterConfig;
+export type SourceConfig =
+  | LinearAdapterConfig
+  | ShellAdapterConfig
+  | TodoTxtAdapterConfig
+  | ManifestSourceConfig;
 
 export interface HookCommands {
   prepareWorktree?: string;

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -24,17 +24,21 @@ describe(sourceSupportsMarkDone, () => {
     expect(actual).toBe(true);
   });
 
-  it("uses discovered manifest commands for manifest-backed source kinds", () => {
+  it("uses discovered manifest commands for manifest-backed source kinds", async () => {
+    vi.resetModules();
     const home = mkdtempSync(path.join(tmpdir(), "source-capabilities-xdg-"));
     vi.stubEnv("XDG_CONFIG_HOME", home);
     try {
+      const { sourceSupportsMarkDone: sourceSupportsMarkDoneWithFreshModule } =
+        await import("./sourceCapabilities.ts");
       const rawSources = [{ kind: "jira" }];
 
-      const actual = sourceSupportsMarkDone({ rawSources, sourceName: "jira" });
+      const actual = sourceSupportsMarkDoneWithFreshModule({ rawSources, sourceName: "jira" });
 
       expect(actual).toBe(true);
     } finally {
       vi.unstubAllEnvs();
+      vi.resetModules();
       rmSync(home, { recursive: true, force: true });
     }
   });

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import type { DiscoveredManifest } from "./adapters/shell/discovery.ts";
 import { sourceSupportsMarkDone, taskSupportsCompletionCommand } from "./sourceCapabilities.ts";
 
 describe(sourceSupportsMarkDone, () => {
@@ -35,6 +36,40 @@ describe(sourceSupportsMarkDone, () => {
     } finally {
       vi.unstubAllEnvs();
       rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("caches discovered manifest capabilities across repeated lookups", async () => {
+    vi.resetModules();
+    const mockDiscoverTaskSourceManifests = vi.fn<() => DiscoveredManifest[]>(() => [
+      {
+        manifest: {
+          name: "jira",
+          kind: "shell",
+          description: "jira",
+          installDir: "~/.config/groundcrew",
+          files: [],
+          commands: { listTasks: "jira list", markDone: "jira done" },
+        },
+        manifestDir: "/tmp/jira",
+        origin: "package",
+      },
+    ]);
+    vi.doMock("./adapters/shell/discovery.ts", () => ({
+      discoverTaskSourceManifests: mockDiscoverTaskSourceManifests,
+    }));
+    try {
+      const { sourceSupportsMarkDone: sourceSupportsMarkDoneWithMock } =
+        await import("./sourceCapabilities.ts");
+      const rawSources = [{ kind: "jira" }];
+
+      expect(sourceSupportsMarkDoneWithMock({ rawSources, sourceName: "jira" })).toBe(true);
+      expect(sourceSupportsMarkDoneWithMock({ rawSources, sourceName: "jira" })).toBe(true);
+
+      expect(mockDiscoverTaskSourceManifests).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("./adapters/shell/discovery.ts");
+      vi.resetModules();
     }
   });
 });

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { sourceSupportsMarkDone, taskSupportsCompletionCommand } from "./sourceCapabilities.ts";
 
 describe(sourceSupportsMarkDone, () => {
@@ -17,6 +21,21 @@ describe(sourceSupportsMarkDone, () => {
     const actual = sourceSupportsMarkDone({ rawSources, sourceName: "todo" });
 
     expect(actual).toBe(true);
+  });
+
+  it("uses discovered manifest commands for manifest-backed source kinds", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "source-capabilities-xdg-"));
+    vi.stubEnv("XDG_CONFIG_HOME", home);
+    try {
+      const rawSources = [{ kind: "jira" }];
+
+      const actual = sourceSupportsMarkDone({ rawSources, sourceName: "jira" });
+
+      expect(actual).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -29,6 +29,8 @@ interface ManifestCapabilitiesForKindArguments {
   kind: string;
 }
 
+let cachedManifestCapabilitiesByKind: ReadonlyMap<string, SourceCapabilities> | undefined;
+
 const nameShape = z.looseObject({ name: z.string().optional() });
 const kindShape = z.object({ kind: z.string() });
 
@@ -84,15 +86,22 @@ function manifestCapabilities(arguments_: ManifestCapabilitiesArguments): Source
   };
 }
 
+function getManifestCapabilitiesByKind(): ReadonlyMap<string, SourceCapabilities> {
+  if (cachedManifestCapabilitiesByKind === undefined) {
+    const capabilitiesByKind = new Map<string, SourceCapabilities>();
+    for (const { manifest } of discoverTaskSourceManifests()) {
+      capabilitiesByKind.set(manifest.name, manifestCapabilities({ manifest }));
+    }
+    cachedManifestCapabilitiesByKind = capabilitiesByKind;
+  }
+  return cachedManifestCapabilitiesByKind;
+}
+
 function manifestCapabilitiesForKind(
   arguments_: ManifestCapabilitiesForKindArguments,
 ): SourceCapabilities | undefined {
   const { kind } = arguments_;
-  const discovered = discoverTaskSourceManifests().find(({ manifest }) => manifest.name === kind);
-  if (discovered === undefined) {
-    return undefined;
-  }
-  return manifestCapabilities({ manifest: discovered.manifest });
+  return getManifestCapabilitiesByKind().get(kind);
 }
 
 const TODO_TXT_CAPABILITIES: SourceCapabilities = {

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { discoverTaskSourceManifests } from "./adapters/shell/discovery.ts";
+import type { SourceManifest } from "./adapters/shell/manifest.ts";
 import { shellAdapterConfigSchema } from "./adapters/shell/schema.ts";
 
 interface SourceCapabilities {
@@ -17,6 +19,14 @@ export interface SourceSummary {
   name: string;
   kind: string;
   capabilities: SourceCapabilities;
+}
+
+interface ManifestCapabilitiesArguments {
+  manifest: SourceManifest;
+}
+
+interface ManifestCapabilitiesForKindArguments {
+  kind: string;
 }
 
 const nameShape = z.looseObject({ name: z.string().optional() });
@@ -59,6 +69,32 @@ function shellCapabilities(raw: unknown): SourceCapabilities {
   };
 }
 
+function manifestCapabilities(arguments_: ManifestCapabilitiesArguments): SourceCapabilities {
+  const { manifest } = arguments_;
+  const { commands } = manifest;
+  return {
+    verify: commands.verify !== undefined,
+    listTasks: true,
+    getTask: commands.getTask !== undefined,
+    createTask: commands.createTask !== undefined,
+    markInProgress: commands.markInProgress !== undefined,
+    markInReview: commands.markInReview !== undefined,
+    markDone: commands.markDone !== undefined,
+    validate: commands.validate !== undefined,
+  };
+}
+
+function manifestCapabilitiesForKind(
+  arguments_: ManifestCapabilitiesForKindArguments,
+): SourceCapabilities | undefined {
+  const { kind } = arguments_;
+  const discovered = discoverTaskSourceManifests().find(({ manifest }) => manifest.name === kind);
+  if (discovered === undefined) {
+    return undefined;
+  }
+  return manifestCapabilities({ manifest: discovered.manifest });
+}
+
 const TODO_TXT_CAPABILITIES: SourceCapabilities = {
   verify: true,
   listTasks: true,
@@ -83,7 +119,7 @@ export function summarizeSource(raw: unknown): SourceSummary {
   } else if (kind === "todo-txt") {
     capabilities = TODO_TXT_CAPABILITIES;
   } else {
-    capabilities = UNKNOWN_KIND_CAPABILITIES;
+    capabilities = manifestCapabilitiesForKind({ kind }) ?? UNKNOWN_KIND_CAPABILITIES;
   }
 
   return { name: sourceName, kind, capabilities };


### PR DESCRIPTION
## Why

Today a shell-backed task source has to be enabled with a full inline `{ kind: "shell", commands: {...} }` block. This makes a shell source enable-able by name alone, exactly like a built-in adapter:

```jsonc
sources: [{ kind: "jira" }]   // same shape as { kind: "linear" }
```

groundcrew discovers `source.json` manifests from two roots, turns each into a synthetic adapter whose `kind` is the manifest name, and at enable-time materializes the source's scripts before building a shell `TaskSource`. Enabling a source is also what installs it.

This is **part 2** of a three-part effort ([design](../plans): open-registry). It implements Tasks 2, 3, 4, 5, 6, and 8 of the source plan. Packaging (Task 1) and the unified catalog / discovery-API export (Tasks 7, 9, 10) ship in the sibling PRs.

## What

All under `src/lib/adapters/shell/` unless noted:

- **`manifest.ts`** - internal `sourceManifestSchema` + `SourceManifest` (+ `manifestTimeoutsSchema`). `files` defaults to `[]`.
- **`install.ts`** - `installShellSource({ manifest, manifestDir })`: idempotent copy of `files[]` into the expanded `installDir` (skips when bytes already match), marks each `0o755`, no-op when `files` is empty, never writes secrets.
- **`manifestAdapter.ts`** - `shellConfigFromManifest` + `manifestAdapter`: a synthetic `AdapterDefinition` with `kind = manifest.name` and an override schema `{ kind, name?, env?, timeouts?, enabled? }`; `create` installs the scripts (idempotent) then builds a shell source.
- **`discovery.ts`** - `discoverFromRoots` (pure; later root overrides earlier by name, recording a warning) + `discoverTaskSourceManifests` (package root `<pkg>/task-sources` then user root `${XDG_CONFIG_HOME:-~/.config}/groundcrew/task-sources`; warnings go to stderr).
- **`registry.ts`** - `mergeManifestAdapters` folds discovered manifests into the code-adapter registry, throwing on a reserved-kind collision (`linear`/`shell`/`todo-txt`); `adapterRegistry` now includes discovered sources.
- **`config.ts`** - `SourceConfig` widened with a permissive manifest-source arm.

## Acceptance criteria

- [x] A `source.json` bundle in either root is discovered and exposed as `kind = <manifest name>`.
- [x] `{ kind: "jira" }` builds a working shell task source and materializes the jira script to `installDir` (`enableByKind.test.ts` drives the full chain).
- [x] A user-root source with the same name as a package source wins, and a warning is written to stderr.
- [x] A manifest named `linear`/`shell`/`todo-txt` is rejected with a collision error.
- [x] The generic `{ kind: "shell" }` adapter and its full inline config form are unchanged.
- [x] `node --run verify` is green (architecture:check, build, cpd, format:check, knip, lint, markdown:lint, spell:check, syncpack:lint, test @ 100% coverage).

## Validation

`node --run verify` passes end-to-end. Built via TDD (red → green per task); 36 new tests across `manifest`, `install`, `manifestAdapter`, `discovery`, `registry`, and an end-to-end `enableByKind` integration test. Coverage gate held at 100%.

## Decisions & areas of concern

An independent review flagged six items. How each was handled:

1. **Packaging: `task-sources/` is not yet in `package.json#files`.** Deliberate: shipping the bundle in the published tarball is **Task 1 of the source plan, scoped to the sibling "part 1" PR** (which adds it with a `packaging.test.ts`). In an installed package, package-root discovery depends on that PR landing. Not duplicated here to avoid a conflict. **This PR should merge together with / after part 1.**

2. **A malformed or reserved-name user manifest fails the whole registry (all commands), not just that source.** The reserved-kind collision throwing is required by acceptance criterion 4 and is directly tested. Discovery runs eagerly in the module-level `adapterRegistry`, so a bad user-dropped `source.json` currently propagates. Kept faithful to the plan's strict-validation design; making a single malformed manifest skip-and-warn (while collisions still throw) is a reasonable follow-up if we want per-source isolation.

3. **Registry production-IIFE test was non-hermetic** (asserted the exact key set, which reads the real `~/.config`). **Fixed:** it now asserts the built-ins + `jira` are present rather than an exact set, so a developer's own user-installed sources don't break the suite.

4. **Widened `SourceConfig` accepts any `{ kind: string }`, loosening author-time types.** Intentional per the design (C5): the concrete per-source schema is built at runtime by `manifestAdapter` and validated at `buildSources` time, so the static type is deliberately permissive. Runtime validation of the inline `shell` form is unchanged.

5. **`installShellSource` has no path-traversal containment on `files[]` / `installDir`** (defense-in-depth). Manifests are groundcrew-shipped or user-installed (low trust boundary), so out of scope here; a `path.relative` escape check is a sensible hardening follow-up.

6. **A `files[]` entry missing from the bundle throws a bare `ENOENT`** rather than a source-attributed error. Minor DX follow-up.

Additional robustness added while wiring the registry: `discoverFromRoots` now tolerates an absent or non-directory root (returns no sources) instead of crashing, and re-raises genuinely unexpected read failures. This fixed an unhandled rejection that a broadly-`fs`-mocked test triggered once discovery ran at registry init.
