### PR TITLE
fix(worktrees): enforce host-dir teardown for scripted worktree cleanup

### DIFF
--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -538,8 +538,8 @@ describe(remove, () => {
     mkdirSync(worktreeDir, { recursive: true });
     userInfoMock.mockReturnValue(makeUserInfo("paul"));
     // Every mocked command returns "" — the template "succeeds" without deleting
-    // the dir. Mirrors a `graft rm ... || true` that no-ops when the provisioner
-    // has no record of the worktree.
+    // the dir. Mirrors a remove command paired with `|| true` that no-ops when
+    // the provisioner has no record of the worktree.
     runCommandMock.mockReturnValue("");
 
     const config = makeConfig({
@@ -548,7 +548,10 @@ describe(remove, () => {
       repositories: [
         {
           name: "billing",
-          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f || true" },
+          provision: {
+            create: "provision-tool new ${branch}",
+            remove: "provision-tool rm ${branch} -f || true",
+          },
         },
       ],
     });
@@ -568,13 +571,13 @@ describe(remove, () => {
     const worktreeDir = path.join(projectDir, "billing-team-220");
     mkdirSync(worktreeDir, { recursive: true });
     userInfoMock.mockReturnValue(makeUserInfo("paul"));
-    // The template shells out and hard-fails (e.g. `graft rm` reports
+    // The template shells out and hard-fails (e.g. the provisioner reports
     // "worktree ... not found in repo ..."). With --force the caller has
     // opted into aggressive cleanup, so the host dir must still be scrubbed.
     runCommandMock.mockImplementation((command) => {
       // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
       if (command === "sh") {
-        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+        throw new Error("remove failed: worktree 'paul-team-220' not found in repo 'billing'");
       }
       return "";
     });
@@ -585,7 +588,10 @@ describe(remove, () => {
       repositories: [
         {
           name: "billing",
-          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+          provision: {
+            create: "provision-tool new ${branch}",
+            remove: "provision-tool rm ${branch} -f",
+          },
         },
       ],
     });
@@ -615,7 +621,7 @@ describe(remove, () => {
     runCommandMock.mockImplementation((command) => {
       // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
       if (command === "sh") {
-        throw new Error("graft rm failed: some other real problem");
+        throw new Error("remove failed: some other real problem");
       }
       return "";
     });
@@ -626,7 +632,10 @@ describe(remove, () => {
       repositories: [
         {
           name: "billing",
-          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+          provision: {
+            create: "provision-tool new ${branch}",
+            remove: "provision-tool rm ${branch} -f",
+          },
         },
       ],
     });
@@ -649,7 +658,7 @@ describe(remove, () => {
     runCommandMock.mockImplementation((command) => {
       // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
       if (command === "sh") {
-        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+        throw new Error("remove failed: worktree 'paul-team-220' not found in repo 'billing'");
       }
       return "";
     });
@@ -660,7 +669,10 @@ describe(remove, () => {
       repositories: [
         {
           name: "billing",
-          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+          provision: {
+            create: "provision-tool new ${branch}",
+            remove: "provision-tool rm ${branch} -f",
+          },
         },
       ],
     });

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -533,6 +533,156 @@ describe(remove, () => {
     expect(gitSubcommands).toStrictEqual([]);
   });
 
+  it("remove scrubs the scripted worktree directory when the template returns 0 but leaves it behind", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // Every mocked command returns "" — the template "succeeds" without deleting
+    // the dir. Mirrors a `graft rm ... || true` that no-ops when the provisioner
+    // has no record of the worktree.
+    runCommandMock.mockReturnValue("");
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f || true" },
+        },
+      ],
+    });
+
+    await remove(config, {
+      repository: "billing",
+      task: "team-220",
+      branchName: "paul-team-220",
+      dir: worktreeDir,
+      kind: "host",
+    });
+
+    expect(existsSync(worktreeDir)).toBe(false);
+  });
+
+  it("remove with --force scrubs the scripted worktree directory when the template fails", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // The template shells out and hard-fails (e.g. `graft rm` reports
+    // "worktree ... not found in repo ..."). With --force the caller has
+    // opted into aggressive cleanup, so the host dir must still be scrubbed.
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await remove(
+      config,
+      {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      },
+      { force: true },
+    );
+
+    expect(existsSync(worktreeDir)).toBe(false);
+  });
+
+  it("remove without --force still surfaces a scripted remove template failure", async () => {
+    const worktreeDir = path.join(projectDir, "billing-team-220");
+    mkdirSync(worktreeDir, { recursive: true });
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    // Dirty-probe returns clean; the template then throws. Without --force we
+    // must NOT silently mask the failure — the caller relies on it to notice
+    // real provisioner problems (missing binary, permissions, etc.).
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: some other real problem");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    await expect(
+      remove(config, {
+        repository: "billing",
+        task: "team-220",
+        branchName: "paul-team-220",
+        dir: worktreeDir,
+        kind: "host",
+      }),
+    ).rejects.toThrow(/some other real problem/);
+    // The failed template must not scrub the on-disk dir without --force.
+    expect(existsSync(worktreeDir)).toBe(true);
+  });
+
+  it("remove with --force treats a missing scripted worktree as cleaned when the template fails", async () => {
+    userInfoMock.mockReturnValue(makeUserInfo("paul"));
+    runCommandMock.mockImplementation((command) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- the mock discriminates so only the template throws
+      if (command === "sh") {
+        throw new Error("graft rm failed: worktree 'paul-team-220' not found in repo 'billing'");
+      }
+      return "";
+    });
+
+    const config = makeConfig({
+      projectDir,
+      knownRepositories: ["billing"],
+      repositories: [
+        {
+          name: "billing",
+          provision: { create: "graft new ${branch}", remove: "graft rm ${branch} -f" },
+        },
+      ],
+    });
+
+    const missingDir = path.join(projectDir, "billing-team-220");
+
+    await expect(
+      remove(
+        config,
+        {
+          repository: "billing",
+          task: "team-220",
+          branchName: "paul-team-220",
+          dir: missingDir, // never created
+          kind: "host",
+        },
+        { force: true },
+      ),
+    ).resolves.toBeUndefined();
+    expect(existsSync(missingDir)).toBe(false);
+  });
+
   it("runs git worktree remove for a host entry whose dir exists", async () => {
     mkdirSync(path.join(projectDir, "repo-a"));
     mkdirSync(path.join(projectDir, "repo-a-team-1"));

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -608,15 +608,15 @@ async function removeScriptedWorktree(
       throw error;
     }
     // --force + template failed: fall back to disk cleanup so a half-provisioned
-    // task (provisioner no longer knows about it — e.g. `graft rm` reporting
-    // "not found in repo") isn't permanently stranded. Mirrors the git-native
-    // orphan recovery in removeWorktree above.
+    // task (the provisioner no longer knows about it and reports "not found")
+    // isn't permanently stranded. Mirrors the git-native orphan recovery in
+    // removeWorktree above.
     debug(`Remove template failed under --force; falling back to disk cleanup of ${entry.dir}`);
   }
   // Post-condition: groundcrew's on-disk worktree dir is gone. The template is
-  // expected to delete it, but scripted provisioners can no-op (e.g. `graft rm`
-  // paired with `|| true`) and leave the dir behind, which then resurrects the
-  // task on the next listWorktrees() scan.
+  // expected to delete it, but scripted provisioners can no-op (e.g. a remove
+  // command paired with `|| true`) and leave the dir behind, which then
+  // resurrects the task on the next listWorktrees() scan.
   if (existsSync(entry.dir)) {
     await removeOrphanWorktreeDirectory(config, entry);
   }

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -601,7 +601,25 @@ async function removeScriptedWorktree(
     }),
   );
   debug(`Removing worktree ${entry.dir} via remove template...`);
-  await runLongShellCommand(command, worktreeRoot, options.signal);
+  try {
+    await runLongShellCommand(command, worktreeRoot, options.signal);
+  } catch (error) {
+    if (options.signal?.aborted === true || !options.force) {
+      throw error;
+    }
+    // --force + template failed: fall back to disk cleanup so a half-provisioned
+    // task (provisioner no longer knows about it — e.g. `graft rm` reporting
+    // "not found in repo") isn't permanently stranded. Mirrors the git-native
+    // orphan recovery in removeWorktree above.
+    debug(`Remove template failed under --force; falling back to disk cleanup of ${entry.dir}`);
+  }
+  // Post-condition: groundcrew's on-disk worktree dir is gone. The template is
+  // expected to delete it, but scripted provisioners can no-op (e.g. `graft rm`
+  // paired with `|| true`) and leave the dir behind, which then resurrects the
+  // task on the next listWorktrees() scan.
+  if (existsSync(entry.dir)) {
+    await removeOrphanWorktreeDirectory(config, entry);
+  }
 }
 
 export type WorktreeDirtiness =


