### PR TITLE
chore: update @clipboard-health/ai-rules to v2.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.46.1",
+  "version": "4.46.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.46.1",
+      "version": "4.46.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.63",
@@ -21,7 +21,7 @@
         "crew-clearance-ensure": "bin/crewClearanceEnsure.js"
       },
       "devDependencies": {
-        "@clipboard-health/ai-rules": "2.29.1",
+        "@clipboard-health/ai-rules": "2.34.0",
         "@clipboard-health/oxlint-config": "1.12.0",
         "@nx/js": "22.7.5",
         "@tsconfig/node24": "24.0.4",
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@clipboard-health/ai-rules": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.29.1.tgz",
-      "integrity": "sha512-a34bba9h7GaNA5fx18RgjAb2oTBkAQOZNtgyPckAW798okA5gTCEP7dNJOrIO6371GbFFMQ6QKsyvFAHfKWinQ==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.34.0.tgz",
+      "integrity": "sha512-DQprMi+dB3HIOqkCNeTvANbWAowbrlbILd86MYLDYsECQtTEI1Ugipj2X9G2pMdGNp6SNmxVxQ1Wmjv5tm5szg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@clipboard-health/ai-rules": "2.29.1",
+    "@clipboard-health/ai-rules": "2.34.0",
     "@clipboard-health/oxlint-config": "1.12.0",
     "@nx/js": "22.7.5",
     "@tsconfig/node24": "24.0.4",


### PR DESCRIPTION
Summary
===
Update @clipboard-health/ai-rules to v2.34.0 across all repos and run "npm install" to execute sync-ai-rules postinstall script to update memory files (e.g., AGENTS.md, CLAUDE.md).

[_Created by Sourcegraph batch change `rockywarren/update-ai-rules-2.34.0`._](https://clipboardhealth.sourcegraphcloud.com/users/rockywarren/batch-changes/update-ai-rules-2.34.0)