### PR TITLE
docs: groundcrew v2 design doc and E2E scenario catalog (DEVOP-5983)

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -183,6 +183,7 @@
     "pluggability",
     "neverthrow",
     "finalizers",
-    "opencode"
+    "opencode",
+    "inspectable"
   ]
 }

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -171,6 +171,18 @@
     "xhigh",
     "mycli",
     "mcps",
-    "APFS"
+    "APFS",
+    "wayfinder",
+    "dogfoods",
+    "cutover",
+    "Cutover",
+    "unbuilt",
+    "unsandboxable",
+    "anticorruption",
+    "renderable",
+    "pluggability",
+    "neverthrow",
+    "finalizers",
+    "opencode"
   ]
 }

--- a/docs/spec/e2e-scenario-catalog.md
+++ b/docs/spec/e2e-scenario-catalog.md
@@ -1,4 +1,4 @@
-# E2E scenario catalog (draft prototype — DEVOP-5974)
+# E2E scenario catalog (DEVOP-5974)
 
 The executable half of the groundcrew v2 spec: the black-box scenarios the acceptance suite must cover, plus the harness shape that makes them hermetic. The suite is written **before v2 code exists** and brings v2 up red→green; it is v2's system-level TDD loop and the language-agnostic escape hatch (any implementation that passes is conformant).
 
@@ -33,8 +33,8 @@ Scenarios call abstract operations bound in exactly one harness module. The CLI 
 configure(fixture)            // write config into the scenario tmpdir
 seedSource(tasks[])           // load the fixture source's task store
 tick()                        // one poll/dispatch cycle
-start(taskId)                 // immediate dispatch, bypassing eligibility
-stop(taskId) / resume(taskId) / cleanup(taskId, {force}) / status(taskId?) / doctor()
+start(taskId, {force?})       // dispatch that task; force bypasses eligibility, never the repo-on-disk gate
+pause(taskId) / resume(taskId) / cleanup(taskId, {force}) / status(taskId?) / doctor()
 killOrchestrator() / restart()  // crash scenarios
 paths: { worktreeFor(repo, task), workspaceFor(task), stateFor(task), logFile }
 expect: { branchFor(task), sessionFor(task) }
@@ -88,7 +88,7 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 
 ### B. Completion & writeback
 
