### PR TITLE
feat(adapters): unified task-source catalog and discovery API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,12 @@ export {
 export { getUsageByAgent, type UsageByAgent } from "./lib/usage.ts";
 export { type Board, createBoard } from "./lib/board.ts";
 export { buildSources, buildSourcesWith } from "./lib/buildSources.ts";
-export type { AdapterContext, AdapterDefinition } from "./lib/adapterDefinition.ts";
+export type {
+  AdapterContext,
+  AdapterDefinition,
+  AdapterMeta,
+  AdapterOrigin,
+} from "./lib/adapterDefinition.ts";
 export {
   adapterRegistry,
   type AdapterLoader,
@@ -57,6 +62,9 @@ export {
   buildSourceConfigSchema,
   listAdapterDirectories,
 } from "./lib/adapters/registry.ts";
+export { listTaskSources, type TaskSourceCatalogEntry } from "./lib/adapters/catalog.ts";
+export { getTaskSourceManifest } from "./lib/adapters/shell/discovery.ts";
+export type { SourceManifest } from "./lib/adapters/shell/manifest.ts";
 export {
   AmbiguousTaskError,
   type Blocker as CanonicalBlocker,

--- a/src/lib/adapterDefinition.ts
+++ b/src/lib/adapterDefinition.ts
@@ -20,6 +20,32 @@ export interface AdapterContext {
   readonly globalConfig: ResolvedConfig;
 }
 
+/**
+ * Where an adapter came from. A superset of a manifest's `ManifestOrigin`
+ * (`package | user`, see `./adapters/shell/discovery.ts`): code adapters shipped
+ * in this package are `builtin`, discovered manifests are `package` (bundled) or
+ * `user` (installed under `~/.config/groundcrew/task-sources`).
+ */
+export type AdapterOrigin = "builtin" | "package" | "user";
+
+/**
+ * Descriptive metadata that lets the unified catalog (`./adapters/catalog.ts`)
+ * list every enable-by-kind source uniformly, whatever its runtime. Purely the
+ * descriptor layer; execution stays per-adapter. The generic `shell` adapter
+ * sets `template: true` so it is excluded from the catalog (it is a
+ * bring-your-own-scripts escape hatch, not an installable source).
+ */
+export interface AdapterMeta {
+  /** One-line human summary shown when enumerating installable sources. */
+  readonly description: string;
+  /** True when enabling the source needs a secret/token (e.g. an API key). */
+  readonly requiresCredentials?: boolean;
+  /** True for the generic `shell` escape hatch; excluded from the catalog. */
+  readonly template?: boolean;
+  /** Provenance of the adapter. */
+  readonly origin: AdapterOrigin;
+}
+
 export interface AdapterDefinition<TSchema extends z.ZodType = z.ZodType> {
   /** Discriminator value used in `SourceConfig.kind`. Must equal the directory name. */
   readonly kind: string;
@@ -27,4 +53,10 @@ export interface AdapterDefinition<TSchema extends z.ZodType = z.ZodType> {
   readonly configSchema: TSchema;
   /** Builds a TaskSource from a validated config and the shared adapter context. */
   readonly create: (config: z.infer<TSchema>, context: AdapterContext) => TaskSource;
+  /**
+   * Optional descriptive metadata for the unified source catalog. Every
+   * built-in and manifest adapter sets it; an adapter without `meta` is simply
+   * absent from `listTaskSources()`.
+   */
+  readonly meta?: AdapterMeta;
 }

--- a/src/lib/adapters/catalog.test.ts
+++ b/src/lib/adapters/catalog.test.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+
+import type { AdapterDefinition, AdapterMeta } from "../adapterDefinition.ts";
+import type { TaskSource } from "../taskSource.ts";
+
+import { catalogFromRegistry, listTaskSources } from "./catalog.ts";
+
+function adapterWith(kind: string, meta?: AdapterMeta): AdapterDefinition {
+  return {
+    kind,
+    configSchema: z.object({ kind: z.literal(kind) }),
+    create: () => ({}) as TaskSource,
+    ...(meta === undefined ? {} : { meta }),
+  };
+}
+
+describe(catalogFromRegistry, () => {
+  it("projects each adapter's meta into a catalog row, defaulting requiresCredentials", () => {
+    const registry = {
+      linear: adapterWith("linear", {
+        description: "Linear source",
+        requiresCredentials: true,
+        origin: "builtin",
+      }),
+      "todo-txt": adapterWith("todo-txt", {
+        description: "todo.txt source",
+        origin: "builtin",
+      }),
+    };
+
+    const actual = catalogFromRegistry(registry);
+
+    expect(actual).toStrictEqual([
+      {
+        name: "linear",
+        description: "Linear source",
+        origin: "builtin",
+        requiresCredentials: true,
+      },
+      {
+        name: "todo-txt",
+        description: "todo.txt source",
+        origin: "builtin",
+        requiresCredentials: false,
+      },
+    ]);
+  });
+
+  it("excludes the generic shell template and adapters without meta", () => {
+    const registry = {
+      shell: adapterWith("shell", {
+        description: "escape hatch",
+        template: true,
+        origin: "builtin",
+      }),
+      legacy: adapterWith("legacy"),
+      jira: adapterWith("jira", {
+        description: "JIRA",
+        requiresCredentials: true,
+        origin: "package",
+      }),
+    };
+
+    const actual = catalogFromRegistry(registry);
+
+    expect(actual.map((entry) => entry.name)).toStrictEqual(["jira"]);
+  });
+});
+
+describe(listTaskSources, () => {
+  it("lists the built-in code adapters and the bundled jira manifest, excluding shell", async () => {
+    const catalog = await listTaskSources();
+    const byName = new Map(catalog.map((entry) => [entry.name, entry]));
+
+    expect(byName.has("linear")).toBe(true);
+    expect(byName.has("todo-txt")).toBe(true);
+    expect(byName.has("jira")).toBe(true);
+    expect(byName.has("shell")).toBe(false);
+
+    expect(byName.get("linear")?.requiresCredentials).toBe(true);
+    expect(byName.get("jira")?.origin).toBe("package");
+  });
+});

--- a/src/lib/adapters/catalog.ts
+++ b/src/lib/adapters/catalog.ts
@@ -1,0 +1,61 @@
+/**
+ * Unified task-source catalog: one descriptor list over every enable-by-kind
+ * source, built-in code adapters (`linear`, `todo-txt`) and discovered manifest
+ * sources (`jira`, ...) alike. Only the descriptive layer is unified; execution
+ * stays per-adapter (a code adapter is not reimplemented as a shell manifest).
+ *
+ * Lives above `registry.ts` and `discovery.ts` and imports the registry
+ * one-directionally, so putting `listTaskSources` here (rather than in
+ * `discovery.ts`, which `registry.ts` already imports) keeps the module graph a
+ * DAG. crew-config calls this to enumerate installable sources instead of
+ * hardcoding presets.
+ */
+
+import type { AdapterDefinition, AdapterOrigin } from "../adapterDefinition.ts";
+
+import { adapterRegistry } from "./registry.ts";
+
+/**
+ * One row of the source catalog. `requiresCredentials` is always concrete (an
+ * adapter's optional `meta.requiresCredentials` defaults to `false`) so callers
+ * never branch on `undefined`.
+ */
+export interface TaskSourceCatalogEntry {
+  readonly name: string;
+  readonly description: string;
+  readonly origin: AdapterOrigin;
+  readonly requiresCredentials: boolean;
+}
+
+/**
+ * Pure projection of a merged registry into catalog rows. Adapters without
+ * `meta`, and the generic `shell` template (`meta.template`), are excluded; the
+ * template is a bring-your-own-scripts escape hatch, not an installable source.
+ */
+export function catalogFromRegistry(
+  registry: Record<string, AdapterDefinition>,
+): TaskSourceCatalogEntry[] {
+  const entries: TaskSourceCatalogEntry[] = [];
+  for (const adapter of Object.values(registry)) {
+    const { meta } = adapter;
+    if (meta === undefined || meta.template === true) {
+      continue;
+    }
+    entries.push({
+      name: adapter.kind,
+      description: meta.description,
+      origin: meta.origin,
+      requiresCredentials: meta.requiresCredentials ?? false,
+    });
+  }
+  return entries;
+}
+
+/**
+ * The production catalog: awaits the merged adapter registry (code adapters plus
+ * discovered manifest sources) and projects it into catalog rows.
+ */
+export async function listTaskSources(): Promise<TaskSourceCatalogEntry[]> {
+  const registry = await adapterRegistry;
+  return catalogFromRegistry(registry);
+}

--- a/src/lib/adapters/linear/client.ts
+++ b/src/lib/adapters/linear/client.ts
@@ -14,9 +14,13 @@ export interface ResolvedLinearApiKey {
 export function resolveLinearApiKey(): ResolvedLinearApiKey | undefined {
   for (const source of LINEAR_API_KEY_SOURCES) {
     const value = readEnvironmentVariable(source);
-    if (value !== undefined && value.length > 0) {
-      return { value, source };
+    if (value === undefined) {
+      continue;
     }
+    if (value.length === 0) {
+      continue;
+    }
+    return { value, source };
   }
   return undefined;
 }

--- a/src/lib/adapters/linear/index.ts
+++ b/src/lib/adapters/linear/index.ts
@@ -7,6 +7,12 @@ const definition: AdapterDefinition<typeof linearAdapterConfigSchema> = {
   kind: "linear",
   configSchema: linearAdapterConfigSchema,
   create: createLinearTaskSource,
+  meta: {
+    description:
+      "Pick up Linear issues assigned to your API key's viewer that carry an agent-* label.",
+    requiresCredentials: true,
+    origin: "builtin",
+  },
 };
 
 export default definition;

--- a/src/lib/adapters/registry.test.ts
+++ b/src/lib/adapters/registry.test.ts
@@ -140,13 +140,14 @@ function discovered(name: string): DiscoveredManifest {
 }
 
 describe(mergeManifestAdapters, () => {
-  it("adds a discovered manifest as an adapter keyed by its name", () => {
+  it("adds a discovered manifest as an adapter keyed by its name, carrying the discovery origin", () => {
     const code = { shell: fakeAdapter("shell") };
 
     const merged = mergeManifestAdapters(code, [discovered("jira")]);
 
     expect(Object.keys(merged).toSorted()).toStrictEqual(["jira", "shell"]);
     expect(merged["jira"]?.kind).toBe("jira");
+    expect(merged["jira"]?.meta?.origin).toBe("user");
   });
 
   it("rejects a manifest whose name shadows a built-in adapter kind", () => {

--- a/src/lib/adapters/registry.ts
+++ b/src/lib/adapters/registry.ts
@@ -86,13 +86,13 @@ export function mergeManifestAdapters(
   discovered: readonly DiscoveredManifest[],
 ): Record<string, AdapterDefinition> {
   const merged: Record<string, AdapterDefinition> = { ...codeRegistry };
-  for (const { manifest, manifestDir } of discovered) {
+  for (const { manifest, manifestDir, origin } of discovered) {
     if (codeRegistry[manifest.name]) {
       throw new Error(
         `Task source "${manifest.name}" collides with the built-in "${manifest.name}" adapter. Rename the source manifest.`,
       );
     }
-    merged[manifest.name] = manifestAdapter(manifest, manifestDir);
+    merged[manifest.name] = manifestAdapter(manifest, manifestDir, origin);
   }
   return merged;
 }

--- a/src/lib/adapters/shell/discovery.test.ts
+++ b/src/lib/adapters/shell/discovery.test.ts
@@ -2,7 +2,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { discoverFromRoots, discoverTaskSourceManifests } from "./discovery.ts";
+import {
+  discoverFromRoots,
+  discoverTaskSourceManifests,
+  getTaskSourceManifest,
+} from "./discovery.ts";
 
 function writeBundle(root: string, name: string, listTasks: string): void {
   const dir = path.join(root, name);
@@ -117,6 +121,22 @@ describe("discoverFromRoots", () => {
       expect(manifests.map((m) => m.manifest.name)).toStrictEqual(["jira"]);
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("getTaskSourceManifest", () => {
+  it("returns the manifest for a discovered source and undefined for a code-adapter kind", () => {
+    const home = mkdtempSync(path.join(tmpdir(), "get-manifest-"));
+    vi.stubEnv("XDG_CONFIG_HOME", home);
+    try {
+      writeBundle(path.join(home, "groundcrew", "task-sources"), "acme", "acme list");
+
+      expect(getTaskSourceManifest("acme")?.name).toBe("acme");
+      expect(getTaskSourceManifest("linear")).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(home, { recursive: true, force: true });
     }
   });
 });

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -114,6 +114,10 @@ export function discoverTaskSourceManifests(): DiscoveredManifest[] {
  * so this returns `undefined` for those kinds. Part of the public discovery API
  * so crew-config can read a source's install-time hints (prerequisites,
  * secrets) without re-scanning the roots itself.
+ *
+ * This reads the discovery roots fresh on each call. Prefer
+ * `discoverTaskSourceManifests()` when looking up multiple names in one flow so
+ * callers only pay the filesystem scan once.
  */
 export function getTaskSourceManifest(name: string): SourceManifest | undefined {
   return discoverTaskSourceManifests().find((discovered) => discovered.manifest.name === name)

--- a/src/lib/adapters/shell/discovery.ts
+++ b/src/lib/adapters/shell/discovery.ts
@@ -107,3 +107,15 @@ export function discoverTaskSourceManifests(): DiscoveredManifest[] {
   }
   return manifests;
 }
+
+/**
+ * Look up a single discovered manifest by name (the enable-by-kind `kind`).
+ * Manifest-only: a built-in code adapter (`linear`, `todo-txt`) has no manifest,
+ * so this returns `undefined` for those kinds. Part of the public discovery API
+ * so crew-config can read a source's install-time hints (prerequisites,
+ * secrets) without re-scanning the roots itself.
+ */
+export function getTaskSourceManifest(name: string): SourceManifest | undefined {
+  return discoverTaskSourceManifests().find((discovered) => discovered.manifest.name === name)
+    ?.manifest;
+}

--- a/src/lib/adapters/shell/index.ts
+++ b/src/lib/adapters/shell/index.ts
@@ -7,6 +7,12 @@ const definition: AdapterDefinition<typeof shellAdapterConfigSchema> = {
   kind: "shell",
   configSchema: shellAdapterConfigSchema,
   create: createShellTaskSource,
+  meta: {
+    description: "Bring-your-own task source wired through shell command templates.",
+    // The generic escape hatch, not an installable source: excluded from the catalog.
+    template: true,
+    origin: "builtin",
+  },
 };
 
 export default definition;

--- a/src/lib/adapters/shell/manifestAdapter.test.ts
+++ b/src/lib/adapters/shell/manifestAdapter.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import type { AdapterContext } from "../../adapterDefinition.ts";
 import type { ResolvedConfig } from "../../config.ts";
 
-import { manifestAdapter, shellConfigFromManifest } from "./manifestAdapter.ts";
+import { manifestAdapter, manifestMeta, shellConfigFromManifest } from "./manifestAdapter.ts";
 import type { SourceManifest } from "./manifest.ts";
 
 const fakeContext: AdapterContext = { globalConfig: {} as ResolvedConfig };
@@ -51,15 +51,61 @@ describe("shellConfigFromManifest", () => {
   });
 });
 
+describe("manifestMeta", () => {
+  it("marks a source with secrets as requiring credentials", () => {
+    const actual = manifestMeta(
+      manifestWith({
+        description: "JIRA source",
+        secrets: [{ env: "JIRA_API_TOKEN", file: "jira.token" }],
+      }),
+      "package",
+    );
+
+    expect(actual).toStrictEqual({
+      description: "JIRA source",
+      requiresCredentials: true,
+      origin: "package",
+    });
+  });
+
+  it("marks a secret-free source as not requiring credentials and carries the origin", () => {
+    const actual = manifestMeta(manifestWith({ description: "no secrets" }), "user");
+
+    expect(actual).toStrictEqual({
+      description: "no secrets",
+      requiresCredentials: false,
+      origin: "user",
+    });
+  });
+});
+
 describe("manifestAdapter", () => {
   it("exposes the manifest name as the adapter kind", () => {
-    const adapter = manifestAdapter(manifestWith({ name: "jira" }), "/tmp/x");
+    const adapter = manifestAdapter(manifestWith({ name: "jira" }), "/tmp/x", "package");
 
     expect(adapter.kind).toBe("jira");
     expect(() => adapter.configSchema.parse({ kind: "jira" })).not.toThrow();
     expect(() => adapter.configSchema.parse({ kind: "jira", bogus: true })).toThrow(
       /unrecognized/i,
     );
+  });
+
+  it("derives catalog meta from the manifest and the discovery origin", () => {
+    const adapter = manifestAdapter(
+      manifestWith({
+        name: "jira",
+        description: "JIRA source",
+        secrets: [{ env: "JIRA_API_TOKEN", file: "jira.token" }],
+      }),
+      "/tmp/x",
+      "package",
+    );
+
+    expect(adapter.meta).toStrictEqual({
+      description: "JIRA source",
+      requiresCredentials: true,
+      origin: "package",
+    });
   });
 
   it("installs scripts then builds a shell task source on create", () => {
@@ -70,7 +116,7 @@ describe("manifestAdapter", () => {
       mkdirSync(manifestDir);
       writeFileSync(path.join(manifestDir, "demo.sh"), "#!/bin/sh\n");
       const manifest = manifestWith({ installDir, files: ["demo.sh"] });
-      const adapter = manifestAdapter(manifest, manifestDir);
+      const adapter = manifestAdapter(manifest, manifestDir, "user");
 
       const source = adapter.create({ kind: "demo" }, fakeContext);
 

--- a/src/lib/adapters/shell/manifestAdapter.ts
+++ b/src/lib/adapters/shell/manifestAdapter.ts
@@ -10,7 +10,12 @@
 
 import { z } from "zod";
 
-import type { AdapterContext, AdapterDefinition } from "../../adapterDefinition.ts";
+import type {
+  AdapterContext,
+  AdapterDefinition,
+  AdapterMeta,
+  AdapterOrigin,
+} from "../../adapterDefinition.ts";
 import type { TaskSource } from "../../taskSource.ts";
 
 import { createShellTaskSource } from "./factory.ts";
@@ -39,7 +44,24 @@ export function shellConfigFromManifest(
   };
 }
 
-export function manifestAdapter(manifest: SourceManifest, manifestDir: string): AdapterDefinition {
+/**
+ * Descriptive metadata for the unified catalog, derived from the manifest. A
+ * source `requiresCredentials` when it declares any `secrets`; `origin` is where
+ * discovery found it (bundled `package` vs. user-installed `user`).
+ */
+export function manifestMeta(manifest: SourceManifest, origin: AdapterOrigin): AdapterMeta {
+  return {
+    description: manifest.description,
+    requiresCredentials: (manifest.secrets?.length ?? 0) > 0,
+    origin,
+  };
+}
+
+export function manifestAdapter(
+  manifest: SourceManifest,
+  manifestDir: string,
+  origin: AdapterOrigin,
+): AdapterDefinition {
   const configSchema = z.strictObject({
     kind: z.literal(manifest.name),
     name: z
@@ -68,5 +90,6 @@ export function manifestAdapter(manifest: SourceManifest, manifestDir: string): 
         context,
       );
     },
+    meta: manifestMeta(manifest, origin),
   };
 }

--- a/src/lib/adapters/todo-txt/index.ts
+++ b/src/lib/adapters/todo-txt/index.ts
@@ -7,6 +7,10 @@ const definition: AdapterDefinition<typeof todoTxtAdapterConfigSchema> = {
   kind: "todo-txt",
   configSchema: todoTxtAdapterConfigSchema,
   create: createTodoTxtTaskSource,
+  meta: {
+    description: "Track tasks from a local todo.txt file; no credentials required.",
+    origin: "builtin",
+  },
 };
 
 export default definition;


### PR DESCRIPTION
A single descriptor catalog, derived from the merged adapter registry, makes every enable-by-kind task source enumerable through one API regardless of how it executes. Built-in code adapters (`linear`, `todo-txt`) and discovered manifest sources (`jira`, and anything an external installer drops in) each carry uniform metadata, so crew-config can ask groundcrew what is installable instead of hardcoding presets. Unification is confined to the descriptive layer: execution stays per-adapter, and code adapters keep their in-process TypeScript implementations rather than being re-expressed as shell manifests.

The seam is an optional `AdapterMeta` on `AdapterDefinition` (`description`, `requiresCredentials`, `template`, `origin`). `listTaskSources()` projects the registry through that metadata, skipping the generic `shell` template; `getTaskSourceManifest(name)` is a separate manifest-only lookup for install-time hints. The catalog lives above both the registry and discovery and imports the registry one-directionally, so adding it does not create a `registry <-> discovery` cycle.

This is the third and final part of the enable-task-sources-by-kind series, built on the shell/manifest discovery work merged in #285.

## Requirements

- Enumerate every enable-by-kind source, built-in code adapter and discovered manifest alike, as one list with uniform `{ name, description, origin, requiresCredentials }`.
- `origin` distinguishes `builtin` (shipped code adapter), `package` (bundled manifest), and `user` (installed under `~/.config/groundcrew/task-sources`); it derives from where discovery found each source.
- Exclude the generic `shell` adapter from the catalog: it is the bring-your-own-scripts escape hatch, not an installable source, so it is marked a template.
- `requiresCredentials` for a manifest source is derived, not declared: true iff the manifest lists any `secrets`.
- Expose `getTaskSourceManifest(name)` returning the manifest only for discovered sources; a code-adapter kind has no manifest and returns `undefined`.
- Export `listTaskSources`, `getTaskSourceManifest`, and `SourceManifest` from the package root for crew-config to consume.
- Preserve the existing execution model: no code adapter is reimplemented as a shell manifest, and the generic `{ kind: "shell" }` form stays the full-control escape hatch.
- No new import cycle; the catalog reads the registry one-directionally.

## Decisions

- **`getTaskSourceManifest` reads fresh, not memoized.** `discoverTaskSourceManifests()` is deliberately un-cached so a lookup reflects current on-disk state (a source installed mid-process is visible immediately); only the startup `adapterRegistry` memoizes. Caching the lookup would return stale results and diverge from discovery semantics. If a hot-loop caller ever appears, caching can be added then with explicit invalidation.
- **Code-adapter descriptions are authored inline** (linear/todo-txt/shell) since they have no manifest; manifest sources derive their `description` from `source.json`.

## Validation

`node --run verify` is green: full test suite, 100% branch and line coverage, lint, format, typecheck. The discovery API was also exercised end to end against the live registry, confirming the catalog lists linear/todo-txt/jira, excludes the `shell` template, marks linear as credentialed, reports jira's origin as `package`, and that `getTaskSourceManifest` resolves `jira` while returning `undefined` for a code-adapter kind.
