### PR TITLE
fix(worktrees): retry recoverable ENOTEMPTY when removing orphan worktree dirs

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -163,6 +163,7 @@
     "qlmanage",
     "xhigh",
     "mycli",
-    "mcps"
+    "mcps",
+    "APFS"
   ]
 }

--- a/src/lib/worktrees.forceRemove.test.ts
+++ b/src/lib/worktrees.forceRemove.test.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { forceRemoveDirectory, isRecoverableRemovalError } from "./worktrees.ts";
+
+function errorWithCode(code: string): Error {
+  const error = new Error(`${code}: simulated removal failure`);
+  Object.assign(error, { code });
+  return error;
+}
+
+function errorWithNumericCode(): Error {
+  const error = new Error("numeric code");
+  Object.assign(error, { code: 42 });
+  return error;
+}
+
+describe("isRecoverableRemovalError", () => {
+  it("recognizes the recoverable filesystem error codes", () => {
+    expect(isRecoverableRemovalError(errorWithCode("ENOTEMPTY"))).toBe(true);
+    expect(isRecoverableRemovalError(errorWithCode("EBUSY"))).toBe(true);
+  });
+
+  it("rejects a non-recoverable filesystem error code", () => {
+    expect(isRecoverableRemovalError(errorWithCode("EACCES"))).toBe(false);
+  });
+
+  it("rejects values that are not Error instances", () => {
+    expect(isRecoverableRemovalError("ENOTEMPTY")).toBe(false);
+    expect(isRecoverableRemovalError({ code: "ENOTEMPTY" })).toBe(false);
+  });
+
+  it("rejects an Error without a code", () => {
+    expect(isRecoverableRemovalError(new Error("no code"))).toBe(false);
+  });
+
+  it("rejects an Error whose code is not a string", () => {
+    expect(isRecoverableRemovalError(errorWithNumericCode())).toBe(false);
+  });
+});
+
+describe("forceRemoveDirectory", () => {
+  it("removes a real nested directory tree with the default remover", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "groundcrew-force-remove-"));
+    mkdirSync(path.join(root, "left", "deep"), { recursive: true });
+    writeFileSync(path.join(root, "left", "deep", "leaf.txt"), "leaf");
+
+    await forceRemoveDirectory(root);
+
+    expect(existsSync(root)).toBe(false);
+  });
+
+  it("retries a recoverable failure until removal succeeds", async () => {
+    let attemptsMade = 0;
+    const remove = vi.fn<(target: string) => void>(() => {
+      attemptsMade += 1;
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- simulate a transient ENOTEMPTY that clears after two tries.
+      if (attemptsMade < 3) {
+        throw errorWithCode("ENOTEMPTY");
+      }
+    });
+
+    await forceRemoveDirectory("/irrelevant", { remove, attempts: 5, delayMs: 1 });
+
+    expect(remove).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows a non-recoverable error without retrying", async () => {
+    const remove = vi.fn<(target: string) => void>(() => {
+      throw errorWithCode("EACCES");
+    });
+
+    await expect(
+      forceRemoveDirectory("/irrelevant", { remove, attempts: 5, delayMs: 1 }),
+    ).rejects.toThrow("EACCES");
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the configured attempts and rethrows the last recoverable error", async () => {
+    const remove = vi.fn<(target: string) => void>(() => {
+      throw errorWithCode("EBUSY");
+    });
+
+    await expect(
+      forceRemoveDirectory("/irrelevant", { remove, attempts: 3, delayMs: 1 }),
+    ).rejects.toThrow("EBUSY");
+    expect(remove).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -12,6 +12,7 @@
 import { type Dirent, existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { userInfo } from "node:os";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 
 import { applySubstitutions } from "./adapters/shell/invoke.ts";
 import { runCommandAsync } from "./commandRunner.ts";
@@ -533,7 +534,7 @@ async function removeWorktree(
         if (registration !== "orphan") {
           throw error;
         }
-        removeOrphanWorktreeDirectory(config, entry);
+        await removeOrphanWorktreeDirectory(config, entry);
       } else {
         const dirtiness = await throwIfWorktreeDirty(entry, options.signal, error);
         if (dirtiness.kind === "unknown") {
@@ -729,7 +730,64 @@ function isInsideDirectory(parentDir: string, childDir: string): boolean {
   );
 }
 
-function removeOrphanWorktreeDirectory(config: ResolvedConfig, entry: WorktreeEntry): void {
+// APFS reports ENOTEMPTY (and occasionally EBUSY/EPERM) from a recursive rmdir
+// when directory-entry caches lag behind the unlinks that just emptied it. This
+// bites large trees like node_modules, where `rmSync` bails partway through even
+// though a plain `rm -rf` succeeds. Retrying the removal lets the caches settle
+// and drains the remaining entries.
+const RECOVERABLE_REMOVAL_ERROR_CODES = new Set([
+  "ENOTEMPTY",
+  "EBUSY",
+  "EPERM",
+  "EMFILE",
+  "ENFILE",
+]);
+
+export function isRecoverableRemovalError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    RECOVERABLE_REMOVAL_ERROR_CODES.has(error.code)
+  );
+}
+
+export interface ForceRemoveDirectoryOptions {
+  attempts?: number;
+  delayMs?: number;
+  remove?: (target: string) => void;
+}
+
+export async function forceRemoveDirectory(
+  targetDir: string,
+  options: ForceRemoveDirectoryOptions = {},
+): Promise<void> {
+  const attempts = options.attempts ?? 8;
+  const delayMs = options.delayMs ?? 100;
+  const removeDirectory =
+    options.remove ??
+    ((target: string) => {
+      rmSync(target, { recursive: true, force: true });
+    });
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      removeDirectory(targetDir);
+      return;
+    } catch (error) {
+      if (attempt >= attempts || !isRecoverableRemovalError(error)) {
+        throw error;
+      }
+      // oxlint-disable-next-line no-await-in-loop -- retries are intentionally serial with a settle delay between attempts.
+      await sleep(delayMs);
+    }
+  }
+}
+
+async function removeOrphanWorktreeDirectory(
+  config: ResolvedConfig,
+  entry: WorktreeEntry,
+): Promise<void> {
   const worktreeRoot = path.resolve(worktreeBaseDir(config));
   const expectedDir = expectedHostWorktreeDir(config, entry);
   const targetDir = path.resolve(entry.dir);
@@ -739,7 +797,7 @@ function removeOrphanWorktreeDirectory(config: ResolvedConfig, entry: WorktreeEn
     );
   }
   debug(`Removing orphaned worktree directory ${entry.dir} (--force)...`);
-  rmSync(targetDir, { recursive: true, force: true });
+  await forceRemoveDirectory(targetDir);
 }
 
 function list(config: ResolvedConfig): WorktreeEntry[] {


### PR DESCRIPTION
## Why

`crew cleanup --force <task>` intermittently fails with `ENOTEMPTY, Directory not empty` while tearing down a worktree whose git registration is already gone. `git worktree remove` succeeds, but groundcrew's own recursive removal of the leftover directory (`removeOrphanWorktreeDirectory` → `rmSync(dir, { recursive: true, force: true })`) chokes on large `node_modules` trees.

Root cause: on APFS the recursive `rmdir` reports `ENOTEMPTY` when directory-entry caches lag behind the unlinks that just emptied the directory. It fails **deterministically even single-threaded**, while a plain `rm -rf` succeeds instantly on the same path. In `--watch` mode the failed cleanup retries the same worktree every tick and floods `groundcrew.log` (observed: 15k+ `Cleanup failed` lines from a handful of stuck worktrees).

## What

- Add `forceRemoveDirectory(targetDir, options?)`: retries the removal a bounded number of times (default 8, 100 ms settle delay) on recoverable codes `ENOTEMPTY`, `EBUSY`, `EPERM`, `EMFILE`, `ENFILE`; rethrows anything else immediately so genuine failures (e.g. `EACCES`) still surface fast.
- `removeOrphanWorktreeDirectory` now awaits it. No behavior change on the happy path.

## Areas of concern

- Retry is intentionally serial (`no-await-in-loop` suppressed with a reason). Worst case on a truly stuck non-recoverable dir is `attempts × delayMs` before rethrow (~0.8 s at defaults).

## Validation

- New unit tests (`worktrees.forceRemove.test.ts`) cover: real nested-tree removal, retry-then-succeed, immediate rethrow on non-recoverable codes, exhaustion, and the `isRecoverableRemovalError` predicate branches.
- Full `node --run verify` green locally (build, lint, knip, 100% coverage test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TXQnrUFMa6XjiXy9aTUsc