### PR DESCRIPTION
## What this is

Scripted worktree cleanup now guarantees the on-disk worktree directory is gone when it returns, instead of trusting the remove template to have deleted it.

## Requirements

- A remove template that exits 0 without deleting the directory must not leave the task resurrectable on the next scan.
- Under `--force`, a failing template must not permanently strand a half-provisioned task.
- Without `--force`, a template failure still surfaces as an error (unchanged).
- Abort signals still propagate immediately (unchanged).

## The architecture

Scripted teardown ends with a post-condition check rather than trust: after the remove template runs, `removeScriptedWorktree` verifies the worktree directory is actually gone and scrubs anything left behind via `removeOrphanWorktreeDirectory`, the same disk-cleanup path git-native teardown already uses for orphan recovery.

Previously the function awaited the template and returned, assuming exit 0 meant the directory was deleted. Scripted provisioners can no-op while reporting success (e.g. a remove command paired with `|| true` when the provisioner no longer knows the task), leaving the directory behind; the next `listWorktrees()` scan then finds it and resurrects the task, so cleanup never converges.

Two paths feed the post-condition:

- Template exits 0 but leaves the directory: scrubbed unconditionally.
- Template fails under `--force`: the error is swallowed and cleanup falls back to disk removal, mirroring the git-native orphan recovery in `removeWorktree`. Without `--force` the failure still throws, and a signal abort always rethrows.

Reusing `removeOrphanWorktreeDirectory` means the fallback inherits its existing ENOTEMPTY retry behavior rather than growing a second removal implementation.

## Testing

Four new tests cover the matrix: template exits 0 but leaves the dir, `--force` with a failing template (dir present and dir already gone), and a failing template without `--force` still throwing. Full `node --run verify` (lint, build, coverage-gated tests) is green.