-- **COMPLETE-01** (core) — _Publishing work is reporting it._ Scripted agent commits, runs `crew artifact add <pr-url> --kind pr`, emits progress. Then: journal shows `update:progress` and the artifact-bearing update; status shows both layers (commits _observed_, PR _reported_); core made no forge call.
+- **COMPLETE-01** (core) — _Publishing work is reporting it._ Scripted agent commits and runs `crew artifact add <pr-url> --kind pr`. Then: the reported artifact appears in the run record and rides the `completed` writeback; status shows both layers (commits _observed_, PR _reported_); core made no forge call.
 - **COMPLETE-02** (core) — _Delivered: slot freed, workspace lingers._ Scripted agent ends `completed {outcome: delivered, artifacts}`. Then: journal carries the completed event exactly once with artifacts intact; state is `complete{delivered}`; session ended; **worktree, branch, and state record still on disk**; next `tick()` dispatches the next queued task (slot freed) while the delivered workspace lingers.
 - **COMPLETE-03** (core) — _Launch failure is truthful and rolled back._ Given an agent profile whose `cmd` doesn't exist. When `start(task)`. Then state records `complete{failed, reason: launch}`; worktree and branch rolled back; the failure appears in the journal if the task was already claimed.
 - **COMPLETE-04** (core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented; workspace lingers for inspection.
@@ -99,7 +99,7 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 
 ### C. Session lifecycle
 
-- **SESSION-01** (core) — _Stop keeps work._ Given a running task. When `stop(task)`. Then session closed, worktree and branch intact, state paused, resumable.
+- **SESSION-01** (core) — _Pause keeps work._ Given a running task. When `pause(task)`. Then session closed, worktree and branch intact, state paused, resumable.
 - **SESSION-02** (core) — _Resume reopens, never recreates._ When `resume(task)` on a paused task: session live again, same worktree, resume count incremented, state running. When `resume` on a task with no worktree: hard error, nothing created.
 - **SESSION-03** (core) — _Status tells the truth about strays._ Given state says running but the tmux session was killed externally. Then `status` flags the disagreement (stray/dead). Given no state but a live session matching a task: `status` flags the stray session.
 
@@ -127,7 +127,7 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **FLOW-01** (core) — _Reported vs observed are separate layers._ Agent commits but reports nothing. Then status shows commits _observed_ and no artifact _reported_ — a missing link, never a lie.
 - **FLOW-02** (core) — _Mixed artifact kinds round-trip._ Agent reports `pr`, `ticket`, and `file` artifacts. Then `completed.artifacts` in the journal carries all three, kinds and locators intact.
 - **FLOW-03** (core) — _Claim rejected._ Given the fixture source answers `claimed` with _rejected_. Then no provisioning, no session; task remains listed; the rejection is visible in log/status. (The remote-runner door.)
-- **FLOW-04** (core) — _Progress events flow._ Agent emits progress notes. Then journal shows `update:progress` with the notes, in order.
+- **FLOW-04** (core, **deferred post-v2.0**) — _Progress events flow._ Requires an agent-facing progress emitter, and v2.0 ships none: `crew progress` is a documented seam, not built (DEVOP-5982 §6). The `progress` event stays in protocol 1; this ID is reserved and the scenario activates when the emitter ships.
 - **FLOW-05** (core) — _Done-ness is not core's business._ After COMPLETE-02, the source's task store still says whatever its own `update` handler chose; core issues no reads to confirm or reconcile it, and status renders the agent's report unchanged.
 - **FLOW-06** (core) — _Core is forge-blind._ Across MULTI/FLOW scenarios, the fake `gh` (and any recorded network attempt in the core lane) shows **zero** invocations by the core process. Agent-initiated calls don't count.
 
@@ -161,3 +161,4 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **Iteration 1** (2026-07-16): green-on-v1 gate dropped in favor of harness self-tests plus a migration-easing budget; completion model codified (forge-blind, agent-reported, linger-until-cleanup); suite stack confirmed (`e2e/` package, TS + vitest); sandbox lane confirmed v2-only. Tier A/B structure and the v1 driver removed accordingly.
 - **Iteration 2** (2026-07-16): linger gets two exits — manual `cleanup` or source-terminal auto-reap (v1's cleaner kept: it watches the source, never the forge; v1's merged-PR reviewer path dies). COMPLETE-07 added; dirty worktrees are never auto-reaped.
 - **Iteration 3** (2026-07-16): absorbed the CLI surface resolution's handoff (DEVOP-5975, resolved concurrently): `workspace add` → `repo add`; completion via `crew done`; task-identity resolution order with exit codes 2/3 (MULTI-04/05/08); `--force` never overrides the repo gate (DISPATCH-07); `done` dirty-guard (COMPLETE-08); `init --yes`, v1-config conversion, and `source doctor` round-trip (SURFACE-05/06/07).
+- **Iteration 4** (2026-07-17): review pass on the design-doc assembly PR: "draft prototype" label dropped (the catalog is ratified); harness binding renamed `stop` → `pause` and `start` gains `{force?}` (SESSION-01, DISPATCH-07); progress assertions removed from COMPLETE-01 and FLOW-04 deferred post-v2.0 — v2.0 ships no agent-facing progress emitter (DEVOP-5982 §6).

--- a/docs/spec/e2e-scenario-catalog.md
+++ b/docs/spec/e2e-scenario-catalog.md
@@ -1,0 +1,149 @@
+# E2E scenario catalog (draft prototype — DEVOP-5974)
+
+The executable half of the groundcrew v2 spec: the black-box scenarios the compat suite must cover, plus the harness shape that makes them hermetic. The suite gets built against **v1 first** (the Bun lesson) — it must run green on v1 before any v2 code exists — yet the v2 decisions deliberately break v1's config shape, CLI surface, and source contract. The catalog resolves that tension with a **driver seam** and **two tiers**.
+
+## 1. Suite architecture
+
+### Black-box rules
+
+- The suite spawns the `crew` binary and observes the world. It never imports groundcrew code, reads groundcrew internals, or mocks in-process. This is the language-agnostic escape hatch: any implementation that passes is conformant.
+- Assertions target the **observation surface** (§1.2), not stdout prose. Stdout/exit codes are asserted only where the output _is_ the behavior (`status`, `doctor`, loud errors), and then loosely (key substrings, not full-text golden files).
+
+### Observation surface
+
+Everything a scenario may assert on:
+
+| Channel                | How observed                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Exit codes             | direct                                                                                                           |
+| Worktrees & branches   | `git worktree list`, `git branch`, `git log`/`status` in the sandbox tmpdir                                      |
+| Run/task state on disk | the version's state files (driver exposes the path + a normalized parse)                                         |
+| Terminal sessions      | real tmux on an isolated socket (`tmux -L <scenario-id>`) — session exists / alive / exited                      |
+| Source interactions    | the fixture source's **call journal** (§1.4): every command invocation with args + stdin, appended as JSON lines |
+| Structured logs        | JSON-line log file under the scenario's state dir                                                                |
+| Human-facing output    | `status` / `doctor` stdout, loose match                                                                          |
+
+### Driver seam (v1 vs v2)
+
+Scenarios are written against a small `CrewDriver` interface; one thin driver per major version maps abstract operations to concrete commands, config files, and paths. The driver is part of the suite, not the product — it is the only place that knows `knownRepositories` (v1) vs base-dir discovery (v2), or `crew run` (v1) vs whatever DEVOP-5975 names the poll command.
+
+Driver operations (proposed):
+
+```text
+configure(fixture)            // write version-appropriate config into the scenario tmpdir
+seedSource(tasks[])           // load the fixture source's task store
+tick()                        // one poll/dispatch cycle (v1: crew run)
+start(taskId)                 // immediate dispatch (v1: crew start)
+stop(taskId) / resume(taskId) / cleanup(taskId, {force}) / status(taskId?) / doctor()
+killDaemon() / restart()      // crash scenarios
+paths: { worktreeFor(repo, task), stateFor(task), logFile }
+expect: { branchFor(task), sessionFor(task) }
+```
+
+A scenario that needs an operation only one version has (e.g. `crew workspace add`) is tiered accordingly.
+
+### Tiers and lanes
+
+- **Tier A — shared behavioral core.** Runs green against v1 _and_ v2 through the drivers. This is the compat guarantee: the behaviors v2 must not regress.
+- **Tier B — v2-only.** New contract behavior (multi-repo workspaces, runtime acquisition, artifact reporting, protocol versioning, source sandboxing). Written now, red until v2 exists; they double as v2's acceptance tests.
+- Orthogonally, two **lanes**: the **core lane** (hermetic, no sandbox runner, runs anywhere including CI) and the **sandbox lane** (real srt; platform-gated to macOS `sandbox-exec` / Linux bubblewrap; asserts denial behavior that can't be faked honestly).
+
+### Fakes
+
+| Real thing                  | Stand-in                                                                                                                                                                                                                                                                                                               | Notes                                                                                                                                                                |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linear / Jira / any tracker | **Fixture source**: a manifest task-source bundle backed by a JSON task store in the scenario tmpdir. Every invocation appends `{command, args, stdin, timestamp}` to `calls.jsonl` — the writeback assertion point. Two thin manifests over one implementation: v1's shell-source contract, v2's protocol-1 contract. | First-party sources are conformance tests of the boundary (DEVOP-5973); the fixture source is the suite's conformance test of the same boundary from the other side. |
+| Agent CLI (claude/codex/…)  | **Scripted agent**: an executable that reads a per-scenario script (env-pointed file) and deterministically acts — sleep, write files, `git commit`, invoke in-session `crew` commands (Tier B), report artifacts, exit 0/1. Both versions support `cmd`-points-at-your-script, so this is honest.                     | Also emits a heartbeat file so scenarios can synchronize on "agent is running" without sleeps.                                                                       |
+| GitHub / forge              | **v1 lane only**: fake `gh` on PATH backed by a JSON PR fixture (v1's reviewer observes PRs via `gh`). **v2 needs no forge fake** — core observes only local git facts; PRs are agent-_reported_ artifacts.                                                                                                            | The asymmetry is itself a spec assertion: v2 core makes zero forge calls (fake `gh` records any invocation → fail).                                                  |
+| Git remotes                 | Local bare repos (`file://` remotes) under the scenario tmpdir; `origin/main` seeded with a few commits.                                                                                                                                                                                                               | Real git throughout.                                                                                                                                                 |
+| tmux                        | Real tmux, isolated per scenario via `-L <socket>`.                                                                                                                                                                                                                                                                    | Real seam, cheap, deterministic enough.                                                                                                                              |
+| Host env                    | Per-scenario tmpdir owning `HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`; PATH prepended with the fakes dir; no network in the core lane.                                                                                                                                                                                |                                                                                                                                                                      |
+
+### Scenario format
+
+Each entry: **ID · tier · lane · Given** (source store, config, disk, scripts) · **When** (driver ops) · **Then** (observation-surface assertions). IDs are stable; the suite implements one test per ID.
+
+## 2. The catalog
+
+### A. Dispatch & happy paths
+
+- **DISPATCH-01** (A, core) — _Single-repo happy path._ Given one todo task designating repo `alpha` and agent `scripted`, repo `alpha` cloned under the base dir. When `tick()`. Then: worktree exists at `paths.worktreeFor(alpha, task)` on branch `expect.branchFor(task)` cut from `origin/main`; tmux session alive; state records running; journal shows the source was told the task started (v1 `markInProgress`, v2 `update:claimed` + progress).
+- **DISPATCH-02** (A, core) — _Slot limit respected._ Given max-in-progress 1 and two eligible tasks. When `tick()`. Then exactly one provisions; the other stays queued (no worktree, no session, no writeback).
+- **DISPATCH-03** (A, core) — _Priority ordering._ Given two eligible tasks with different priorities and one slot. Then the higher-priority task is the one provisioned.
+- **DISPATCH-04** (A, core) — _Blocked task skipped, dispatched when unblocked._ Given a task with an open blocker. When `tick()`: nothing provisions. When the fixture marks the blocker done and `tick()` again: it provisions.
+- **DISPATCH-05** (A, core) — _Ineligible task ignored._ Given a task with no agent routing. When `tick()`. Then no provisioning, no writeback, task still listed as queued.
+- **DISPATCH-06** (A, core) — _Designated repo unavailable → visible skip, nothing provisioned._ Given a task designating a repo not present (v1: not in `knownRepositories`; v2: not cloned under base dir). When `tick()`. Then no worktree/branch/session/state; the task stays queued at the source; the skip reason is visible (log line + status). (v2 "bail", DEVOP-5967 §2.)
+- **DISPATCH-07** (A, core) — _Manual start bypasses eligibility._ Given an unlabeled/no-agent task. When `start(task)`. Then it provisions exactly as DISPATCH-01.
+- **DISPATCH-08** (A, core) — _Branch reuse._ Given a prior local branch `expect.branchFor(task)` with a commit. When dispatched. Then the worktree re-attaches to that branch (prior commit present), not a fresh one.
+- **DISPATCH-09** (A, core) — _Recurrence is a source concern._ Given a fixture source that re-lists a completed task per its recurrence rule. When the task completes and `tick()` runs after re-listing. Then a fresh dispatch occurs; core has no recurrence machinery to observe. (DEVOP-5968 §6.)
+
+### B. Completion & writeback
+
+- **COMPLETE-01** (A, core) — _Work published → source reaches in-review._ Scripted agent commits and publishes (v1: fake `gh` gains an open PR for the branch; v2: agent runs `crew artifact add <pr-url> --kind pr` and emits progress). Then: journal shows the source moved to in-review (v1 `markInReview`) / received the artifact-bearing update (v2); slot freed for the next tick (v1 semantics — see Open question 3).
+- **COMPLETE-02** (A, core) — _Task done → source told, workspace torn down._ v1: fake `gh` marks the PR merged; next tick → journal shows `markDone`, worktree removed, run state deleted. v2: scripted agent ends with `completed {outcome: delivered, artifacts}`; journal shows the completed event; teardown per DEVOP-5975's call (see Open question 3). Shared assertion: source told exactly once; final state is terminal.
+- **COMPLETE-03** (A, core) — _Launch failure is truthful and rolled back._ Given an agent whose `cmd` doesn't exist. When `start(task)`. Then state records the launch failure (v1 `failed-to-launch`; v2 `complete{failed, reason: launch}`); worktree and branch rolled back; source not told the task is in progress — or if already claimed, the failure lands in the journal.
+- **COMPLETE-04** (A, core) — _Writeback unsupported → skip, never crash._ Given a fixture source without done-writeback (v1: no `markDone` command; v2: no `update` at all — read-only). When completion occurs. Then the writeback is a logged no-op; nothing errors; local teardown still proceeds.
+- **COMPLETE-05** (B, core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented.
+
+### C. Session lifecycle
+
+- **SESSION-01** (A, core) — _Stop keeps work._ Given a running task. When `stop(task)`. Then session closed, worktree and branch intact, state paused/interrupted, resumable.
+- **SESSION-02** (A, core) — _Resume reopens, never recreates._ When `resume(task)` on a stopped task: session live again, same worktree, resume count incremented. When `resume` on a task with no worktree: hard error, nothing created.
+- **SESSION-03** (A, core) — _Status tells the truth about strays._ Given state says running but the tmux session was killed externally. Then `status` flags the disagreement (stray/dead). Given no state but a live session matching a task: `status` flags the stray session.
+
+### D. Crash & recovery
+
+- **CRASH-01** (A, core) — _SIGKILL mid-run, restart reconciles._ Given a running task. When the orchestrator is SIGKILLed and restarted with `tick()`. Then no duplicate worktree/session/dispatch; state agrees with disk; the running task is still running. (v2: reconcile-on-startup is the guarantee, DEVOP-5972.)
+- **CRASH-02** (A, core) — _Orphan worktree directory._ Given a directory at the expected worktree path but absent from `git worktree list`. Then `cleanup --force` removes it only when the path exactly matches the expected shape; a non-matching path is refused.
+- **CRASH-03** (A, core) — _Dirty worktree is a data-loss guard._ Given a worktree with uncommitted changes. When `cleanup(task)`: refused, names the dirt. When `cleanup(task, {force})`: removed.
+- **CRASH-04** (A, core) — _Stale state, no disk._ Given a state file for a task with no worktree and no session. Then cleanup clears it; if the session probe is unavailable, everything is left intact.
+- **CRASH-05** (B, core) — _Reconcile GCs the full triple._ After SIGKILL during provisioning (worktree half-created, session never launched), restart reconciles worktrees **and** tmux **and** sandbox state against expected task state; orphans of each kind GC'd; a journal/log line records each GC action.
+
+### E. Multi-repo & workspace (v2-only — DEVOP-5967)
+
+- **MULTI-01** (B, core) — _Designated multi-repo._ Given `Repos: alpha, beta`, both cloned. Then one workspace directory with two worktrees side by side, the **same** task branch in each, **one** tmux session at the workspace root.
+- **MULTI-02** (B, core) — _Designated-and-missing → bail._ Given `Repos: alpha, gamma`, `gamma` not cloned. Then nothing provisions (not even `alpha`), visible "repo not found" skip, task stays queued.
+- **MULTI-03** (B, core) — _Empty-workspace dispatch._ Given a task with no repo designation. Then the session launches in an empty workspace; zero worktrees; state running.
+- **MULTI-04** (B, core) — _Runtime acquisition, allowed._ Scripted agent runs `crew workspace add alpha` in-session (task identity via workspace state/env). Then a worktree for `alpha` appears under the workspace on the uniform task branch; the addition is recorded in task state; prepare-worktree hook ran.
+- **MULTI-05** (B, core) — _Runtime acquisition, gate-rejected._ Agent runs `crew workspace add not-cloned`. Then a loud error, nothing created, exit nonzero in-session; task keeps running.
+- **MULTI-06** (B, core) — _Partial completion truth-telling._ Agent commits in `alpha` and `beta`, reports a pr artifact for `alpha` only, completes `{outcome: failed}`. Then per-repo records show exactly that (alpha: artifact reported + commits observed; beta: commits observed, nothing reported); no invented atomicity, no rollback.
+- **MULTI-07** (B, core) — _Repo-less delivery._ Agent in an empty workspace reports `{kind: document, locator: <url>}` and completes delivered. Then the completed event carries the artifact; no git facts exist or are claimed.
+
+### F. Artifacts & source contract (v2-only — DEVOP-5968)
+
+- **FLOW-01** (B, core) — _Reported vs observed are separate layers._ Agent commits but reports nothing. Then status shows commits _observed_ and no artifact _reported_ — a missing link, never a lie.
+- **FLOW-02** (B, core) — _Mixed artifact kinds round-trip._ Agent reports `pr`, `ticket`, and `file` artifacts. Then `completed.artifacts` in the journal carries all three, kinds and locators intact.
+- **FLOW-03** (B, core) — _Read-only source end-to-end._ Given a fixture manifest with no `update` command. Then dispatch, run, completion all succeed; journal shows zero update calls; status labels the source read-only.
+- **FLOW-04** (B, core) — _Claim rejected._ Given the fixture source answers `claimed` with _rejected_. Then no provisioning, no session; task remains listed; the rejection is visible in log/status. (The remote-runner door.)
+- **FLOW-05** (B, core) — _Progress events flow._ Agent emits progress notes. Then journal shows `update:progress` with the notes, in order.
+- **FLOW-06** (B, core) — _Core is forge-blind._ Across MULTI/FLOW scenarios, the fake `gh` (and any recorded network attempt in the core lane) shows **zero** invocations by the core process. Agent-initiated calls don't count.
+
+### G. Source packaging & protocol (v2-only — DEVOP-5973)
+
+- **PLUGIN-01** (B, core) — _User-dir source discovery._ Given a bundle at `~/.config/groundcrew/task-sources/fixture/` (`source.json` + scripts). Then it lists in `source list`, verifies, and serves dispatch.
+- **PLUGIN-02** (B, core) — _Name collision: user dir wins._ Given a package-shipped bundle and a user-dir bundle with the same name. Then the user's is used; the override is visible in `source list`/doctor.
+- **PLUGIN-03** (B, core) — _Protocol mismatch is loud._ Given `protocolVersion: 99`. Then discovery/doctor/status emit an explicit, actionable error naming the version and the supported set; the source is not silently skipped; other sources unaffected.
+- **PLUGIN-04** (B, core) — _Unparseable manifest: skip + warn._ Given malformed `source.json`. Then a warning names the file; everything else proceeds.
+- **PLUGIN-05** (B, core) — _Capability by omission._ Given a manifest omitting `update`. Then no version sniffing, no error: the source is treated read-only (= FLOW-03's mechanism, asserted at discovery level).
+
+### H. Sandbox posture (sandbox lane, platform-gated)
+
+- **SANDBOX-01** (A, sandbox) — _Agent contained by default._ Scripted agent writes inside the worktree (succeeds) and outside `HOME`-scoped allowed paths (fails). Both outcomes observed via marker files.
+- **SANDBOX-02** (A, sandbox) — _Agent network egress allowlisted._ Agent curls an allowlisted host (loopback fixture; succeeds) and a non-allowlisted one (fails).
+- **SANDBOX-03** (B, sandbox) — _Sources sandboxed by default._ Fixture source's `list` script attempts undeclared egress and an out-of-scope write → both denied; declared scratch dir + install dir (read) work. (Manifest `network` allowlist, DEVOP-5973 §4.)
+- **SANDBOX-04** (B, sandbox) — _`sandbox: false` opt-out is loud._ Given the fixture source configured with `sandbox: false`. Then it runs unsandboxed (undeclared write succeeds) **and** status/doctor visibly flag the opt-out.
+
+### I. Surface & diagnostics
+
+- **SURFACE-01** (A, core) — _Init → doctor green._ On a healthy fixture host, the version's init flow produces a config that `doctor` passes and DISPATCH-01 runs against unmodified.
+- **SURFACE-02** (A, core) — _Doctor catches broken hosts._ Missing agent binary; unreachable/failing source verify; missing base dir — each produces a failing doctor with the cause named, exit 1.
+- **SURFACE-03** (A, core) — _Status degrades gracefully._ Given the fixture source errors on list. Then `status` still prints local truth (worktrees, sessions, state) and marks the queue unavailable with the reason; exit 0.
+- **SURFACE-04** (A, core) — _Structured logs are parseable._ After DISPATCH-01 + COMPLETE-02, every line of the log file parses as JSON and carries the task id on task-scoped events. (Deeper schema assertions belong to the observability design — fog.)
+
+## 3. Open questions (for reaction)
+
+1. **Tier A "green on v1" definition.** Proposed: Tier A must pass on v1 via the v1 driver before any v2 code lands, and the v2 driver reuses the same scenario bodies verbatim. Accepting a scenario into Tier A is therefore a compat promise — is this list (A/B/C/D + SURFACE) the right promise, or should any of it be demoted to v1-only pinning?
+2. **v1's in-review/done loop is forge-coupled; v2 dropped the forge.** v1 advances in-review/done by polling `gh` for PR state. v2 core is forge-blind, so nothing in core can observe "merged." COMPLETE-01/02 assume the v2 path is agent-reported (artifact add → completed). That leaves a real gap: a merged-later PR no longer advances the source to done. Is "done = agent says done (or human `task done`)" the intended v2 semantics, with tracker automation (e.g. Linear's GitHub integration) owning merge-driven transitions?
+3. **Teardown trigger in v2.** v1 tears down on observed merge. If v2 completion is agent-reported, does `completed{delivered}` tear down immediately, or does the worktree linger for human review until `cleanup`? COMPLETE-02 currently leaves this to DEVOP-5975; the suite needs one answer.
+4. **Suite repo/harness stack.** Proposed: suite lives in the groundcrew repo as a separate package (`e2e/`), plain TypeScript + vitest, spawning the built binary; fixture source + scripted agent are committed executables. Objections?
+5. **Sandbox lane scope.** SANDBOX-01/02 as Tier A means proving v1's safehouse/srt posture in CI too, which may be flaky on shared runners. Alternative: sandbox lane is v2-only (Tier B), and v1 keeps only its existing unit-level coverage. Which?

--- a/docs/spec/e2e-scenario-catalog.md
+++ b/docs/spec/e2e-scenario-catalog.md
@@ -68,7 +68,7 @@ An `e2e/` package in the groundcrew repo, plain TypeScript + vitest, spawning th
 
 - **Core never polls a destination for done-ness.** No forge calls, no tracker reads to infer task completion. `status` reports what groundcrew knows: **observed** workspace git facts (branches, commits, dirty state) and **agent-reported** events and artifacts. Whether the tracker moves to done is the source's business (its `update` handler) or tracker automation's — humans see the agent's report and judge for themselves.
 - **`completed{outcome}` frees the dispatch slot immediately** — a finished task never blocks the queue.
-- **The workspace lingers after completion.** Worktrees, branches, and the final state record stay on disk until a human runs `cleanup` — the review window for seeing what the agent reported before it disappears.
+- **The workspace lingers after completion, with two exits.** Worktrees, branches, and the final state record stay on disk until **either** a human runs `cleanup` **or** polling observes the _source_ reporting the task terminal (e.g. the tracker moved to Done after the PR merged) — v1's cleaner, kept as-is because it watches the source, not the forge. The review window holds in practice: the tracker rarely reaches done the instant the agent reports delivered. Auto-reap never removes a dirty worktree; it skips loudly and leaves it for a human.
 
 ## 3. The catalog
 
@@ -93,7 +93,8 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **COMPLETE-03** (core) — _Launch failure is truthful and rolled back._ Given an agent profile whose `cmd` doesn't exist. When `start(task)`. Then state records `complete{failed, reason: launch}`; worktree and branch rolled back; the failure appears in the journal if the task was already claimed.
 - **COMPLETE-04** (core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented; workspace lingers for inspection.
 - **COMPLETE-05** (core) — _Read-only source end-to-end._ Given a fixture manifest with no `update` command. Then dispatch, run, and completion all succeed; journal shows zero update calls; status labels the source read-only. (Also asserted at discovery level in PLUGIN-05.)
-- **COMPLETE-06** (core) — _Cleanup ends the linger._ Given a delivered task's lingering workspace. When `cleanup(task)`. Then worktree removed, branch deleted, state record gone; the source hears nothing new.
+- **COMPLETE-06** (core) — _Manual cleanup ends the linger._ Given a delivered task's lingering workspace. When `cleanup(task)`. Then worktree removed, branch deleted, state record gone; the source hears nothing new.
+- **COMPLETE-07** (core) — _Source-terminal auto-reap (v1 cleaner parity)._ Given a delivered task's lingering clean workspace. When the fixture source's store marks the task done and `tick()` runs. Then worktree, branch, and state record reaped automatically; the reap is logged. Variant: if the lingering worktree is dirty, auto-reap skips it with a visible warning and everything stays on disk.
 
 ### C. Session lifecycle
 
@@ -153,3 +154,4 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 ## 4. Iteration log
 
 - **Iteration 1** (2026-07-16): green-on-v1 gate dropped in favor of harness self-tests plus a migration-easing budget; completion model codified (forge-blind, agent-reported, linger-until-cleanup); suite stack confirmed (`e2e/` package, TS + vitest); sandbox lane confirmed v2-only. Tier A/B structure and the v1 driver removed accordingly.
+- **Iteration 2** (2026-07-16): linger gets two exits — manual `cleanup` or source-terminal auto-reap (v1's cleaner kept: it watches the source, never the forge; v1's merged-PR reviewer path dies). COMPLETE-07 added; dirty worktrees are never auto-reaped.

--- a/docs/spec/e2e-scenario-catalog.md
+++ b/docs/spec/e2e-scenario-catalog.md
@@ -1,149 +1,155 @@
 # E2E scenario catalog (draft prototype — DEVOP-5974)
 
-The executable half of the groundcrew v2 spec: the black-box scenarios the compat suite must cover, plus the harness shape that makes them hermetic. The suite gets built against **v1 first** (the Bun lesson) — it must run green on v1 before any v2 code exists — yet the v2 decisions deliberately break v1's config shape, CLI surface, and source contract. The catalog resolves that tension with a **driver seam** and **two tiers**.
+The executable half of the groundcrew v2 spec: the black-box scenarios the acceptance suite must cover, plus the harness shape that makes them hermetic. The suite is written **before v2 code exists** and brings v2 up red→green; it is v2's system-level TDD loop and the language-agnostic escape hatch (any implementation that passes is conformant).
+
+**Iteration 1 changes:** the green-on-v1 gate is dropped — v2 breaks too much of v1's surface for v1 scenarios to pay for themselves; that budget moves to migration easing (map fog item). Suite trustworthiness comes from harness self-tests instead (§1.5). The v1 reviewer loop (poll `gh`, advance in-review/done) does not survive into v2: the completion model (§2) is agent-reported, forge-blind, and lingers for human review.
 
 ## 1. Suite architecture
 
-### Black-box rules
+### 1.1 Black-box rules
 
-- The suite spawns the `crew` binary and observes the world. It never imports groundcrew code, reads groundcrew internals, or mocks in-process. This is the language-agnostic escape hatch: any implementation that passes is conformant.
+- The suite spawns the `crew` binary and observes the world. It never imports groundcrew code, reads groundcrew internals, or mocks in-process.
 - Assertions target the **observation surface** (§1.2), not stdout prose. Stdout/exit codes are asserted only where the output _is_ the behavior (`status`, `doctor`, loud errors), and then loosely (key substrings, not full-text golden files).
 
-### Observation surface
+### 1.2 Observation surface
 
 Everything a scenario may assert on:
 
 | Channel                | How observed                                                                                                     |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Exit codes             | direct                                                                                                           |
-| Worktrees & branches   | `git worktree list`, `git branch`, `git log`/`status` in the sandbox tmpdir                                      |
-| Run/task state on disk | the version's state files (driver exposes the path + a normalized parse)                                         |
+| Worktrees & branches   | `git worktree list`, `git branch`, `git log`/`status` in the scenario tmpdir                                     |
+| Run/task state on disk | v2's state files (path + schema fixed by the spec; suite parses them read-only)                                  |
 | Terminal sessions      | real tmux on an isolated socket (`tmux -L <scenario-id>`) — session exists / alive / exited                      |
 | Source interactions    | the fixture source's **call journal** (§1.4): every command invocation with args + stdin, appended as JSON lines |
 | Structured logs        | JSON-line log file under the scenario's state dir                                                                |
 | Human-facing output    | `status` / `doctor` stdout, loose match                                                                          |
 
-### Driver seam (v1 vs v2)
+### 1.3 Command binding
 
-Scenarios are written against a small `CrewDriver` interface; one thin driver per major version maps abstract operations to concrete commands, config files, and paths. The driver is part of the suite, not the product — it is the only place that knows `knownRepositories` (v1) vs base-dir discovery (v2), or `crew run` (v1) vs whatever DEVOP-5975 names the poll command.
-
-Driver operations (proposed):
+The CLI surface ([DEVOP-5975](https://linear.app/clipboardhealth/issue/DEVOP-5975)) is still open, so scenarios call abstract operations bound in exactly one harness module — the only file that changes when command names land:
 
 ```text
-configure(fixture)            // write version-appropriate config into the scenario tmpdir
+configure(fixture)            // write config into the scenario tmpdir
 seedSource(tasks[])           // load the fixture source's task store
-tick()                        // one poll/dispatch cycle (v1: crew run)
-start(taskId)                 // immediate dispatch (v1: crew start)
+tick()                        // one poll/dispatch cycle
+start(taskId)                 // immediate dispatch, bypassing eligibility
 stop(taskId) / resume(taskId) / cleanup(taskId, {force}) / status(taskId?) / doctor()
-killDaemon() / restart()      // crash scenarios
-paths: { worktreeFor(repo, task), stateFor(task), logFile }
+killOrchestrator() / restart()  // crash scenarios
+paths: { worktreeFor(repo, task), workspaceFor(task), stateFor(task), logFile }
 expect: { branchFor(task), sessionFor(task) }
 ```
 
-A scenario that needs an operation only one version has (e.g. `crew workspace add`) is tiered accordingly.
+### 1.4 Fakes
 
-### Tiers and lanes
+| Real thing                  | Stand-in                                                                                                                                                                                                                                                                                 | Notes                                                                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Linear / Jira / any tracker | **Fixture source**: a protocol-1 manifest bundle backed by a JSON task store in the scenario tmpdir. Every invocation appends `{command, args, stdin, timestamp}` to `calls.jsonl` — the writeback assertion point.                                                                      | First-party sources are conformance tests of the boundary (DEVOP-5973); the fixture source tests the same boundary from the other side. |
+| Agent CLI (claude/codex/…)  | **Scripted agent**: an executable that reads a per-scenario script (env-pointed file) and deterministically acts — sleep, write files, `git commit`, invoke in-session `crew` commands, report artifacts, exit 0/1. Agent profiles are declarative config with `cmd`, so this is honest. | Emits a heartbeat file so scenarios synchronize on "agent is running" without sleeps.                                                   |
+| GitHub / forge              | **Fake `gh` on PATH that exists only to record calls.** v2 core is forge-blind; any core-process invocation is a failure (FLOW-06). Agent-initiated calls are scripted and allowed.                                                                                                      | The absence of a real forge fake is itself a spec assertion.                                                                            |
+| Git remotes                 | Local bare repos (`file://` remotes) under the scenario tmpdir; `origin/main` seeded with a few commits.                                                                                                                                                                                 | Real git throughout.                                                                                                                    |
+| tmux                        | Real tmux, isolated per scenario via `-L <socket>`.                                                                                                                                                                                                                                      | Real seam, cheap, deterministic enough.                                                                                                 |
+| Host env                    | Per-scenario tmpdir owning `HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`; PATH prepended with the fakes dir; no network in the core lane.                                                                                                                                                  |                                                                                                                                         |
 
-- **Tier A — shared behavioral core.** Runs green against v1 _and_ v2 through the drivers. This is the compat guarantee: the behaviors v2 must not regress.
-- **Tier B — v2-only.** New contract behavior (multi-repo workspaces, runtime acquisition, artifact reporting, protocol versioning, source sandboxing). Written now, red until v2 exists; they double as v2's acceptance tests.
-- Orthogonally, two **lanes**: the **core lane** (hermetic, no sandbox runner, runs anywhere including CI) and the **sandbox lane** (real srt; platform-gated to macOS `sandbox-exec` / Linux bubblewrap; asserts denial behavior that can't be faked honestly).
+### 1.5 Harness self-tests
 
-### Fakes
+With no working implementation to validate against (green-on-v1 dropped), the harness proves itself directly: the fixture source, scripted agent, journal, and tmux/git observation helpers each get their own tests that run without any `crew` binary. A suite failure during v2 bring-up then points at v2, not at the suite.
 
-| Real thing                  | Stand-in                                                                                                                                                                                                                                                                                                               | Notes                                                                                                                                                                |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Linear / Jira / any tracker | **Fixture source**: a manifest task-source bundle backed by a JSON task store in the scenario tmpdir. Every invocation appends `{command, args, stdin, timestamp}` to `calls.jsonl` — the writeback assertion point. Two thin manifests over one implementation: v1's shell-source contract, v2's protocol-1 contract. | First-party sources are conformance tests of the boundary (DEVOP-5973); the fixture source is the suite's conformance test of the same boundary from the other side. |
-| Agent CLI (claude/codex/…)  | **Scripted agent**: an executable that reads a per-scenario script (env-pointed file) and deterministically acts — sleep, write files, `git commit`, invoke in-session `crew` commands (Tier B), report artifacts, exit 0/1. Both versions support `cmd`-points-at-your-script, so this is honest.                     | Also emits a heartbeat file so scenarios can synchronize on "agent is running" without sleeps.                                                                       |
-| GitHub / forge              | **v1 lane only**: fake `gh` on PATH backed by a JSON PR fixture (v1's reviewer observes PRs via `gh`). **v2 needs no forge fake** — core observes only local git facts; PRs are agent-_reported_ artifacts.                                                                                                            | The asymmetry is itself a spec assertion: v2 core makes zero forge calls (fake `gh` records any invocation → fail).                                                  |
-| Git remotes                 | Local bare repos (`file://` remotes) under the scenario tmpdir; `origin/main` seeded with a few commits.                                                                                                                                                                                                               | Real git throughout.                                                                                                                                                 |
-| tmux                        | Real tmux, isolated per scenario via `-L <socket>`.                                                                                                                                                                                                                                                                    | Real seam, cheap, deterministic enough.                                                                                                                              |
-| Host env                    | Per-scenario tmpdir owning `HOME`, `XDG_CONFIG_HOME`, `XDG_STATE_HOME`; PATH prepended with the fakes dir; no network in the core lane.                                                                                                                                                                                |                                                                                                                                                                      |
+### 1.6 Lanes
 
-### Scenario format
+- **Core lane**: hermetic, no sandbox runner, runs anywhere including CI.
+- **Sandbox lane**: real srt (macOS `sandbox-exec` / Linux bubblewrap), platform-gated; asserts denial behavior that can't be faked honestly. v2-only by definition — v1's posture keeps its existing unit-level coverage.
 
-Each entry: **ID · tier · lane · Given** (source store, config, disk, scripts) · **When** (driver ops) · **Then** (observation-surface assertions). IDs are stable; the suite implements one test per ID.
+### 1.7 Suite packaging
 
-## 2. The catalog
+An `e2e/` package in the groundcrew repo, plain TypeScript + vitest, spawning the built binary; fixture source and scripted agent are committed executables.
+
+## 2. Completion model (codified from iteration 1)
+
+- **Core never polls a destination for done-ness.** No forge calls, no tracker reads to infer task completion. `status` reports what groundcrew knows: **observed** workspace git facts (branches, commits, dirty state) and **agent-reported** events and artifacts. Whether the tracker moves to done is the source's business (its `update` handler) or tracker automation's — humans see the agent's report and judge for themselves.
+- **`completed{outcome}` frees the dispatch slot immediately** — a finished task never blocks the queue.
+- **The workspace lingers after completion.** Worktrees, branches, and the final state record stay on disk until a human runs `cleanup` — the review window for seeing what the agent reported before it disappears.
+
+## 3. The catalog
+
+Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **When** (harness ops) · **Then** (observation-surface assertions). IDs are stable; the suite implements one test per ID.
 
 ### A. Dispatch & happy paths
 
-- **DISPATCH-01** (A, core) — _Single-repo happy path._ Given one todo task designating repo `alpha` and agent `scripted`, repo `alpha` cloned under the base dir. When `tick()`. Then: worktree exists at `paths.worktreeFor(alpha, task)` on branch `expect.branchFor(task)` cut from `origin/main`; tmux session alive; state records running; journal shows the source was told the task started (v1 `markInProgress`, v2 `update:claimed` + progress).
-- **DISPATCH-02** (A, core) — _Slot limit respected._ Given max-in-progress 1 and two eligible tasks. When `tick()`. Then exactly one provisions; the other stays queued (no worktree, no session, no writeback).
-- **DISPATCH-03** (A, core) — _Priority ordering._ Given two eligible tasks with different priorities and one slot. Then the higher-priority task is the one provisioned.
-- **DISPATCH-04** (A, core) — _Blocked task skipped, dispatched when unblocked._ Given a task with an open blocker. When `tick()`: nothing provisions. When the fixture marks the blocker done and `tick()` again: it provisions.
-- **DISPATCH-05** (A, core) — _Ineligible task ignored._ Given a task with no agent routing. When `tick()`. Then no provisioning, no writeback, task still listed as queued.
-- **DISPATCH-06** (A, core) — _Designated repo unavailable → visible skip, nothing provisioned._ Given a task designating a repo not present (v1: not in `knownRepositories`; v2: not cloned under base dir). When `tick()`. Then no worktree/branch/session/state; the task stays queued at the source; the skip reason is visible (log line + status). (v2 "bail", DEVOP-5967 §2.)
-- **DISPATCH-07** (A, core) — _Manual start bypasses eligibility._ Given an unlabeled/no-agent task. When `start(task)`. Then it provisions exactly as DISPATCH-01.
-- **DISPATCH-08** (A, core) — _Branch reuse._ Given a prior local branch `expect.branchFor(task)` with a commit. When dispatched. Then the worktree re-attaches to that branch (prior commit present), not a fresh one.
-- **DISPATCH-09** (A, core) — _Recurrence is a source concern._ Given a fixture source that re-lists a completed task per its recurrence rule. When the task completes and `tick()` runs after re-listing. Then a fresh dispatch occurs; core has no recurrence machinery to observe. (DEVOP-5968 §6.)
+- **DISPATCH-01** (core) — _Single-repo happy path._ Given one todo task designating repo `alpha` and an agent profile, repo `alpha` cloned under the base dir. When `tick()`. Then: worktree exists at `paths.worktreeFor(alpha, task)` on branch `expect.branchFor(task)` cut from `origin/main`; tmux session alive; state records running; journal shows `update:claimed` acknowledged.
+- **DISPATCH-02** (core) — _Slot limit respected._ Given max-in-progress 1 and two eligible tasks. When `tick()`. Then exactly one provisions; the other stays queued (no worktree, no session, no writeback).
+- **DISPATCH-03** (core) — _Priority ordering._ Given two eligible tasks with different priorities and one slot. Then the higher-priority task is the one provisioned.
+- **DISPATCH-04** (core) — _Blocked task skipped, dispatched when unblocked._ Given a task with an open blocker. When `tick()`: nothing provisions. When the fixture marks the blocker done and `tick()` again: it provisions.
+- **DISPATCH-05** (core) — _Ineligible task ignored._ Given a task with no agent routing. When `tick()`. Then no provisioning, no writeback, task still listed as queued.
+- **DISPATCH-06** (core) — _Designated repo not on disk → bail._ Given a task designating a repo not cloned under the base dir. When `tick()`. Then no worktree/branch/session/state; the task stays queued at the source; the skip reason is visible (log line + status). (DEVOP-5967 §2.)
+- **DISPATCH-07** (core) — _Manual start bypasses eligibility._ Given an unlabeled/no-agent task. When `start(task)`. Then it provisions exactly as DISPATCH-01.
+- **DISPATCH-08** (core) — _Branch reuse._ Given a prior local branch `expect.branchFor(task)` with a commit. When dispatched. Then the worktree re-attaches to that branch (prior commit present), not a fresh one.
+- **DISPATCH-09** (core) — _Recurrence is a source concern._ Given a fixture source that re-lists a completed task per its recurrence rule. When the task completes and `tick()` runs after re-listing. Then a fresh dispatch occurs; core has no recurrence machinery to observe. (DEVOP-5968 §6.)
 
 ### B. Completion & writeback
 
-- **COMPLETE-01** (A, core) — _Work published → source reaches in-review._ Scripted agent commits and publishes (v1: fake `gh` gains an open PR for the branch; v2: agent runs `crew artifact add <pr-url> --kind pr` and emits progress). Then: journal shows the source moved to in-review (v1 `markInReview`) / received the artifact-bearing update (v2); slot freed for the next tick (v1 semantics — see Open question 3).
-- **COMPLETE-02** (A, core) — _Task done → source told, workspace torn down._ v1: fake `gh` marks the PR merged; next tick → journal shows `markDone`, worktree removed, run state deleted. v2: scripted agent ends with `completed {outcome: delivered, artifacts}`; journal shows the completed event; teardown per DEVOP-5975's call (see Open question 3). Shared assertion: source told exactly once; final state is terminal.
-- **COMPLETE-03** (A, core) — _Launch failure is truthful and rolled back._ Given an agent whose `cmd` doesn't exist. When `start(task)`. Then state records the launch failure (v1 `failed-to-launch`; v2 `complete{failed, reason: launch}`); worktree and branch rolled back; source not told the task is in progress — or if already claimed, the failure lands in the journal.
-- **COMPLETE-04** (A, core) — _Writeback unsupported → skip, never crash._ Given a fixture source without done-writeback (v1: no `markDone` command; v2: no `update` at all — read-only). When completion occurs. Then the writeback is a logged no-op; nothing errors; local teardown still proceeds.
-- **COMPLETE-05** (B, core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented.
+- **COMPLETE-01** (core) — _Publishing work is reporting it._ Scripted agent commits, runs `crew artifact add <pr-url> --kind pr`, emits progress. Then: journal shows `update:progress` and the artifact-bearing update; status shows both layers (commits _observed_, PR _reported_); core made no forge call.
+- **COMPLETE-02** (core) — _Delivered: slot freed, workspace lingers._ Scripted agent ends `completed {outcome: delivered, artifacts}`. Then: journal carries the completed event exactly once with artifacts intact; state is `complete{delivered}`; session ended; **worktree, branch, and state record still on disk**; next `tick()` dispatches the next queued task (slot freed) while the delivered workspace lingers.
+- **COMPLETE-03** (core) — _Launch failure is truthful and rolled back._ Given an agent profile whose `cmd` doesn't exist. When `start(task)`. Then state records `complete{failed, reason: launch}`; worktree and branch rolled back; the failure appears in the journal if the task was already claimed.
+- **COMPLETE-04** (core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented; workspace lingers for inspection.
+- **COMPLETE-05** (core) — _Read-only source end-to-end._ Given a fixture manifest with no `update` command. Then dispatch, run, and completion all succeed; journal shows zero update calls; status labels the source read-only. (Also asserted at discovery level in PLUGIN-05.)
+- **COMPLETE-06** (core) — _Cleanup ends the linger._ Given a delivered task's lingering workspace. When `cleanup(task)`. Then worktree removed, branch deleted, state record gone; the source hears nothing new.
 
 ### C. Session lifecycle
 
-- **SESSION-01** (A, core) — _Stop keeps work._ Given a running task. When `stop(task)`. Then session closed, worktree and branch intact, state paused/interrupted, resumable.
-- **SESSION-02** (A, core) — _Resume reopens, never recreates._ When `resume(task)` on a stopped task: session live again, same worktree, resume count incremented. When `resume` on a task with no worktree: hard error, nothing created.
-- **SESSION-03** (A, core) — _Status tells the truth about strays._ Given state says running but the tmux session was killed externally. Then `status` flags the disagreement (stray/dead). Given no state but a live session matching a task: `status` flags the stray session.
+- **SESSION-01** (core) — _Stop keeps work._ Given a running task. When `stop(task)`. Then session closed, worktree and branch intact, state paused, resumable.
+- **SESSION-02** (core) — _Resume reopens, never recreates._ When `resume(task)` on a paused task: session live again, same worktree, resume count incremented, state running. When `resume` on a task with no worktree: hard error, nothing created.
+- **SESSION-03** (core) — _Status tells the truth about strays._ Given state says running but the tmux session was killed externally. Then `status` flags the disagreement (stray/dead). Given no state but a live session matching a task: `status` flags the stray session.
 
 ### D. Crash & recovery
 
-- **CRASH-01** (A, core) — _SIGKILL mid-run, restart reconciles._ Given a running task. When the orchestrator is SIGKILLed and restarted with `tick()`. Then no duplicate worktree/session/dispatch; state agrees with disk; the running task is still running. (v2: reconcile-on-startup is the guarantee, DEVOP-5972.)
-- **CRASH-02** (A, core) — _Orphan worktree directory._ Given a directory at the expected worktree path but absent from `git worktree list`. Then `cleanup --force` removes it only when the path exactly matches the expected shape; a non-matching path is refused.
-- **CRASH-03** (A, core) — _Dirty worktree is a data-loss guard._ Given a worktree with uncommitted changes. When `cleanup(task)`: refused, names the dirt. When `cleanup(task, {force})`: removed.
-- **CRASH-04** (A, core) — _Stale state, no disk._ Given a state file for a task with no worktree and no session. Then cleanup clears it; if the session probe is unavailable, everything is left intact.
-- **CRASH-05** (B, core) — _Reconcile GCs the full triple._ After SIGKILL during provisioning (worktree half-created, session never launched), restart reconciles worktrees **and** tmux **and** sandbox state against expected task state; orphans of each kind GC'd; a journal/log line records each GC action.
+- **CRASH-01** (core) — _SIGKILL mid-run, restart reconciles._ Given a running task. When the orchestrator is SIGKILLed and restarted with `tick()`. Then no duplicate worktree/session/dispatch; state agrees with disk; the running task is still running. (Reconcile-on-startup, DEVOP-5972.)
+- **CRASH-02** (core) — _Orphan worktree directory._ Given a directory at the expected worktree path but absent from `git worktree list`. Then `cleanup --force` removes it only when the path exactly matches the expected shape; a non-matching path is refused.
+- **CRASH-03** (core) — _Dirty worktree is a data-loss guard._ Given a worktree with uncommitted changes. When `cleanup(task)`: refused, names the dirt. When `cleanup(task, {force})`: removed.
+- **CRASH-04** (core) — _Stale state, no disk._ Given a state file for a task with no worktree and no session. Then cleanup clears it; if the session probe is unavailable, everything is left intact.
+- **CRASH-05** (core) — _Reconcile GCs the full triple._ After SIGKILL during provisioning (worktree half-created, session never launched), restart reconciles worktrees **and** tmux **and** sandbox state against expected task state; orphans of each kind GC'd; a log line records each GC action.
 
-### E. Multi-repo & workspace (v2-only — DEVOP-5967)
+### E. Multi-repo & workspace (DEVOP-5967)
 
-- **MULTI-01** (B, core) — _Designated multi-repo._ Given `Repos: alpha, beta`, both cloned. Then one workspace directory with two worktrees side by side, the **same** task branch in each, **one** tmux session at the workspace root.
-- **MULTI-02** (B, core) — _Designated-and-missing → bail._ Given `Repos: alpha, gamma`, `gamma` not cloned. Then nothing provisions (not even `alpha`), visible "repo not found" skip, task stays queued.
-- **MULTI-03** (B, core) — _Empty-workspace dispatch._ Given a task with no repo designation. Then the session launches in an empty workspace; zero worktrees; state running.
-- **MULTI-04** (B, core) — _Runtime acquisition, allowed._ Scripted agent runs `crew workspace add alpha` in-session (task identity via workspace state/env). Then a worktree for `alpha` appears under the workspace on the uniform task branch; the addition is recorded in task state; prepare-worktree hook ran.
-- **MULTI-05** (B, core) — _Runtime acquisition, gate-rejected._ Agent runs `crew workspace add not-cloned`. Then a loud error, nothing created, exit nonzero in-session; task keeps running.
-- **MULTI-06** (B, core) — _Partial completion truth-telling._ Agent commits in `alpha` and `beta`, reports a pr artifact for `alpha` only, completes `{outcome: failed}`. Then per-repo records show exactly that (alpha: artifact reported + commits observed; beta: commits observed, nothing reported); no invented atomicity, no rollback.
-- **MULTI-07** (B, core) — _Repo-less delivery._ Agent in an empty workspace reports `{kind: document, locator: <url>}` and completes delivered. Then the completed event carries the artifact; no git facts exist or are claimed.
+- **MULTI-01** (core) — _Designated multi-repo._ Given `Repos: alpha, beta`, both cloned. Then one workspace directory with two worktrees side by side, the **same** task branch in each, **one** tmux session at the workspace root.
+- **MULTI-02** (core) — _Designated-and-missing → bail._ Given `Repos: alpha, gamma`, `gamma` not cloned. Then nothing provisions (not even `alpha`), visible "repo not found" skip, task stays queued.
+- **MULTI-03** (core) — _Empty-workspace dispatch._ Given a task with no repo designation. Then the session launches in an empty workspace; zero worktrees; state running.
+- **MULTI-04** (core) — _Runtime acquisition, allowed._ Scripted agent runs `crew workspace add alpha` in-session (task identity via workspace state/env). Then a worktree for `alpha` appears under the workspace on the uniform task branch; the addition is recorded in task state; prepare-worktree hook ran.
+- **MULTI-05** (core) — _Runtime acquisition, gate-rejected._ Agent runs `crew workspace add not-cloned`. Then a loud error, nothing created, nonzero exit in-session; task keeps running.
+- **MULTI-06** (core) — _Partial completion truth-telling._ Agent commits in `alpha` and `beta`, reports a pr artifact for `alpha` only, completes `{outcome: failed}`. Then per-repo records show exactly that (alpha: artifact reported + commits observed; beta: commits observed, nothing reported); no invented atomicity, no rollback.
+- **MULTI-07** (core) — _Repo-less delivery._ Agent in an empty workspace reports `{kind: document, locator: <url>}` and completes delivered. Then the completed event carries the artifact; no git facts exist or are claimed.
 
-### F. Artifacts & source contract (v2-only — DEVOP-5968)
+### F. Artifacts & source contract (DEVOP-5968)
 
-- **FLOW-01** (B, core) — _Reported vs observed are separate layers._ Agent commits but reports nothing. Then status shows commits _observed_ and no artifact _reported_ — a missing link, never a lie.
-- **FLOW-02** (B, core) — _Mixed artifact kinds round-trip._ Agent reports `pr`, `ticket`, and `file` artifacts. Then `completed.artifacts` in the journal carries all three, kinds and locators intact.
-- **FLOW-03** (B, core) — _Read-only source end-to-end._ Given a fixture manifest with no `update` command. Then dispatch, run, completion all succeed; journal shows zero update calls; status labels the source read-only.
-- **FLOW-04** (B, core) — _Claim rejected._ Given the fixture source answers `claimed` with _rejected_. Then no provisioning, no session; task remains listed; the rejection is visible in log/status. (The remote-runner door.)
-- **FLOW-05** (B, core) — _Progress events flow._ Agent emits progress notes. Then journal shows `update:progress` with the notes, in order.
-- **FLOW-06** (B, core) — _Core is forge-blind._ Across MULTI/FLOW scenarios, the fake `gh` (and any recorded network attempt in the core lane) shows **zero** invocations by the core process. Agent-initiated calls don't count.
+- **FLOW-01** (core) — _Reported vs observed are separate layers._ Agent commits but reports nothing. Then status shows commits _observed_ and no artifact _reported_ — a missing link, never a lie.
+- **FLOW-02** (core) — _Mixed artifact kinds round-trip._ Agent reports `pr`, `ticket`, and `file` artifacts. Then `completed.artifacts` in the journal carries all three, kinds and locators intact.
+- **FLOW-03** (core) — _Claim rejected._ Given the fixture source answers `claimed` with _rejected_. Then no provisioning, no session; task remains listed; the rejection is visible in log/status. (The remote-runner door.)
+- **FLOW-04** (core) — _Progress events flow._ Agent emits progress notes. Then journal shows `update:progress` with the notes, in order.
+- **FLOW-05** (core) — _Done-ness is not core's business._ After COMPLETE-02, the source's task store still says whatever its own `update` handler chose; core issues no reads to confirm or reconcile it, and status renders the agent's report unchanged.
+- **FLOW-06** (core) — _Core is forge-blind._ Across MULTI/FLOW scenarios, the fake `gh` (and any recorded network attempt in the core lane) shows **zero** invocations by the core process. Agent-initiated calls don't count.
 
-### G. Source packaging & protocol (v2-only — DEVOP-5973)
+### G. Source packaging & protocol (DEVOP-5973)
 
-- **PLUGIN-01** (B, core) — _User-dir source discovery._ Given a bundle at `~/.config/groundcrew/task-sources/fixture/` (`source.json` + scripts). Then it lists in `source list`, verifies, and serves dispatch.
-- **PLUGIN-02** (B, core) — _Name collision: user dir wins._ Given a package-shipped bundle and a user-dir bundle with the same name. Then the user's is used; the override is visible in `source list`/doctor.
-- **PLUGIN-03** (B, core) — _Protocol mismatch is loud._ Given `protocolVersion: 99`. Then discovery/doctor/status emit an explicit, actionable error naming the version and the supported set; the source is not silently skipped; other sources unaffected.
-- **PLUGIN-04** (B, core) — _Unparseable manifest: skip + warn._ Given malformed `source.json`. Then a warning names the file; everything else proceeds.
-- **PLUGIN-05** (B, core) — _Capability by omission._ Given a manifest omitting `update`. Then no version sniffing, no error: the source is treated read-only (= FLOW-03's mechanism, asserted at discovery level).
+- **PLUGIN-01** (core) — _User-dir source discovery._ Given a bundle at `~/.config/groundcrew/task-sources/fixture/` (`source.json` + scripts). Then it lists in `source list`, verifies, and serves dispatch.
+- **PLUGIN-02** (core) — _Name collision: user dir wins._ Given a package-shipped bundle and a user-dir bundle with the same name. Then the user's is used; the override is visible in `source list`/doctor.
+- **PLUGIN-03** (core) — _Protocol mismatch is loud._ Given `protocolVersion: 99`. Then discovery/doctor/status emit an explicit, actionable error naming the version and the supported set; the source is not silently skipped; other sources unaffected.
+- **PLUGIN-04** (core) — _Unparseable manifest: skip + warn._ Given malformed `source.json`. Then a warning names the file; everything else proceeds.
+- **PLUGIN-05** (core) — _Capability by omission._ Given a manifest omitting `update`. Then no version sniffing, no error: the source is treated read-only (COMPLETE-05's mechanism, asserted at discovery level).
 
 ### H. Sandbox posture (sandbox lane, platform-gated)
 
-- **SANDBOX-01** (A, sandbox) — _Agent contained by default._ Scripted agent writes inside the worktree (succeeds) and outside `HOME`-scoped allowed paths (fails). Both outcomes observed via marker files.
-- **SANDBOX-02** (A, sandbox) — _Agent network egress allowlisted._ Agent curls an allowlisted host (loopback fixture; succeeds) and a non-allowlisted one (fails).
-- **SANDBOX-03** (B, sandbox) — _Sources sandboxed by default._ Fixture source's `list` script attempts undeclared egress and an out-of-scope write → both denied; declared scratch dir + install dir (read) work. (Manifest `network` allowlist, DEVOP-5973 §4.)
-- **SANDBOX-04** (B, sandbox) — _`sandbox: false` opt-out is loud._ Given the fixture source configured with `sandbox: false`. Then it runs unsandboxed (undeclared write succeeds) **and** status/doctor visibly flag the opt-out.
+- **SANDBOX-01** (sandbox) — _Agent contained by default._ Scripted agent writes inside the worktree (succeeds) and outside `HOME`-scoped allowed paths (fails). Both outcomes observed via marker files.
+- **SANDBOX-02** (sandbox) — _Agent network egress allowlisted._ Agent curls an allowlisted host (loopback fixture; succeeds) and a non-allowlisted one (fails).
+- **SANDBOX-03** (sandbox) — _Sources sandboxed by default._ Fixture source's `list` script attempts undeclared egress and an out-of-scope write → both denied; declared scratch dir + install dir (read) work. (Manifest `network` allowlist, DEVOP-5973 §4.)
+- **SANDBOX-04** (sandbox) — _`sandbox: false` opt-out is loud._ Given the fixture source configured with `sandbox: false`. Then it runs unsandboxed (undeclared write succeeds) **and** status/doctor visibly flag the opt-out.
 
 ### I. Surface & diagnostics
 
-- **SURFACE-01** (A, core) — _Init → doctor green._ On a healthy fixture host, the version's init flow produces a config that `doctor` passes and DISPATCH-01 runs against unmodified.
-- **SURFACE-02** (A, core) — _Doctor catches broken hosts._ Missing agent binary; unreachable/failing source verify; missing base dir — each produces a failing doctor with the cause named, exit 1.
-- **SURFACE-03** (A, core) — _Status degrades gracefully._ Given the fixture source errors on list. Then `status` still prints local truth (worktrees, sessions, state) and marks the queue unavailable with the reason; exit 0.
-- **SURFACE-04** (A, core) — _Structured logs are parseable._ After DISPATCH-01 + COMPLETE-02, every line of the log file parses as JSON and carries the task id on task-scoped events. (Deeper schema assertions belong to the observability design — fog.)
+- **SURFACE-01** (core) — _Init → doctor green._ On a healthy fixture host, the init flow produces a config that `doctor` passes and DISPATCH-01 runs against unmodified.
+- **SURFACE-02** (core) — _Doctor catches broken hosts._ Missing agent binary; unreachable/failing source verify; missing base dir — each produces a failing doctor with the cause named, exit 1.
+- **SURFACE-03** (core) — _Status degrades gracefully._ Given the fixture source errors on list. Then `status` still prints local truth (worktrees, sessions, state) and marks the queue unavailable with the reason; exit 0.
+- **SURFACE-04** (core) — _Structured logs are parseable._ After DISPATCH-01 + COMPLETE-02, every line of the log file parses as JSON and carries the task id on task-scoped events. (Deeper schema assertions belong to the observability design — fog.)
 
-## 3. Open questions (for reaction)
+## 4. Iteration log
 
-1. **Tier A "green on v1" definition.** Proposed: Tier A must pass on v1 via the v1 driver before any v2 code lands, and the v2 driver reuses the same scenario bodies verbatim. Accepting a scenario into Tier A is therefore a compat promise — is this list (A/B/C/D + SURFACE) the right promise, or should any of it be demoted to v1-only pinning?
-2. **v1's in-review/done loop is forge-coupled; v2 dropped the forge.** v1 advances in-review/done by polling `gh` for PR state. v2 core is forge-blind, so nothing in core can observe "merged." COMPLETE-01/02 assume the v2 path is agent-reported (artifact add → completed). That leaves a real gap: a merged-later PR no longer advances the source to done. Is "done = agent says done (or human `task done`)" the intended v2 semantics, with tracker automation (e.g. Linear's GitHub integration) owning merge-driven transitions?
-3. **Teardown trigger in v2.** v1 tears down on observed merge. If v2 completion is agent-reported, does `completed{delivered}` tear down immediately, or does the worktree linger for human review until `cleanup`? COMPLETE-02 currently leaves this to DEVOP-5975; the suite needs one answer.
-4. **Suite repo/harness stack.** Proposed: suite lives in the groundcrew repo as a separate package (`e2e/`), plain TypeScript + vitest, spawning the built binary; fixture source + scripted agent are committed executables. Objections?
-5. **Sandbox lane scope.** SANDBOX-01/02 as Tier A means proving v1's safehouse/srt posture in CI too, which may be flaky on shared runners. Alternative: sandbox lane is v2-only (Tier B), and v1 keeps only its existing unit-level coverage. Which?
+- **Iteration 1** (2026-07-16): green-on-v1 gate dropped in favor of harness self-tests plus a migration-easing budget; completion model codified (forge-blind, agent-reported, linger-until-cleanup); suite stack confirmed (`e2e/` package, TS + vitest); sandbox lane confirmed v2-only. Tier A/B structure and the v1 driver removed accordingly.

--- a/docs/spec/e2e-scenario-catalog.md
+++ b/docs/spec/e2e-scenario-catalog.md
@@ -27,7 +27,7 @@ Everything a scenario may assert on:
 
 ### 1.3 Command binding
 
-The CLI surface ([DEVOP-5975](https://linear.app/clipboardhealth/issue/DEVOP-5975)) is still open, so scenarios call abstract operations bound in exactly one harness module — the only file that changes when command names land:
+Scenarios call abstract operations bound in exactly one harness module. The CLI surface ([DEVOP-5975](https://linear.app/clipboardhealth/issue/DEVOP-5975)) has since landed the concrete names — `start` (merged run+start, `--watch`/`--force`), `pause`/`resume`, `cleanup`, `status`, `doctor`, and in-session `repo add` / `artifact add` / `done` — so the binding is now mechanical:
 
 ```text
 configure(fixture)            // write config into the scenario tmpdir
@@ -82,7 +82,7 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **DISPATCH-04** (core) — _Blocked task skipped, dispatched when unblocked._ Given a task with an open blocker. When `tick()`: nothing provisions. When the fixture marks the blocker done and `tick()` again: it provisions.
 - **DISPATCH-05** (core) — _Ineligible task ignored._ Given a task with no agent routing. When `tick()`. Then no provisioning, no writeback, task still listed as queued.
 - **DISPATCH-06** (core) — _Designated repo not on disk → bail._ Given a task designating a repo not cloned under the base dir. When `tick()`. Then no worktree/branch/session/state; the task stays queued at the source; the skip reason is visible (log line + status). (DEVOP-5967 §2.)
-- **DISPATCH-07** (core) — _Manual start bypasses eligibility._ Given an unlabeled/no-agent task. When `start(task)`. Then it provisions exactly as DISPATCH-01.
+- **DISPATCH-07** (core) — _Manual start bypasses eligibility, never the repo gate._ Given an unlabeled/no-agent task. When `start(task)` (`crew start <task> --force`). Then it provisions exactly as DISPATCH-01. Variant: the same forced start on a task designating a repo not on disk still bails per DISPATCH-06 — `--force` cannot override the repo-on-disk gate.
 - **DISPATCH-08** (core) — _Branch reuse._ Given a prior local branch `expect.branchFor(task)` with a commit. When dispatched. Then the worktree re-attaches to that branch (prior commit present), not a fresh one.
 - **DISPATCH-09** (core) — _Recurrence is a source concern._ Given a fixture source that re-lists a completed task per its recurrence rule. When the task completes and `tick()` runs after re-listing. Then a fresh dispatch occurs; core has no recurrence machinery to observe. (DEVOP-5968 §6.)
 
@@ -93,6 +93,7 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **COMPLETE-03** (core) — _Launch failure is truthful and rolled back._ Given an agent profile whose `cmd` doesn't exist. When `start(task)`. Then state records `complete{failed, reason: launch}`; worktree and branch rolled back; the failure appears in the journal if the task was already claimed.
 - **COMPLETE-04** (core) — _Agent failure is truth-told._ Scripted agent ends `completed {outcome: failed, message}`. Then journal carries the failure event with the message; state is `complete{failed}`; no artifact records invented; workspace lingers for inspection.
 - **COMPLETE-05** (core) — _Read-only source end-to-end._ Given a fixture manifest with no `update` command. Then dispatch, run, and completion all succeed; journal shows zero update calls; status labels the source read-only. (Also asserted at discovery level in PLUGIN-05.)
+- **COMPLETE-08** (core) — _`crew done` honors the dirty-worktree guard._ Scripted agent leaves uncommitted changes and runs `crew done --outcome delivered`: refused with a nonzero exit naming the dirt; task stays running; no completed event. Rerun with `--allow-dirty`: completes normally.
 - **COMPLETE-06** (core) — _Manual cleanup ends the linger._ Given a delivered task's lingering workspace. When `cleanup(task)`. Then worktree removed, branch deleted, state record gone; the source hears nothing new.
 - **COMPLETE-07** (core) — _Source-terminal auto-reap (v1 cleaner parity)._ Given a delivered task's lingering clean workspace. When the fixture source's store marks the task done and `tick()` runs. Then worktree, branch, and state record reaped automatically; the reap is logged. Variant: if the lingering worktree is dirty, auto-reap skips it with a visible warning and everything stays on disk.
 
@@ -115,8 +116,9 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **MULTI-01** (core) — _Designated multi-repo._ Given `Repos: alpha, beta`, both cloned. Then one workspace directory with two worktrees side by side, the **same** task branch in each, **one** tmux session at the workspace root.
 - **MULTI-02** (core) — _Designated-and-missing → bail._ Given `Repos: alpha, gamma`, `gamma` not cloned. Then nothing provisions (not even `alpha`), visible "repo not found" skip, task stays queued.
 - **MULTI-03** (core) — _Empty-workspace dispatch._ Given a task with no repo designation. Then the session launches in an empty workspace; zero worktrees; state running.
-- **MULTI-04** (core) — _Runtime acquisition, allowed._ Scripted agent runs `crew workspace add alpha` in-session (task identity via workspace state/env). Then a worktree for `alpha` appears under the workspace on the uniform task branch; the addition is recorded in task state; prepare-worktree hook ran.
-- **MULTI-05** (core) — _Runtime acquisition, gate-rejected._ Agent runs `crew workspace add not-cloned`. Then a loud error, nothing created, nonzero exit in-session; task keeps running.
+- **MULTI-04** (core) — _Runtime acquisition, allowed._ Scripted agent runs `crew repo add alpha` in-session (task identity via `$GROUNDCREW_WORKSPACE`). Then a worktree for `alpha` appears under the workspace on the uniform task branch; the addition is recorded in task state; prepare-worktree hook ran. Variants exercise the other two identity paths: explicit `--task`, and env unset with cwd inside the workspace (walk-up to `.groundcrew/task.json`).
+- **MULTI-05** (core) — _Runtime acquisition, gate-rejected._ Agent runs `crew repo add not-cloned`. Then a loud error, **exit 2** (repo not cloned under the base directory), nothing created; task keeps running.
+- **MULTI-08** (core) — _In-session command without task context._ `crew repo add alpha` run outside any workspace, with no `--task` and no `$GROUNDCREW_WORKSPACE`. Then **exit 3** (no task context), nothing created, no journal entry.
 - **MULTI-06** (core) — _Partial completion truth-telling._ Agent commits in `alpha` and `beta`, reports a pr artifact for `alpha` only, completes `{outcome: failed}`. Then per-repo records show exactly that (alpha: artifact reported + commits observed; beta: commits observed, nothing reported); no invented atomicity, no rollback.
 - **MULTI-07** (core) — _Repo-less delivery._ Agent in an empty workspace reports `{kind: document, locator: <url>}` and completes delivered. Then the completed event carries the artifact; no git facts exist or are claimed.
 
@@ -150,8 +152,12 @@ Each entry: **ID · lane · Given** (source store, config, disk, scripts) · **W
 - **SURFACE-02** (core) — _Doctor catches broken hosts._ Missing agent binary; unreachable/failing source verify; missing base dir — each produces a failing doctor with the cause named, exit 1.
 - **SURFACE-03** (core) — _Status degrades gracefully._ Given the fixture source errors on list. Then `status` still prints local truth (worktrees, sessions, state) and marks the queue unavailable with the reason; exit 0.
 - **SURFACE-04** (core) — _Structured logs are parseable._ After DISPATCH-01 + COMPLETE-02, every line of the log file parses as JSON and carries the task id on task-scoped events. (Deeper schema assertions belong to the observability design — fog.)
+- **SURFACE-05** (core) — _`init --yes` is non-interactive and sufficient._ On a fixture host with an agent CLI on PATH. When `crew init --yes`. Then a `crew.config.jsonc` exists that `doctor` passes and DISPATCH-01 runs against unmodified — no prompts, exit 0.
+- **SURFACE-06** (core) — _v1 config conversion._ Given a v1 `crew.config.ts` (with `knownRepositories`, a `shell` source block, and a safehouse runner setting). When `crew init`. Then a converted `crew.config.jsonc` is written and every dropped or renamed key is named in the output; `doctor` passes afterward.
+- **SURFACE-07** (core) — _`source doctor` live round-trip._ Given the fixture source installed. When `crew source doctor`. Then it exercises the source's verify/read probe end-to-end (journal shows the probe call) and reports healthy; with the fixture's script made to fail, it reports the failure with the source named, exit 1.
 
 ## 4. Iteration log
 
 - **Iteration 1** (2026-07-16): green-on-v1 gate dropped in favor of harness self-tests plus a migration-easing budget; completion model codified (forge-blind, agent-reported, linger-until-cleanup); suite stack confirmed (`e2e/` package, TS + vitest); sandbox lane confirmed v2-only. Tier A/B structure and the v1 driver removed accordingly.
 - **Iteration 2** (2026-07-16): linger gets two exits — manual `cleanup` or source-terminal auto-reap (v1's cleaner kept: it watches the source, never the forge; v1's merged-PR reviewer path dies). COMPLETE-07 added; dirty worktrees are never auto-reaped.
+- **Iteration 3** (2026-07-16): absorbed the CLI surface resolution's handoff (DEVOP-5975, resolved concurrently): `workspace add` → `repo add`; completion via `crew done`; task-identity resolution order with exit codes 2/3 (MULTI-04/05/08); `--force` never overrides the repo gate (DISPATCH-07); `done` dirty-guard (COMPLETE-08); `init --yes`, v1-config conversion, and `source doctor` round-trip (SURFACE-05/06/07).

--- a/docs/spec/v2-design.md
+++ b/docs/spec/v2-design.md
@@ -1,0 +1,351 @@
+# Groundcrew v2 design
+
+The implementation handoff for groundcrew v2, assembled from the [Groundcrew v2 spec wayfinder map](https://linear.app/clipboardhealth/issue/DEVOP-5966) (DEVOP-5966). Every decision below was resolved on that map; the [decision record](#13-decision-record) links each section to its ticket, where the full resolution and its rationale live. Where resolutions conflicted, later amendments win and are marked.
+
+This document and the [E2E scenario catalog](./e2e-scenario-catalog.md) together are the spec. **The first implementation task is building the acceptance suite red-first from the catalog — before any v2 code exists.** The suite brings v2 up red-to-green; harness self-tests carry the suite's trustworthiness (the green-on-v1 gate was dropped: v2 breaks too much of v1's surface for v1 scenarios to pay for themselves).
+
+## 1. Destination and locked constraints
+
+Groundcrew dispatches task backlogs to local, interactive AI coding agents — one workspace per task, sandboxed by default. v2 is a rewrite of that product with a smaller, sharper surface.
+
+Locked constraints, not to be re-litigated during implementation:
+
+- **TypeScript.** The language-agnostic escape hatch is the black-box acceptance suite (any implementation that passes is conformant), not a new language.
+- **Free to break v1** — config, CLI, conventions — easing migration opportunistically (section 11).
+- **Sandboxed and secure by default**; interactive sessions are the baseline.
+- **Pluggable agent harnesses** with model and effort-level selection.
+- **Structured logs; minimal CLI surface; sane defaults with minimal required config; install/setup script.**
+- **E2E-first confidence**: the black-box acceptance suite exists red-first before v2 code starts.
+
+## 2. Verdict: rewrite
+
+**Rewrite, not evolve.** ([Rewrite vs evolve](https://linear.app/clipboardhealth/issue/DEVOP-5978))
+
+- The locked decisions kill or fundamentally reshape most of v1 (~21K source lines, ~38K test lines): `config.ts` dies with the TS-config format, the reviewer PR-polling loop dies, clearance/safehouse/sbx die, several commands die, and the core nouns are redefined. Every external surface breaks: config, CLI, source contract, sandbox posture, completion model.
+- Evolve's safety-net premise was stale: the acceptance suite never runs against v1 (green-on-v1 dropped), so in-place evolution gets zero protection from it. "Evolve" would be the same rewrite executed as a thousand PRs fighting 38K test lines that assert dying behavior.
+- Roughly 15–25% of v1 survives recognizably (srtPolicy/srtLaunch, the cleaner, tmux/git plumbing, doctor pieces, usage, completions). Surviving code is **ported file-by-file with its unit tests**; `git mv` preserves history.
+
+**Repo strategy: same repo, isolated `v2/` workspace.** v2 grows on `main` under a top-level `v2/` with its own `package.json`, flat `src/<module>` layout, and its own `CLAUDE.md`/`AGENTS.md`/`CONTEXT.md` carrying the v2 ubiquitous language. v1 and v2 use the same nouns with contradictory meanings ("Workspace" means a terminal pane in v1 and a per-task directory of worktrees in v2), so sharing one `src/` was rejected — it would contaminate agent-driven work. dependency-cruiser forbids cross-tree imports in both directions. **Flip condition:** if v2-building agents keep tripping over v1 despite the boundary, escalate mid-build to a new repo initialized from a full clone, then rename old → `groundcrew-v1`, new → `groundcrew`.
+
+**Package strategy.** Keep `@clipboard-health/groundcrew` and the `crew` bin; the release is **5.0.0** (v1 is at 4.47.x). No npm publish until the E2E suite is green — the team dogfoods from the repo. v1 goes **fixes-only** once v2 construction starts. Cutover: cut a `4.x` maintenance branch, flatten `v2/` to the repo root, delete the v1 tree; later v1 patches publish from `4.x` under a `v4` dist-tag.
+
+**Release-automation wrinkle (must be handled before v2 commits land):** `main`'s Nx Release automation would treat v2 conventional commits as 4.x releases — it needs a path filter or commit-scope exclusion so v2 commits don't trigger 4.x publishes.
+
+## 3. Flow model
+
+([Flow model](https://linear.app/clipboardhealth/issue/DEVOP-5968), informed by the [prior-art research](https://linear.app/clipboardhealth/issue/DEVOP-5969): symmetric source/sink type systems are where Concourse and Tekton died, so the generalization is asymmetric.)
+
+What exists: **sources, agent profiles, tasks, artifact records.** Two things deliberately do not exist:
+
+- **Sinks dissolve.** Every task output happens through the agent's own tools (it opens PRs with `gh`, writes docs, files tickets — it has the credentials and the judgment) or the source's writeback. No typed sink stage; "produce a PR" is the default writeback pattern for repo work, not a privileged path.
+- **Flows dissolve.** Config declares sources and agent profiles; each task carries its routing (an agent designation); a source-level default agent covers the common case. No pipeline/flow config object.
+
+**Artifact record: plural, kind-tagged, agent-reported — no exceptions.** Per task: `{status, logs, artifacts: []}`, each artifact `{kind, locator, title?, repo?}` with an open kind set (`pr | branch | document | file | ticket | …`). All artifacts are reported by the agent via in-session `crew artifact add`. Groundcrew observes only what it owns — workspace-local git facts (branches, commits, dirty state), readable without credentials. **The core knows nothing about GitHub or any forge.** Status renders both layers ("3 commits _observed_; PR _reported_"); a forgotten report is a missing link, never a lie.
+
+**Source contract** — `list`, `get`, `update`, capability by omission:
+
+- `list` (poll for ready tasks) and `get` are required; a source without `update` is legal and read-only (writeback no-ops).
+- `update(task, event)` is the single callback verb. Events: `claimed` (ack; may return _rejected_ where the source arbitrates contention — the remote-runner door, open but unbuilt), `progress` (note), `completed{outcome, artifacts, message}`. Errors are `outcome: failed`, not a separate channel.
+- `create` is dropped; tasks are created in the tracker or file directly.
+
+**Run states** (core-owned, recorded only for started work; the queue stays derived from source polls):
+
+```text
+provisioning → running ⇄ paused → complete{outcome: delivered | failed | stopped}
+```
+
+v1's `resumed` collapses into `running` (resumeCount is a field), `interrupted` → `paused`, `failed-to-launch` → `complete{failed, reason: launch}`. Bail (designated repo not on disk) never enters the machine — the task stays queued at the source with a visible skip reason. `input-required` is **not** a state: in interactive mode the terminal is the input surface; the extensible event set is the seam if headless needs it later.
+
+**Recurring tasks are a source concern.** A source that re-lists a task on a schedule is indistinguishable from a human re-creating it; core ships no recurrence machinery.
+
+## 4. Task model: workspaces of worktrees
+
+([Multi-repo task model](https://linear.app/clipboardhealth/issue/DEVOP-5967))
+
+**One agent session per task, over a workspace of worktrees.** Groundcrew provisions worktrees side by side under a single task workspace directory; one agent session launches at the workspace root and coordinates all repos itself. One terminal surface per task, N PRs out. The session can start before any worktree exists — an empty workspace is legal. The capable agent is the coordinator; there are no federated sessions or relay pipelines.
+
+**Repo resolution — two modes, one mechanism:**
+
+- **Designated:** the task carries a `Repos:` designation. Groundcrew resolves each name against what is actually cloned under the configured base directory and provisions those worktrees up front. Any designated repo not found on disk → **bail**: skip the task with a visible "repo not found" status, provision nothing (not even the repos that do exist).
+- **Not designated:** dispatch anyway, into an empty workspace. The ticket's prose decides what happens: the agent discovers repos and acquires worktrees at runtime, or never touches a repo at all. Repo-less tasks are legal.
+- There is no `Repos: discover` marker, and v1's prose-inference (scanning descriptions for repo mentions) is dropped: explicit designation or nothing.
+
+**`knownRepositories` dies.** The repo universe is the disk under the base directory. Groundcrew never clones — provisioning is always worktree-from-local-clone. (The agent may clone repos itself if the sandbox policy allows; that is the sandbox's jurisdiction.) Accepted tradeoff, recorded honestly: the gate widens from "repos listed in config" to "anything cloned under the base directory" — mitigated by sandboxing; an optional allowlist can be layered on later without redesign.
+
+**Runtime acquisition:** the agent runs `crew repo add <repo>` in-session. The CLI applies the disk-presence gate, creates the worktree from the local clone on the uniform task branch, runs the repo's prepare-worktree hook, and records the addition in task state. Provisioning stays groundcrew's job with all guarantees intact — only the trigger moves from dispatch-time to agent-runtime.
+
+**Branch/PR topology:** a uniform task-derived branch name across every acquired worktree — the correlation key that keeps status/resume/cleanup trivial; one PR per repo as the default writeback, cross-linked to each other and the task; one artifact record per repo. A repo that needs no change simply produces no PR.
+
+**Partial failure: groundcrew does nothing but tell the truth.** Cross-repo atomicity is an explicit non-goal. Per-repo artifact records show exactly how far each repo got; merge outcomes are human/CI territory; recovery is a human action. The uniform branch plus cross-linked PRs guarantee the full blast radius is reconstructible from any one artifact.
+
+Single-repo tasks stay dead simple as the degenerate case: one designated repo, one worktree, one branch, one PR — exactly v1's shape.
+
+## 5. Completion model
+
+(Codified in the [E2E scenario catalog](https://linear.app/clipboardhealth/issue/DEVOP-5974); full statement in [the catalog, section 2](./e2e-scenario-catalog.md#2-completion-model-codified-from-iteration-1).)
+
+- **Core never polls a destination for done-ness.** No forge calls, no tracker reads to infer completion. v1's reviewer (merged-PR polling via `gh`) dies.
+- Status = **observed** workspace git facts plus **agent-reported** events and artifacts; humans judge from the agent's report.
+- `completed{outcome}` **frees the dispatch slot immediately** — a finished task never blocks the queue.
+- **The workspace lingers after completion, with two exits:** a human runs `cleanup`, or polling observes the _source_ reporting the task terminal — v1's cleaner survives unchanged because it watches the source, never the forge (this is how Linear cleanup actually worked in v1: Linear's GitHub integration moves the issue; the poll observes it). Dirty worktrees are never auto-reaped — loud skip, left for a human.
+
+## 6. Plugin boundary: task sources
+
+([Plugin packaging and review isolation](https://linear.app/clipboardhealth/issue/DEVOP-5973), informed by the [plugin-distribution research](https://linear.app/clipboardhealth/issue/DEVOP-5971): in-process npm plugins deliver no sandboxing and no real review isolation; the models that work — Terraform providers, MCP — use a versioned process boundary.)
+
+**"Plugin" means exactly one thing in v2: a task source.** Everything else that looked pluggable is config or core:
+
+- **Agent harnesses are declarative config**, not plugins: `cmd`, resume args, sandbox preferences, plus first-class `model`/`effort` fields. `cmd`-points-at-your-script is the escape hatch for odd agents.
+- **Sandbox runners are core-only**, explicitly not pluggable — a pluggable sandbox is a contradiction under sandboxed-by-default. **v2 ships exactly one runner: srt** (`sandbox-exec` on macOS, bubblewrap on Linux). Safehouse, clearance, and sbx die, including the `crew-clearance-ensure` bin.
+- **No in-process plugin class exists.** The internal `TaskSource` interface survives only as core's private representation of a discovered manifest.
+
+**Packaging:** a plugin is a **directory bundle** — `source.json` plus scripts — discovered under `~/.config/groundcrew/task-sources/<name>/` (user) or bundled in the package (first-party). The directory is the plugin: language-agnostic, no runtime loading. Distribution is deliberately not groundcrew's problem (git clone, `curl | tar`, npm postinstall). No registry or catalog in v2.0; provenance tiers collapse to `package | user`. Review isolation is met structurally: third-party code never enters the core repo and never runs in the core process.
+
+**Versioning:** `source.json` carries a required integer `protocolVersion: 1` naming the contract generation, bumped only on breaking change — capability-by-omission carries all additive change (no version sniffing: `update` absent means read-only). Parseable-but-unsupported version → explicit actionable error in discovery/doctor/status, never a silent skip; unparseable manifests keep skip-plus-warn. Core declares a supported set; v2.0 ships `{1}`. No v1 command aliases.
+
+**Sources are sandboxed by default**, under the same srt machinery as agents: deny-by-default; a source gets its install dir (read), declared secret files, declared env, stdout/stderr, and a per-source scratch dir. The manifest gains a **network egress allowlist** (e.g. `network: ["api.linear.app"]`) alongside `secrets`/`env`/`prerequisites`. Uniform across origins — bundled first-party sources run under the same policy. Per-source opt-out (`sandbox: false`) is loud in status/doctor.
+
+**Batteries included, kernel-pure code paths:** `linear`, `jira`, and `todo-txt` ship as manifest bundles crossing the same process boundary as third-party sources — first-party sources are the protocol's permanent conformance tests. The generic `shell` config-block adapter dies: bring-your-own-scripts is just a user-dir manifest.
+
+## 7. CLI surface and config
+
+([CLI surface](https://linear.app/clipboardhealth/issue/DEVOP-5975); prototype with rendered `--help` for every command on branch [`prototype/devop-5975-cli-surface`](https://github.com/ClipboardHealth/groundcrew/tree/prototype/devop-5975-cli-surface), `node --run proto:cli2 -- --tour`. Amended by [Headless extension point](https://linear.app/clipboardhealth/issue/DEVOP-5976): config field `multiplexer` → `presenter`.)
+
+### 7.1 Commands — 14 leaves (v1 had ~20)
+
+| Group      | Command                                                       | Notes                                                                                                                                                                                                                |
+| ---------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Operate    | `start [task]`                                                | Merged v1 `run`+`start`. No task = poll and dispatch eligible (`--watch` continuous); with task = dispatch that one (`--force` bypasses eligibility but never the repo-on-disk gate; `--agent` override).            |
+| Operate    | `status [task]`                                               | Absorbs `task list`/`get`. Renders **observed** git facts vs **reported** agent claims as separate layers; is the "why" affordance (section 10.4).                                                                   |
+| Operate    | `pause` / `resume`                                            | v1 `stop` renamed. `resume` reopens the _same conversation_ via captured `{{sessionId}}` where the harness exposes one (Claude Code and Codex do); falls back to `resumeArguments`; `--fresh` = new session.         |
+| Operate    | `cleanup [task\|--all]`                                       | An uncompleted task completes as `stopped`.                                                                                                                                                                          |
+| In-session | `repo add <repo>`                                             | Runtime acquisition (section 4). Renamed from `workspace add` to dodge the cmux "workspace" collision.                                                                                                               |
+| In-session | `artifact add <locator> [--kind\|--title\|--repo]`            | Agent-reported artifacts (section 3).                                                                                                                                                                                |
+| In-session | `done [--outcome delivered\|failed\|stopped] [--allow-dirty]` | Replaces `$GROUNDCREW_COMPLETE` — the prompt just says "run `crew done`". Dirty-worktree guard refuses with the dirt named unless `--allow-dirty`.                                                                   |
+| Setup      | `init`                                                        | Interactive 5-step: baseDirectory, agent detection, source pick, write config, run doctor. Detects a v1 `crew.config.ts` and converts it, printing every dropped/renamed key. Global by default; `--local`, `--yes`. |
+| Setup      | `doctor` / `upgrade` / `completions`                          | `doctor` is the health-check verb everywhere: `crew doctor`, `crew source doctor` (absorbs `source verify` + `task validate`).                                                                                       |
+
+In-session commands are ordinary subcommands (no separate namespace). **Task identity resolution:** `--task` flag → `$GROUNDCREW_WORKSPACE` env (injected at launch) → walk up from cwd to `.groundcrew/task.json`. Exit codes: **2** = repo not cloned under `baseDirectory`, **3** = no task context.
+
+**Killed:** `open`, `task create`, `task list/get/validate`, `source install`, `source verify`, `interrupt`, `sandbox`, `setup`, the `crew-clearance-ensure` bin. No `progress` command in v2.0 (the protocol event exists; add a CLI if the need shows up). No `crew migrate` — `init`'s conversion is the migration aid.
+
+**Verb families locked:** lifecycle `start → pause → resume → done`; health checks are `doctor`.
+
+### 7.2 Config — `crew.config.jsonc`
+
+- **JSONC plus a published JSON Schema** (generated from zod, referenced via `$schema`). TS config dies: a global config can't resolve the package import for its types, so it was ceremony without safety. One filename, one location rule: `~/.config/groundcrew/`, or project-local.
+- **Principle 1 — omitted = detected, specified = exactly yours, never merged.** `sources` omitted → `[{ "kind": "todo-txt" }]`; `agents` omitted → presets for CLIs on PATH (claude > codex > cursor); `presenter` omitted → first of cmux/tmux/zellij found. Listing anything replaces the detected set — disabling = not listing.
+- **Principle 2 — no secrets, structurally.** No schema field accepts a token value; manifests declare secret _names_, resolved from the parent environment, a `secrets.env` (doctor warns unless 0600), or `op run`. `GROUNDCREW_LINEAR_API_KEY` dies; the linear bundle declares `LINEAR_API_KEY` like any source. Doctor flags credential-looking strings in config.
+- Minimal legal config: `{ "workspace": { "baseDirectory": "~/dev" } }`. Worktrees default to `<baseDirectory>/.groundcrew/worktrees`. No abbreviations anywhere (`maximumInProgress`, `pollIntervalMilliseconds`, `sessionLimitPercentage`, `readOnlyDirectories`, `workingDirectory`).
+- Agent profiles get first-class `model` / `effort` / `resume` fields; presets map them to CLI flags; `{{model}}` / `{{sessionId}}` placeholders for custom commands. Per-harness session-id capture mechanics are an implementation detail under this shape.
+
+### 7.3 Setup
+
+`curl -fsSL …/install.sh | sh` → node ≥ 24 check, global npm install, exec `crew init` (`--yes` for CI/dotfiles). Deliberately manual forever: cloning repos, minting API keys, installing agent CLIs.
+
+## 8. Session presenter
+
+([Headless extension point](https://linear.app/clipboardhealth/issue/DEVOP-5976))
+
+**The seam is a standalone core interface: the session presenter** — presentation-only, deciding where a local, already-sandbox-wrapped agent process runs and how a human reaches it. Remote execution is permanently outside this seam: a remote runner enters via the source-contract door (`claimed` → _rejected_ arbitration), never as a presenter.
+
+**Contract — born serializable.** JSON in/out, nothing in-process, which outlaws v1's real leak (cmux `set-progress` hooks injected through the launch layer) by construction:
+
+- `open(spec)` — spec = `{name, displayName?, cwd, command, status?}`; `command` arrives fully composed, sandbox wrap included. Nesting is **presenter → sandbox → agent**; the presenter never knows about sandboxing.
+- `probe()` — live workspace list; "unavailable" is never treated as "empty".
+- `close(name)`.
+- `accessHint(name)` — how a human attaches, or nothing.
+- `setStatus(name, {text, color?, icon?})` — **optional, capability by omission** (cmux implements; tmux/zellij omit). Driven by core's run-state machine, not agent-internal hooks. v1's cmux/Claude in-sandbox hook plumbing dies with no replacement.
+
+**Packaging:** cmux/tmux/zellij ship in-core for v2.0; sources remain the only v2.0 plugin kind. Presenter _bundles_ are pre-committed as an additive v2.x kind — same manifest/process-boundary mechanics as sources but an explicitly different trust posture: presenters are inherently unsandboxable (their job is spawning the agent's pane on the host, launch command in hand), so a presenter bundle is **host-trusted like an agent CLI**, never sandbox-defaulted.
+
+**Headless = a future "detached" presenter** implementing the same contract (`open` spawns directly, `probe` is process liveness, `accessHint` returns nothing, `setStatus` omitted). v2.0 ships no detached presenter — one of cmux/tmux/zellij on PATH stays required (doctor checks). **Subagent panes: same seam, deferred** — a future presenter verb plus an in-session command routed through core; nothing outside the presenter may ever talk to a multiplexer.
+
+The fate of v1's tmux-shaped env toggles (`GROUNDCREW_TMUX_SESSION_PER_TASK`, `GROUNDCREW_KEEP_DEAD_WINDOWS`) is presenter-internal implementation detail.
+
+## 9. Architecture: one context, seven modules
+
+([Bounded-context layout](https://linear.app/clipboardhealth/issue/DEVOP-5977))
+
+### 9.1 Single bounded context
+
+One root `CONTEXT.md`, no `CONTEXT-MAP.md`. v2's real boundaries are **process seams** — the source protocol, the presenter contract, the sandbox wrap — and each carries the _same_ language across it; a source bundle translating tracker-speak into protocol-speak is an anticorruption layer living outside the repo. One team, one deployable, one language ⇒ one context.
+
+### 9.2 The core noun triple
+
+- **Workspace** — the per-task directory set: the worktrees (possibly zero) a task's agent works over. Filesystem/git facts only. v1's "Workspace = terminal pane" dies.
+- **Run** — the core-owned execution lifecycle of a claimed task: the state machine of section 3, resumeCount. One claim = one run.
+- **Session** — one live occupancy of a run: the harness process in a presenter surface, with its captured harness session-id. A run spans sessions (`pause`/`resume`; `--fresh` = new session, same run).
+
+Consequences: the session presenter presents sessions, not runs; `status` renders runs; `resume` reopens a session within a run.
+
+### 9.3 Modules
+
+| Module          | Responsibility                                                                                                                                                                             | Owns                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| **Acquisition** | Source bundle discovery, the versioned `list`/`get`/`update` process protocol, source sandboxing                                                                                           | the **source-protocol contract seam**                          |
+| **Dispatch**    | Per-tick picker: poll, eligibility, claim, provision, terminal-status sweep; persists per-task skip verdicts (section 10.4)                                                                | wiring the Writeback adapter into Run                          |
+| **Run**         | The run record: state machine, **reported layer** (`artifact add`/`done` intake), outcomes, writeback point                                                                                | the **Writeback port** (consumer-owned, defined in `src/run/`) |
+| **Workspace**   | Worktrees, branches, **observed layer** (credential-free git facts), `.groundcrew/task.json` and the task-identity resolver; typed errors that Shell maps to exit codes 2/3                | the workspace marker-file format                               |
+| **Session**     | Harness profiles (declarative), launch composition (presenter → sandbox → agent), pause/resume and session-id capture; cmux/tmux/zellij adapters in-core                                   | the **presenter contract seam**                                |
+| **Sandbox**     | Pure library: `wrap(command, policy) → command`; srt mechanics hidden; no lifecycle ownership                                                                                              | nothing pluggable — core-only by decision                      |
+| **Shell**       | commander wiring, routing (`repo add` → Workspace; `artifact add`/`done` → Run), rendering, error→exit-code mapping; `status` = read model joining Run (reported) and Workspace (observed) | —                                                              |
+
+The flow model's central invariant gets one owner per layer — **observed = Workspace, reported = Run** — so a lie or missing link is always attributable to exactly one module. Sandbox has two real callers (Session wraps agents, Acquisition wraps sources): a real seam, and the one place that keeps "sandbox runners are not pluggable" enforceable.
+
+### 9.4 Dependency graph
+
+```text
+Shell ──▶ everything (thin)
+Dispatch ──▶ Acquisition · Workspace · Session · Run
+Run ──▶ Writeback port only (Dispatch injects the adapter closed over the source)
+Session ──▶ Sandbox        Acquisition ──▶ Sandbox
+Workspace ──▶ git only     Sandbox ──▶ nothing
+```
+
+Load-bearing properties: **(a)** Run never sees Acquisition — a read-only source is a no-op handle, and Run's tests never touch discovery; **(b)** each edge module owns exactly one published contract seam; **(c)** acyclic, nothing calls upward — sources are spawned processes that answer; agents talk back only via in-session Shell commands routed downward.
+
+### 9.5 Layout
+
+```text
+CONTEXT.md            ← the one glossary
+docs/adr/             ← wayfinder resolutions seed the first ADRs
+src/
+  acquisition/ dispatch/ run/ workspace/ session/ sandbox/ shell/
+task-sources/
+  linear/ jira/ todo-txt/   ← shipped bundles, OUTSIDE src/ — no import path
+e2e/                  ← black-box suite (spawns the built binary only)
+```
+
+Conventions: **a module's interface is its `index.ts`** — the only importable path from outside; flat `src/<module>/` so path = glossary noun; colocated `*.test.ts` are intra-module and free.
+
+### 9.6 Enforcement — the graph as CI rules
+
+Extend v1's `config/dependencyCruiser.cjs` (already wired as `architecture:check`), keeping `no-circular`/`no-orphans` and adding:
+
+1. **Entry-point boundary** — imports into `src/<module>/` from outside must target `index.ts`.
+2. **The section 9.4 graph as an allowlist** — one `forbidden` rule per module encoding exactly the ratified edges; an undeclared edge fails CI naming the violated seam. The spec diagram and lint config cannot drift silently.
+3. **Process-boundary rules** — `src ↛ task-sources`, `task-sources ↛ src`, `e2e ↛ src` (the suite stays black-box).
+
+Validation step: prove the rules bite with one deliberate deep import and one undeclared edge, watch both fail, revert.
+
+### 9.7 Glossary seed for v2 `CONTEXT.md`
+
+Task · Source · Bundle · Workspace · Worktree · Run · Session · Presenter · Agent profile · Sandbox · Artifact · Writeback · Observed/Reported · Reconcile · Skip verdict — with the triple from 9.2 as the anchor definitions.
+
+## 10. Observability
+
+([Observability design](https://linear.app/clipboardhealth/issue/DEVOP-5982))
+
+**Root fork: logs are diagnostics; the run record is the truth.** "Why did/didn't X happen" is answered from the run record plus observed git facts, never by parsing logs. The run record gains a compact, versioned, append-only event history `{ts, event, detail}` covering state transitions and writeback events. Logs stay freely deletable; no log line is a compatibility surface beyond the line format itself.
+
+### 10.1 Topology
+
+One global JSON-lines file (config `logging.file`), size-based rotation (~10 MB × 3). Runs interleave; run-less events (poll ticks, reconcile, claim-rejected, doctor) share the stream. Correlation ids are the filter mechanism — no per-run files, no sink routing.
+
+### 10.2 Line schema
+
+```json
+{
+  "ts": "…Z",
+  "level": "info",
+  "module": "dispatch",
+  "event": "task_claimed",
+  "msg": "claimed DEVOP-123 from linear",
+  "taskId": "DEVOP-123",
+  "runId": "r_8f3a",
+  "source": "linear"
+}
+```
+
+- `ts` ISO-8601 UTC; `level` ∈ `debug|info|warn|error` (four, no trace/fatal); `module` ∈ the seven ratified modules — all three on every line.
+- `event`: required snake_case name, unique per call site; no dotted module prefix.
+- Correlation ids **flat at top level**, present when known: `taskId`, `runId`, `sessionId`, plus `source`/`repo` where relevant. Extra fields flat too; reserved keys enforced by the logging lib's types. `msg` optional (human lines only).
+- The cross-cutting logging lib (no eighth module) **exports a zod schema for the line format**; the E2E suite validates every emitted line against it.
+
+### 10.3 Console rendering
+
+The file sink gets everything, always. Console: `info`+ by default, human-rendered; `--verbose` = debug threshold. Raw JSON never hits the console — the file is the only JSON surface.
+
+### 10.4 The "why" affordance — no 15th command
+
+`crew status <task>` is the why affordance. It must answer three situations:
+
+1. **Ran / running** — run-record event history merged chronologically with observed git facts, observed-vs-reported layering explicit, ending with a log pointer (file path plus a ready-made jq filter on the run id).
+2. **Queued, never starts** — **spec commitment:** Dispatch persists its last-poll verdict per task id (`{skipReason, ts}` — repo missing / slots full / claim rejected) in a small dispatch-owned state map, making the flow model's "visible skip reason" promise renderable. No run record exists for unclaimed tasks, so this is the only home.
+3. **Finished / lingering** — terminal outcome, delivered vs merely observed, what `cleanup` would do.
+
+### 10.5 Reconcile and reaping
+
+**Active sweep yes, TTL no.** srt sandboxes are process-scoped — nothing standing to reap except a live agent process, and the interactive baseline forbids killing those on a timer.
+
+- **Reconcile is an idempotent library routine with two callers**: startup (the crash-safety guarantee — on-disk git/tmux/sandbox state is the source of truth, compared against expected task state; `using`/signal handlers are the graceful path only) and the dispatcher tick (every Nth poll cycle).
+- Auto-GC only the provably dead: presenter surfaces whose process exited, stale run records, clean worktrees of source-terminal tasks (the cleaner, section 5).
+- **Never auto-kill a live agent process.** Orphaned-but-running sessions are reported loudly — `warn` line plus a prominent `status` flag — and left to the human.
+
+### 10.6 Live activity finer than run-state
+
+Nothing finer ships in v2.0. Run-state drives presenter `setStatus`; the observed layer is the truthful on-demand activity signal for free. The seam is documented, not built: a future in-session `crew progress <note>` routed to Run, fanning out to presenter `setStatus` and the source `progress` event — fully additive.
+
+## 11. Migration
+
+([Migration easing](https://linear.app/clipboardhealth/issue/DEVOP-5981))
+
+**Migration easing is deferred to post-v2 handoff work** — designing conversion details against a spec that will shift during implementation is waste. The spec carries exactly two commitments:
+
+1. **5.0.0 release blocker — the `crew upgrade` ambush.** v1's `upgrade` self-updates to `@latest`; the moment 5.0.0 hits the `latest` dist-tag, every v1 user who runs `crew upgrade` gets silently major-bumped. Before publishing 5.0.0, decide a dist-tag strategy or a first-run v1 guard. (No publish happens until the E2E suite is green, so this fires late — it must not be forgotten.)
+2. **v2 fails loudly on v1-only config.** When v2 finds a v1 config (`crew.config.ts` et al.) and no v2 config, it errors with a migration pointer — never silently falls back to defaults.
+
+Everything else — `crew init` conversion detail, killed-command stubs, the migration doc, 5.0.0 release notes — moves to the handoff backlog, gated on a working v2.
+
+## 12. Implementation stack and handoff
+
+### 12.1 Stack
+
+**Plain TypeScript** ([Effect vs plain TypeScript](https://linear.app/clipboardhealth/issue/DEVOP-5972), informed by the [Effect research](https://linear.app/clipboardhealth/issue/DEVOP-5970)). Effect was rejected for now: v4-beta churn with the platform/CLI layers least stable, span-based-not-stack-based debugging against "dead simple to know what happened", and function coloring as a contributor/AI filter against pluggability.
+
+- **Public plugin/source boundary: result-shaped protocol data on one channel.** Authors emit a structured response; expected failure is a failure variant in it; a process crash or nonzero exit is mapped by the core into the _same_ failure shape.
+- **Internals: plain exceptions plus typed error classes** (native stack traces). The adapter layer is the single seam converting caught exception / nonzero exit → protocol failure. No code anywhere handles both models. neverthrow dies.
+- **Crash safety = reconcile-on-startup** (section 10.5), strictly stronger than in-process finalizers since it survives SIGKILL/OOM/power loss.
+
+| Capability             | Choice                                                    |
+| ---------------------- | --------------------------------------------------------- |
+| Retry / backoff        | p-retry                                                   |
+| Concurrency and cancel | p-limit plus AbortSignal (cooperative)                    |
+| Process spawning       | execa (deletes most of v1's 325-line `commandRunner.ts`)  |
+| Schema / config        | zod 4                                                     |
+| CLI parsing            | commander plus `@commander-js/extra-typings`              |
+| Logs                   | JSON-lines via the cross-cutting logging lib (section 10) |
+
+If Effect is ever reconsidered: gate on v4-stable, follow the opencode pattern (Effect core plus platform, skip `@effect/cli`), mandate `Effect.fn` spans from day one.
+
+### 12.2 Handoff sequence
+
+1. **Build the acceptance suite red-first from the [E2E scenario catalog](./e2e-scenario-catalog.md)** — the `e2e/` package, fixture source, scripted agent, fake `gh`, harness self-tests. This is the entry point; no v2 code before it.
+2. Fix `main`'s release automation (path/scope filter) so v2 commits don't trigger 4.x publishes (section 2).
+3. Scaffold the `v2/` workspace: seven-module skeleton, dependency-cruiser rules (section 9.6) proven to bite, `CONTEXT.md` from the glossary seed, ADRs seeded from the wayfinder resolutions.
+4. Bring the suite green module by module, porting the surviving v1 code (srtPolicy/srtLaunch, cleaner, tmux/git plumbing, doctor pieces) file-by-file with its tests.
+5. Before publishing 5.0.0: resolve the `crew upgrade` ambush (section 11) and execute the cutover (section 2).
+
+Post-v2 handoff backlog (deferred by decision): migration easing detail (section 11); presenter bundles and their trust posture (section 8); `crew progress` (section 10.6); an optional repo allowlist (section 4).
+
+## 13. Decision record
+
+Every map decision, in resolution order. Full rationale lives in the linked tickets.
+
+| Decision                                                                                     | Outcome                                                                                                                | Section |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- |
+| [Prior-art research](https://linear.app/clipboardhealth/issue/DEVOP-5969)                    | Symmetric source/sink abstractions die in practice; generalize asymmetrically (branch `research/agent-flow-prior-art`) | 3       |
+| [Plugin-distribution research](https://linear.app/clipboardhealth/issue/DEVOP-5971)          | Versioned process boundary, not in-process npm plugins (branch `research/plugin-distribution-models`)                  | 6       |
+| [Effect research](https://linear.app/clipboardhealth/issue/DEVOP-5970)                       | Effect's costs cut against the locked constraints (branch `research/effect-for-cli-orchestrator`)                      | 12.1    |
+| [Multi-repo task model](https://linear.app/clipboardhealth/issue/DEVOP-5967)                 | One session per task over a workspace of worktrees                                                                     | 4       |
+| [Flow model](https://linear.app/clipboardhealth/issue/DEVOP-5968)                            | Sinks and flows dissolve; `list`/`get`/`update` source contract; run-state machine                                     | 3       |
+| [Effect vs plain TypeScript](https://linear.app/clipboardhealth/issue/DEVOP-5972)            | Plain TypeScript; exceptions inside, result-shaped protocol at the boundary; reconcile-on-startup                      | 12.1    |
+| [Plugin packaging and review isolation](https://linear.app/clipboardhealth/issue/DEVOP-5973) | Task sources are the only plugin kind; directory bundles; `protocolVersion`; sandboxed by default; srt only            | 6       |
+| [CLI surface](https://linear.app/clipboardhealth/issue/DEVOP-5975)                           | 14 commands; `crew.config.jsonc`; install.sh → `crew init`                                                             | 7       |
+| [E2E scenario catalog](https://linear.app/clipboardhealth/issue/DEVOP-5974)                  | v2-only red-first suite; harness self-tests; completion model codified (amends the destination)                        | 5       |
+| [Headless extension point](https://linear.app/clipboardhealth/issue/DEVOP-5976)              | Session-presenter seam; headless = future detached presenter (amends CLI config: `multiplexer` → `presenter`)          | 8       |
+| [Bounded-context layout](https://linear.app/clipboardhealth/issue/DEVOP-5977)                | One context, seven modules, graph enforced by dependency-cruiser                                                       | 9       |
+| [Rewrite vs evolve](https://linear.app/clipboardhealth/issue/DEVOP-5978)                     | Rewrite in `v2/` on `main`; ships as 5.0.0                                                                             | 2       |
+| [Migration easing](https://linear.app/clipboardhealth/issue/DEVOP-5981)                      | Deferred post-v2; two spec commitments carried                                                                         | 11      |
+| [Observability design](https://linear.app/clipboardhealth/issue/DEVOP-5982)                  | Run record is the truth; one JSON-lines file; `status` is the why affordance; active sweep, no TTL                     | 10      |

--- a/docs/spec/v2-design.md
+++ b/docs/spec/v2-design.md
@@ -122,12 +122,14 @@ Single-repo tasks stay dead simple as the degenerate case: one designated repo, 
 | In-session | `repo add <repo>`                                             | Runtime acquisition (section 4). Renamed from `workspace add` to dodge the cmux "workspace" collision.                                                                                                               |
 | In-session | `artifact add <locator> [--kind\|--title\|--repo]`            | Agent-reported artifacts (section 3).                                                                                                                                                                                |
 | In-session | `done [--outcome delivered\|failed\|stopped] [--allow-dirty]` | Replaces `$GROUNDCREW_COMPLETE` — the prompt just says "run `crew done`". Dirty-worktree guard refuses with the dirt named unless `--allow-dirty`.                                                                   |
+| Sources    | `source list`                                                 | Discovered source bundles with origin (`package`/`user`), protocol version, and user-dir override visibility (catalog PLUGIN-01/02).                                                                                 |
+| Sources    | `source doctor`                                               | Live round-trip probe of each configured source, naming the failing source on exit 1 (catalog SURFACE-07). Absorbs v1 `source verify` and `task validate`.                                                           |
 | Setup      | `init`                                                        | Interactive 5-step: baseDirectory, agent detection, source pick, write config, run doctor. Detects a v1 `crew.config.ts` and converts it, printing every dropped/renamed key. Global by default; `--local`, `--yes`. |
-| Setup      | `doctor` / `upgrade` / `completions`                          | `doctor` is the health-check verb everywhere: `crew doctor`, `crew source doctor` (absorbs `source verify` + `task validate`).                                                                                       |
+| Setup      | `doctor` / `upgrade` / `completions`                          | `doctor` is the health-check verb everywhere: `crew doctor`, `crew source doctor`.                                                                                                                                   |
 
 In-session commands are ordinary subcommands (no separate namespace). **Task identity resolution:** `--task` flag → `$GROUNDCREW_WORKSPACE` env (injected at launch) → walk up from cwd to `.groundcrew/task.json`. Exit codes: **2** = repo not cloned under `baseDirectory`, **3** = no task context.
 
-**Killed:** `open`, `task create`, `task list/get/validate`, `source install`, `source verify`, `interrupt`, `sandbox`, `setup`, the `crew-clearance-ensure` bin. No `progress` command in v2.0 (the protocol event exists; add a CLI if the need shows up). No `crew migrate` — `init`'s conversion is the migration aid.
+**Killed:** `open`, `task create`, `task list/get/validate`, `source install`, `interrupt`, `sandbox`, `setup`, the `crew-clearance-ensure` bin (`source verify` is renamed into `source doctor`, not killed). No `progress` command in v2.0 (the protocol event exists; add a CLI if the need shows up). No `crew migrate` — `init`'s conversion is the migration aid.
 
 **Verb families locked:** lifecycle `start → pause → resume → done`; health checks are `doctor`.
 
@@ -141,7 +143,7 @@ In-session commands are ordinary subcommands (no separate namespace). **Task ide
 
 ### 7.3 Setup
 
-`curl -fsSL …/install.sh | sh` → node ≥ 24 check, global npm install, exec `crew init` (`--yes` for CI/dotfiles). Deliberately manual forever: cloning repos, minting API keys, installing agent CLIs.
+`curl -fsSL …/install.sh | sh` → node ≥ 24 check, global npm install, exec `crew init` (`--yes` for CI/dotfiles). The script is a thin, inspectable wrapper over `npm install -g @clipboard-health/groundcrew`; that command is the direct path for anyone unwilling to pipe a remote script into a shell, and npm's registry integrity checks are the trust anchor either way. Deliberately manual forever: cloning repos, minting API keys, installing agent CLIs.
 
 ## 8. Session presenter
 


### PR DESCRIPTION
## Why

The [Groundcrew v2 spec wayfinder map](https://linear.app/clipboardhealth/issue/DEVOP-5966) resolved its final decision ticket; this PR lands the implementation handoff it was working toward: [DEVOP-5983](https://linear.app/clipboardhealth/issue/DEVOP-5983).

## What

- `docs/spec/v2-design.md` — the v2 design doc, consolidating all thirteen map resolutions: rewrite verdict, flow model, multi-repo task model, completion model, plugin boundary, CLI surface and config, session presenter, seven-module architecture, observability, migration commitments, stack, and the handoff sequence. Where resolutions conflicted, later amendments win (`multiplexer` → `presenter`; green-on-v1 gate dropped).
- `docs/spec/e2e-scenario-catalog.md` — merged in from `prototype/devop-5974-e2e-scenario-catalog` (the ratified deliverable of [DEVOP-5974](https://linear.app/clipboardhealth/issue/DEVOP-5974)), so the two halves of the spec land together.
- `config/cspell.json` — dictionary entries for the doc's domain vocabulary.

## Validation

Docs-only change; `node --run verify` passes locally (format, cspell, markdown lint all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)