### PR TITLE
fix(status): exclude dispatched worktrees from the Queue section

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1245,6 +1245,57 @@ describe(status, () => {
     expect(output).toContain("team-104");
   });
 
+  it("excludes Queue and Blocked rows whose task already has a local worktree", async () => {
+    // Reproduces the "queued + provisioning at the same time" bug: when a task
+    // has been dispatched (worktree exists, local run state is provisioning)
+    // but the board still reports it as todo, it must not appear in the Queue.
+    listWorktreesMock.mockReturnValue([
+      worktree({ repository: "repo-a", task: "team-101" }),
+      worktree({ repository: "repo-b", task: "team-102", dir: "/work/repo-b-team-102" }),
+    ]);
+    const runStatesByTask = new Map<string, RunState>([
+      ["team-101", runState({ task: "team-101", repository: "repo-a", state: "provisioning" })],
+      ["team-102", runState({ task: "team-102", repository: "repo-b", state: "provisioning" })],
+    ]);
+    readRunStateMock.mockImplementation((_config, task) => runStatesByTask.get(task));
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        // Dispatched todo — should NOT appear in Queue.
+        sourceIssue({
+          id: "linear:team-101",
+          title: "Already dispatched",
+          repository: "repo-a",
+          agent: "claude",
+        }),
+        // Dispatched todo, blocked — should NOT appear in Blocked.
+        sourceIssue({
+          id: "linear:team-102",
+          title: "Dispatched but blocked upstream",
+          repository: "repo-b",
+          agent: "claude",
+          blockers: [{ id: "linear:team-50", title: "x", status: "in-progress" }],
+        }),
+        // Not yet dispatched — should still appear in Queue as a control.
+        sourceIssue({
+          id: "linear:team-777",
+          title: "Genuinely queued",
+          repository: "repo-a",
+          agent: "claude",
+        }),
+      ]),
+    ]);
+
+    await status(makeConfig({ sources: [{ kind: "linear", name: "linear" }] }));
+
+    const output = consoleLog.output();
+    const queueSection = output.slice(output.indexOf("Queue\n-----"));
+    expect(queueSection).not.toContain("team-101");
+    expect(queueSection).not.toContain("team-102");
+    expect(queueSection).toContain("team-777");
+    expect(output).not.toContain("Blocked\n-------");
+  });
+
   it("hides the Queue section when the source has only non-Todo issues", async () => {
     listWorktreesMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -602,15 +602,23 @@ function statusByWorktreeTask(
   return statuses;
 }
 
-function writeQueueSections(boardResult: BoardFetchResult): void {
+function writeQueueSections(
+  boardResult: BoardFetchResult,
+  worktreeTasks: ReadonlySet<string>,
+): void {
   if (boardResult.kind === "error") {
     writeSection("Queue");
     writeOutput(`unavailable: ${errorMessage(boardResult.error)}`);
     return;
   }
   // Only groundcrew-eligible Todos are dispatchable; non-eligible ones lack
-  // a repo or agent, so `crew run` would skip them.
-  const todos = boardResult.issues.filter(isTodoSourceIssue).filter(isGroundcrewIssue);
+  // a repo or agent, so `crew run` would skip them. Todos whose task already
+  // has a local worktree are omitted so a dispatched-but-not-yet-transitioned
+  // ticket doesn't show as both provisioning and queued.
+  const todos = boardResult.issues
+    .filter(isTodoSourceIssue)
+    .filter(isGroundcrewIssue)
+    .filter((i) => !worktreeTasks.has(naturalIdFromCanonical(i.id).toLowerCase()));
   const ready = todos.filter((i) => !hasOpenBlocker(i));
   const blocked = todos.filter(hasOpenBlocker);
 
@@ -716,7 +724,7 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
     writeOutput();
     writeOutput(`slots: ${used}/${config.orchestrator.maximumInProgress} used`);
   }
-  writeQueueSections(boardResult);
+  writeQueueSections(boardResult, worktreeTasks);
 }
 
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {


### PR DESCRIPTION
## Summary
- A task with a local worktree was appearing in both the `Worktrees` (state: provisioning) and `Queue` sections of `crew status` at the same time.
- `writeQueueSections` filtered purely on the remote board status (`todo`); when a dispatch had begun but the ticket had not yet transitioned to in-progress on the board, the same task rendered twice with contradictory framing.
- Filter Queue and Blocked entries by the set of local worktree tasks so a dispatched ticket disappears from the queue on the first status render. Matches the existing pattern used by `writeInProgressWithoutWorktree`.

## Test plan
- [x] `node --run verify` passes
- [x] New test: dispatched worktree (with matching board todo) is excluded from Queue and Blocked; an undispatched todo is still shown as a control