### PR TITLE
feat: operator-only unsandboxedHooks host-setup for known repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ There is no `linear` config block. Groundcrew reads `GROUNDCREW_LINEAR_API_KEY` 
 - [Runners](./docs/runners.md): Safehouse, Docker Sandboxes, and the `none` escape hatch.
 - [Credentials](./docs/credentials.md): Linear API keys, 1Password, build secrets, and `preLaunch`.
 - [Prepare worktree hooks](./docs/setup-hooks.md): `.groundcrew/config.json` `hooks.prepareWorktree` for per-repo dependency setup.
-- [Operator host setup](./docs/setup-hooks.md#prepareworktreeunsandboxed-operator-only-host-setup): `crew.config.ts` `knownRepositories[].prepareWorktreeUnsandboxed` runs trusted, per-repo setup on the host outside the sandbox.
+- [Operator host setup](./docs/setup-hooks.md#unsandboxedhooks-operator-only-host-setup): `crew.config.ts` `knownRepositories[].unsandboxedHooks.prepareWorktree` runs trusted, per-repo setup on the host outside the sandbox.
 - [Task sources](./docs/task-sources.md): custom shell/Jira/local-plan adapters.
 - [Development](./docs/development.md): local source workflow and README/demo asset regeneration.
 - [Troubleshooting](./docs/troubleshooting.md): common operational pitfalls and fixes.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ There is no `linear` config block. Groundcrew reads `GROUNDCREW_LINEAR_API_KEY` 
 - [Runners](./docs/runners.md): Safehouse, Docker Sandboxes, and the `none` escape hatch.
 - [Credentials](./docs/credentials.md): Linear API keys, 1Password, build secrets, and `preLaunch`.
 - [Prepare worktree hooks](./docs/setup-hooks.md): `.groundcrew/config.json` `hooks.prepareWorktree` for per-repo dependency setup.
+- [Operator host setup](./docs/setup-hooks.md#prepareworktreeunsandboxed-operator-only-host-setup): `crew.config.ts` `knownRepositories[].prepareWorktreeUnsandboxed` runs trusted, per-repo setup on the host outside the sandbox.
 - [Task sources](./docs/task-sources.md): custom shell/Jira/local-plan adapters.
 - [Development](./docs/development.md): local source workflow and README/demo asset regeneration.
 - [Troubleshooting](./docs/troubleshooting.md): common operational pitfalls and fixes.

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -122,7 +122,6 @@
     "sourcegraph",
     "spinup",
     "statusline",
-    "subshell",
     "subshells",
     "teardownreporter",
     "tsgolint",

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -122,6 +122,7 @@
     "sourcegraph",
     "spinup",
     "statusline",
+    "subshell",
     "subshells",
     "teardownreporter",
     "tsgolint",

--- a/config/oxlint.config.ts
+++ b/config/oxlint.config.ts
@@ -50,12 +50,13 @@ export default defineConfig(
         },
         {
           // config.test.ts exhaustively covers config resolution, merging, and
-          // validation for every field (agents, sources, hooks, resumeArgs, …).
-          // Splitting it would scatter the shared loadFreshConfig / writeConfigFile
-          // harness across files without improving readability. Bump the cap.
+          // validation for every field (agents, sources, hooks, resumeArgs,
+          // prepareWorktreeUnsandboxed, …). Splitting it would scatter the shared
+          // loadFreshConfig / writeConfigFile harness across files without improving
+          // readability. Bump the cap.
           files: ["**/config.test.ts"],
           rules: {
-            "max-lines": ["error", 2200],
+            "max-lines": ["error", 2300],
           },
         },
         {

--- a/config/oxlint.config.ts
+++ b/config/oxlint.config.ts
@@ -41,11 +41,12 @@ export default defineConfig(
         {
           // setupWorkspace.test.ts covers launch composition across cmux,
           // tmux, safehouse, srt, sdx, rollback, and CLI source-resolution
-          // paths. Keep those shared mocks together; splitting the file causes
+          // paths, plus per-repo prepareWorktreeUnsandboxed host-command tests.
+          // Keep those shared mocks together; splitting the file causes
           // duplicate module mocks to race under Vitest's parallel runner.
           files: ["**/setupWorkspace.test.ts"],
           rules: {
-            "max-lines": ["error", 2200],
+            "max-lines": ["error", 2300],
           },
         },
         {

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -44,6 +44,13 @@ Net effect: by the time the agent process exists, the values are gone from the e
 
 `preLaunch` runs a host-shell snippet outside Safehouse/sdx before the agent starts. Use it when the agent needs a short-lived credential that must be minted from something the sandbox cannot reach, such as an engineer CLI session in Keychain.
 
+Build secrets are staged whenever either `prepareWorktree` or
+`prepareWorktreeUnsandboxed` is configured. When `prepareWorktreeUnsandboxed`
+is set, it runs on the host before `prepareWorktree` with build secrets sourced;
+`preLaunchEnv` names are scrubbed before it runs so the command cannot read
+agent credentials. After it completes, execution continues with the normal
+sandboxed `prepareWorktree` phase.
+
 The "preLaunch never sees build secrets" contract is enforced differently per runner:
 
 - `runner: "safehouse"`: `preLaunch` runs immediately after `cd`, before `secrets.env` is sourced into the launch shell. `prepareWorktree` then runs inside its own profile-neutral `safehouse-clearance` wrap with `--env-pass=NPM_TOKEN,BUF_TOKEN`; build secrets are unset on the host before the agent's Safehouse wrap is executed.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -32,7 +32,7 @@ Set them in the shell you run `crew` from. Anything not in this list is ignored.
 
 For each task:
 
-1. If a `prepareWorktree` hook is configured and any recognized var is set and non-empty, groundcrew writes `secrets.env` with mode `0600` into the task's temp prompt dir as `KEY='value'` lines.
+1. If a `prepareWorktree` or `prepareWorktreeUnsandboxed` hook is configured and any recognized var is set and non-empty, groundcrew writes `secrets.env` with mode `0600` into the task's temp prompt dir as `KEY='value'` lines.
 2. The launch script sources `secrets.env` with `set -a` so the values are exported into the `prepareWorktree` phase only. Under `sdx`, they are forwarded into the sandbox via `-e KEY` flags.
 3. After `prepareWorktree` completes, the script removes every name in `BUILD_SECRET_NAMES` from the environment and removes the entire prompt dir before executing the agent.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -32,7 +32,7 @@ Set them in the shell you run `crew` from. Anything not in this list is ignored.
 
 For each task:
 
-1. If a `prepareWorktree` or `prepareWorktreeUnsandboxed` hook is configured and any recognized var is set and non-empty, groundcrew writes `secrets.env` with mode `0600` into the task's temp prompt dir as `KEY='value'` lines.
+1. If a `prepareWorktree` or `unsandboxedHooks.prepareWorktree` hook is configured and any recognized var is set and non-empty, groundcrew writes `secrets.env` with mode `0600` into the task's temp prompt dir as `KEY='value'` lines.
 2. The launch script sources `secrets.env` with `set -a` so the values are exported into the `prepareWorktree` phase only. Under `sdx`, they are forwarded into the sandbox via `-e KEY` flags.
 3. After `prepareWorktree` completes, the script removes every name in `BUILD_SECRET_NAMES` from the environment and removes the entire prompt dir before executing the agent.
 
@@ -45,11 +45,11 @@ Net effect: by the time the agent process exists, the values are gone from the e
 `preLaunch` runs a host-shell snippet outside Safehouse/sdx before the agent starts. Use it when the agent needs a short-lived credential that must be minted from something the sandbox cannot reach, such as an engineer CLI session in Keychain.
 
 Build secrets are staged whenever either `prepareWorktree` or
-`prepareWorktreeUnsandboxed` is configured. When `prepareWorktreeUnsandboxed`
-is set, it runs on the host before `prepareWorktree` with build secrets sourced;
-`preLaunchEnv` names are scrubbed before it runs so the command cannot read
-agent credentials. After it completes, execution continues with the normal
-sandboxed `prepareWorktree` phase.
+`unsandboxedHooks.prepareWorktree` is configured. When
+`unsandboxedHooks.prepareWorktree` is set, it runs on the host before
+`prepareWorktree` with build secrets sourced; `preLaunchEnv` names are scrubbed
+before it runs so the command cannot read agent credentials. After it completes,
+execution continues with the normal sandboxed `prepareWorktree` phase.
 
 The "preLaunch never sees build secrets" contract is enforced differently per runner:
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -97,7 +97,7 @@ sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
 ## Docker Sandboxes Setup
 
-`sdx` does not support `prepareWorktreeUnsandboxed`. The sdx container has no
+`sdx` does not support `unsandboxedHooks`. The sdx container has no
 host to run it on; configuring it for an `sdx`-runner repo is a launch-time
 config error. Use `safehouse`, `srt`, or `none` if you need host-side setup.
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -97,6 +97,10 @@ sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
 ## Docker Sandboxes Setup
 
+`sdx` does not support `prepareWorktreeUnsandboxed`. The sdx container has no
+host to run it on; configuring it for an `sdx`-runner repo is a launch-time
+config error. Use `safehouse`, `srt`, or `none` if you need host-side setup.
+
 Each agent that runs under `sdx` needs a `sandbox: { agent: "<sbx-agent>" }` block in `crew.config.ts`. Groundcrew addresses the sandbox as `groundcrew-<agent>` and reuses one existing sandbox per agent across repos and tasks.
 
 First-time setup is manual:

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -94,27 +94,28 @@ This reuses the same `hooks` container and `prepareWorktree` contract as the
 other two layers. It beats `defaults.hooks` but still yields to a committed
 `.groundcrew/config.json` in that repo.
 
-## `prepareWorktreeUnsandboxed` (operator-only host setup)
+## `unsandboxedHooks` (operator-only host setup)
 
 Some setup cannot run in the sandbox — it needs host toolchains, host network
 posture, or writes outside the worktree. For those cases an operator may grant a
-**per-repository** host command:
+**per-repository** host hook. It mirrors the `hooks` container's
+`prepareWorktree` phase, on the opposite side of the sandbox boundary:
 
 ```ts
 // crew.config.ts (operator only)
 knownRepositories: [
   {
     name: "catalog-admin",
-    hooks: { prepareWorktree: "npm ci" }, // runs where the agent runs
-    prepareWorktreeUnsandboxed: "bin/setup", // HOST, explicit opt-in
+    hooks: { prepareWorktree: "npm ci" }, // sandboxed
+    unsandboxedHooks: { prepareWorktree: "bin/setup" }, // HOST, explicit opt-in
   },
 ];
 ```
 
-When both are set, `prepareWorktreeUnsandboxed` runs first on the host, then
-`prepareWorktree` runs sandboxed, then the agent starts.
+When both are set, `unsandboxedHooks.prepareWorktree` runs first on the host,
+then `hooks.prepareWorktree` runs sandboxed, then the agent starts.
 
-**The trust granted.** `prepareWorktreeUnsandboxed` runs on the host shell
+**The trust granted.** `unsandboxedHooks.prepareWorktree` runs on the host shell
 outside any sandbox, with the operator's full host authority, against
 repo-controlled code (lifecycle scripts, `Gemfile`, the repo's own `bin/setup`).
 Grant it only to repositories you trust to run arbitrary code on the host.
@@ -122,9 +123,9 @@ Grant it only to repositories you trust to run arbitrary code on the host.
 **Constraints.**
 
 - **Operator-only.** It is honored only from `crew.config.ts`. Setting
-  `prepareWorktreeUnsandboxed` in a repo-committed `.groundcrew/config.json`
+  `unsandboxedHooks` in a repo-committed `.groundcrew/config.json`
   (top-level or under `hooks`) is a hard config error.
-- **Per-repository only.** There is no `defaults.prepareWorktreeUnsandboxed`;
+- **Per-repository only.** There is no `defaults.unsandboxedHooks`;
   host execution is never a fleet-wide default.
 - **Runner support.** Runs on the host for `safehouse`, `srt`, and `none`. The
   `sdx` runner rejects it at launch — a container has no host to run it on.

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -94,6 +94,44 @@ This reuses the same `hooks` container and `prepareWorktree` contract as the
 other two layers. It beats `defaults.hooks` but still yields to a committed
 `.groundcrew/config.json` in that repo.
 
+## `prepareWorktreeUnsandboxed` (operator-only host setup)
+
+Some setup cannot run in the sandbox — it needs host toolchains, host network
+posture, or writes outside the worktree. For those cases an operator may grant a
+**per-repository** host command:
+
+```ts
+// crew.config.ts (operator only)
+knownRepositories: [
+  {
+    name: "catalog-admin",
+    hooks: { prepareWorktree: "npm ci" }, // sandboxed, always
+    prepareWorktreeUnsandboxed: "bin/setup", // HOST, explicit opt-in
+  },
+];
+```
+
+When both are set, `prepareWorktreeUnsandboxed` runs first on the host, then
+`prepareWorktree` runs sandboxed, then the agent starts.
+
+**The trust granted.** `prepareWorktreeUnsandboxed` runs on the host shell
+outside any sandbox, with the operator's full host authority, against
+repo-controlled code (lifecycle scripts, `Gemfile`, the repo's own `bin/setup`).
+Grant it only to repositories you trust to run arbitrary code on the host.
+
+**Constraints.**
+
+- **Operator-only.** It is honored only from `crew.config.ts`. Setting
+  `prepareWorktreeUnsandboxed` in a repo-committed `.groundcrew/config.json`
+  (top-level or under `hooks`) is a hard config error.
+- **Per-repository only.** There is no `defaults.prepareWorktreeUnsandboxed`;
+  host execution is never a fleet-wide default.
+- **Runner support.** Runs on the host for `safehouse`, `srt`, and `none`. The
+  `sdx` runner rejects it at launch — a container has no host to run it on.
+- **Credentials.** Build secrets are available so `npm`/`bundle` can
+  authenticate; the agent's `preLaunchEnv` names are scrubbed so the command
+  cannot read agent credentials.
+
 ## Examples
 
 Python with uv:

--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -105,7 +105,7 @@ posture, or writes outside the worktree. For those cases an operator may grant a
 knownRepositories: [
   {
     name: "catalog-admin",
-    hooks: { prepareWorktree: "npm ci" }, // sandboxed, always
+    hooks: { prepareWorktree: "npm ci" }, // runs where the agent runs
     prepareWorktreeUnsandboxed: "bin/setup", // HOST, explicit opt-in
   },
 ];

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -527,7 +527,7 @@ describe(openWorkspace, () => {
   });
 
   it("stages the prepareWorktree hook into the launch when one is configured", async () => {
-    resolvePrepareWorktreeCommandMock.mockReturnValue("npm ci");
+    resolvePrepareWorktreeCommandMock.mockReturnValue({ command: "npm ci", source: "operator" });
 
     await openWorkspace(config, {
       input: { kind: "pr", pr: "42" },

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -538,6 +538,39 @@ describe(openWorkspace, () => {
     expect(stagedLaunchScript()).toContain("npm ci");
   });
 
+  it("forwards per-repo hooks to resolvePrepareWorktreeCommand when opening", async () => {
+    const repoConfig = makeConfigWithRepositories(["acme/widgets"]);
+    repoConfig.workspace.repositories = [
+      { name: "acme/widgets", hooks: { prepareWorktree: "npm ci" } },
+    ];
+    resolvePrepareWorktreeCommandMock.mockReturnValue("npm ci");
+
+    await openWorkspace(repoConfig, {
+      input: { kind: "pr", pr: "42" },
+      repository: "acme/widgets",
+      promptText: "go",
+    });
+
+    expect(resolvePrepareWorktreeCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ perRepoHooks: { prepareWorktree: "npm ci" } }),
+    );
+  });
+
+  it("runs a per-repo prepareWorktreeUnsandboxed command on the host when opening", async () => {
+    const repoConfig = makeConfigWithRepositories(["acme/widgets"]);
+    repoConfig.workspace.repositories = [
+      { name: "acme/widgets", prepareWorktreeUnsandboxed: "bin/setup" },
+    ];
+
+    await openWorkspace(repoConfig, {
+      input: { kind: "pr", pr: "42" },
+      repository: "acme/widgets",
+      promptText: "go",
+    });
+
+    expect(stagedLaunchScript()).toContain("(bin/setup); prepare_status=$?");
+  });
+
   it("rolls back the worktree when opening the workspace fails", async () => {
     workspacesOpenMock.mockRejectedValue(new Error("cmux down"));
 

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -527,7 +527,7 @@ describe(openWorkspace, () => {
   });
 
   it("stages the prepareWorktree hook into the launch when one is configured", async () => {
-    resolvePrepareWorktreeCommandMock.mockReturnValue({ command: "npm ci", source: "operator" });
+    resolvePrepareWorktreeCommandMock.mockReturnValue("npm ci");
 
     await openWorkspace(config, {
       input: { kind: "pr", pr: "42" },

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -556,10 +556,10 @@ describe(openWorkspace, () => {
     );
   });
 
-  it("runs a per-repo prepareWorktreeUnsandboxed command on the host when opening", async () => {
+  it("runs a per-repo unsandboxedHooks.prepareWorktree command on the host when opening", async () => {
     const repoConfig = makeConfigWithRepositories(["acme/widgets"]);
     repoConfig.workspace.repositories = [
-      { name: "acme/widgets", prepareWorktreeUnsandboxed: "bin/setup" },
+      { name: "acme/widgets", unsandboxedHooks: { prepareWorktree: "bin/setup" } },
     ];
 
     await openWorkspace(repoConfig, {

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -245,12 +245,12 @@ export async function openWorkspace(
   });
   let srtSettingsDir: string | undefined;
   try {
-    const prepareWorktree = resolvePrepareWorktreeCommand({
+    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       defaultHooks: config.defaults.hooks,
     });
     const secretsFile =
-      prepareWorktree === undefined ? undefined : stageBuildSecrets(stagedPrompt.directory);
+      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(stagedPrompt.directory);
     seedLaunchWorkspaceTrust({
       agentCommandName: inferAgentCommandName(definition.cmd),
       launchDir,
@@ -265,8 +265,7 @@ export async function openWorkspace(
       worktreeDir: created.dir,
       workingDir: launchDir,
       secretsFile,
-      prepareWorktreeCommand: prepareWorktree?.command,
-      prepareWorktreeSource: prepareWorktree?.source,
+      prepareWorktreeCommand,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -245,12 +245,12 @@ export async function openWorkspace(
   });
   let srtSettingsDir: string | undefined;
   try {
-    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
+    const prepareWorktree = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       defaultHooks: config.defaults.hooks,
     });
     const secretsFile =
-      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(stagedPrompt.directory);
+      prepareWorktree === undefined ? undefined : stageBuildSecrets(stagedPrompt.directory);
     seedLaunchWorkspaceTrust({
       agentCommandName: inferAgentCommandName(definition.cmd),
       launchDir,
@@ -265,7 +265,8 @@ export async function openWorkspace(
       worktreeDir: created.dir,
       workingDir: launchDir,
       secretsFile,
-      prepareWorktreeCommand,
+      prepareWorktreeCommand: prepareWorktree?.command,
+      prepareWorktreeSource: prepareWorktree?.source,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -245,12 +245,23 @@ export async function openWorkspace(
   });
   let srtSettingsDir: string | undefined;
   try {
+    const repositoryEntry = config.workspace.repositories.find(
+      (entry) => entry.name === repository,
+    );
     const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
+      // Spread-conditional: exactOptionalPropertyTypes forbids an explicit
+      // `undefined` for an optional field, and the lookup yields undefined for
+      // repos with no hooks. Mirrors setupWorkspace so `crew open` honors the
+      // same per-repo operator hooks as `crew setup`.
+      ...(repositoryEntry?.hooks === undefined ? {} : { perRepoHooks: repositoryEntry.hooks }),
       defaultHooks: config.defaults.hooks,
     });
+    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.prepareWorktreeUnsandboxed;
     const secretsFile =
-      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(stagedPrompt.directory);
+      prepareWorktreeCommand === undefined && prepareWorktreeUnsandboxedCommand === undefined
+        ? undefined
+        : stageBuildSecrets(stagedPrompt.directory);
     seedLaunchWorkspaceTrust({
       agentCommandName: inferAgentCommandName(definition.cmd),
       launchDir,
@@ -266,6 +277,7 @@ export async function openWorkspace(
       workingDir: launchDir,
       secretsFile,
       prepareWorktreeCommand,
+      prepareWorktreeUnsandboxedCommand,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -257,7 +257,7 @@ export async function openWorkspace(
       ...(repositoryEntry?.hooks === undefined ? {} : { perRepoHooks: repositoryEntry.hooks }),
       defaultHooks: config.defaults.hooks,
     });
-    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.prepareWorktreeUnsandboxed;
+    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.unsandboxedHooks?.prepareWorktree;
     const secretsFile =
       prepareWorktreeCommand === undefined && prepareWorktreeUnsandboxedCommand === undefined
         ? undefined

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -917,6 +917,36 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain("npm ci");
   });
 
+  it("runs a per-repo prepareWorktreeUnsandboxed command on the host", async () => {
+    detectHostMock.mockResolvedValue(host());
+    const base = makeConfig({
+      definitions: {
+        claude: {
+          cmd: "claude --permission-mode auto",
+          color: "#fff",
+        },
+      },
+    });
+    const config: ResolvedConfig = {
+      ...base,
+      workspace: {
+        ...base.workspace,
+        repositories: [{ name: "repo-a", prepareWorktreeUnsandboxed: "bin/setup" }],
+      },
+    };
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      task: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      details: { title: "Test Title", description: "Body" },
+    });
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(launchScript).toContain("(bin/setup); prepare_status=$?");
+  });
+
   it("passes groundcrew's bundled clearance allowlist to Safehouse without requiring an export", async () => {
     vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");
     detectHostMock.mockResolvedValue(host());

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -804,15 +804,16 @@ describe(setupWorkspace, () => {
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
     expect(launchScript).toContain("cd '/work/repo-a-team-1'");
-    expect(launchScript).toContain("npm ci");
+    // The prepareWorktree hook runs unsandboxed on the host — no Safehouse wrap.
+    expect(launchScript).toContain("(npm ci); prepare_status=$?");
+    expect(launchScript).not.toContain("safehouse-clearance' sh -c");
     expect(launchScript).not.toContain(".groundcrew/setup.sh");
-    // Both wraps grant the worktree root and git common dir so git works in the
-    // prepareWorktree hook and the agent. The grant flag precedes the wrapped command;
-    // optional flags (e.g. --env-pass from ambient build secrets) may appear between them.
+    // Only the agent wrap grants the worktree root and git common dir (the host
+    // hook already has full git access). The grant flag precedes the wrapped
+    // command; optional flags (e.g. --env-pass) may appear between them.
     const addDirsPattern = `--add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/\\.git'`;
     const safehouseWithDirs = `safehouse-clearance' ${addDirsPattern}`;
-    expect(launchScript).toMatch(new RegExp(`${safehouseWithDirs}(?: --\\S+)* sh -c`));
-    // The agent runs inside the wrap (after prepareWorktree), so the prompt is the sh -c arg.
+    // The agent runs inside the wrap, so the prompt is the sh -c arg.
     expect(launchScript).toMatch(
       new RegExp(`${safehouseWithDirs}(?: --\\S+)* "\\$_safehouse_shim" -c`),
     );

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -804,16 +804,15 @@ describe(setupWorkspace, () => {
     const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
     expect(command).toBe("bash '/tmp/groundcrew-team-1-x/launch.sh'");
     expect(launchScript).toContain("cd '/work/repo-a-team-1'");
-    // The prepareWorktree hook runs unsandboxed on the host — no Safehouse wrap.
-    expect(launchScript).toContain("(npm ci); prepare_status=$?");
-    expect(launchScript).not.toContain("safehouse-clearance' sh -c");
+    expect(launchScript).toContain("npm ci");
     expect(launchScript).not.toContain(".groundcrew/setup.sh");
-    // Only the agent wrap grants the worktree root and git common dir (the host
-    // hook already has full git access). The grant flag precedes the wrapped
-    // command; optional flags (e.g. --env-pass) may appear between them.
+    // Both wraps grant the worktree root and git common dir so git works in the
+    // prepareWorktree hook and the agent. The grant flag precedes the wrapped command;
+    // optional flags (e.g. --env-pass from ambient build secrets) may appear between them.
     const addDirsPattern = `--add-dirs='/work/repo-a-team-1:/tmp/groundcrew-team-1-x/\\.git'`;
     const safehouseWithDirs = `safehouse-clearance' ${addDirsPattern}`;
-    // The agent runs inside the wrap, so the prompt is the sh -c arg.
+    expect(launchScript).toMatch(new RegExp(`${safehouseWithDirs}(?: --\\S+)* sh -c`));
+    // The agent runs inside the wrap (after prepareWorktree), so the prompt is the sh -c arg.
     expect(launchScript).toMatch(
       new RegExp(`${safehouseWithDirs}(?: --\\S+)* "\\$_safehouse_shim" -c`),
     );

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -917,7 +917,7 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain("npm ci");
   });
 
-  it("runs a per-repo prepareWorktreeUnsandboxed command on the host", async () => {
+  it("runs a per-repo unsandboxedHooks.prepareWorktree command on the host", async () => {
     detectHostMock.mockResolvedValue(host());
     const base = makeConfig({
       definitions: {
@@ -931,7 +931,7 @@ describe(setupWorkspace, () => {
       ...base,
       workspace: {
         ...base.workspace,
-        repositories: [{ name: "repo-a", prepareWorktreeUnsandboxed: "bin/setup" }],
+        repositories: [{ name: "repo-a", unsandboxedHooks: { prepareWorktree: "bin/setup" } }],
       },
     };
     mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -141,7 +141,7 @@ export async function setupWorkspace(
       (entry) => entry.name === repository,
     );
     const perRepoHooks = repositoryEntry?.hooks;
-    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.prepareWorktreeUnsandboxed;
+    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.unsandboxedHooks?.prepareWorktree;
     const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       // Spread-conditional rather than a direct assignment: under

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -140,7 +140,7 @@ export async function setupWorkspace(
     const perRepoHooks = config.workspace.repositories.find(
       (entry) => entry.name === repository,
     )?.hooks;
-    const prepareWorktree = resolvePrepareWorktreeCommand({
+    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       // Spread-conditional rather than a direct assignment: under
       // exactOptionalPropertyTypes an optional field can't take an explicit
@@ -148,7 +148,8 @@ export async function setupWorkspace(
       ...(perRepoHooks === undefined ? {} : { perRepoHooks }),
       defaultHooks: config.defaults.hooks,
     });
-    const secretsFile = prepareWorktree === undefined ? undefined : stageBuildSecrets(promptDir);
+    const secretsFile =
+      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
     const completionTaskId = options.completionTaskId ?? task;
     const completionMarkDoneSupported = options.completionMarkDoneSupported ?? true;
     const taskSourceWritePaths =
@@ -172,8 +173,7 @@ export async function setupWorkspace(
       worktreeDir,
       workingDir: launchDir,
       secretsFile,
-      prepareWorktreeCommand: prepareWorktree?.command,
-      prepareWorktreeSource: prepareWorktree?.source,
+      prepareWorktreeCommand,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -137,9 +137,11 @@ export async function setupWorkspace(
     });
     promptDir = stagedPrompt.directory;
 
-    const perRepoHooks = config.workspace.repositories.find(
+    const repositoryEntry = config.workspace.repositories.find(
       (entry) => entry.name === repository,
-    )?.hooks;
+    );
+    const perRepoHooks = repositoryEntry?.hooks;
+    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.prepareWorktreeUnsandboxed;
     const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       // Spread-conditional rather than a direct assignment: under
@@ -149,7 +151,9 @@ export async function setupWorkspace(
       defaultHooks: config.defaults.hooks,
     });
     const secretsFile =
-      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
+      prepareWorktreeCommand === undefined && prepareWorktreeUnsandboxedCommand === undefined
+        ? undefined
+        : stageBuildSecrets(promptDir);
     const completionTaskId = options.completionTaskId ?? task;
     const completionMarkDoneSupported = options.completionMarkDoneSupported ?? true;
     const taskSourceWritePaths =
@@ -174,6 +178,7 @@ export async function setupWorkspace(
       workingDir: launchDir,
       secretsFile,
       prepareWorktreeCommand,
+      prepareWorktreeUnsandboxedCommand,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -140,7 +140,7 @@ export async function setupWorkspace(
     const perRepoHooks = config.workspace.repositories.find(
       (entry) => entry.name === repository,
     )?.hooks;
-    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
+    const prepareWorktree = resolvePrepareWorktreeCommand({
       worktreeDir: launchDir,
       // Spread-conditional rather than a direct assignment: under
       // exactOptionalPropertyTypes an optional field can't take an explicit
@@ -148,8 +148,7 @@ export async function setupWorkspace(
       ...(perRepoHooks === undefined ? {} : { perRepoHooks }),
       defaultHooks: config.defaults.hooks,
     });
-    const secretsFile =
-      prepareWorktreeCommand === undefined ? undefined : stageBuildSecrets(promptDir);
+    const secretsFile = prepareWorktree === undefined ? undefined : stageBuildSecrets(promptDir);
     const completionTaskId = options.completionTaskId ?? task;
     const completionMarkDoneSupported = options.completionMarkDoneSupported ?? true;
     const taskSourceWritePaths =
@@ -173,7 +172,8 @@ export async function setupWorkspace(
       worktreeDir,
       workingDir: launchDir,
       secretsFile,
-      prepareWorktreeCommand,
+      prepareWorktreeCommand: prepareWorktree?.command,
+      prepareWorktreeSource: prepareWorktree?.source,
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -151,16 +151,14 @@ describe(composeAgentLaunch, () => {
       taskSourceWritePaths: ["/Users/dev/v", "/Users/dev/v/.tasks"],
     });
 
-    const shimSetupIndex = launchCommand.indexOf("_safehouse_shim_dir=");
+    const prepareWrapIndex = launchCommand.indexOf("safehouse-clearance' --add-dirs=");
+    const prepareCommandIndex = launchCommand.indexOf("npm ci");
     const agentWrapIndex = launchCommand.indexOf('"$_safehouse_shim" -c');
-    // The host prepareWorktree region (everything before the shim setup) runs
-    // unsandboxed, so it carries no --add-dirs grant at all.
-    const beforeAgent = launchCommand.slice(0, shimSetupIndex);
-    const agentWrap = launchCommand.slice(shimSetupIndex, agentWrapIndex + 200);
+    const prepareWrap = launchCommand.slice(prepareWrapIndex, prepareCommandIndex);
+    const agentWrap = launchCommand.slice(prepareCommandIndex, agentWrapIndex + 200);
 
-    expect(beforeAgent).toContain("(npm ci); prepare_status=$?");
-    expect(beforeAgent).not.toContain("--add-dirs");
-    expect(beforeAgent).not.toContain("/Users/dev/v");
+    expect(prepareWrap).toContain("--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git'");
+    expect(prepareWrap).not.toContain("/Users/dev/v");
     expect(agentWrap).toContain(
       "--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git:/Users/dev/v:/Users/dev/v/.tasks'",
     );

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -148,8 +148,6 @@ describe(composeAgentLaunch, () => {
   it("adds task source write paths only to the Safehouse agent wrap", () => {
     const launchCommand = compose({
       prepareWorktreeCommand: "npm ci",
-      // Operator-authored hook runs on the host, so this asserts the host path.
-      prepareWorktreeSource: "operator",
       taskSourceWritePaths: ["/Users/dev/v", "/Users/dev/v/.tasks"],
     });
 

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -151,14 +151,16 @@ describe(composeAgentLaunch, () => {
       taskSourceWritePaths: ["/Users/dev/v", "/Users/dev/v/.tasks"],
     });
 
-    const prepareWrapIndex = launchCommand.indexOf("safehouse-clearance' --add-dirs=");
-    const prepareCommandIndex = launchCommand.indexOf("npm ci");
+    const shimSetupIndex = launchCommand.indexOf("_safehouse_shim_dir=");
     const agentWrapIndex = launchCommand.indexOf('"$_safehouse_shim" -c');
-    const prepareWrap = launchCommand.slice(prepareWrapIndex, prepareCommandIndex);
-    const agentWrap = launchCommand.slice(prepareCommandIndex, agentWrapIndex + 200);
+    // The host prepareWorktree region (everything before the shim setup) runs
+    // unsandboxed, so it carries no --add-dirs grant at all.
+    const beforeAgent = launchCommand.slice(0, shimSetupIndex);
+    const agentWrap = launchCommand.slice(shimSetupIndex, agentWrapIndex + 200);
 
-    expect(prepareWrap).toContain("--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git'");
-    expect(prepareWrap).not.toContain("/Users/dev/v");
+    expect(beforeAgent).toContain("(npm ci); prepare_status=$?");
+    expect(beforeAgent).not.toContain("--add-dirs");
+    expect(beforeAgent).not.toContain("/Users/dev/v");
     expect(agentWrap).toContain(
       "--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git:/Users/dev/v:/Users/dev/v/.tasks'",
     );

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -242,6 +242,15 @@ describe(composeAgentLaunch, () => {
 
     expect(launchCommand).not.toContain("--add-dirs-ro");
   });
+
+  it("forwards prepareWorktreeUnsandboxed into the launch command", () => {
+    const launchCommand = compose({
+      runner: "none",
+      prepareWorktreeUnsandboxedCommand: "bin/setup",
+    });
+
+    expect(launchCommand).toContain("(bin/setup); prepare_status=$?");
+  });
 });
 
 function configWithTitleFlag(enabled: boolean): ResolvedConfig {

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -148,6 +148,8 @@ describe(composeAgentLaunch, () => {
   it("adds task source write paths only to the Safehouse agent wrap", () => {
     const launchCommand = compose({
       prepareWorktreeCommand: "npm ci",
+      // Operator-authored hook runs on the host, so this asserts the host path.
+      prepareWorktreeSource: "operator",
       taskSourceWritePaths: ["/Users/dev/v", "/Users/dev/v/.tasks"],
     });
 

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -14,7 +14,6 @@ import {
   type LocalRunner,
   type AgentDefinition,
   type NetworkEgressSetting,
-  type PrepareWorktreeSource,
   type ResolvedConfig,
 } from "./config.ts";
 import { detectHostCapabilities } from "./host.ts";
@@ -48,7 +47,6 @@ export function composeAgentLaunch(input: {
   workingDir: string;
   secretsFile?: string | undefined;
   prepareWorktreeCommand?: string | undefined;
-  prepareWorktreeSource?: PrepareWorktreeSource | undefined;
   sandboxName?: string | undefined;
   workspaceKind: WorkspaceKind;
   workerEnvironment?: WorkerEnvironment | undefined;
@@ -78,7 +76,6 @@ export function composeAgentLaunch(input: {
     workingDir: input.workingDir,
     secretsFile: input.secretsFile,
     prepareWorktreeCommand: input.prepareWorktreeCommand,
-    prepareWorktreeSource: input.prepareWorktreeSource,
     runner: input.runner,
     networkEgress: input.networkEgress,
     sandboxName: input.sandboxName,

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -47,6 +47,7 @@ export function composeAgentLaunch(input: {
   workingDir: string;
   secretsFile?: string | undefined;
   prepareWorktreeCommand?: string | undefined;
+  prepareWorktreeUnsandboxedCommand?: string | undefined;
   sandboxName?: string | undefined;
   workspaceKind: WorkspaceKind;
   workerEnvironment?: WorkerEnvironment | undefined;
@@ -76,6 +77,7 @@ export function composeAgentLaunch(input: {
     workingDir: input.workingDir,
     secretsFile: input.secretsFile,
     prepareWorktreeCommand: input.prepareWorktreeCommand,
+    prepareWorktreeUnsandboxedCommand: input.prepareWorktreeUnsandboxedCommand,
     runner: input.runner,
     networkEgress: input.networkEgress,
     sandboxName: input.sandboxName,

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -14,6 +14,7 @@ import {
   type LocalRunner,
   type AgentDefinition,
   type NetworkEgressSetting,
+  type PrepareWorktreeSource,
   type ResolvedConfig,
 } from "./config.ts";
 import { detectHostCapabilities } from "./host.ts";
@@ -47,6 +48,7 @@ export function composeAgentLaunch(input: {
   workingDir: string;
   secretsFile?: string | undefined;
   prepareWorktreeCommand?: string | undefined;
+  prepareWorktreeSource?: PrepareWorktreeSource | undefined;
   sandboxName?: string | undefined;
   workspaceKind: WorkspaceKind;
   workerEnvironment?: WorkerEnvironment | undefined;
@@ -76,6 +78,7 @@ export function composeAgentLaunch(input: {
     workingDir: input.workingDir,
     secretsFile: input.secretsFile,
     prepareWorktreeCommand: input.prepareWorktreeCommand,
+    prepareWorktreeSource: input.prepareWorktreeSource,
     runner: input.runner,
     networkEgress: input.networkEgress,
     sandboxName: input.sandboxName,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1735,6 +1735,40 @@ describe("loadConfig", () => {
     expect(recipe).toStrictEqual({ name: "billing", hooks: { prepareWorktree: "make setup" } });
   });
 
+  it("normalizes per-repo prepareWorktreeUnsandboxed on a repo entry", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: temporary,
+          knownRepositories: [{ name: "billing", prepareWorktreeUnsandboxed: "bin/setup" }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    const [recipe] = config.workspace.repositories;
+    expect(recipe).toStrictEqual({ name: "billing", prepareWorktreeUnsandboxed: "bin/setup" });
+  });
+
+  it("rejects an empty per-repo prepareWorktreeUnsandboxed command", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: temporary,
+          knownRepositories: [{ name: "billing", prepareWorktreeUnsandboxed: " " }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /workspace\.knownRepositories\[0\]\.prepareWorktreeUnsandboxed must be a non-empty string/,
+    );
+  });
+
   it("rejects an empty per-repo prepareWorktree hook", async () => {
     const configPath = writeConfigFile(
       temporary,

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1735,13 +1735,15 @@ describe("loadConfig", () => {
     expect(recipe).toStrictEqual({ name: "billing", hooks: { prepareWorktree: "make setup" } });
   });
 
-  it("normalizes per-repo prepareWorktreeUnsandboxed on a repo entry", async () => {
+  it("normalizes per-repo unsandboxedHooks.prepareWorktree on a repo entry", async () => {
     const configPath = writeConfigFile(
       temporary,
       validConfigSource({
         workspace: {
           projectDir: temporary,
-          knownRepositories: [{ name: "billing", prepareWorktreeUnsandboxed: "bin/setup" }],
+          knownRepositories: [
+            { name: "billing", unsandboxedHooks: { prepareWorktree: "bin/setup" } },
+          ],
         },
       }),
     );
@@ -1749,23 +1751,55 @@ describe("loadConfig", () => {
     const { loadConfig } = await loadFreshConfig();
     const config = await loadConfig();
     const [recipe] = config.workspace.repositories;
-    expect(recipe).toStrictEqual({ name: "billing", prepareWorktreeUnsandboxed: "bin/setup" });
+    expect(recipe).toStrictEqual({
+      name: "billing",
+      unsandboxedHooks: { prepareWorktree: "bin/setup" },
+    });
   });
 
-  it("rejects an empty per-repo prepareWorktreeUnsandboxed command", async () => {
+  it("normalizes an empty per-repo unsandboxedHooks container", async () => {
     const configPath = writeConfigFile(
       temporary,
       validConfigSource({
         workspace: {
           projectDir: temporary,
-          knownRepositories: [{ name: "billing", prepareWorktreeUnsandboxed: " " }],
+          knownRepositories: [{ name: "billing", unsandboxedHooks: {} }],
+        },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    const config = await loadConfig();
+    const [recipe] = config.workspace.repositories;
+    expect(recipe).toStrictEqual({ name: "billing", unsandboxedHooks: {} });
+  });
+
+  it("rejects a per-repo unsandboxedHooks that is not an object", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      `export default { workspace: { projectDir: ${JSON.stringify(temporary)}, knownRepositories: [{ name: "billing", unsandboxedHooks: [] }] }, agents: { definitions: { claude: {} } } };\n`,
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+    const { loadConfig } = await loadFreshConfig();
+    await expect(loadConfig()).rejects.toThrow(
+      /workspace\.knownRepositories\[0\]\.unsandboxedHooks must be an object/,
+    );
+  });
+
+  it("rejects an empty per-repo unsandboxedHooks.prepareWorktree command", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: {
+          projectDir: temporary,
+          knownRepositories: [{ name: "billing", unsandboxedHooks: { prepareWorktree: " " } }],
         },
       }),
     );
     setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
     const { loadConfig } = await loadFreshConfig();
     await expect(loadConfig()).rejects.toThrow(
-      /workspace\.knownRepositories\[0\]\.prepareWorktreeUnsandboxed must be a non-empty string/,
+      /workspace\.knownRepositories\[0\]\.unsandboxedHooks\.prepareWorktree must be a non-empty string/,
     );
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,6 +46,18 @@ export interface HookCommands {
 }
 
 /**
+ * Operator-only hooks that run OUTSIDE the sandbox, on the host shell. Mirrors
+ * the `prepareWorktree` phase name of {@link HookCommands} but is a distinct
+ * type: the two families follow opposite rules (host hooks are operator-only
+ * with no `defaults` cascade), and keeping them separate lets a consumer that
+ * takes an `UnsandboxedHookCommands` be self-documenting about isolation and
+ * lets the two shapes diverge without leaking into each other.
+ */
+export interface UnsandboxedHookCommands {
+  prepareWorktree?: string;
+}
+
+/**
  * Reserved agent name. A task labeled `agent-any` resolves at runtime
  * to the configured agent with the most available session capacity, so
  * `any` cannot itself be a agent. orchestrator.ts imports this constant
@@ -244,16 +256,17 @@ export interface KnownRepository {
    */
   hooks?: HookCommands;
   /**
-   * Operator-only, per-repository setup command run on the HOST shell outside
-   * any sandbox, before the sandboxed `prepareWorktree` and the agent. Honored
-   * ONLY from `crew.config.ts`; a `.groundcrew/config.json` that sets it is a
-   * hard config error (see `repositoryHooks.ts`). There is deliberately no
-   * `defaults` equivalent — host execution is an explicit per-repo grant, never
-   * a global default. Runs the operator's full host authority against
+   * Operator-only, per-repository hooks run on the HOST shell outside any
+   * sandbox. `unsandboxedHooks.prepareWorktree` runs before the sandboxed
+   * `hooks.prepareWorktree` and the agent. Honored ONLY from `crew.config.ts`;
+   * a `.groundcrew/config.json` that sets `unsandboxedHooks` is a hard config
+   * error (see `repositoryHooks.ts`). There is deliberately no `defaults`
+   * equivalent — host execution is an explicit per-repo grant, never a global
+   * default. Runs with the operator's full host authority against
    * repo-controlled code (lifecycle scripts, the repo's own `bin/setup`), so
    * granting it is an explicit trust decision.
    */
-  prepareWorktreeUnsandboxed?: string;
+  unsandboxedHooks?: UnsandboxedHookCommands;
 }
 
 export interface Config {
@@ -741,6 +754,27 @@ function normalizeHookCommands(value: unknown, configKey: string): HookCommands 
   return hooks;
 }
 
+// Caller guards `entry.unsandboxedHooks !== undefined`, so unlike
+// `normalizeHookCommands` (also reached via `defaults.hooks`) this never sees
+// `undefined` — there is deliberately no `defaults.unsandboxedHooks`.
+function normalizeUnsandboxedHookCommands(
+  value: unknown,
+  configKey: string,
+): UnsandboxedHookCommands {
+  if (!isPlainObject(value)) {
+    fail(`${configKey} must be an object`);
+  }
+  const hooks: UnsandboxedHookCommands = {};
+  const prepareWorktree = normalizeOptionalString(
+    value["prepareWorktree"],
+    `${configKey}.prepareWorktree`,
+  );
+  if (prepareWorktree !== undefined) {
+    hooks.prepareWorktree = prepareWorktree;
+  }
+  return hooks;
+}
+
 function normalizeDefaults(value: unknown): ResolvedConfig["defaults"] {
   if (value === undefined) {
     return { hooks: {} };
@@ -1195,12 +1229,11 @@ function normalizeKnownRepository(entry: string | KnownRepository, index: number
   if (entry.hooks !== undefined) {
     recipe.hooks = normalizeHookCommands(entry.hooks, `${label}.hooks`);
   }
-  const prepareWorktreeUnsandboxed = normalizeOptionalString(
-    entry.prepareWorktreeUnsandboxed,
-    `${label}.prepareWorktreeUnsandboxed`,
-  );
-  if (prepareWorktreeUnsandboxed !== undefined) {
-    recipe.prepareWorktreeUnsandboxed = prepareWorktreeUnsandboxed;
+  if (entry.unsandboxedHooks !== undefined) {
+    recipe.unsandboxedHooks = normalizeUnsandboxedHookCommands(
+      entry.unsandboxedHooks,
+      `${label}.unsandboxedHooks`,
+    );
   }
   return recipe;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -243,6 +243,17 @@ export interface KnownRepository {
    * they don't want to (or can't) commit a `.groundcrew/config.json` into.
    */
   hooks?: HookCommands;
+  /**
+   * Operator-only, per-repository setup command run on the HOST shell outside
+   * any sandbox, before the sandboxed `prepareWorktree` and the agent. Honored
+   * ONLY from `crew.config.ts`; a `.groundcrew/config.json` that sets it is a
+   * hard config error (see `repositoryHooks.ts`). There is deliberately no
+   * `defaults` equivalent — host execution is an explicit per-repo grant, never
+   * a global default. Runs the operator's full host authority against
+   * repo-controlled code (lifecycle scripts, the repo's own `bin/setup`), so
+   * granting it is an explicit trust decision.
+   */
+  prepareWorktreeUnsandboxed?: string;
 }
 
 export interface Config {
@@ -1183,6 +1194,13 @@ function normalizeKnownRepository(entry: string | KnownRepository, index: number
   }
   if (entry.hooks !== undefined) {
     recipe.hooks = normalizeHookCommands(entry.hooks, `${label}.hooks`);
+  }
+  const prepareWorktreeUnsandboxed = normalizeOptionalString(
+    entry.prepareWorktreeUnsandboxed,
+    `${label}.prepareWorktreeUnsandboxed`,
+  );
+  if (prepareWorktreeUnsandboxed !== undefined) {
+    recipe.prepareWorktreeUnsandboxed = prepareWorktreeUnsandboxed;
   }
   return recipe;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,6 +46,16 @@ export interface HookCommands {
 }
 
 /**
+ * Which configuration layer supplied a resolved `prepareWorktree` hook.
+ * `"repository"` means the repo-committed `.groundcrew/config.json` — untrusted,
+ * because repository authors control it. `"operator"` means the operator's own
+ * `crew.config.ts` (`knownRepositories[].hooks` or `defaults.hooks`). The
+ * safehouse runner sandboxes `"repository"` hooks and runs `"operator"` hooks on
+ * the host, so this provenance is a security boundary, not a cosmetic label.
+ */
+export type PrepareWorktreeSource = "repository" | "operator";
+
+/**
  * Reserved agent name. A task labeled `agent-any` resolves at runtime
  * to the configured agent with the most available session capacity, so
  * `any` cannot itself be a agent. orchestrator.ts imports this constant

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,16 +46,6 @@ export interface HookCommands {
 }
 
 /**
- * Which configuration layer supplied a resolved `prepareWorktree` hook.
- * `"repository"` means the repo-committed `.groundcrew/config.json` — untrusted,
- * because repository authors control it. `"operator"` means the operator's own
- * `crew.config.ts` (`knownRepositories[].hooks` or `defaults.hooks`). The
- * safehouse runner sandboxes `"repository"` hooks and runs `"operator"` hooks on
- * the host, so this provenance is a security boundary, not a cosmetic label.
- */
-export type PrepareWorktreeSource = "repository" | "operator";
-
-/**
  * Reserved agent name. A task labeled `agent-any` resolves at runtime
  * to the configured agent with the most available session capacity, so
  * `any` cannot itself be a agent. orchestrator.ts imports this constant

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -32,10 +32,6 @@ function arguments_(
     workingDir: worktreeDir,
     runner: "safehouse",
     networkEgress: "allowlisted",
-    // Default to a trusted operator hook so the many host-run prepareWorktree
-    // assertions below exercise the operator path; repo/unknown provenance is
-    // covered by dedicated tests that override this.
-    prepareWorktreeSource: "operator",
     ...overrides,
   };
 }
@@ -290,68 +286,6 @@ describe(buildLaunchCommand, () => {
     expect(agentWrapIndex).toBeGreaterThan(shimIndex);
     expect(agentIndex).toBeGreaterThan(agentWrapIndex);
     expect(out.slice(agentWrapIndex)).not.toContain("npm ci");
-  });
-
-  it("sandboxes a repo-authored prepareWorktree hook instead of running it on the host", () => {
-    const out = buildLaunchCommand(
-      arguments_({ prepareWorktreeCommand: "npm ci", prepareWorktreeSource: "repository" }),
-    );
-
-    const prepareWrapIndex = out.indexOf("safehouse-clearance' sh -c");
-    const shimIndex = out.indexOf("_safehouse_shim_dir=$(mktemp");
-    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
-
-    // The untrusted repo hook runs inside a Safehouse wrap as `sh -c '<hook>'`...
-    expect(out).toContain("safehouse-clearance' sh -c '(npm ci); prepare_status=$?");
-    // ...and never as a bare host `&&` chain element.
-    expect(out).not.toContain("&& (npm ci); prepare_status=$?");
-    // Sandboxed prepare wrap precedes the agent shim wrap.
-    expect(prepareWrapIndex).toBeGreaterThan(-1);
-    expect(shimIndex).toBeGreaterThan(prepareWrapIndex);
-    expect(agentWrapIndex).toBeGreaterThan(shimIndex);
-  });
-
-  it("sandboxes the prepareWorktree hook when its provenance is unknown (fails safe)", () => {
-    const out = buildLaunchCommand(
-      arguments_({ prepareWorktreeCommand: "npm ci", prepareWorktreeSource: undefined }),
-    );
-
-    expect(out).toContain("safehouse-clearance' sh -c '(npm ci); prepare_status=$?");
-    expect(out).not.toContain("&& (npm ci); prepare_status=$?");
-  });
-
-  it("forwards build secrets into the sandboxed repo prepareWorktree wrap only, never the agent wrap", () => {
-    const out = buildLaunchCommand(
-      arguments_({
-        prepareWorktreeCommand: "npm ci",
-        prepareWorktreeSource: "repository",
-        secretsFile: "/tmp/prompt-team-1/secrets.env",
-      }),
-    );
-
-    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
-    const envPassFlag = `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
-
-    // The sandboxed prepare wrap forwards build secrets so `npm ci` can auth...
-    expect(out).toContain(`${envPassFlag}sh -c '(npm ci); prepare_status=$?`);
-    // ...and they are unset on the host before the agent wrap, so it never sees them.
-    expect(out).toContain(`unset ${BUILD_SECRET_NAMES.join(" ")}`);
-    expect(out.slice(agentWrapIndex - 200, agentWrapIndex)).not.toContain(envPassFlag);
-  });
-
-  it("grants safehouseAddDirs to the sandboxed repo prepareWorktree wrap so it can reach git", () => {
-    const out = buildLaunchCommand(
-      arguments_({
-        prepareWorktreeCommand: "npm ci",
-        prepareWorktreeSource: "repository",
-        safehouseAddDirs: ["/work/repo-a-team-1", "/src/carrot/.git"],
-      }),
-    );
-
-    const addDirsFlag = "--add-dirs='/work/repo-a-team-1:/src/carrot/.git'";
-    // Both the sandboxed prepare wrap and the agent wrap get the git grant.
-    expect(out).toContain(`${addDirsFlag} sh -c '(npm ci); prepare_status=$?`);
-    expect(out).toContain(`${addDirsFlag} "$_safehouse_shim" -c`);
   });
 
   it("skips the prepareWorktree phase when no hook command is configured", () => {

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -754,6 +754,37 @@ describe(buildLaunchCommand, () => {
       expect(execIndex).toBeGreaterThan(unsetIndex);
       expect(out).not.toContain("--env-pass");
     });
+
+    it("runs prepareWorktreeUnsandboxed on the host before prepareWorktree", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          runner: "none",
+          prepareWorktreeUnsandboxedCommand: "bin/setup",
+          prepareWorktreeCommand: "npm ci",
+        }),
+      );
+
+      const unsandboxedIndex = out.indexOf("bin/setup");
+      const prepareIndex = out.indexOf("npm ci");
+      const agentIndex = out.indexOf("exec claude");
+      expect(unsandboxedIndex).toBeGreaterThan(-1);
+      expect(prepareIndex).toBeGreaterThan(unsandboxedIndex);
+      expect(agentIndex).toBeGreaterThan(prepareIndex);
+      // Both run with status reporting so a failure is surfaced, not swallowed.
+      expect(out).toContain("(bin/setup); prepare_status=$?");
+    });
+
+    it("scrubs preLaunchEnv names inside the prepareWorktreeUnsandboxed subshell", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          runner: "none",
+          definition: { cmd: "claude", color: "#fff", preLaunchEnv: ["TOKEN"] },
+          prepareWorktreeUnsandboxedCommand: "bin/setup",
+        }),
+      );
+
+      expect(out).toContain("(unset TOKEN; bin/setup); prepare_status=$?");
+    });
   });
 
   describe("EXIT-trap promptDir cleanup", () => {

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -832,6 +832,35 @@ describe(buildLaunchCommand, () => {
       expect(out).toContain("(bin/setup); prepare_status=$?");
     });
 
+    it("does not launch the agent when a prerequisite before prepareWorktreeUnsandboxed fails", () => {
+      const markerDir = mkdtempSync(path.join(tmpdir(), "groundcrew-host-hook-marker-"));
+      const promptDir = mkdtempSync(path.join(tmpdir(), "groundcrew-host-hook-prompt-"));
+      const promptFile = path.join(promptDir, "prompt.txt");
+      const agentMarker = path.join(markerDir, "agent-ran");
+      const missingWorktreeDir = path.join(markerDir, "missing-worktree");
+      try {
+        writeFileSync(promptFile, "the prompt body\n");
+        const out = buildLaunchCommand(
+          arguments_({
+            runner: "none",
+            promptFile,
+            worktreeDir: missingWorktreeDir,
+            prepareWorktreeUnsandboxedCommand: "true",
+            definition: { cmd: `touch '${agentMarker}'`, color: "#fff" },
+            omitPromptArgument: true,
+          }),
+        );
+
+        const result = spawnSync("sh", ["-c", out]);
+
+        expect(result.status).not.toBe(0);
+        expect(() => statSync(agentMarker)).toThrow(/ENOENT/);
+      } finally {
+        rmSync(markerDir, { recursive: true, force: true });
+        rmSync(promptDir, { recursive: true, force: true });
+      }
+    });
+
     it("scrubs preLaunchEnv names inside the prepareWorktreeUnsandboxed subshell", () => {
       const out = buildLaunchCommand(
         arguments_({

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -694,6 +694,44 @@ describe(buildLaunchCommand, () => {
     });
   });
 
+  describe("prepareWorktreeUnsandboxed (runner=safehouse)", () => {
+    it("runs prepareWorktreeUnsandboxed on the host before the sandboxed prepareWorktree wrap", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          prepareWorktreeUnsandboxedCommand: "bin/setup",
+          prepareWorktreeCommand: "npm ci",
+        }),
+      );
+
+      const unsandboxedIndex = out.indexOf("(bin/setup); prepare_status=$?");
+      const sandboxedWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+      const npmIndex = out.indexOf("npm ci");
+      const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
+
+      // The unsandboxed host command runs first, and is NOT inside a safehouse wrap.
+      expect(unsandboxedIndex).toBeGreaterThan(-1);
+      expect(unsandboxedIndex).toBeLessThan(sandboxedWrapIndex);
+      // prepareWorktree still runs inside the safehouse prepare wrap.
+      expect(sandboxedWrapIndex).toBeGreaterThan(-1);
+      expect(npmIndex).toBeGreaterThan(sandboxedWrapIndex);
+      expect(agentWrapIndex).toBeGreaterThan(npmIndex);
+      // bin/setup is on the host, not wrapped by safehouse-clearance.
+      expect(out).not.toContain("safehouse-clearance' sh -c '(bin/setup)");
+    });
+
+    it("runs prepareWorktreeUnsandboxed on the host even when no sandboxed prepareWorktree is set", () => {
+      const out = buildLaunchCommand(
+        arguments_({ prepareWorktreeUnsandboxedCommand: "bin/setup" }),
+      );
+
+      expect(out).toContain("(bin/setup); prepare_status=$?");
+      // No sandboxed prepare wrap when prepareWorktree is unset.
+      expect(out).not.toContain("safehouse-clearance' sh -c");
+      // The agent wrap still runs.
+      expect(out).toContain('"$_safehouse_shim" -c');
+    });
+  });
+
   describe("runner='none'", () => {
     it("execs the agent directly without the safehouse wrapper", () => {
       const out = buildLaunchCommand(arguments_({ runner: "none" }));

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -259,11 +259,10 @@ describe(`${buildLaunchCommand.name} (runner='srt')`, () => {
 });
 
 describe(buildLaunchCommand, () => {
-  it("runs prepareWorktree under plain Safehouse, then runs only the agent through the profile shim", () => {
+  it("runs prepareWorktree on the host, then runs only the agent through the profile shim", () => {
     const out = buildLaunchCommand(arguments_({ prepareWorktreeCommand: "npm ci" }));
 
-    const setupWrapIndex = out.indexOf("safehouse-clearance' sh -c");
-    const setupIndex = out.indexOf("npm ci");
+    const setupIndex = out.indexOf("(npm ci); prepare_status=$?");
     const shimIndex = out.indexOf("_safehouse_shim_dir=$(mktemp");
     const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
     const agentIndex = out.indexOf(`exec claude "$@"`);
@@ -271,18 +270,18 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain("cd '/work/repo-a-team-1'");
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
-    expect(out).toContain(
-      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -c",
-    );
+    // The prepareWorktree hook runs unsandboxed on the host — no Safehouse wrap.
+    expect(out).not.toContain("safehouse-clearance' sh -c");
+    // Only the agent runs through the Safehouse profile shim.
     expect(out).toContain(
       '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -c',
     );
     expect(out).not.toContain("--enable=all-agents");
-    expect(out).toContain("npm ci");
+    expect(out).toContain("(npm ci); prepare_status=$?");
     expect(out).toContain(`exec claude "$@"`);
     expect(out).toContain('sh "$_p"; _safehouse_status=$?');
-    expect(setupWrapIndex).toBeGreaterThan(-1);
-    expect(setupIndex).toBeGreaterThan(setupWrapIndex);
+    // Host hook precedes the shim setup, which precedes the agent wrap.
+    expect(setupIndex).toBeGreaterThan(-1);
     expect(shimIndex).toBeGreaterThan(setupIndex);
     expect(agentWrapIndex).toBeGreaterThan(shimIndex);
     expect(agentIndex).toBeGreaterThan(agentWrapIndex);
@@ -298,7 +297,7 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain('"$_safehouse_shim" -c');
   });
 
-  it("grants the worktree root and git common dir to both safehouse wraps via --add-dirs", () => {
+  it("grants the worktree root and git common dir to the agent wrap via --add-dirs", () => {
     const out = buildLaunchCommand(
       arguments_({
         prepareWorktreeCommand: "npm ci",
@@ -307,13 +306,13 @@ describe(buildLaunchCommand, () => {
     );
 
     const addDirsFlag = "--add-dirs='/work/repo-a-team-1:/src/carrot/.git'";
-    // One grant per wrap: the prepareWorktree wrap (so the hook's git/npm can
-    // reach the checkout) and the agent wrap (so git works inside a graft /
-    // sparse-checkout worktree whose real `.git` lives outside the worktree
-    // tree — e.g. an external `~/carrot/.git`).
-    expect(out.split(addDirsFlag).length - 1).toBe(2);
-    expect(out).toContain(`${addDirsFlag} sh -c`);
+    // The prepareWorktree hook runs unsandboxed on the host (full git access), so
+    // only the agent wrap needs the grant — so git works inside a graft /
+    // sparse-checkout worktree whose real `.git` lives outside the worktree tree
+    // (e.g. an external `~/carrot/.git`).
+    expect(out.split(addDirsFlag).length - 1).toBe(1);
     expect(out).toContain(`${addDirsFlag} "$_safehouse_shim" -c`);
+    expect(out).not.toContain(`${addDirsFlag} sh -c`);
   });
 
   it("forwards worker completion env into the Safehouse agent wrap only", () => {
@@ -438,7 +437,8 @@ describe(buildLaunchCommand, () => {
       }),
     );
 
-    const prepareWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+    const prepareIndex = out.indexOf("(npm ci); prepare_status=$?");
+    const shimSetupIndex = out.indexOf("_safehouse_shim_dir=");
     const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
     const readOnlyGrantIndex = out.indexOf(
       "--add-dirs-ro='/Applications/cmux.app:/Users/dev/.local/state/cmux'",
@@ -446,21 +446,22 @@ describe(buildLaunchCommand, () => {
     const envPassIndex = out.indexOf(
       "--env-pass=CMUX_SURFACE_ID,CMUX_SOCKET_PATH,CMUX_CLAUDE_WRAPPER_SHIM,CMUX_CLAUDE_WRAPPER_SHIM_ROOT,CMUX_CUSTOM_CLAUDE_PATH",
     );
-    const shimSetupIndex = out.indexOf("_safehouse_shim_dir=", prepareWrapIndex);
     const preludeIndex = out.indexOf("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
     const execIndex = out.indexOf('exec claude --permission-mode auto "$@"');
-    expect(prepareWrapIndex).toBeGreaterThan(-1);
-    expect(readOnlyGrantIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(prepareIndex).toBeGreaterThan(-1);
+    expect(readOnlyGrantIndex).toBeGreaterThan(prepareIndex);
     expect(readOnlyGrantIndex).toBeLessThan(agentWrapIndex);
-    expect(envPassIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(envPassIndex).toBeGreaterThan(prepareIndex);
     expect(envPassIndex).toBeLessThan(agentWrapIndex);
     expect(preludeIndex).toBeGreaterThan(agentWrapIndex);
     expect(execIndex).toBeGreaterThan(preludeIndex);
-    expect(shimSetupIndex).toBeGreaterThan(prepareWrapIndex);
-    const prepareWrap = out.slice(prepareWrapIndex, shimSetupIndex);
-    expect(prepareWrap).not.toContain("--add-dirs-ro");
-    expect(prepareWrap).not.toContain("CMUX_SURFACE_ID");
-    expect(prepareWrap).not.toContain("CMUX_SOCKET_PATH");
+    expect(shimSetupIndex).toBeGreaterThan(prepareIndex);
+    // The host prepareWorktree region (everything up to the shim setup) carries
+    // none of the agent-only cmux grants.
+    const beforeAgent = out.slice(0, shimSetupIndex);
+    expect(beforeAgent).not.toContain("--add-dirs-ro");
+    expect(beforeAgent).not.toContain("CMUX_SURFACE_ID");
+    expect(beforeAgent).not.toContain("CMUX_SOCKET_PATH");
     expect(out).not.toContain("_groundcrew_path_without_cmux");
   });
 
@@ -650,7 +651,7 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("--env-pass");
     });
 
-    it("sources secrets on the host, forwards them only to prepareWorktree, and clears them before the agent", () => {
+    it("sources build secrets on the host for the prepareWorktree hook, then clears them before the agent", () => {
       const out = buildLaunchCommand(
         arguments_({
           secretsFile: "/tmp/prompt-team-1/secrets.env",
@@ -659,24 +660,21 @@ describe(buildLaunchCommand, () => {
       );
 
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
-      const setupWrapIndex = out.indexOf(
-        "safehouse-clearance' --env-pass=NPM_TOKEN,BUF_TOKEN sh -c",
-      );
-      const setupIndex = out.indexOf("prepare_status=$?");
+      const setupIndex = out.indexOf("(npm ci); prepare_status=$?");
       const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
       const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
       const agentIndex = out.indexOf(`exec claude "$@"`);
 
-      // Secrets are sourced into the host shell before the wrap so Safehouse can
-      // forward them into prepareWorktree; the agent Safehouse process never gets them.
+      // Secrets are sourced into the host shell before the hook runs, so the
+      // host-run prepareWorktree inherits them directly — no --env-pass, no
+      // Safehouse prepare wrap. They are cleared before the agent wrap.
       expect(sourceIndex).toBeGreaterThan(-1);
-      expect(setupWrapIndex).toBeGreaterThan(sourceIndex);
-      expect(out).toContain("--env-pass=NPM_TOKEN,BUF_TOKEN");
-      expect(setupIndex).toBeGreaterThan(setupWrapIndex);
+      expect(setupIndex).toBeGreaterThan(sourceIndex);
+      expect(out).not.toContain("--env-pass=NPM_TOKEN");
+      expect(out).not.toContain("safehouse-clearance' --env-pass");
       expect(unsetIndex).toBeGreaterThan(setupIndex);
       expect(agentWrapIndex).toBeGreaterThan(unsetIndex);
       expect(agentIndex).toBeGreaterThan(agentWrapIndex);
-      expect(out.slice(agentWrapIndex)).not.toContain("--env-pass");
       expect(out.slice(agentWrapIndex)).not.toContain("unset NPM_TOKEN");
       expect(out).toContain(
         "if [ -f '/tmp/prompt-team-1/secrets.env' ]; then set -a && . '/tmp/prompt-team-1/secrets.env' && set +a; fi",
@@ -914,24 +912,24 @@ describe(buildLaunchCommand, () => {
       const preLaunchIndex = out.indexOf("export FOO=bar");
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
       const readPromptIndex = out.indexOf("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
-      const setupWrapIndex = out.indexOf("safehouse-clearance");
+      const prepareIndex = out.indexOf("(npm ci); prepare_status=$?");
       // Two `unset NPM_TOKEN BUF_TOKEN` occurrences now: the first scrubs the
       // inherited env before preLaunch, the last clears the file-sourced
-      // values between the prepareWorktree and agent wraps.
+      // values between the host prepareWorktree hook and the agent wrap.
       const scrubUnsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
       const betweenWrapsUnsetIndex = out.lastIndexOf("unset NPM_TOKEN BUF_TOKEN");
       const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
       // trap → cd → unset (scrub inherited) → preLaunch → source secrets.env →
-      //   read prompt → prepareWorktree wrap → host-side unset → agent wrap. The scrub
-      // runs before preLaunch so it sees neither inherited nor sourced build
+      //   read prompt → host prepareWorktree → host-side unset → agent wrap. The
+      // scrub runs before preLaunch so it sees neither inherited nor sourced build
       // secrets; the between-wraps unset keeps them off the agent wrap (#128).
       expect(cdIndex).toBeGreaterThan(-1);
       expect(scrubUnsetIndex).toBeGreaterThan(cdIndex);
       expect(preLaunchIndex).toBeGreaterThan(scrubUnsetIndex);
       expect(sourceIndex).toBeGreaterThan(preLaunchIndex);
       expect(readPromptIndex).toBeGreaterThan(sourceIndex);
-      expect(setupWrapIndex).toBeGreaterThan(readPromptIndex);
-      expect(betweenWrapsUnsetIndex).toBeGreaterThan(setupWrapIndex);
+      expect(prepareIndex).toBeGreaterThan(readPromptIndex);
+      expect(betweenWrapsUnsetIndex).toBeGreaterThan(prepareIndex);
       expect(agentWrapIndex).toBeGreaterThan(betweenWrapsUnsetIndex);
       // No build-secret *values* are sourced into env before preLaunch runs.
       expect(out.slice(0, preLaunchIndex)).not.toContain(". '/tmp/prompt-team-1/secrets.env'");
@@ -1121,7 +1119,7 @@ describe(buildLaunchCommand, () => {
   });
 
   describe("preLaunchEnv", () => {
-    it("splits --env-pass per wrap: build secrets to prepareWorktree, preLaunchEnv to agent (PR #128 isolation)", () => {
+    it("withholds preLaunchEnv credentials from the host prepareWorktree hook and forwards them to the agent (PR #128 isolation)", () => {
       const out = buildLaunchCommand(
         arguments_({
           secretsFile: "/tmp/prompt-team-1/secrets.env",
@@ -1134,21 +1132,23 @@ describe(buildLaunchCommand, () => {
         }),
       );
 
-      const setupWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?sh -c '[^']*'/;
       const agentWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?"\$_safehouse_shim"/;
-      const setupWrapMatch = setupWrapRe.exec(out);
       const agentWrapMatch = agentWrapRe.exec(out);
-      // prepareWorktree wrap: build secrets only — preLaunch credentials must never reach
-      // the profile-neutral prepare phase that #128 deliberately walled off.
-      expect(setupWrapMatch?.[1]).toBe(`--env-pass=${BUILD_SECRET_NAMES.join(",")} `);
+      // The trusted host hook runs with the preLaunch credential names unset in
+      // its own status-reporting subshell, so it cannot read them — #128's wall,
+      // preserved now that the hook runs on the host instead of a prepare wrap.
+      expect(out).toContain("(unset SESSION_TOKEN TEAM_ID; npm ci); prepare_status=$?");
+      // Build secrets are never forwarded via --env-pass — the host hook inherits
+      // them from the sourced env directly.
+      expect(out).not.toContain(`--env-pass=${BUILD_SECRET_NAMES.join(",")}`);
       // Agent wrap: preLaunchEnv only — build secrets are `unset` on the host
-      // between the two wraps, so forwarding them here would silently no-op.
+      // before the wrap, so forwarding them here would silently no-op.
       expect(agentWrapMatch?.[1]).toBe("--env-pass=SESSION_TOKEN,TEAM_ID ");
       // The old single-wrap composition must NOT reappear anywhere.
       expect(out).not.toContain(`--env-pass=${BUILD_SECRET_NAMES.join(",")},SESSION_TOKEN`);
     });
 
-    it("emits an agent-wrap --env-pass when no secretsFile is staged (prepareWorktree wrap unflagged)", () => {
+    it("emits an agent-wrap --env-pass when no secretsFile is staged (host hook scrubs the name)", () => {
       const out = buildLaunchCommand(
         arguments_({
           prepareWorktreeCommand: "npm ci",
@@ -1160,11 +1160,12 @@ describe(buildLaunchCommand, () => {
         }),
       );
 
-      const setupWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?sh -c '[^']*'/;
       const agentWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?"\$_safehouse_shim"/;
-      const setupWrapMatch = setupWrapRe.exec(out);
       const agentWrapMatch = agentWrapRe.exec(out);
-      expect(setupWrapMatch?.[1]).toBeUndefined();
+      // No Safehouse prepare wrap exists — the hook runs on the host, scrubbing
+      // the preLaunchEnv name in its own subshell (#128).
+      expect(out).not.toContain("safehouse-clearance' sh -c");
+      expect(out).toContain("(unset SESSION_TOKEN; npm ci); prepare_status=$?");
       expect(agentWrapMatch?.[1]).toBe("--env-pass=SESSION_TOKEN ");
       // No build-secret names should sneak in (no secretsFile staged).
       for (const name of BUILD_SECRET_NAMES) {
@@ -1382,15 +1383,16 @@ describe(buildLaunchCommand, () => {
   });
 
   describe(`${buildLaunchCommand.name} (runner='safehouse', networkEgress='open')`, () => {
-    it("wraps both safehouse phases with the bare safehouse binary, dropping the clearance shim and proxy env", () => {
+    it("wraps the agent with the bare safehouse binary, dropping the clearance shim and proxy env", () => {
       const out = buildLaunchCommand(
         arguments_({ networkEgress: "open", prepareWorktreeCommand: "npm ci" }),
       );
 
-      // Bare safehouse for both the prepareWorktree wrap (`sh -c`) and the agent
-      // wrap (the profile-selection shim), with no clearance layer.
-      expect(out).toContain("safehouse sh -c");
+      // Bare safehouse for the agent wrap (the profile-selection shim), with no
+      // clearance layer. The prepareWorktree hook runs unsandboxed on the host.
       expect(out).toContain('safehouse "$_safehouse_shim" -c');
+      expect(out).toContain("(npm ci); prepare_status=$?");
+      expect(out).not.toContain("safehouse sh -c");
       expect(out).not.toContain("safehouse-clearance");
       expect(out).not.toContain("CLEARANCE_ALLOW_HOSTS_FILES");
     });
@@ -1409,19 +1411,19 @@ describe(buildLaunchCommand, () => {
       // The agent-named symlink-to-/bin/sh profile-selection trick is unchanged.
       expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
       expect(out).toContain('ln -s /bin/sh "$_safehouse_shim"');
-      // --add-dirs (both wraps), the agent-only --add-dirs grant, and --env-pass
-      // all still compose around the bare-safehouse wrapper.
-      expect(out).toContain("--add-dirs='/work/repo-a-team-1:/src/carrot/.git'");
+      // The base grant merged with the agent-only --add-dirs grant, plus
+      // --env-pass, all still compose around the bare-safehouse agent wrapper.
       expect(out).toContain("--add-dirs='/work/repo-a-team-1:/src/carrot/.git:/Users/dev/v'");
       expect(out).toContain("--env-pass=SESSION_TOKEN ");
       expect(out).toContain(`exec claude "$@"`);
     });
 
-    it("default allowlisted network egress still wraps with the clearance shim (regression)", () => {
+    it("default allowlisted network egress still wraps the agent with the clearance shim (regression)", () => {
       const out = buildLaunchCommand(arguments_({ prepareWorktreeCommand: "npm ci" }));
 
-      expect(out).toContain("safehouse-clearance' sh -c");
+      expect(out).toContain('safehouse-clearance\' "$_safehouse_shim" -c');
       expect(out).toContain("CLEARANCE_ALLOW_HOSTS_FILES=");
+      expect(out).not.toContain("safehouse-clearance' sh -c");
       expect(out).not.toContain("safehouse sh -c");
     });
   });

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -259,10 +259,11 @@ describe(`${buildLaunchCommand.name} (runner='srt')`, () => {
 });
 
 describe(buildLaunchCommand, () => {
-  it("runs prepareWorktree on the host, then runs only the agent through the profile shim", () => {
+  it("runs prepareWorktree under plain Safehouse, then runs only the agent through the profile shim", () => {
     const out = buildLaunchCommand(arguments_({ prepareWorktreeCommand: "npm ci" }));
 
-    const setupIndex = out.indexOf("(npm ci); prepare_status=$?");
+    const setupWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+    const setupIndex = out.indexOf("npm ci");
     const shimIndex = out.indexOf("_safehouse_shim_dir=$(mktemp");
     const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
     const agentIndex = out.indexOf(`exec claude "$@"`);
@@ -270,18 +271,18 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain("cd '/work/repo-a-team-1'");
     expect(out).toContain("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
     expect(out).toContain("rm -rf '/tmp/prompt-team-1'");
-    // The prepareWorktree hook runs unsandboxed on the host — no Safehouse wrap.
-    expect(out).not.toContain("safehouse-clearance' sh -c");
-    // Only the agent runs through the Safehouse profile shim.
+    expect(out).toContain(
+      "/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance' sh -c",
+    );
     expect(out).toContain(
       '/node_modules/@clipboard-health/clearance/safehouse/safehouse-clearance\' "$_safehouse_shim" -c',
     );
     expect(out).not.toContain("--enable=all-agents");
-    expect(out).toContain("(npm ci); prepare_status=$?");
+    expect(out).toContain("npm ci");
     expect(out).toContain(`exec claude "$@"`);
     expect(out).toContain('sh "$_p"; _safehouse_status=$?');
-    // Host hook precedes the shim setup, which precedes the agent wrap.
-    expect(setupIndex).toBeGreaterThan(-1);
+    expect(setupWrapIndex).toBeGreaterThan(-1);
+    expect(setupIndex).toBeGreaterThan(setupWrapIndex);
     expect(shimIndex).toBeGreaterThan(setupIndex);
     expect(agentWrapIndex).toBeGreaterThan(shimIndex);
     expect(agentIndex).toBeGreaterThan(agentWrapIndex);
@@ -297,7 +298,7 @@ describe(buildLaunchCommand, () => {
     expect(out).toContain('"$_safehouse_shim" -c');
   });
 
-  it("grants the worktree root and git common dir to the agent wrap via --add-dirs", () => {
+  it("grants the worktree root and git common dir to both safehouse wraps via --add-dirs", () => {
     const out = buildLaunchCommand(
       arguments_({
         prepareWorktreeCommand: "npm ci",
@@ -306,13 +307,13 @@ describe(buildLaunchCommand, () => {
     );
 
     const addDirsFlag = "--add-dirs='/work/repo-a-team-1:/src/carrot/.git'";
-    // The prepareWorktree hook runs unsandboxed on the host (full git access), so
-    // only the agent wrap needs the grant — so git works inside a graft /
-    // sparse-checkout worktree whose real `.git` lives outside the worktree tree
-    // (e.g. an external `~/carrot/.git`).
-    expect(out.split(addDirsFlag).length - 1).toBe(1);
+    // One grant per wrap: the prepareWorktree wrap (so the hook's git/npm can
+    // reach the checkout) and the agent wrap (so git works inside a graft /
+    // sparse-checkout worktree whose real `.git` lives outside the worktree
+    // tree — e.g. an external `~/carrot/.git`).
+    expect(out.split(addDirsFlag).length - 1).toBe(2);
+    expect(out).toContain(`${addDirsFlag} sh -c`);
     expect(out).toContain(`${addDirsFlag} "$_safehouse_shim" -c`);
-    expect(out).not.toContain(`${addDirsFlag} sh -c`);
   });
 
   it("forwards worker completion env into the Safehouse agent wrap only", () => {
@@ -437,8 +438,7 @@ describe(buildLaunchCommand, () => {
       }),
     );
 
-    const prepareIndex = out.indexOf("(npm ci); prepare_status=$?");
-    const shimSetupIndex = out.indexOf("_safehouse_shim_dir=");
+    const prepareWrapIndex = out.indexOf("safehouse-clearance' sh -c");
     const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
     const readOnlyGrantIndex = out.indexOf(
       "--add-dirs-ro='/Applications/cmux.app:/Users/dev/.local/state/cmux'",
@@ -446,22 +446,21 @@ describe(buildLaunchCommand, () => {
     const envPassIndex = out.indexOf(
       "--env-pass=CMUX_SURFACE_ID,CMUX_SOCKET_PATH,CMUX_CLAUDE_WRAPPER_SHIM,CMUX_CLAUDE_WRAPPER_SHIM_ROOT,CMUX_CUSTOM_CLAUDE_PATH",
     );
+    const shimSetupIndex = out.indexOf("_safehouse_shim_dir=", prepareWrapIndex);
     const preludeIndex = out.indexOf("export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude");
     const execIndex = out.indexOf('exec claude --permission-mode auto "$@"');
-    expect(prepareIndex).toBeGreaterThan(-1);
-    expect(readOnlyGrantIndex).toBeGreaterThan(prepareIndex);
+    expect(prepareWrapIndex).toBeGreaterThan(-1);
+    expect(readOnlyGrantIndex).toBeGreaterThan(prepareWrapIndex);
     expect(readOnlyGrantIndex).toBeLessThan(agentWrapIndex);
-    expect(envPassIndex).toBeGreaterThan(prepareIndex);
+    expect(envPassIndex).toBeGreaterThan(prepareWrapIndex);
     expect(envPassIndex).toBeLessThan(agentWrapIndex);
     expect(preludeIndex).toBeGreaterThan(agentWrapIndex);
     expect(execIndex).toBeGreaterThan(preludeIndex);
-    expect(shimSetupIndex).toBeGreaterThan(prepareIndex);
-    // The host prepareWorktree region (everything up to the shim setup) carries
-    // none of the agent-only cmux grants.
-    const beforeAgent = out.slice(0, shimSetupIndex);
-    expect(beforeAgent).not.toContain("--add-dirs-ro");
-    expect(beforeAgent).not.toContain("CMUX_SURFACE_ID");
-    expect(beforeAgent).not.toContain("CMUX_SOCKET_PATH");
+    expect(shimSetupIndex).toBeGreaterThan(prepareWrapIndex);
+    const prepareWrap = out.slice(prepareWrapIndex, shimSetupIndex);
+    expect(prepareWrap).not.toContain("--add-dirs-ro");
+    expect(prepareWrap).not.toContain("CMUX_SURFACE_ID");
+    expect(prepareWrap).not.toContain("CMUX_SOCKET_PATH");
     expect(out).not.toContain("_groundcrew_path_without_cmux");
   });
 
@@ -651,7 +650,7 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("--env-pass");
     });
 
-    it("sources build secrets on the host for the prepareWorktree hook, then clears them before the agent", () => {
+    it("sources secrets on the host, forwards them only to prepareWorktree, and clears them before the agent", () => {
       const out = buildLaunchCommand(
         arguments_({
           secretsFile: "/tmp/prompt-team-1/secrets.env",
@@ -660,21 +659,24 @@ describe(buildLaunchCommand, () => {
       );
 
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
-      const setupIndex = out.indexOf("(npm ci); prepare_status=$?");
+      const setupWrapIndex = out.indexOf(
+        "safehouse-clearance' --env-pass=NPM_TOKEN,BUF_TOKEN sh -c",
+      );
+      const setupIndex = out.indexOf("prepare_status=$?");
       const unsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
       const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
       const agentIndex = out.indexOf(`exec claude "$@"`);
 
-      // Secrets are sourced into the host shell before the hook runs, so the
-      // host-run prepareWorktree inherits them directly — no --env-pass, no
-      // Safehouse prepare wrap. They are cleared before the agent wrap.
+      // Secrets are sourced into the host shell before the wrap so Safehouse can
+      // forward them into prepareWorktree; the agent Safehouse process never gets them.
       expect(sourceIndex).toBeGreaterThan(-1);
-      expect(setupIndex).toBeGreaterThan(sourceIndex);
-      expect(out).not.toContain("--env-pass=NPM_TOKEN");
-      expect(out).not.toContain("safehouse-clearance' --env-pass");
+      expect(setupWrapIndex).toBeGreaterThan(sourceIndex);
+      expect(out).toContain("--env-pass=NPM_TOKEN,BUF_TOKEN");
+      expect(setupIndex).toBeGreaterThan(setupWrapIndex);
       expect(unsetIndex).toBeGreaterThan(setupIndex);
       expect(agentWrapIndex).toBeGreaterThan(unsetIndex);
       expect(agentIndex).toBeGreaterThan(agentWrapIndex);
+      expect(out.slice(agentWrapIndex)).not.toContain("--env-pass");
       expect(out.slice(agentWrapIndex)).not.toContain("unset NPM_TOKEN");
       expect(out).toContain(
         "if [ -f '/tmp/prompt-team-1/secrets.env' ]; then set -a && . '/tmp/prompt-team-1/secrets.env' && set +a; fi",
@@ -912,24 +914,24 @@ describe(buildLaunchCommand, () => {
       const preLaunchIndex = out.indexOf("export FOO=bar");
       const sourceIndex = out.indexOf(". '/tmp/prompt-team-1/secrets.env'");
       const readPromptIndex = out.indexOf("_p=$(cat '/tmp/prompt-team-1/prompt.txt')");
-      const prepareIndex = out.indexOf("(npm ci); prepare_status=$?");
+      const setupWrapIndex = out.indexOf("safehouse-clearance");
       // Two `unset NPM_TOKEN BUF_TOKEN` occurrences now: the first scrubs the
       // inherited env before preLaunch, the last clears the file-sourced
-      // values between the host prepareWorktree hook and the agent wrap.
+      // values between the prepareWorktree and agent wraps.
       const scrubUnsetIndex = out.indexOf("unset NPM_TOKEN BUF_TOKEN");
       const betweenWrapsUnsetIndex = out.lastIndexOf("unset NPM_TOKEN BUF_TOKEN");
       const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
       // trap → cd → unset (scrub inherited) → preLaunch → source secrets.env →
-      //   read prompt → host prepareWorktree → host-side unset → agent wrap. The
-      // scrub runs before preLaunch so it sees neither inherited nor sourced build
+      //   read prompt → prepareWorktree wrap → host-side unset → agent wrap. The scrub
+      // runs before preLaunch so it sees neither inherited nor sourced build
       // secrets; the between-wraps unset keeps them off the agent wrap (#128).
       expect(cdIndex).toBeGreaterThan(-1);
       expect(scrubUnsetIndex).toBeGreaterThan(cdIndex);
       expect(preLaunchIndex).toBeGreaterThan(scrubUnsetIndex);
       expect(sourceIndex).toBeGreaterThan(preLaunchIndex);
       expect(readPromptIndex).toBeGreaterThan(sourceIndex);
-      expect(prepareIndex).toBeGreaterThan(readPromptIndex);
-      expect(betweenWrapsUnsetIndex).toBeGreaterThan(prepareIndex);
+      expect(setupWrapIndex).toBeGreaterThan(readPromptIndex);
+      expect(betweenWrapsUnsetIndex).toBeGreaterThan(setupWrapIndex);
       expect(agentWrapIndex).toBeGreaterThan(betweenWrapsUnsetIndex);
       // No build-secret *values* are sourced into env before preLaunch runs.
       expect(out.slice(0, preLaunchIndex)).not.toContain(". '/tmp/prompt-team-1/secrets.env'");
@@ -1119,7 +1121,7 @@ describe(buildLaunchCommand, () => {
   });
 
   describe("preLaunchEnv", () => {
-    it("withholds preLaunchEnv credentials from the host prepareWorktree hook and forwards them to the agent (PR #128 isolation)", () => {
+    it("splits --env-pass per wrap: build secrets to prepareWorktree, preLaunchEnv to agent (PR #128 isolation)", () => {
       const out = buildLaunchCommand(
         arguments_({
           secretsFile: "/tmp/prompt-team-1/secrets.env",
@@ -1132,23 +1134,21 @@ describe(buildLaunchCommand, () => {
         }),
       );
 
+      const setupWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?sh -c '[^']*'/;
       const agentWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?"\$_safehouse_shim"/;
+      const setupWrapMatch = setupWrapRe.exec(out);
       const agentWrapMatch = agentWrapRe.exec(out);
-      // The trusted host hook runs with the preLaunch credential names unset in
-      // its own status-reporting subshell, so it cannot read them — #128's wall,
-      // preserved now that the hook runs on the host instead of a prepare wrap.
-      expect(out).toContain("(unset SESSION_TOKEN TEAM_ID; npm ci); prepare_status=$?");
-      // Build secrets are never forwarded via --env-pass — the host hook inherits
-      // them from the sourced env directly.
-      expect(out).not.toContain(`--env-pass=${BUILD_SECRET_NAMES.join(",")}`);
+      // prepareWorktree wrap: build secrets only — preLaunch credentials must never reach
+      // the profile-neutral prepare phase that #128 deliberately walled off.
+      expect(setupWrapMatch?.[1]).toBe(`--env-pass=${BUILD_SECRET_NAMES.join(",")} `);
       // Agent wrap: preLaunchEnv only — build secrets are `unset` on the host
-      // before the wrap, so forwarding them here would silently no-op.
+      // between the two wraps, so forwarding them here would silently no-op.
       expect(agentWrapMatch?.[1]).toBe("--env-pass=SESSION_TOKEN,TEAM_ID ");
       // The old single-wrap composition must NOT reappear anywhere.
       expect(out).not.toContain(`--env-pass=${BUILD_SECRET_NAMES.join(",")},SESSION_TOKEN`);
     });
 
-    it("emits an agent-wrap --env-pass when no secretsFile is staged (host hook scrubs the name)", () => {
+    it("emits an agent-wrap --env-pass when no secretsFile is staged (prepareWorktree wrap unflagged)", () => {
       const out = buildLaunchCommand(
         arguments_({
           prepareWorktreeCommand: "npm ci",
@@ -1160,12 +1160,11 @@ describe(buildLaunchCommand, () => {
         }),
       );
 
+      const setupWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?sh -c '[^']*'/;
       const agentWrapRe = /safehouse-clearance' (?<envPass>--env-pass=[^ ]+ )?"\$_safehouse_shim"/;
+      const setupWrapMatch = setupWrapRe.exec(out);
       const agentWrapMatch = agentWrapRe.exec(out);
-      // No Safehouse prepare wrap exists — the hook runs on the host, scrubbing
-      // the preLaunchEnv name in its own subshell (#128).
-      expect(out).not.toContain("safehouse-clearance' sh -c");
-      expect(out).toContain("(unset SESSION_TOKEN; npm ci); prepare_status=$?");
+      expect(setupWrapMatch?.[1]).toBeUndefined();
       expect(agentWrapMatch?.[1]).toBe("--env-pass=SESSION_TOKEN ");
       // No build-secret names should sneak in (no secretsFile staged).
       for (const name of BUILD_SECRET_NAMES) {
@@ -1383,16 +1382,15 @@ describe(buildLaunchCommand, () => {
   });
 
   describe(`${buildLaunchCommand.name} (runner='safehouse', networkEgress='open')`, () => {
-    it("wraps the agent with the bare safehouse binary, dropping the clearance shim and proxy env", () => {
+    it("wraps both safehouse phases with the bare safehouse binary, dropping the clearance shim and proxy env", () => {
       const out = buildLaunchCommand(
         arguments_({ networkEgress: "open", prepareWorktreeCommand: "npm ci" }),
       );
 
-      // Bare safehouse for the agent wrap (the profile-selection shim), with no
-      // clearance layer. The prepareWorktree hook runs unsandboxed on the host.
+      // Bare safehouse for both the prepareWorktree wrap (`sh -c`) and the agent
+      // wrap (the profile-selection shim), with no clearance layer.
+      expect(out).toContain("safehouse sh -c");
       expect(out).toContain('safehouse "$_safehouse_shim" -c');
-      expect(out).toContain("(npm ci); prepare_status=$?");
-      expect(out).not.toContain("safehouse sh -c");
       expect(out).not.toContain("safehouse-clearance");
       expect(out).not.toContain("CLEARANCE_ALLOW_HOSTS_FILES");
     });
@@ -1411,19 +1409,19 @@ describe(buildLaunchCommand, () => {
       // The agent-named symlink-to-/bin/sh profile-selection trick is unchanged.
       expect(out).toContain('_safehouse_shim="$_safehouse_shim_dir/claude"');
       expect(out).toContain('ln -s /bin/sh "$_safehouse_shim"');
-      // The base grant merged with the agent-only --add-dirs grant, plus
-      // --env-pass, all still compose around the bare-safehouse agent wrapper.
+      // --add-dirs (both wraps), the agent-only --add-dirs grant, and --env-pass
+      // all still compose around the bare-safehouse wrapper.
+      expect(out).toContain("--add-dirs='/work/repo-a-team-1:/src/carrot/.git'");
       expect(out).toContain("--add-dirs='/work/repo-a-team-1:/src/carrot/.git:/Users/dev/v'");
       expect(out).toContain("--env-pass=SESSION_TOKEN ");
       expect(out).toContain(`exec claude "$@"`);
     });
 
-    it("default allowlisted network egress still wraps the agent with the clearance shim (regression)", () => {
+    it("default allowlisted network egress still wraps with the clearance shim (regression)", () => {
       const out = buildLaunchCommand(arguments_({ prepareWorktreeCommand: "npm ci" }));
 
-      expect(out).toContain('safehouse-clearance\' "$_safehouse_shim" -c');
+      expect(out).toContain("safehouse-clearance' sh -c");
       expect(out).toContain("CLEARANCE_ALLOW_HOSTS_FILES=");
-      expect(out).not.toContain("safehouse-clearance' sh -c");
       expect(out).not.toContain("safehouse sh -c");
     });
   });

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -1498,10 +1498,10 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("-e BUF_TOKEN");
     });
 
-    it("rejects prepareWorktreeUnsandboxed because the container has no host to run it on", () => {
+    it("rejects unsandboxedHooks.prepareWorktree because the container has no host to run it on", () => {
       expect(() =>
         buildLaunchCommand(sdxArguments({ prepareWorktreeUnsandboxedCommand: "bin/setup" })),
-      ).toThrow(/prepareWorktreeUnsandboxed is not supported for runner='sdx'/);
+      ).toThrow(/unsandboxedHooks\.prepareWorktree is not supported for runner='sdx'/);
     });
   });
 

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -256,6 +256,26 @@ describe(`${buildLaunchCommand.name} (runner='srt')`, () => {
     expect(out).not.toContain("CODEX_HOME");
     expect(out).not.toContain("CLAUDE_CONFIG_DIR");
   });
+
+  it("runs prepareWorktreeUnsandboxed on the host before the srt prepare wrap", () => {
+    const out = buildLaunchCommand(
+      srtArguments({
+        prepareWorktreeUnsandboxedCommand: "bin/setup",
+        prepareWorktreeCommand: "npm ci",
+      }),
+    );
+
+    const unsandboxedIndex = out.indexOf("(bin/setup); prepare_status=$?");
+    const prepareWrapIndex = out.indexOf("prepare-settings.json' -- sh -c");
+    const npmIndex = out.indexOf("npm ci");
+
+    expect(unsandboxedIndex).toBeGreaterThan(-1);
+    // The host command runs before the srt-wrapped prepare hook, and is not itself
+    // wrapped by srt (no `env -i` / `--settings` between it and bin/setup).
+    expect(unsandboxedIndex).toBeLessThan(prepareWrapIndex);
+    expect(npmIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(out).not.toContain("-- sh -c '(bin/setup)");
+  });
 });
 
 describe(buildLaunchCommand, () => {

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -32,6 +32,10 @@ function arguments_(
     workingDir: worktreeDir,
     runner: "safehouse",
     networkEgress: "allowlisted",
+    // Default to a trusted operator hook so the many host-run prepareWorktree
+    // assertions below exercise the operator path; repo/unknown provenance is
+    // covered by dedicated tests that override this.
+    prepareWorktreeSource: "operator",
     ...overrides,
   };
 }
@@ -286,6 +290,68 @@ describe(buildLaunchCommand, () => {
     expect(agentWrapIndex).toBeGreaterThan(shimIndex);
     expect(agentIndex).toBeGreaterThan(agentWrapIndex);
     expect(out.slice(agentWrapIndex)).not.toContain("npm ci");
+  });
+
+  it("sandboxes a repo-authored prepareWorktree hook instead of running it on the host", () => {
+    const out = buildLaunchCommand(
+      arguments_({ prepareWorktreeCommand: "npm ci", prepareWorktreeSource: "repository" }),
+    );
+
+    const prepareWrapIndex = out.indexOf("safehouse-clearance' sh -c");
+    const shimIndex = out.indexOf("_safehouse_shim_dir=$(mktemp");
+    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
+
+    // The untrusted repo hook runs inside a Safehouse wrap as `sh -c '<hook>'`...
+    expect(out).toContain("safehouse-clearance' sh -c '(npm ci); prepare_status=$?");
+    // ...and never as a bare host `&&` chain element.
+    expect(out).not.toContain("&& (npm ci); prepare_status=$?");
+    // Sandboxed prepare wrap precedes the agent shim wrap.
+    expect(prepareWrapIndex).toBeGreaterThan(-1);
+    expect(shimIndex).toBeGreaterThan(prepareWrapIndex);
+    expect(agentWrapIndex).toBeGreaterThan(shimIndex);
+  });
+
+  it("sandboxes the prepareWorktree hook when its provenance is unknown (fails safe)", () => {
+    const out = buildLaunchCommand(
+      arguments_({ prepareWorktreeCommand: "npm ci", prepareWorktreeSource: undefined }),
+    );
+
+    expect(out).toContain("safehouse-clearance' sh -c '(npm ci); prepare_status=$?");
+    expect(out).not.toContain("&& (npm ci); prepare_status=$?");
+  });
+
+  it("forwards build secrets into the sandboxed repo prepareWorktree wrap only, never the agent wrap", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        prepareWorktreeCommand: "npm ci",
+        prepareWorktreeSource: "repository",
+        secretsFile: "/tmp/prompt-team-1/secrets.env",
+      }),
+    );
+
+    const agentWrapIndex = out.indexOf('"$_safehouse_shim" -c');
+    const envPassFlag = `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
+
+    // The sandboxed prepare wrap forwards build secrets so `npm ci` can auth...
+    expect(out).toContain(`${envPassFlag}sh -c '(npm ci); prepare_status=$?`);
+    // ...and they are unset on the host before the agent wrap, so it never sees them.
+    expect(out).toContain(`unset ${BUILD_SECRET_NAMES.join(" ")}`);
+    expect(out.slice(agentWrapIndex - 200, agentWrapIndex)).not.toContain(envPassFlag);
+  });
+
+  it("grants safehouseAddDirs to the sandboxed repo prepareWorktree wrap so it can reach git", () => {
+    const out = buildLaunchCommand(
+      arguments_({
+        prepareWorktreeCommand: "npm ci",
+        prepareWorktreeSource: "repository",
+        safehouseAddDirs: ["/work/repo-a-team-1", "/src/carrot/.git"],
+      }),
+    );
+
+    const addDirsFlag = "--add-dirs='/work/repo-a-team-1:/src/carrot/.git'";
+    // Both the sandboxed prepare wrap and the agent wrap get the git grant.
+    expect(out).toContain(`${addDirsFlag} sh -c '(npm ci); prepare_status=$?`);
+    expect(out).toContain(`${addDirsFlag} "$_safehouse_shim" -c`);
   });
 
   it("skips the prepareWorktree phase when no hook command is configured", () => {

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -1468,6 +1468,12 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("-e NPM_TOKEN");
       expect(out).not.toContain("-e BUF_TOKEN");
     });
+
+    it("rejects prepareWorktreeUnsandboxed because the container has no host to run it on", () => {
+      expect(() =>
+        buildLaunchCommand(sdxArguments({ prepareWorktreeUnsandboxedCommand: "bin/setup" })),
+      ).toThrow(/prepareWorktreeUnsandboxed is not supported for runner='sdx'/);
+    });
   });
 
   describe(`${buildLaunchCommand.name} (runner='safehouse', networkEgress='open')`, () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -916,6 +916,14 @@ function buildSrtLaunchCommand(arguments_: LaunchCommandArguments): string {
       secretsFile: arguments_.secretsFile,
     }),
   ];
+  if (arguments_.prepareWorktreeUnsandboxedCommand !== undefined) {
+    lines.push(
+      hostPrepareWorktreeLine(
+        arguments_.prepareWorktreeUnsandboxedCommand,
+        arguments_.definition.preLaunchEnv ?? [],
+      ),
+    );
+  }
   if (prepareWorktreeCommand !== undefined) {
     lines.push(`${prepareWrap} sh -c ${shellSingleQuote(prepareWorktreeCommand)}`);
   }

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -129,25 +129,6 @@ function prepareWorktreeWithStatusReporting(prepareWorktreeCommand: string): str
 }
 
 /**
- * Host-shell prepareWorktree line for the safehouse runner: the trusted repo
- * hook runs directly on the host (not inside the agent sandbox), so it has the
- * host toolchain's full filesystem access. `scrubNames` are `unset` inside the
- * status-reporting subshell — used for the declared `preLaunchEnv` credential
- * names, which `preLaunch` has already minted into the host env by this point,
- * so the hook cannot read them (PR #128's credential wall) while the parent
- * shell keeps them for the agent wrap's `--env-pass`. Build secrets are left in
- * env so the hook can authenticate `npm install` etc.; they are `unset` on the
- * host afterward, before the agent wrap.
- */
-function hostPrepareWorktreeLine(
-  prepareWorktreeCommand: string,
-  scrubNames: readonly string[],
-): string {
-  const scrub = scrubNames.length === 0 ? "" : `${unsetEnvironmentLine(scrubNames)}; `;
-  return prepareWorktreeWithStatusReporting(`${scrub}${prepareWorktreeCommand}`);
-}
-
-/**
  * Source a `KEY='value'` file with auto-export so build-time secrets land
  * in the shell env before prepareWorktree runs. The `-f` guard keeps it a
  * no-op if the file disappeared between staging and launch.
@@ -648,18 +629,13 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 }
 
 /**
- * Safehouse launch. The prepareWorktree hook runs on the **host shell**
- * (unsandboxed), and only the **agent** runs inside a Safehouse wrap:
+ * Safehouse launch. Two Safehouse wraps, by design:
  *
- *   1. **prepareWorktree (host)**: the repo preparation hook runs directly on
- *      the host launch shell — same as the `none` runner — so it has the host
- *      toolchain's full filesystem access. This is deliberate: the hook is
- *      trusted, pre-agent provisioning (a user-configured command run over a
- *      fresh base-branch checkout, before the agent has touched anything), so
- *      the agent's deny-by-default profile has no business constraining it.
- *      Wrapping it in the sandbox only made the operator's own setup script
- *      fail on host paths the profile masks (e.g. Ruby's XDG gem dirs).
- *      Omitted entirely when no hook command is configured.
+ *   1. **prepareWorktree wrap**: plain
+ *      `safehouse-clearance ... sh -c '<prepareWorktree>'`. Runs the repo
+ *      preparation hook filesystem-isolated and egress-restricted,
+ *      **without** inheriting agent-profile grants. Omitted entirely when no
+ *      hook command is configured.
  *   2. **Agent wrap**: `safehouse-clearance "$shim" -c '<exec agent>' sh "$_p"`
  *      where `$shim` is a `mktemp`-d symlink to `/bin/sh` named after the
  *      agent (e.g. `claude`). Safehouse selects the matching agent profile
@@ -672,50 +648,51 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
  * env — neither inherited values (the launch shell inherits groundcrew's env,
  * from which `stageBuildSecrets` reads them) nor file-sourced values — and keeps
  * stale same-named ambient credentials from being forwarded. `secrets.env` is
- * then sourced into the host launch shell so the host-run prepareWorktree hook
- * inherits build secrets directly (for `npm install` etc.). After prepareWorktree
- * returns, `BUILD_SECRET_NAMES` are `unset` again on the host so they cannot
- * reach the agent wrap.
+ * then sourced into the host launch shell so Safehouse can forward build secrets
+ * into the **prepareWorktree wrap** via `--env-pass=` (Safehouse's `--env=FILE` mode strips
+ * them otherwise). After prepareWorktree returns, `BUILD_SECRET_NAMES` are `unset` again
+ * on the host so they cannot reach the agent wrap.
  *
- * PR #128's credential wall is preserved: `preLaunch` runs before the host
- * prepareWorktree line, so its minted `preLaunchEnv` credentials are already in
- * the host env. The host prepareWorktree line therefore `unset`s those declared
- * names inside its own status-reporting subshell, so the trusted hook still
- * cannot read them, while the parent shell retains them for the agent wrap's
- * `--env-pass`.
+ * `--env-pass` composition is split per wrap (deliberate, post PR #128):
+ * - prepareWorktree wrap forwards build secrets only.
+ * - Agent wrap forwards `preLaunchEnv` names only. preLaunch credentials never
+ *   reach the profile-neutral prepare phase.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  // Only the agent command comes from here; the prepareWorktree hook runs on the
-  // host shell (see below), not through a Safehouse wrap.
-  const { agentCommand: rawAgentCommand } = renderPrepareAndAgentCommand(arguments_);
+  const { agentCommand: rawAgentCommand, prepareWorktreeCommand } =
+    renderPrepareAndAgentCommand(arguments_);
   const { safehouseAgentIntegration } = arguments_;
   const agentCommand = [
     ...(safehouseAgentIntegration?.commandPreludes ?? []),
     rawAgentCommand,
   ].join("; ");
 
-  // The agent wrap forwards the user's preLaunchEnv (plus worker/integration
-  // env). Build secrets are never forwarded to the agent wrap — they are sourced
-  // into the host shell for the host-run prepareWorktree hook, then `unset` on
-  // the host before this wrap. Keeps preLaunch credentials paired with the agent
-  // only, and (with the host prepareWorktree scrub) out of the hook — see PR #128.
+  // Split --env-pass per wrap: the prepareWorktree wrap only needs build secrets (so
+  // `npm install` etc. can authenticate); the agent wrap only needs the
+  // user's preLaunchEnv (build secrets are `unset` on the host between the
+  // two wraps, so forwarding them here would silently no-op). Keeps preLaunch
+  // credentials out of the profile-neutral prepare phase — see PR #128.
+  // Trailing space keeps each flag separated from the next argv token.
+  const prepareWorktreeEnvPassFlag =
+    arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
   const agentEnvPassFlag = envPassFlag([
     ...(arguments_.definition.preLaunchEnv ?? []),
     ...workerEnvironmentNames(arguments_.workerEnvironment),
     ...(safehouseAgentIntegration?.envPass ?? []),
   ]);
-  // safehouse reads colon-separated paths from `--add-dirs`. Only the agent wrap
-  // needs them now (the prepareWorktree hook runs unsandboxed on the host, so it
-  // already has full git access). The base grant (`safehouseAddDirs` — worktree
-  // root + git common dir; see `resolveSafehouseAddDirs`) is merged with the
-  // agent-only paths. Quote the whole value so shell-special chars survive; the
-  // trailing space separates it from the next argv token.
+  // safehouse reads colon-separated paths from `--add-dirs`; both wraps get the
+  // same grant so the prepareWorktree hook and the agent can each reach git.
+  // Quote the whole value so shell-special chars survive; the trailing space
+  // separates it from the next argv token. See `resolveSafehouseAddDirs` for
+  // which paths these are and why.
+  const safehousePrepareAddDirs = arguments_.safehouseAddDirs ?? [];
   const safehouseAgentAddDirs = uniqueStrings([
-    ...(arguments_.safehouseAddDirs ?? []),
+    ...safehousePrepareAddDirs,
     ...(arguments_.safehouseAgentAddDirs ?? []),
   ]);
+  const safehouseAddDirsFlag = safehousePathListFlag("--add-dirs", safehousePrepareAddDirs);
   const safehouseAgentAddDirsFlag = safehousePathListFlag("--add-dirs", safehouseAgentAddDirs);
   const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
     "--add-dirs-ro",
@@ -749,15 +726,9 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
       secretsFile: arguments_.secretsFile,
     }),
   );
-  if (arguments_.prepareWorktreeCommand !== undefined) {
-    // Trusted, pre-agent provisioning: run the hook on the host shell, not in a
-    // Safehouse wrap. Scrub the declared preLaunchEnv credential names so the
-    // hook cannot read them (PR #128) while the agent wrap still can.
+  if (prepareWorktreeCommand !== undefined) {
     lines.push(
-      hostPrepareWorktreeLine(
-        arguments_.prepareWorktreeCommand,
-        arguments_.definition.preLaunchEnv ?? [],
-      ),
+      `${safehouseWrapper} ${safehouseAddDirsFlag}${prepareWorktreeEnvPassFlag}sh -c ${shellSingleQuote(prepareWorktreeCommand)}`,
     );
   }
   if (arguments_.secretsFile !== undefined) {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -129,6 +129,20 @@ function prepareWorktreeWithStatusReporting(prepareWorktreeCommand: string): str
 }
 
 /**
+ * Host-shell line for the operator-only `prepareWorktreeUnsandboxed` command.
+ * Reuses the same status-reporting wrapper as the sandboxed hook so a failure is
+ * surfaced but non-fatal. `scrubNames` (the agent's `preLaunchEnv`) are `unset`
+ * inside the subshell so this trusted host command cannot read agent
+ * credentials minted by `preLaunch`. Build secrets are intentionally left in
+ * scope so `npm`/`bundle` can authenticate; the caller `unset`s them before the
+ * agent wrap.
+ */
+function hostPrepareWorktreeLine(command: string, scrubNames: readonly string[]): string {
+  const scrub = scrubNames.length === 0 ? "" : `${unsetEnvironmentLine(scrubNames)}; `;
+  return prepareWorktreeWithStatusReporting(`${scrub}${command}`);
+}
+
+/**
  * Source a `KEY='value'` file with auto-export so build-time secrets land
  * in the shell env before prepareWorktree runs. The `-f` guard keeps it a
  * no-op if the file disappeared between staging and launch.
@@ -440,6 +454,14 @@ interface LaunchCommandArguments {
    */
   prepareWorktreeCommand?: string | undefined;
   /**
+   * Operator-only, per-repository setup command run on the HOST shell (never a
+   * sandbox), before `prepareWorktreeCommand` and the agent. Resolved by the
+   * caller from `knownRepositories[].prepareWorktreeUnsandboxed` in
+   * crew.config.ts. Emitted for the safehouse, srt, and none runners; the sdx
+   * runner rejects it (no host to run it on).
+   */
+  prepareWorktreeUnsandboxedCommand?: string | undefined;
+  /**
    * Concrete local isolation backend chosen for this launch. Resolved
    * from `config.local.runner` via `resolveLocalRunner` before this
    * function is called — `auto` is never seen here.
@@ -609,6 +631,14 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
     ...hostTrapAndCd({ workingDir: arguments_.workingDir, promptDir }),
     ...hostSourceSecrets(arguments_.secretsFile),
   ];
+  if (arguments_.prepareWorktreeUnsandboxedCommand !== undefined) {
+    lines.push(
+      hostPrepareWorktreeLine(
+        arguments_.prepareWorktreeUnsandboxedCommand,
+        arguments_.definition.preLaunchEnv ?? [],
+      ),
+    );
+  }
   if (arguments_.prepareWorktreeCommand !== undefined) {
     lines.push(prepareWorktreeWithStatusReporting(arguments_.prepareWorktreeCommand));
   }

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -139,7 +139,7 @@ function prepareWorktreeWithStatusReporting(prepareWorktreeCommand: string): str
  */
 function hostPrepareWorktreeLine(command: string, scrubNames: readonly string[]): string {
   const scrub = scrubNames.length === 0 ? "" : `${unsetEnvironmentLine(scrubNames)}; `;
-  return prepareWorktreeWithStatusReporting(`${scrub}${command}`);
+  return `{ ${prepareWorktreeWithStatusReporting(`${scrub}${command}`)}; }`;
 }
 
 /**

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -8,7 +8,6 @@ import {
   type LocalRunner,
   type AgentDefinition,
   type NetworkEgressSetting,
-  type PrepareWorktreeSource,
 } from "./config.ts";
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import { shellSingleQuote } from "./shell.ts";
@@ -460,15 +459,6 @@ interface LaunchCommandArguments {
    */
   prepareWorktreeCommand?: string | undefined;
   /**
-   * Provenance of `prepareWorktreeCommand`, consumed only by the safehouse
-   * runner. `"operator"` (from crew.config.ts) is trusted and runs on the host
-   * shell; `"repository"` (from the repo-committed `.groundcrew/config.json`) is
-   * untrusted and runs inside the Safehouse wrap. When a hook is present but the
-   * source is absent, safehouse fails safe and sandboxes it. The srt and sdx
-   * runners ignore this — they sandbox every hook regardless.
-   */
-  prepareWorktreeSource?: PrepareWorktreeSource | undefined;
-  /**
    * Concrete local isolation backend chosen for this launch. Resolved
    * from `config.local.runner` via `resolveLocalRunner` before this
    * function is called — `auto` is never seen here.
@@ -697,12 +687,9 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  // The agent command always runs through the Safehouse wrap. The
-  // prepareWorktree hook's placement depends on provenance (see the prepare
-  // block below): operator-authored hooks run on the host shell; repo-authored
-  // (or unknown-provenance) hooks stay sandboxed via `prepareWorktreeCommand`.
-  const { agentCommand: rawAgentCommand, prepareWorktreeCommand } =
-    renderPrepareAndAgentCommand(arguments_);
+  // Only the agent command comes from here; the prepareWorktree hook runs on the
+  // host shell (see below), not through a Safehouse wrap.
+  const { agentCommand: rawAgentCommand } = renderPrepareAndAgentCommand(arguments_);
   const { safehouseAgentIntegration } = arguments_;
   const agentCommand = [
     ...(safehouseAgentIntegration?.commandPreludes ?? []),
@@ -719,27 +706,17 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     ...workerEnvironmentNames(arguments_.workerEnvironment),
     ...(safehouseAgentIntegration?.envPass ?? []),
   ]);
-  // safehouse reads colon-separated paths from `--add-dirs`. The base grant
-  // (`safehouseAddDirs` — worktree root + git common dir; see
-  // `resolveSafehouseAddDirs`) goes to both wraps: a sandboxed prepareWorktree
-  // hook needs git access, and the agent wrap merges it with the agent-only
-  // paths. An operator-run (host) hook already has full git access, so its grant
-  // flag simply goes unused. Quote the whole value so shell-special chars
-  // survive; the trailing space separates it from the next argv token.
-  const safehousePrepareAddDirs = arguments_.safehouseAddDirs ?? [];
-  const safehousePrepareAddDirsFlag = safehousePathListFlag("--add-dirs", safehousePrepareAddDirs);
+  // safehouse reads colon-separated paths from `--add-dirs`. Only the agent wrap
+  // needs them now (the prepareWorktree hook runs unsandboxed on the host, so it
+  // already has full git access). The base grant (`safehouseAddDirs` — worktree
+  // root + git common dir; see `resolveSafehouseAddDirs`) is merged with the
+  // agent-only paths. Quote the whole value so shell-special chars survive; the
+  // trailing space separates it from the next argv token.
   const safehouseAgentAddDirs = uniqueStrings([
-    ...safehousePrepareAddDirs,
+    ...(arguments_.safehouseAddDirs ?? []),
     ...(arguments_.safehouseAgentAddDirs ?? []),
   ]);
   const safehouseAgentAddDirsFlag = safehousePathListFlag("--add-dirs", safehouseAgentAddDirs);
-  // Build secrets reach a sandboxed prepareWorktree hook via `--env-pass` only
-  // (Safehouse's `--env=FILE` baseline strips inherited env, and preLaunchEnv
-  // credentials are never listed here — keeping them out of the untrusted repo
-  // hook, per PR #128). Unused when the hook runs on the host, which sources
-  // secrets directly instead.
-  const prepareWorktreeEnvPassFlag =
-    arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
   const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
     "--add-dirs-ro",
     uniqueStrings([
@@ -772,29 +749,15 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
       secretsFile: arguments_.secretsFile,
     }),
   );
-  if (
-    arguments_.prepareWorktreeSource === "operator" &&
-    arguments_.prepareWorktreeCommand !== undefined
-  ) {
-    // Operator-authored (crew.config.ts) hook — trusted, pre-agent provisioning.
-    // Run it on the host shell, not in a Safehouse wrap, so the operator's own
-    // `bin/setup`/`bundle install` gets full host access. Scrub the declared
-    // preLaunchEnv credential names so the hook cannot read them (PR #128) while
-    // the agent wrap still can.
+  if (arguments_.prepareWorktreeCommand !== undefined) {
+    // Trusted, pre-agent provisioning: run the hook on the host shell, not in a
+    // Safehouse wrap. Scrub the declared preLaunchEnv credential names so the
+    // hook cannot read them (PR #128) while the agent wrap still can.
     lines.push(
       hostPrepareWorktreeLine(
         arguments_.prepareWorktreeCommand,
         arguments_.definition.preLaunchEnv ?? [],
       ),
-    );
-  } else if (prepareWorktreeCommand !== undefined) {
-    // Repo-authored (or unknown-provenance) hook — untrusted. Keep it sandboxed
-    // inside a Safehouse wrap so repository-controlled code cannot run with the
-    // operator's full host authority (build secrets, ambient credentials,
-    // unrestricted network) before the agent sandbox starts. Fail-safe: any
-    // source other than "operator" lands here.
-    lines.push(
-      `${safehouseWrapper} ${safehousePrepareAddDirsFlag}${prepareWorktreeEnvPassFlag}sh -c ${shellSingleQuote(prepareWorktreeCommand)}`,
     );
   }
   if (arguments_.secretsFile !== undefined) {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -129,6 +129,25 @@ function prepareWorktreeWithStatusReporting(prepareWorktreeCommand: string): str
 }
 
 /**
+ * Host-shell prepareWorktree line for the safehouse runner: the trusted repo
+ * hook runs directly on the host (not inside the agent sandbox), so it has the
+ * host toolchain's full filesystem access. `scrubNames` are `unset` inside the
+ * status-reporting subshell — used for the declared `preLaunchEnv` credential
+ * names, which `preLaunch` has already minted into the host env by this point,
+ * so the hook cannot read them (PR #128's credential wall) while the parent
+ * shell keeps them for the agent wrap's `--env-pass`. Build secrets are left in
+ * env so the hook can authenticate `npm install` etc.; they are `unset` on the
+ * host afterward, before the agent wrap.
+ */
+function hostPrepareWorktreeLine(
+  prepareWorktreeCommand: string,
+  scrubNames: readonly string[],
+): string {
+  const scrub = scrubNames.length === 0 ? "" : `${unsetEnvironmentLine(scrubNames)}; `;
+  return prepareWorktreeWithStatusReporting(`${scrub}${prepareWorktreeCommand}`);
+}
+
+/**
  * Source a `KEY='value'` file with auto-export so build-time secrets land
  * in the shell env before prepareWorktree runs. The `-f` guard keeps it a
  * no-op if the file disappeared between staging and launch.
@@ -629,13 +648,18 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 }
 
 /**
- * Safehouse launch. Two Safehouse wraps, by design:
+ * Safehouse launch. The prepareWorktree hook runs on the **host shell**
+ * (unsandboxed), and only the **agent** runs inside a Safehouse wrap:
  *
- *   1. **prepareWorktree wrap**: plain
- *      `safehouse-clearance ... sh -c '<prepareWorktree>'`. Runs the repo
- *      preparation hook filesystem-isolated and egress-restricted,
- *      **without** inheriting agent-profile grants. Omitted entirely when no
- *      hook command is configured.
+ *   1. **prepareWorktree (host)**: the repo preparation hook runs directly on
+ *      the host launch shell — same as the `none` runner — so it has the host
+ *      toolchain's full filesystem access. This is deliberate: the hook is
+ *      trusted, pre-agent provisioning (a user-configured command run over a
+ *      fresh base-branch checkout, before the agent has touched anything), so
+ *      the agent's deny-by-default profile has no business constraining it.
+ *      Wrapping it in the sandbox only made the operator's own setup script
+ *      fail on host paths the profile masks (e.g. Ruby's XDG gem dirs).
+ *      Omitted entirely when no hook command is configured.
  *   2. **Agent wrap**: `safehouse-clearance "$shim" -c '<exec agent>' sh "$_p"`
  *      where `$shim` is a `mktemp`-d symlink to `/bin/sh` named after the
  *      agent (e.g. `claude`). Safehouse selects the matching agent profile
@@ -648,51 +672,50 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
  * env — neither inherited values (the launch shell inherits groundcrew's env,
  * from which `stageBuildSecrets` reads them) nor file-sourced values — and keeps
  * stale same-named ambient credentials from being forwarded. `secrets.env` is
- * then sourced into the host launch shell so Safehouse can forward build secrets
- * into the **prepareWorktree wrap** via `--env-pass=` (Safehouse's `--env=FILE` mode strips
- * them otherwise). After prepareWorktree returns, `BUILD_SECRET_NAMES` are `unset` again
- * on the host so they cannot reach the agent wrap.
+ * then sourced into the host launch shell so the host-run prepareWorktree hook
+ * inherits build secrets directly (for `npm install` etc.). After prepareWorktree
+ * returns, `BUILD_SECRET_NAMES` are `unset` again on the host so they cannot
+ * reach the agent wrap.
  *
- * `--env-pass` composition is split per wrap (deliberate, post PR #128):
- * - prepareWorktree wrap forwards build secrets only.
- * - Agent wrap forwards `preLaunchEnv` names only. preLaunch credentials never
- *   reach the profile-neutral prepare phase.
+ * PR #128's credential wall is preserved: `preLaunch` runs before the host
+ * prepareWorktree line, so its minted `preLaunchEnv` credentials are already in
+ * the host env. The host prepareWorktree line therefore `unset`s those declared
+ * names inside its own status-reporting subshell, so the trusted hook still
+ * cannot read them, while the parent shell retains them for the agent wrap's
+ * `--env-pass`.
  */
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  const { agentCommand: rawAgentCommand, prepareWorktreeCommand } =
-    renderPrepareAndAgentCommand(arguments_);
+  // Only the agent command comes from here; the prepareWorktree hook runs on the
+  // host shell (see below), not through a Safehouse wrap.
+  const { agentCommand: rawAgentCommand } = renderPrepareAndAgentCommand(arguments_);
   const { safehouseAgentIntegration } = arguments_;
   const agentCommand = [
     ...(safehouseAgentIntegration?.commandPreludes ?? []),
     rawAgentCommand,
   ].join("; ");
 
-  // Split --env-pass per wrap: the prepareWorktree wrap only needs build secrets (so
-  // `npm install` etc. can authenticate); the agent wrap only needs the
-  // user's preLaunchEnv (build secrets are `unset` on the host between the
-  // two wraps, so forwarding them here would silently no-op). Keeps preLaunch
-  // credentials out of the profile-neutral prepare phase — see PR #128.
-  // Trailing space keeps each flag separated from the next argv token.
-  const prepareWorktreeEnvPassFlag =
-    arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
+  // The agent wrap forwards the user's preLaunchEnv (plus worker/integration
+  // env). Build secrets are never forwarded to the agent wrap — they are sourced
+  // into the host shell for the host-run prepareWorktree hook, then `unset` on
+  // the host before this wrap. Keeps preLaunch credentials paired with the agent
+  // only, and (with the host prepareWorktree scrub) out of the hook — see PR #128.
   const agentEnvPassFlag = envPassFlag([
     ...(arguments_.definition.preLaunchEnv ?? []),
     ...workerEnvironmentNames(arguments_.workerEnvironment),
     ...(safehouseAgentIntegration?.envPass ?? []),
   ]);
-  // safehouse reads colon-separated paths from `--add-dirs`; both wraps get the
-  // same grant so the prepareWorktree hook and the agent can each reach git.
-  // Quote the whole value so shell-special chars survive; the trailing space
-  // separates it from the next argv token. See `resolveSafehouseAddDirs` for
-  // which paths these are and why.
-  const safehousePrepareAddDirs = arguments_.safehouseAddDirs ?? [];
+  // safehouse reads colon-separated paths from `--add-dirs`. Only the agent wrap
+  // needs them now (the prepareWorktree hook runs unsandboxed on the host, so it
+  // already has full git access). The base grant (`safehouseAddDirs` — worktree
+  // root + git common dir; see `resolveSafehouseAddDirs`) is merged with the
+  // agent-only paths. Quote the whole value so shell-special chars survive; the
+  // trailing space separates it from the next argv token.
   const safehouseAgentAddDirs = uniqueStrings([
-    ...safehousePrepareAddDirs,
+    ...(arguments_.safehouseAddDirs ?? []),
     ...(arguments_.safehouseAgentAddDirs ?? []),
   ]);
-  const safehouseAddDirsFlag = safehousePathListFlag("--add-dirs", safehousePrepareAddDirs);
   const safehouseAgentAddDirsFlag = safehousePathListFlag("--add-dirs", safehouseAgentAddDirs);
   const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
     "--add-dirs-ro",
@@ -726,9 +749,15 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
       secretsFile: arguments_.secretsFile,
     }),
   );
-  if (prepareWorktreeCommand !== undefined) {
+  if (arguments_.prepareWorktreeCommand !== undefined) {
+    // Trusted, pre-agent provisioning: run the hook on the host shell, not in a
+    // Safehouse wrap. Scrub the declared preLaunchEnv credential names so the
+    // hook cannot read them (PR #128) while the agent wrap still can.
     lines.push(
-      `${safehouseWrapper} ${safehouseAddDirsFlag}${prepareWorktreeEnvPassFlag}sh -c ${shellSingleQuote(prepareWorktreeCommand)}`,
+      hostPrepareWorktreeLine(
+        arguments_.prepareWorktreeCommand,
+        arguments_.definition.preLaunchEnv ?? [],
+      ),
     );
   }
   if (arguments_.secretsFile !== undefined) {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -756,6 +756,14 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
       secretsFile: arguments_.secretsFile,
     }),
   );
+  if (arguments_.prepareWorktreeUnsandboxedCommand !== undefined) {
+    lines.push(
+      hostPrepareWorktreeLine(
+        arguments_.prepareWorktreeUnsandboxedCommand,
+        arguments_.definition.preLaunchEnv ?? [],
+      ),
+    );
+  }
   if (prepareWorktreeCommand !== undefined) {
     lines.push(
       `${safehouseWrapper} ${safehouseAddDirsFlag}${prepareWorktreeEnvPassFlag}sh -c ${shellSingleQuote(prepareWorktreeCommand)}`,

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -8,6 +8,7 @@ import {
   type LocalRunner,
   type AgentDefinition,
   type NetworkEgressSetting,
+  type PrepareWorktreeSource,
 } from "./config.ts";
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
 import { shellSingleQuote } from "./shell.ts";
@@ -459,6 +460,15 @@ interface LaunchCommandArguments {
    */
   prepareWorktreeCommand?: string | undefined;
   /**
+   * Provenance of `prepareWorktreeCommand`, consumed only by the safehouse
+   * runner. `"operator"` (from crew.config.ts) is trusted and runs on the host
+   * shell; `"repository"` (from the repo-committed `.groundcrew/config.json`) is
+   * untrusted and runs inside the Safehouse wrap. When a hook is present but the
+   * source is absent, safehouse fails safe and sandboxes it. The srt and sdx
+   * runners ignore this — they sandbox every hook regardless.
+   */
+  prepareWorktreeSource?: PrepareWorktreeSource | undefined;
+  /**
    * Concrete local isolation backend chosen for this launch. Resolved
    * from `config.local.runner` via `resolveLocalRunner` before this
    * function is called — `auto` is never seen here.
@@ -687,9 +697,12 @@ function buildUnwrappedHostLaunchCommand(arguments_: LaunchCommandArguments): st
 function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string {
   const promptDir = path.dirname(arguments_.promptFile);
   const safehouseCommandName = inferAgentCommandName(arguments_.definition.cmd);
-  // Only the agent command comes from here; the prepareWorktree hook runs on the
-  // host shell (see below), not through a Safehouse wrap.
-  const { agentCommand: rawAgentCommand } = renderPrepareAndAgentCommand(arguments_);
+  // The agent command always runs through the Safehouse wrap. The
+  // prepareWorktree hook's placement depends on provenance (see the prepare
+  // block below): operator-authored hooks run on the host shell; repo-authored
+  // (or unknown-provenance) hooks stay sandboxed via `prepareWorktreeCommand`.
+  const { agentCommand: rawAgentCommand, prepareWorktreeCommand } =
+    renderPrepareAndAgentCommand(arguments_);
   const { safehouseAgentIntegration } = arguments_;
   const agentCommand = [
     ...(safehouseAgentIntegration?.commandPreludes ?? []),
@@ -706,17 +719,27 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
     ...workerEnvironmentNames(arguments_.workerEnvironment),
     ...(safehouseAgentIntegration?.envPass ?? []),
   ]);
-  // safehouse reads colon-separated paths from `--add-dirs`. Only the agent wrap
-  // needs them now (the prepareWorktree hook runs unsandboxed on the host, so it
-  // already has full git access). The base grant (`safehouseAddDirs` — worktree
-  // root + git common dir; see `resolveSafehouseAddDirs`) is merged with the
-  // agent-only paths. Quote the whole value so shell-special chars survive; the
-  // trailing space separates it from the next argv token.
+  // safehouse reads colon-separated paths from `--add-dirs`. The base grant
+  // (`safehouseAddDirs` — worktree root + git common dir; see
+  // `resolveSafehouseAddDirs`) goes to both wraps: a sandboxed prepareWorktree
+  // hook needs git access, and the agent wrap merges it with the agent-only
+  // paths. An operator-run (host) hook already has full git access, so its grant
+  // flag simply goes unused. Quote the whole value so shell-special chars
+  // survive; the trailing space separates it from the next argv token.
+  const safehousePrepareAddDirs = arguments_.safehouseAddDirs ?? [];
+  const safehousePrepareAddDirsFlag = safehousePathListFlag("--add-dirs", safehousePrepareAddDirs);
   const safehouseAgentAddDirs = uniqueStrings([
-    ...(arguments_.safehouseAddDirs ?? []),
+    ...safehousePrepareAddDirs,
     ...(arguments_.safehouseAgentAddDirs ?? []),
   ]);
   const safehouseAgentAddDirsFlag = safehousePathListFlag("--add-dirs", safehouseAgentAddDirs);
+  // Build secrets reach a sandboxed prepareWorktree hook via `--env-pass` only
+  // (Safehouse's `--env=FILE` baseline strips inherited env, and preLaunchEnv
+  // credentials are never listed here — keeping them out of the untrusted repo
+  // hook, per PR #128). Unused when the hook runs on the host, which sources
+  // secrets directly instead.
+  const prepareWorktreeEnvPassFlag =
+    arguments_.secretsFile === undefined ? "" : `--env-pass=${BUILD_SECRET_NAMES.join(",")} `;
   const safehouseAgentAddDirsReadOnlyFlag = safehousePathListFlag(
     "--add-dirs-ro",
     uniqueStrings([
@@ -749,15 +772,29 @@ function buildSafehouseLaunchCommand(arguments_: LaunchCommandArguments): string
       secretsFile: arguments_.secretsFile,
     }),
   );
-  if (arguments_.prepareWorktreeCommand !== undefined) {
-    // Trusted, pre-agent provisioning: run the hook on the host shell, not in a
-    // Safehouse wrap. Scrub the declared preLaunchEnv credential names so the
-    // hook cannot read them (PR #128) while the agent wrap still can.
+  if (
+    arguments_.prepareWorktreeSource === "operator" &&
+    arguments_.prepareWorktreeCommand !== undefined
+  ) {
+    // Operator-authored (crew.config.ts) hook — trusted, pre-agent provisioning.
+    // Run it on the host shell, not in a Safehouse wrap, so the operator's own
+    // `bin/setup`/`bundle install` gets full host access. Scrub the declared
+    // preLaunchEnv credential names so the hook cannot read them (PR #128) while
+    // the agent wrap still can.
     lines.push(
       hostPrepareWorktreeLine(
         arguments_.prepareWorktreeCommand,
         arguments_.definition.preLaunchEnv ?? [],
       ),
+    );
+  } else if (prepareWorktreeCommand !== undefined) {
+    // Repo-authored (or unknown-provenance) hook — untrusted. Keep it sandboxed
+    // inside a Safehouse wrap so repository-controlled code cannot run with the
+    // operator's full host authority (build secrets, ambient credentials,
+    // unrestricted network) before the agent sandbox starts. Fail-safe: any
+    // source other than "operator" lands here.
+    lines.push(
+      `${safehouseWrapper} ${safehousePrepareAddDirsFlag}${prepareWorktreeEnvPassFlag}sh -c ${shellSingleQuote(prepareWorktreeCommand)}`,
     );
   }
   if (arguments_.secretsFile !== undefined) {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -129,7 +129,7 @@ function prepareWorktreeWithStatusReporting(prepareWorktreeCommand: string): str
 }
 
 /**
- * Host-shell line for the operator-only `prepareWorktreeUnsandboxed` command.
+ * Host-shell line for the operator-only `unsandboxedHooks.prepareWorktree` command.
  * Reuses the same status-reporting wrapper as the sandboxed hook so a failure is
  * surfaced but non-fatal. `scrubNames` (the agent's `preLaunchEnv`) are `unset`
  * inside the subshell so this trusted host command cannot read agent
@@ -456,7 +456,7 @@ interface LaunchCommandArguments {
   /**
    * Operator-only, per-repository setup command run on the HOST shell (never a
    * sandbox), before `prepareWorktreeCommand` and the agent. Resolved by the
-   * caller from `knownRepositories[].prepareWorktreeUnsandboxed` in
+   * caller from `knownRepositories[].unsandboxedHooks.prepareWorktree` in
    * crew.config.ts. Emitted for the safehouse, srt, and none runners; the sdx
    * runner rejects it (no host to run it on).
    */
@@ -580,7 +580,7 @@ export function buildLaunchCommand(arguments_: LaunchCommandArguments): string {
     }
     if (arguments_.prepareWorktreeUnsandboxedCommand !== undefined) {
       throw new Error(
-        "prepareWorktreeUnsandboxed is not supported for runner='sdx': the sdx container has no host to run it on. Remove prepareWorktreeUnsandboxed for this repo, or use runner 'safehouse', 'srt', or 'none'.",
+        "unsandboxedHooks.prepareWorktree is not supported for runner='sdx': the sdx container has no host to run it on. Remove unsandboxedHooks for this repo, or use runner 'safehouse', 'srt', or 'none'.",
       );
     }
     return buildSdxLaunchCommand(arguments_);

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -578,6 +578,11 @@ export function buildLaunchCommand(arguments_: LaunchCommandArguments): string {
         "preLaunchEnv is not yet supported for runner='sdx'. Set local.runner to 'safehouse' or 'none', or open an issue for sdx support.",
       );
     }
+    if (arguments_.prepareWorktreeUnsandboxedCommand !== undefined) {
+      throw new Error(
+        "prepareWorktreeUnsandboxed is not supported for runner='sdx': the sdx container has no host to run it on. Remove prepareWorktreeUnsandboxed for this repo, or use runner 'safehouse', 'srt', or 'none'.",
+      );
+    }
     return buildSdxLaunchCommand(arguments_);
   }
   if (shouldWrapWithSafehouse(arguments_)) {

--- a/src/lib/repositoryHooks.test.ts
+++ b/src/lib/repositoryHooks.test.ts
@@ -39,7 +39,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "npm ci", source: "operator" });
+      expect(actual).toBe("npm ci");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -58,7 +58,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "uv sync --dev", source: "repository" });
+      expect(actual).toBe("uv sync --dev");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -73,7 +73,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "make setup", source: "operator" });
+      expect(actual).toBe("make setup");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -88,7 +88,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: {},
       });
 
-      expect(actual).toEqual({ command: "make setup", source: "operator" });
+      expect(actual).toBe("make setup");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -108,7 +108,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "uv sync --dev", source: "repository" });
+      expect(actual).toBe("uv sync --dev");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -123,7 +123,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "npm ci", source: "operator" });
+      expect(actual).toBe("npm ci");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -139,7 +139,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "npm ci", source: "operator" });
+      expect(actual).toBe("npm ci");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -155,7 +155,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toEqual({ command: "npm ci", source: "operator" });
+      expect(actual).toBe("npm ci");
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }

--- a/src/lib/repositoryHooks.test.ts
+++ b/src/lib/repositoryHooks.test.ts
@@ -39,7 +39,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("npm ci");
+      expect(actual).toEqual({ command: "npm ci", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -58,7 +58,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("uv sync --dev");
+      expect(actual).toEqual({ command: "uv sync --dev", source: "repository" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -73,7 +73,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("make setup");
+      expect(actual).toEqual({ command: "make setup", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -88,7 +88,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: {},
       });
 
-      expect(actual).toBe("make setup");
+      expect(actual).toEqual({ command: "make setup", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -108,7 +108,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("uv sync --dev");
+      expect(actual).toEqual({ command: "uv sync --dev", source: "repository" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -123,7 +123,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("npm ci");
+      expect(actual).toEqual({ command: "npm ci", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -139,7 +139,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("npm ci");
+      expect(actual).toEqual({ command: "npm ci", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
@@ -155,7 +155,7 @@ describe(resolvePrepareWorktreeCommand, () => {
         defaultHooks: { prepareWorktree: "npm ci" },
       });
 
-      expect(actual).toBe("npm ci");
+      expect(actual).toEqual({ command: "npm ci", source: "operator" });
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }

--- a/src/lib/repositoryHooks.test.ts
+++ b/src/lib/repositoryHooks.test.ts
@@ -257,4 +257,43 @@ describe(resolvePrepareWorktreeCommand, () => {
       rmSync(worktreeDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects a repo config that sets prepareWorktreeUnsandboxed at the top level", () => {
+    const worktreeDir = temporaryWorktree();
+    try {
+      writeRepositoryConfig(worktreeDir, { version: 1, prepareWorktreeUnsandboxed: "bin/setup" });
+
+      expect(() =>
+        resolvePrepareWorktreeCommand({
+          worktreeDir,
+          defaultHooks: {},
+        }),
+      ).toThrow(
+        /prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config\. Move it to crew\.config\.ts\./,
+      );
+    } finally {
+      rmSync(worktreeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a repo config that nests prepareWorktreeUnsandboxed under hooks", () => {
+    const worktreeDir = temporaryWorktree();
+    try {
+      writeRepositoryConfig(worktreeDir, {
+        version: 1,
+        hooks: { prepareWorktreeUnsandboxed: "bin/setup" },
+      });
+
+      expect(() =>
+        resolvePrepareWorktreeCommand({
+          worktreeDir,
+          defaultHooks: {},
+        }),
+      ).toThrow(
+        /prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config\./,
+      );
+    } finally {
+      rmSync(worktreeDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/lib/repositoryHooks.test.ts
+++ b/src/lib/repositoryHooks.test.ts
@@ -258,30 +258,12 @@ describe(resolvePrepareWorktreeCommand, () => {
     }
   });
 
-  it("rejects a repo config that sets prepareWorktreeUnsandboxed at the top level", () => {
-    const worktreeDir = temporaryWorktree();
-    try {
-      writeRepositoryConfig(worktreeDir, { version: 1, prepareWorktreeUnsandboxed: "bin/setup" });
-
-      expect(() =>
-        resolvePrepareWorktreeCommand({
-          worktreeDir,
-          defaultHooks: {},
-        }),
-      ).toThrow(
-        /prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config\. Move it to crew\.config\.ts\./,
-      );
-    } finally {
-      rmSync(worktreeDir, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects a repo config that nests prepareWorktreeUnsandboxed under hooks", () => {
+  it("rejects a repo config that sets unsandboxedHooks at the top level", () => {
     const worktreeDir = temporaryWorktree();
     try {
       writeRepositoryConfig(worktreeDir, {
         version: 1,
-        hooks: { prepareWorktreeUnsandboxed: "bin/setup" },
+        unsandboxedHooks: { prepareWorktree: "bin/setup" },
       });
 
       expect(() =>
@@ -290,8 +272,27 @@ describe(resolvePrepareWorktreeCommand, () => {
           defaultHooks: {},
         }),
       ).toThrow(
-        /prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config\./,
+        /unsandboxedHooks is operator-only and cannot be set in a repository config\. Move it to crew\.config\.ts\./,
       );
+    } finally {
+      rmSync(worktreeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a repo config that nests unsandboxedHooks under hooks", () => {
+    const worktreeDir = temporaryWorktree();
+    try {
+      writeRepositoryConfig(worktreeDir, {
+        version: 1,
+        hooks: { unsandboxedHooks: { prepareWorktree: "bin/setup" } },
+      });
+
+      expect(() =>
+        resolvePrepareWorktreeCommand({
+          worktreeDir,
+          defaultHooks: {},
+        }),
+      ).toThrow(/unsandboxedHooks is operator-only and cannot be set in a repository config\./);
     } finally {
       rmSync(worktreeDir, { recursive: true, force: true });
     }

--- a/src/lib/repositoryHooks.ts
+++ b/src/lib/repositoryHooks.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import type { HookCommands } from "./config.ts";
+import type { HookCommands, PrepareWorktreeSource } from "./config.ts";
 
 const REPOSITORY_CONFIG_RELATIVE_PATH = ".groundcrew/config.json";
 
@@ -17,19 +17,35 @@ interface ResolvePrepareWorktreeCommandArguments {
   defaultHooks: HookCommands;
 }
 
+export interface ResolvedPrepareWorktreeCommand {
+  command: string;
+  /**
+   * Which layer supplied `command`. The safehouse runner keys its host-vs-sandbox
+   * decision off this: `"repository"` hooks are untrusted and stay sandboxed;
+   * `"operator"` hooks are trusted and run on the host. See {@link PrepareWorktreeSource}.
+   */
+  source: PrepareWorktreeSource;
+}
+
 // Flat precedence cascade, highest priority first: the repo-committed
 // `.groundcrew/config.json` wins (closest to the code), then the per-repo
-// operator layer, then the global `defaults.hooks` fallback. All three reuse
-// the same `HookCommands` shape so this stays a plain `?? ?? ??`.
+// operator layer, then the global `defaults.hooks` fallback. The winning layer's
+// provenance is returned alongside the command because it is a security boundary
+// — only the operator layers are trusted enough to run unsandboxed.
 export function resolvePrepareWorktreeCommand(
   arguments_: ResolvePrepareWorktreeCommandArguments,
-): string | undefined {
+): ResolvedPrepareWorktreeCommand | undefined {
   const repositoryConfig = readRepositoryConfig(arguments_.worktreeDir);
-  return (
-    repositoryConfig?.hooks.prepareWorktree ??
-    arguments_.perRepoHooks?.prepareWorktree ??
-    arguments_.defaultHooks.prepareWorktree
-  );
+  const repositoryCommand = repositoryConfig?.hooks.prepareWorktree;
+  if (repositoryCommand !== undefined) {
+    return { command: repositoryCommand, source: "repository" };
+  }
+  const operatorCommand =
+    arguments_.perRepoHooks?.prepareWorktree ?? arguments_.defaultHooks.prepareWorktree;
+  if (operatorCommand !== undefined) {
+    return { command: operatorCommand, source: "operator" };
+  }
+  return undefined;
 }
 
 interface RepositoryConfig {

--- a/src/lib/repositoryHooks.ts
+++ b/src/lib/repositoryHooks.ts
@@ -64,9 +64,25 @@ function normalizeRepositoryConfig(value: unknown): RepositoryConfig {
   if (value["version"] !== 1) {
     fail("version must be 1");
   }
+  rejectUnsandboxedField(value);
   return {
     hooks: normalizeHookCommands(value["hooks"]),
   };
+}
+
+// `prepareWorktreeUnsandboxed` grants host execution, which is operator-only. A
+// repo-committed config must never be able to set it — top-level or nested under
+// `hooks` — so fail closed with guidance to move it to crew.config.ts. Checked
+// before `normalizeHookCommands`, which would otherwise silently drop the nested
+// form.
+function rejectUnsandboxedField(value: Record<string, unknown>): void {
+  const hooks = value["hooks"];
+  const nestedHasField = isPlainObject(hooks) && "prepareWorktreeUnsandboxed" in hooks;
+  if ("prepareWorktreeUnsandboxed" in value || nestedHasField) {
+    fail(
+      "prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config. Move it to crew.config.ts.",
+    );
+  }
 }
 
 function normalizeHookCommands(value: unknown): HookCommands {

--- a/src/lib/repositoryHooks.ts
+++ b/src/lib/repositoryHooks.ts
@@ -70,17 +70,17 @@ function normalizeRepositoryConfig(value: unknown): RepositoryConfig {
   };
 }
 
-// `prepareWorktreeUnsandboxed` grants host execution, which is operator-only. A
+// `unsandboxedHooks` grants host execution, which is operator-only. A
 // repo-committed config must never be able to set it — top-level or nested under
 // `hooks` — so fail closed with guidance to move it to crew.config.ts. Checked
 // before `normalizeHookCommands`, which would otherwise silently drop the nested
 // form.
 function rejectUnsandboxedField(value: Record<string, unknown>): void {
   const hooks = value["hooks"];
-  const nestedHasField = isPlainObject(hooks) && "prepareWorktreeUnsandboxed" in hooks;
-  if ("prepareWorktreeUnsandboxed" in value || nestedHasField) {
+  const nestedHasField = isPlainObject(hooks) && "unsandboxedHooks" in hooks;
+  if ("unsandboxedHooks" in value || nestedHasField) {
     fail(
-      "prepareWorktreeUnsandboxed is operator-only and cannot be set in a repository config. Move it to crew.config.ts.",
+      "unsandboxedHooks is operator-only and cannot be set in a repository config. Move it to crew.config.ts.",
     );
   }
 }

--- a/src/lib/repositoryHooks.ts
+++ b/src/lib/repositoryHooks.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import type { HookCommands, PrepareWorktreeSource } from "./config.ts";
+import type { HookCommands } from "./config.ts";
 
 const REPOSITORY_CONFIG_RELATIVE_PATH = ".groundcrew/config.json";
 
@@ -17,35 +17,19 @@ interface ResolvePrepareWorktreeCommandArguments {
   defaultHooks: HookCommands;
 }
 
-export interface ResolvedPrepareWorktreeCommand {
-  command: string;
-  /**
-   * Which layer supplied `command`. The safehouse runner keys its host-vs-sandbox
-   * decision off this: `"repository"` hooks are untrusted and stay sandboxed;
-   * `"operator"` hooks are trusted and run on the host. See {@link PrepareWorktreeSource}.
-   */
-  source: PrepareWorktreeSource;
-}
-
 // Flat precedence cascade, highest priority first: the repo-committed
 // `.groundcrew/config.json` wins (closest to the code), then the per-repo
-// operator layer, then the global `defaults.hooks` fallback. The winning layer's
-// provenance is returned alongside the command because it is a security boundary
-// — only the operator layers are trusted enough to run unsandboxed.
+// operator layer, then the global `defaults.hooks` fallback. All three reuse
+// the same `HookCommands` shape so this stays a plain `?? ?? ??`.
 export function resolvePrepareWorktreeCommand(
   arguments_: ResolvePrepareWorktreeCommandArguments,
-): ResolvedPrepareWorktreeCommand | undefined {
+): string | undefined {
   const repositoryConfig = readRepositoryConfig(arguments_.worktreeDir);
-  const repositoryCommand = repositoryConfig?.hooks.prepareWorktree;
-  if (repositoryCommand !== undefined) {
-    return { command: repositoryCommand, source: "repository" };
-  }
-  const operatorCommand =
-    arguments_.perRepoHooks?.prepareWorktree ?? arguments_.defaultHooks.prepareWorktree;
-  if (operatorCommand !== undefined) {
-    return { command: operatorCommand, source: "operator" };
-  }
-  return undefined;
+  return (
+    repositoryConfig?.hooks.prepareWorktree ??
+    arguments_.perRepoHooks?.prepareWorktree ??
+    arguments_.defaultHooks.prepareWorktree
+  );
 }
 
 interface RepositoryConfig {


### PR DESCRIPTION
## What this is

Adds an operator-only, per-repository `unsandboxedHooks` container and its `prepareWorktree` hook: the explicit opt-in for repo setup that must run on the host rather than in the agent's execution context. It covers setup the sandbox blocks — native gem/dependency compilation, host toolchains, writes outside the worktree. `unsandboxedHooks` is the host-side mirror of the existing sandboxed `hooks` container, so the `prepareWorktree` phase reads the same on both sides of the sandbox boundary.

## Requirements

- Host execution must be a deliberate, auditable grant: **operator-only** and **per-repository**. Non-goals: no `defaults.unsandboxedHooks` (host execution is never a fleet-wide default), and a repo cannot grant itself host execution.
- The existing credential wall must hold: the agent's `preLaunchEnv` credentials must not leak into repo-controlled host code.

## The architecture

Host execution is a distinct, named capability granted per repo in operator config: a separate `unsandboxedHooks` container that parallels the sandboxed `hooks` container. When both `prepareWorktree` hooks are set on a repo, they run in order:

```
unsandboxedHooks.prepareWorktree (HOST)
        -> hooks.prepareWorktree (SANDBOXED)
        -> agent
```

Load-bearing decisions:

- **A parallel container, not a bare field.** `unsandboxedHooks` mirrors `hooks` and carries the same `prepareWorktree` phase name, so the isolation axis (which container) is separate from the phase axis (which key). This keeps future host-side hooks from polluting the top level and gives host hooks a distinct `UnsandboxedHookCommands` type that can diverge from the sandboxed shape.
- **Operator-only, per-repo, no defaults.** The container lives only on `knownRepositories[]` entries in `crew.config.ts`. Setting `unsandboxedHooks` in a repo-committed `.groundcrew/config.json` (top-level or nested under `hooks`) is a hard, fail-closed config error — a repo cannot grant itself host execution. There is deliberately no `defaults.unsandboxedHooks`.
- **`sdx` rejects it at launch.** A container has no host to run on, so `runner=sdx` + `unsandboxedHooks` is a config error pointing the operator to `safehouse`/`srt`/`none`.
- **Credential wall preserved.** The host command runs with build secrets available (so `npm`/`bundle` can authenticate) but with the agent's `preLaunchEnv` names scrubbed inside the same subshell, and all build secrets unset before the agent starts.

The `prepareWorktree` phase, the secret-shuttle mechanics, and the runner wrappers are untouched — covered by the existing launch-command and config suites staying green.

## Interface changes

Operator config (`crew.config.ts`) gains one per-repo container:

```ts
knownRepositories: [
  {
    name: "catalog-admin",
    hooks: { prepareWorktree: "npm ci" }, // sandboxed
    unsandboxedHooks: { prepareWorktree: "bin/setup" }, // HOST, explicit opt-in
  },
]
```

Honored by both `crew setup` and `crew open`. Documented in `docs/setup-hooks.md`, with cross-references in `README.md`, `docs/runners.md`, and `docs/credentials.md`.

## Testing

Unit-tested end-to-end per layer: config normalization and the operator-only/no-defaults contract; repo-config rejection (both shapes); host-line emission and ordering for `none`/`safehouse`/`srt`; the `sdx` launch-time rejection; and resolution/forwarding through both `crew setup` and `crew open`. Full `node --run verify` green.

### Local end-to-end validation

Validated manually against `catalog-admin` (a real native-gem repo) with `runner=safehouse` and `unsandboxedHooks.prepareWorktree = "bin/setup && bundle pristine red-arrow red-parquet"`. The host hook compiled the native gems (`red-arrow`, `red-parquet`) on the host — where `/usr/bin/clang++` works — before the agent's sandbox started; the sandbox then read the precompiled gems (via `readOnlyDirs`) instead of rebuilding them. The hook exited 0 and the session stayed alive.

This reproduces and resolves the original failure mode: the same native build fails inside the sandbox, where `/usr/bin/clang++` is a broken `xcrun` stub — the exact case `unsandboxedHooks` exists to move onto the host.
