### PR TITLE
fix: enforce host-dir teardown for scripted worktree cleanup

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -529,6 +529,156 @@ describe(remove, () => {
     expect(gitSubcommands).toStrictEqual([]);
   });
 
+  it("remove scrubs the scripted worktree directory when the template returns 0 but leaves it behind", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // Every mocked command returns "" — the template "succeeds" without deleting
+    // the dir. Mirrors a `graft rm ... || true` that no-ops when the provisioner
+    // has no record of the worktree.
+    runCommandMock.mockReturnValue("");
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f || true" },
+        },
+      ],
+    });
+
+    await remove(config, {
+      repository: "billing",
+      task: "team-220",
+      branchName: "paul-team-220",
+      dir: worktreeDir,
+      kind: "host",
+    });
+
+    expect(existsSync(worktreeDir)).toBe(false);
+  });
+
+  it("remove with --force scrubs the scripted worktree directory when the template fails", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // The template shells out and hard-fails (e.g. `graft rm` reports
+    // "worktree ... not found in repo ..."). With --force the caller has
+    // opted into aggressive cleanup, so the host dir must still be scrubbed.
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await remove(
+      config,
+      {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      },
+      { force: true },
+    );
+
+    expect(existsSync(worktreeDir)).toBe(false);
+  });
+
+  it("remove without --force still surfaces a scripted remove template failure", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // Dirty-probe returns clean; the template then throws. Without --force we
+    // must NOT silently mask the failure — the caller relies on it to notice
+    // real provisioner problems (missing binary, permissions, etc.).
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: some other real problem");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await expect(
+      remove(config, {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      }),
+    ).rejects.toThrow(/some other real problem/);
+    // The failed template must not scrub the on-disk dir without --force.
+    expect(existsSync(worktreeDir)).toBe(true);
+  });
+
+  it("remove with --force treats a missing scripted worktree as cleaned when the template fails", async () => {
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    const missingDir = path.join(projectDir, "billing-team-220");
+
+    await expect(
+      remove(
+        config,
+        {
+          repository: "billing",
+          task: "team-220",
+          branchName: "paul-team-220",
+          dir: missingDir, // never created
+          kind: "host",
+        },
+        { force: true },
+      ),
+    ).resolves.toBeUndefined();
+    expect(existsSync(missingDir)).toBe(false);
+  });
+
   it("runs git worktree remove for a host entry whose dir exists", async () => {
     mkdirSync(path.join(projectDir, "repo-a"));
     mkdirSync(path.join(projectDir, "repo-a-team-1"));

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -600,7 +600,25 @@ async function removeScriptedWorktree(
     }),
   );
   debug(`Removing worktree ${entry.dir} via remove template...`);
-  await runLongShellCommand(command, worktreeRoot, options.signal);
+  try {
+    await runLongShellCommand(command, worktreeRoot, options.signal);
+  } catch (error) {
+    if (options.signal?.aborted === true || !options.force) {
+      throw error;
+    }
+    // --force + template failed: fall back to disk cleanup so a half-provisioned
+    // task (provisioner no longer knows about it — e.g. `graft rm` reporting
+    // "not found in repo") isn't permanently stranded. Mirrors the git-native
+    // orphan recovery in removeWorktree above.
+    debug(`Remove template failed under --force; falling back to disk cleanup of ${entry.dir}`);
+  }
+  // Post-condition: groundcrew's on-disk worktree dir is gone. The template is
+  // expected to delete it, but scripted provisioners can no-op (e.g. `graft rm`
+  // paired with `|| true`) and leave the dir behind, which then resurrects the
+  // task on the next listWorktrees() scan.
+  if (existsSync(entry.dir)) {
+    removeOrphanWorktreeDirectory(config, entry);
+  }
 }
 
 export type WorktreeDirtiness =


### PR DESCRIPTION
## Summary

Scripted worktree teardown relied solely on the user's `remove:` template (e.g. `graft rm`) to delete the on-disk worktree directory. Two failure modes escaped recovery:

1. **Provisioner has no record of the worktree** (half-provisioned task, or a template ending in `|| true`): the template errored or no-op'd, but the host dir survived. The next `listWorktrees()` scan resurrected the task in `crew status`.
2. **`crew cleanup --force` couldn't recover either**: a template failure short-circuited teardown instead of falling back to disk cleanup — a gap the git-native path had already closed at `removeOrphanWorktreeDirectory` (`src/lib/worktrees.ts:536`).

Concrete symptom seen locally:

\`\`\`
$ crew cleanup --force cat-66781
Cleanup failed for cat-66781 (host): Command failed: sh -c graft rm 'paulbaranowski-cat-66781' -f --repo carrot
Error: worktree 'paulbaranowski-cat-66781' not found in repo 'carrot'
\`\`\`

## What changed

`removeScriptedWorktree` now:

- Swallows a template failure under `--force`, mirroring the git-native orphan recovery. Non-force teardown still surfaces the failure to preserve the data-loss guard.
- Enforces the post-condition that the host dir is gone after the template runs, scrubbing it via the same safety-bounded `removeOrphanWorktreeDirectory` the git-native path uses (path must equal `expectedHostWorktreeDir` and live inside `worktreeBaseDir`).

Once this ships, users can drop workarounds like `graft rm ${branch} -f || true; rm -rf ${dir}` from their `remove:` template and go back to the plain form — groundcrew enforces the "dir is gone after teardown" contract itself.

## Test plan

- [x] 4 new unit tests in `src/lib/worktrees.test.ts`:
  - Scrubs the dir when the template returns 0 but leaves it behind (the `|| true` case).
  - Scrubs the dir under `--force` when the template fails (the `graft rm ... not found` case).
  - Without `--force`, template failures still surface (regression guard for real provisioner failures — missing binary, permissions, etc.).
  - `--force` + missing dir + failing template resolves successfully with no dir left behind.
- [x] Full `node --run verify` green (all 65 worktree tests pass, plus every other suite; lint, format, cspell, coverage thresholds).