### PR TITLE
feat: add `crew cleanup --all` to reap idle worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ crew resume [--new] <TASK>                             # reopen a paused task (-
 crew open <pr> | --branch <name> [--repo <owner/repo>] # iterate on an existing PR or branch
          [--prompt <text> | --prompt-file <path>] [--task <id>] [--dry-run]
 crew cleanup [--force] <TASK>                          # tear down every worktree for a task
+crew cleanup [--force] --all                           # tear down every idle worktree (no live workspace)
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,8 +193,8 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: statusCli,
   },
   cleanup: {
-    summary: "Tear down a worktree",
-    usage: "[--force] <task>",
+    summary: "Tear down a worktree, or every idle worktree with --all",
+    usage: "[--force] <task> | [--force] --all",
     invoke: cleanupWorkspaceCli,
   },
   stop: {

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -5,7 +5,7 @@ import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
-import { cleanupWorkspace, cleanupWorkspaceCli } from "./cleanupWorkspace.ts";
+import { cleanupAllWorkspaces, cleanupWorkspace, cleanupWorkspaceCli } from "./cleanupWorkspace.ts";
 
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -17,6 +17,7 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
     ...actual,
     worktrees: {
       ...actual.worktrees,
+      list: vi.fn<typeof actual.worktrees.list>(),
       findByTask: vi.fn<typeof actual.worktrees.findByTask>(),
       teardown: vi.fn<typeof actual.worktrees.teardown>(),
     },
@@ -42,6 +43,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
 });
 
 const loadConfigMock = vi.mocked(loadConfig);
+const listMock = vi.mocked(worktrees.list);
 const findByTaskMock = vi.mocked(worktrees.findByTask);
 const teardownMock = vi.mocked(worktrees.teardown);
 const readRunStateMock = vi.mocked(readRunState);
@@ -53,6 +55,14 @@ const hostEntry: WorktreeEntry = {
   task: "team-1",
   branchName: "dev-team-1",
   dir: "/work/repo-a-team-1",
+  kind: "host",
+};
+
+const secondEntry: WorktreeEntry = {
+  repository: "repo-a",
+  task: "team-2",
+  branchName: "dev-team-2",
+  dir: "/work/repo-a-team-2",
   kind: "host",
 };
 
@@ -304,6 +314,110 @@ describe(cleanupWorkspace, () => {
   });
 });
 
