### PR TITLE
chore: add Devin MCP allow host

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -26,6 +26,7 @@ developers.notion.com
 linear.app
 mcp-proxy.anthropic.com
 mcp.datadoghq.com
+mcp.devin.ai
 mcp.incident.io
 mcp.linear.app
 mcp.notion.com


### PR DESCRIPTION
## Summary

Adds `mcp.devin.ai` to groundcrew's shipped Clearance allowlist so Safehouse-wrapped agents can reach Devin's hosted MCP endpoint without requiring user-specific allowlist overrides.

## Validation

- `node --run verify` (passed)
- Pre-push hook from `git push -u origin chore/add-devin-mcp-allow-host` ran `node --run verify` (passed)

## Notes

No Linear ticket was provided.
`cb-review --effort low --report`: no actionable findings.
Agent session: `codex resume 019f3d2a-b331-79a2-a7a2-c44f97c91d79`

<sub>🤖 <code>cb-ship:created v1 core@3.15.0</code></sub>