+describe(cleanupAllWorkspaces, () => {
+  let consoleLog: ConsoleCapture;
+
+  beforeEach(() => {
+    consoleLog = captureConsoleLog();
+    teardownMock.mockResolvedValue(emptyTeardownResult());
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+  });
+
+  afterEach(() => {
+    consoleLog.restore();
+    vi.resetAllMocks();
+  });
+
+  it("tears down every worktree when no workspace is in use", async () => {
+    listMock.mockReturnValue([hostEntry, secondEntry]);
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry, secondEntry] }));
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry, secondEntry], { force: false });
+    expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
+    expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-2");
+  });
+
+  it("skips worktrees whose workspace is live and tears down the rest", async () => {
+    listMock.mockReturnValue([hostEntry, secondEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [secondEntry] }));
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).toHaveBeenCalledWith(config, [secondEntry], { force: false });
+    expect(consoleLog.output()).toContain("team-1");
+    expect(consoleLog.output()).toContain("in use");
+  });
+
+  it("treats an exited workspace session as idle and cleans it up", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+      exitedNames: new Set(["team-1"]),
+    });
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: false });
+  });
+
+  it("cleans up nothing when the workspace probe is unavailable", async () => {
+    listMock.mockReturnValue([hostEntry, secondEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("probe unavailable");
+  });
+
+  it("logs and returns when there are no worktrees at all", async () => {
+    listMock.mockReturnValue([]);
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(workspaceProbeMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("nothing to clean up");
+  });
+
+  it("logs and returns when every worktree is in use", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await cleanupAllWorkspaces(config, {});
+
+    expect(teardownMock).not.toHaveBeenCalled();
+    expect(consoleLog.output()).toContain("No idle worktrees");
+  });
+
+  it("passes --force through to teardown", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+
+    await cleanupAllWorkspaces(config, { force: true });
+
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: true });
+  });
+
+  it("re-throws the first failure reported by teardown", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        failures: [
+          { entry: hostEntry, step: "worktree_remove", error: new Error("worktree busy") },
+        ],
+      }),
+    );
+
+    await expect(cleanupAllWorkspaces(config, {})).rejects.toThrow(/worktree busy/);
+  });
+});
+
 describe(cleanupWorkspaceCli, () => {
   let consoleLog: ConsoleCapture;
 
@@ -312,6 +426,7 @@ describe(cleanupWorkspaceCli, () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     loadConfigMock.mockResolvedValue(config);
     teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
   });
 
   afterEach(() => {
@@ -350,6 +465,32 @@ describe(cleanupWorkspaceCli, () => {
 
   it("rejects extra positional args", async () => {
     await expect(cleanupWorkspaceCli(["team-1", "extra"])).rejects.toThrow(/Usage: crew cleanup/);
+    expect(findByTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("routes --all to the batch cleanup instead of a single task", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+
+    await cleanupWorkspaceCli(["--all"]);
+
+    expect(listMock).toHaveBeenCalledWith(config);
+    expect(findByTaskMock).not.toHaveBeenCalled();
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: false });
+  });
+
+  it("passes --force through with --all", async () => {
+    listMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+
+    await cleanupWorkspaceCli(["--all", "--force"]);
+
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: true });
+  });
+
+  it("rejects --all combined with a task argument", async () => {
+    await expect(cleanupWorkspaceCli(["--all", "team-1"])).rejects.toThrow(/Usage: crew cleanup/);
+    expect(listMock).not.toHaveBeenCalled();
     expect(findByTaskMock).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -2,9 +2,15 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, removeRunState } from "../lib/runState.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { log } from "../lib/util.ts";
-import { workspaces } from "../lib/workspaces.ts";
-import { worktrees } from "../lib/worktrees.ts";
+import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { logTeardown } from "./teardownReporter.ts";
+
+const USAGE = [
+  "Usage: crew cleanup [--force] <task>",
+  "       crew cleanup [--force] --all",
+  "Example: crew cleanup team-220",
+].join("\n");
 
 export interface CleanupWorkspaceOptions {
   task: string;
@@ -12,26 +18,70 @@ export interface CleanupWorkspaceOptions {
   force?: boolean;
 }
 
-function parseArguments(argv: string[]): CleanupWorkspaceOptions {
+export interface CleanupAllOptions {
+  /** Default false. Force-remove even worktrees with uncommitted work. */
+  force?: boolean;
+}
+
+type CleanupArguments =
+  | { mode: "task"; task: string; force: boolean }
+  | { mode: "all"; force: boolean };
+
+function parseArguments(argv: string[]): CleanupArguments {
   let force = false;
+  let all = false;
   const positionals: string[] = [];
   for (const argument of argv) {
     if (argument === "--force") {
       force = true;
       continue;
     }
+    if (argument === "--all") {
+      all = true;
+      continue;
+    }
     if (argument.startsWith("-")) {
-      throw new Error(
-        `Unknown option: ${argument}\nUsage: crew cleanup [--force] <task>\nExample: crew cleanup team-220`,
-      );
+      throw new Error(`Unknown option: ${argument}\n${USAGE}`);
     }
     positionals.push(argument);
   }
+  if (all) {
+    if (positionals.length > 0) {
+      throw new Error(`crew cleanup --all takes no task argument.\n${USAGE}`);
+    }
+    return { mode: "all", force };
+  }
   const [task, ...extras] = positionals;
   if (task === undefined || task.length === 0 || extras.length > 0) {
-    throw new Error("Usage: crew cleanup [--force] <task>\nExample: crew cleanup team-220");
+    throw new Error(USAGE);
   }
-  return { task: task.toLowerCase(), force };
+  return { mode: "task", task: task.toLowerCase(), force };
+}
+
+/**
+ * A worktree is "in use" when its task has a live workspace session — present
+ * in the probe and not exited. An exited session is a dead agent, so its
+ * worktree is idle and safe to reap. An `unavailable` probe is "we don't know",
+ * handled by the caller (never inferred as idle).
+ */
+function isWorkspaceInUse(probe: WorkspaceProbe, task: string): boolean {
+  if (probe.kind !== "ok" || !probe.names.has(task)) {
+    return false;
+  }
+  return probe.exitedNames?.has(task) !== true;
+}
+
+async function teardownEntries(
+  config: ResolvedConfig,
+  entries: readonly WorktreeEntry[],
+  force: boolean,
+): Promise<void> {
+  const result = await worktrees.teardown(config, entries, { force });
+  recordCleanedUpRuns(config, result.removed);
+  logTeardown(result);
+  if (result.failures.length > 0) {
+    throw result.failures[0]?.error;
+  }
 }
 
 export async function cleanupWorkspace(
@@ -60,16 +110,55 @@ export async function cleanupWorkspace(
     return;
   }
 
-  const result = await worktrees.teardown(config, entries, { force });
-  recordCleanedUpRuns(config, result.removed);
-  logTeardown(result);
-  if (result.failures.length > 0) {
-    throw result.failures[0]?.error;
+  await teardownEntries(config, entries, force);
+}
+
+/**
+ * Tear down every local worktree whose task is not currently in use — that is,
+ * has no live workspace session. Worktrees backed by a running session are left
+ * untouched. Uncommitted work is still protected by teardown's dirtiness guard
+ * unless `--force` is passed.
+ */
+export async function cleanupAllWorkspaces(
+  config: ResolvedConfig,
+  options: CleanupAllOptions,
+): Promise<void> {
+  const { force = false } = options;
+  const entries = worktrees.list(config);
+  if (entries.length === 0) {
+    log("No worktrees found; nothing to clean up.");
+    return;
   }
+
+  const workspaceProbe = await workspaces.probe(config);
+  if (workspaceProbe.kind === "unavailable") {
+    log("Workspace probe unavailable; cannot tell which worktrees are in use, leaving all intact.");
+    return;
+  }
+
+  const idle: WorktreeEntry[] = [];
+  for (const entry of entries) {
+    if (isWorkspaceInUse(workspaceProbe, entry.task)) {
+      log(`Skipping ${entry.task} (${entry.repository}); workspace in use.`);
+      continue;
+    }
+    idle.push(entry);
+  }
+
+  if (idle.length === 0) {
+    log("No idle worktrees to clean up.");
+    return;
+  }
+
+  await teardownEntries(config, idle, force);
 }
 
 export async function cleanupWorkspaceCli(argv: string[]): Promise<void> {
   const config = await loadConfig();
-  const options = parseArguments(argv);
-  await cleanupWorkspace(config, options);
+  const parsed = parseArguments(argv);
+  if (parsed.mode === "all") {
+    await cleanupAllWorkspaces(config, { force: parsed.force });
+    return;
+  }
+  await cleanupWorkspace(config, { task: parsed.task, force: parsed.force });
 }


### PR DESCRIPTION
## Summary

Adds a `--all` flag to `crew cleanup` that tears down **every** local worktree that isn't in use, so you can reclaim idle worktrees in one command instead of naming each task.

- **"In use" = a live workspace session.** A worktree whose task has a running (non-exited) workspace session is skipped. An exited/dead session counts as idle and gets reaped.
- **Fails safe on an unavailable probe.** If the workspace backend can't be queried (`unavailable` = "we don't know"), `--all` removes nothing and says so, rather than guessing a worktree is idle and deleting a live checkout.
- **Uncommitted work stays protected.** Dirty worktrees are guarded by teardown's existing data-loss check unless `--force` is passed; `--force` works with `--all` to discard uncommitted work.
- `--all` combined with a task argument is rejected with a usage error.

Single-task `crew cleanup <task>` behavior is unchanged; both paths share a small `teardownEntries` helper.

## Validation

- `node --run verify` — all checks pass (74 test files; lint, typecheck, format, knip, cspell, architecture, cpd all green).
- TDD: 10 new unit tests in `cleanupWorkspace.test.ts` covering idle teardown, in-use skip, exited-as-idle, unavailable probe, empty/all-in-use, `--force` passthrough, teardown-failure re-throw, and CLI routing/mutual-exclusion.
- Runtime end-to-end against a throwaway config via the built CLI:
  - `crew cleanup --all` (no worktrees) → `No worktrees found; nothing to clean up.` (exit 0)
  - `crew cleanup --all team-1` → mutual-exclusion usage error (exit 1)
  - `crew cleanup --bogus` → unknown-option usage error (exit 1)
  - `crew --help` shows the updated usage line.

## Notes

Scope is on-disk worktrees; orphaned run-state without a worktree is still handled only by the single-task path. README and the `crew --help` usage line are updated.

Agent session: \`claude --resume 2ed09c88-eb43-4fef-8899-986a4f46406c\`

<sub>🤖 <code>cb-ship:created v1 core@3.14.0</code></sub>