### PR TITLE
feat(attachments): stage task attachments into worktrees and prompts

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -184,6 +184,7 @@
     "neverthrow",
     "finalizers",
     "opencode",
-    "inspectable"
+    "inspectable",
+    "backticked"
   ]
 }

--- a/config/oxlint.config.ts
+++ b/config/oxlint.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(
           // Vitest's parallel runner.
           files: ["**/setupWorkspace.test.ts"],
           rules: {
-            "max-lines": ["error", 2500],
+            "max-lines": ["error", 2600],
           },
         },
         {

--- a/config/oxlint.config.ts
+++ b/config/oxlint.config.ts
@@ -40,22 +40,24 @@ export default defineConfig(
         },
         {
           // setupWorkspace.test.ts covers launch composition across cmux,
-          // tmux, safehouse, srt, sdx, rollback, and CLI source-resolution
-          // paths. Keep those shared mocks together; splitting the file causes
-          // duplicate module mocks to race under Vitest's parallel runner.
+          // tmux, safehouse, srt, sdx, rollback, attachment staging, and CLI
+          // source-resolution paths. Keep those shared mocks together;
+          // splitting the file causes duplicate module mocks to race under
+          // Vitest's parallel runner.
           files: ["**/setupWorkspace.test.ts"],
           rules: {
-            "max-lines": ["error", 2200],
+            "max-lines": ["error", 2500],
           },
         },
         {
           // config.test.ts exhaustively covers config resolution, merging, and
-          // validation for every field (agents, sources, hooks, resumeArgs, …).
-          // Splitting it would scatter the shared loadFreshConfig / writeConfigFile
-          // harness across files without improving readability. Bump the cap.
+          // validation for every field (agents, sources, hooks, resumeArgs,
+          // attachments, …). Splitting it would scatter the shared
+          // loadFreshConfig / writeConfigFile harness across files without
+          // improving readability. Bump the cap.
           files: ["**/config.test.ts"],
           rules: {
-            "max-lines": ["error", 2200],
+            "max-lines": ["error", 2400],
           },
         },
         {

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -43,6 +43,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -43,7 +43,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -93,6 +93,7 @@ const config: ResolvedConfig = {
     pollIntervalMilliseconds: 1000,
     sessionLimitPercentage: 85,
   },
+  attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
   agents: {
     default: "claude",
     definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -7,12 +7,22 @@ import { workspaces } from "../lib/workspaces.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { setVerbose } from "../lib/util.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
+import { sourceSupportsFetchAttachments } from "../lib/sourceCapabilities.ts";
 import { createDispatcher, formatActiveSlotList } from "./dispatcher.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
 vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, setupWorkspace: vi.fn<typeof setupWorkspace>() };
+});
+vi.mock(import("../lib/sourceCapabilities.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    sourceSupportsFetchAttachments: vi.fn<typeof actual.sourceSupportsFetchAttachments>(
+      actual.sourceSupportsFetchAttachments,
+    ),
+  };
 });
 vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -47,6 +57,11 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
+    },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
     },
     agents: {
       default: "claude",
@@ -162,6 +177,49 @@ describe(createDispatcher, () => {
 
       const setupCall = setupMock.mock.calls.at(-1);
       expect(setupCall?.[1]?.details.url).toBe("https://linear.app/example/issue/TEAM-1");
+    });
+
+    it("omits the fetchAttachments closure when the source lacks the capability", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue()]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      const setupCall = setupMock.mock.calls.at(-1);
+      expect(setupCall?.[1]).not.toHaveProperty("fetchAttachments");
+    });
+
+    it("passes a Board-backed fetchAttachments closure when the source supports staging", async () => {
+      // Once-only so the capability override cannot leak past this test:
+      // the file's afterEach clears calls but not implementations.
+      vi.mocked(sourceSupportsFetchAttachments).mockReturnValueOnce(true);
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue()]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      const setupCall = setupMock.mock.calls.at(-1);
+      const closure = setupCall?.[1]?.fetchAttachments;
+      expect(closure).toBeTypeOf("function");
+
+      await closure?.("/stage/dir");
+
+      expect(board.fetchAttachments).toHaveBeenCalledWith({
+        issue: expect.objectContaining({ id: "linear:team-1" }),
+        stageDir: "/stage/dir",
+        maxAttachmentBytes: 26_214_400,
+        maxTotalBytes: 104_857_600,
+      });
     });
 
     it("logs `At capacity` when no slots remain", async () => {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -62,6 +62,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       enabled: true,
       maxAttachmentBytes: 26_214_400,
       maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
     },
     agents: {
       default: "claude",

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -31,7 +31,7 @@ import {
   type SkipVerdict,
   type StartVerdict,
 } from "./eligibility.ts";
-import { setupWorkspace } from "./setupWorkspace.ts";
+import { buildFetchAttachmentsClosure, setupWorkspace } from "./setupWorkspace.ts";
 
 interface DispatcherDeps {
   config: ResolvedConfig;
@@ -129,6 +129,12 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       if (recovery) {
         log(`Worktree and workspace already exist for ${taskId}; resuming with markInProgress`);
       } else {
+        const fetchAttachments = buildFetchAttachmentsClosure({
+          config,
+          board,
+          issue,
+          rawSources,
+        });
         const setupOptions = {
           repository: issue.repository,
           task: taskId,
@@ -143,6 +149,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
             description: issue.description,
             ...(issue.url === undefined ? {} : { url: issue.url }),
           },
+          ...(fetchAttachments === undefined ? {} : { fetchAttachments }),
         };
         await (signal === undefined
           ? setupWorkspace(config, setupOptions)

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -114,6 +114,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -37,7 +37,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -71,6 +71,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -179,6 +179,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -112,6 +112,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -112,7 +112,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -190,6 +190,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude --auto", color: "#fff" } },

--- a/src/commands/reviewer.test.ts
+++ b/src/commands/reviewer.test.ts
@@ -80,6 +80,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -10,7 +10,12 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { recordRunState } from "../lib/runState.ts";
 import { sourceSupportsFetchAttachments } from "../lib/sourceCapabilities.ts";
-import type { AttachmentFetchResult } from "../lib/taskSource.ts";
+import type {
+  Attachment,
+  AttachmentFetchResult,
+  FetchAttachmentsArguments,
+  TaskSource,
+} from "../lib/taskSource.ts";
 import { canonicalLinearIssue, canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { createBoard, type Board } from "../lib/board.ts";
 import type * as boardModule from "../lib/board.ts";
@@ -777,7 +782,7 @@ describe(setupWorkspace, () => {
     expect(prompt).not.toContain("{{workspaceContinuationInstruction}}");
   });
 
-  it("omits the workspace continuation instruction when the backend has no access hint", async () => {
+  it("omits the workspace continuation instruction and its line when the backend has no access hint", async () => {
     const config = {
       ...makeConfig(),
       prompts: {
@@ -793,7 +798,9 @@ describe(setupWorkspace, () => {
       details: { title: "Test Title", description: "Body" },
     });
 
-    expect(writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt")).toBe("Before\n\nAfter");
+    // The empty optional placeholder absorbs its own line rather than
+    // leaving a stray blank line in every dispatched prompt.
+    expect(writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt")).toBe("Before\nAfter");
   });
 
   it("wraps the agent command with Safehouse and runs the default prepareWorktree hook", async () => {
@@ -1982,7 +1989,7 @@ describe(setupWorkspace, () => {
     }
 
     it("stages files via the fetch closure, hides them from git, and renders them into the prompt", async () => {
-      const fetchAttachments = vi.fn<(stageDir: string) => Promise<AttachmentFetchResult>>(
+      const fetchAttachmentsMock = vi.fn<(stageDir: string) => Promise<AttachmentFetchResult>>(
         async (stageDir: string): Promise<AttachmentFetchResult> => {
           await writeFile(path.join(stageDir, "mockup.png"), "png-bytes");
           return {
@@ -2018,11 +2025,11 @@ describe(setupWorkspace, () => {
         repository: "repo-a",
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
-        fetchAttachments,
+        fetchAttachments: fetchAttachmentsMock,
       });
 
       const stageDir = path.join(launchDir, ".groundcrew", "attachments");
-      expect(fetchAttachments).toHaveBeenCalledWith(stageDir);
+      expect(fetchAttachmentsMock).toHaveBeenCalledWith(stageDir);
       await expect(access(path.join(stageDir, "mockup.png"))).resolves.toBeUndefined();
       expect(writeFileMock).toHaveBeenCalledWith(
         path.join(launchDir, ".groundcrew", ".gitignore"),
@@ -2034,6 +2041,38 @@ describe(setupWorkspace, () => {
       );
       expect(prompt).toContain('- "Related PR" - https://github.com/acme/widgets/pull/42');
       expect(prompt).toContain('- "huge.zip" - not staged');
+    });
+
+    it("absorbs the placeholder's blank line when attachments render empty", async () => {
+      const config: ResolvedConfig = {
+        ...makeConfig(),
+        prompts: { initial: "X\n\n{{attachments}}\n\nY" },
+      };
+
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      expect(writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt")).toBe("X\n\nY");
+    });
+
+    it("never reflows blank-line runs the user authored in the template body", async () => {
+      const config: ResolvedConfig = {
+        ...makeConfig(),
+        prompts: { initial: "A\n\n\n\nB{{attachments}}" },
+      };
+
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      expect(writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt")).toBe("A\n\n\n\nB");
     });
 
     it("creates no .groundcrew directory and renders an empty section when no closure is provided", async () => {
@@ -2050,7 +2089,7 @@ describe(setupWorkspace, () => {
     });
 
     it("skips fetching entirely when attachments.enabled is false", async () => {
-      const fetchAttachments = vi
+      const fetchAttachmentsMock = vi
         .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
         .mockResolvedValue({ attachments: [] });
       const config: ResolvedConfig = {
@@ -2063,15 +2102,15 @@ describe(setupWorkspace, () => {
         repository: "repo-a",
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
-        fetchAttachments,
+        fetchAttachments: fetchAttachmentsMock,
       });
 
-      expect(fetchAttachments).not.toHaveBeenCalled();
+      expect(fetchAttachmentsMock).not.toHaveBeenCalled();
       await expect(access(path.join(launchDir, ".groundcrew"))).rejects.toThrow(/ENOENT/);
     });
 
     it("still launches the workspace when the fetch closure throws", async () => {
-      const fetchAttachments = vi
+      const fetchAttachmentsMock = vi
         .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
         .mockRejectedValue(new Error("boom"));
 
@@ -2080,7 +2119,7 @@ describe(setupWorkspace, () => {
         repository: "repo-a",
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
-        fetchAttachments,
+        fetchAttachments: fetchAttachmentsMock,
       });
 
       expect(teardownMock).not.toHaveBeenCalled();
@@ -2092,7 +2131,7 @@ describe(setupWorkspace, () => {
     });
 
     it("logs and renders a notice when the fetch result carries fetchError", async () => {
-      const fetchAttachments = vi
+      const fetchAttachmentsMock = vi
         .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
         .mockResolvedValue({ attachments: [], fetchError: "GraphQL down" });
 
@@ -2101,7 +2140,7 @@ describe(setupWorkspace, () => {
         repository: "repo-a",
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
-        fetchAttachments,
+        fetchAttachments: fetchAttachmentsMock,
       });
 
       expect(logMock).toHaveBeenCalledWith(
@@ -2240,6 +2279,64 @@ describe(setupWorkspaceCli, () => {
     await setupWorkspaceCli("team-1");
 
     expect(defaultBoard.fetchAttachments).not.toHaveBeenCalled();
+  });
+
+  it("stages attachments end-to-end: stub source through a real Board into the rendered prompt", async () => {
+    vi.mocked(sourceSupportsFetchAttachments).mockReturnValueOnce(true);
+    const { createBoard: actualCreateBoard } =
+      await vi.importActual<typeof boardModule>("../lib/board.ts");
+    const issue = canonicalLinearIssue({
+      naturalId: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      title: "Title",
+      description: "Body for repo-a",
+    });
+    const stubSource: TaskSource = {
+      name: issue.source,
+      verify: vi.fn<() => Promise<void>>().mockResolvedValue(),
+      listTasks: vi.fn<() => Promise<Issue[]>>().mockResolvedValue([]),
+      getTask: vi.fn<(id: string) => Promise<Issue | null>>().mockResolvedValue(issue),
+      fetch: vi.fn<() => Promise<Issue[]>>().mockResolvedValue([]),
+      resolveOne: vi.fn<(id: string) => Promise<Issue | undefined>>().mockResolvedValue(issue),
+      markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
+      markInReview: vi.fn<TaskSource["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
+      fetchAttachments: vi.fn<
+        (arguments_: FetchAttachmentsArguments) => Promise<readonly Attachment[]>
+      >(async ({ stageDir }) => {
+        await writeFile(path.join(stageDir, "mockup.png"), "png-bytes");
+        return [
+          {
+            kind: "file",
+            filename: "mockup.png",
+            relativePath: ".groundcrew/attachments/mockup.png",
+            title: "mockup.png",
+            sizeBytes: 9,
+          },
+        ];
+      }),
+    };
+    createBoardMock.mockImplementation(actualCreateBoard);
+    buildSourcesMock.mockResolvedValueOnce([stubSource]);
+    loadConfigMock.mockResolvedValue({
+      ...makeConfig(),
+      prompts: { initial: "Begin {{task}}\n{{attachments}}" },
+    });
+    const launchDir = await mkdtemp(path.join(tmpdir(), "groundcrew-attach-e2e-"));
+    createMock.mockImplementation(async () => ({ ...hostEntry(), dir: launchDir }));
+    try {
+      await setupWorkspaceCli("team-1");
+
+      // The staged file must exist exactly where the reported relativePath
+      // says it does — the value-level correspondence no seam test checks.
+      await expect(
+        access(path.join(launchDir, ".groundcrew", "attachments", "mockup.png")),
+      ).resolves.toBeUndefined();
+      const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+      expect(prompt).toContain("- `.groundcrew/attachments/mockup.png`");
+    } finally {
+      await rm(launchDir, { recursive: true, force: true });
+    }
   });
 
   it("does not provision or mark In Progress in dry-run mode", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,5 +1,7 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-health/clearance";
@@ -7,6 +9,8 @@ import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { recordRunState } from "../lib/runState.ts";
+import { sourceSupportsFetchAttachments } from "../lib/sourceCapabilities.ts";
+import type { AttachmentFetchResult } from "../lib/taskSource.ts";
 import { canonicalLinearIssue, canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { createBoard, type Board } from "../lib/board.ts";
 import type * as boardModule from "../lib/board.ts";
@@ -127,12 +131,25 @@ vi.mock(import("../lib/board.ts"), async (importOriginal) => {
       markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
       markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
       markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),
+      fetchAttachments: vi.fn<Board["fetchAttachments"]>().mockResolvedValue({ attachments: [] }),
     })),
   };
 });
 vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof buildSourcesModule>();
-  return { ...actual, buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]) };
+  return {
+    ...actual,
+    buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]),
+  };
+});
+vi.mock(import("../lib/sourceCapabilities.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    sourceSupportsFetchAttachments: vi.fn<typeof actual.sourceSupportsFetchAttachments>(
+      actual.sourceSupportsFetchAttachments,
+    ),
+  };
 });
 
 const mkdtempMock = vi.mocked(mkdtempSync);
@@ -203,6 +220,11 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
       maximumInProgress: 4,
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
+    },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
     },
     agents: {
       default: "claude",
@@ -1942,6 +1964,155 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain(String.raw`_p=$(cat '/tmp/with'\''quote-1/prompt.txt')`);
   });
 
+  describe("attachment staging", () => {
+    let launchDir: string;
+
+    beforeEach(async () => {
+      launchDir = await mkdtemp(path.join(tmpdir(), "groundcrew-attach-"));
+      createMock.mockImplementation(async () => ({ ...hostEntry(), dir: launchDir }));
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+    });
+
+    afterEach(async () => {
+      await rm(launchDir, { recursive: true, force: true });
+    });
+
+    function configWithAttachmentsTemplate(): ResolvedConfig {
+      return { ...makeConfig(), prompts: { initial: "Begin {{task}}\n{{attachments}}" } };
+    }
+
+    it("stages files via the fetch closure, hides them from git, and renders them into the prompt", async () => {
+      const fetchAttachments = vi.fn<(stageDir: string) => Promise<AttachmentFetchResult>>(
+        async (stageDir: string): Promise<AttachmentFetchResult> => {
+          await writeFile(path.join(stageDir, "mockup.png"), "png-bytes");
+          return {
+            attachments: [
+              {
+                kind: "file",
+                filename: "mockup.png",
+                relativePath: ".groundcrew/attachments/mockup.png",
+                title: "Homepage mockup",
+                url: "https://example.test/mockup",
+                sizeBytes: 9,
+              },
+              {
+                kind: "link",
+                title: "Related PR",
+                url: "https://github.com/acme/widgets/pull/42",
+                sourceType: "github",
+              },
+              {
+                kind: "skipped",
+                title: "huge.zip",
+                url: "https://example.test/huge",
+                reason: "exceeds-per-file-cap",
+                detail: "89 MiB exceeds 25 MiB cap",
+              },
+            ],
+          };
+        },
+      );
+
+      await setupWorkspace(configWithAttachmentsTemplate(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+        fetchAttachments,
+      });
+
+      const stageDir = path.join(launchDir, ".groundcrew", "attachments");
+      expect(fetchAttachments).toHaveBeenCalledWith(stageDir);
+      await expect(access(path.join(stageDir, "mockup.png"))).resolves.toBeUndefined();
+      expect(writeFileMock).toHaveBeenCalledWith(
+        path.join(launchDir, ".groundcrew", ".gitignore"),
+        "*\n",
+      );
+      const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+      expect(prompt).toContain(
+        '- `.groundcrew/attachments/mockup.png` - originally "Homepage mockup"',
+      );
+      expect(prompt).toContain('- "Related PR" - https://github.com/acme/widgets/pull/42');
+      expect(prompt).toContain('- "huge.zip" - not staged');
+    });
+
+    it("creates no .groundcrew directory and renders an empty section when no closure is provided", async () => {
+      await setupWorkspace(configWithAttachmentsTemplate(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      await expect(access(path.join(launchDir, ".groundcrew"))).rejects.toThrow(/ENOENT/);
+      const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+      expect(prompt).toBe("Begin team-1\n");
+    });
+
+    it("skips fetching entirely when attachments.enabled is false", async () => {
+      const fetchAttachments = vi
+        .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
+        .mockResolvedValue({ attachments: [] });
+      const config: ResolvedConfig = {
+        ...configWithAttachmentsTemplate(),
+        attachments: { enabled: false, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+      };
+
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+        fetchAttachments,
+      });
+
+      expect(fetchAttachments).not.toHaveBeenCalled();
+      await expect(access(path.join(launchDir, ".groundcrew"))).rejects.toThrow(/ENOENT/);
+    });
+
+    it("still launches the workspace when the fetch closure throws", async () => {
+      const fetchAttachments = vi
+        .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
+        .mockRejectedValue(new Error("boom"));
+
+      await setupWorkspace(configWithAttachmentsTemplate(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+        fetchAttachments,
+      });
+
+      expect(teardownMock).not.toHaveBeenCalled();
+      expect(lastRecordedRunState()).toMatchObject({ task: "team-1", state: "running" });
+      const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+      expect(prompt).toContain(
+        "*Attachment fetch failed: boom. The task may have attachments that are not available here.*",
+      );
+    });
+
+    it("logs and renders a notice when the fetch result carries fetchError", async () => {
+      const fetchAttachments = vi
+        .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
+        .mockResolvedValue({ attachments: [], fetchError: "GraphQL down" });
+
+      await setupWorkspace(configWithAttachmentsTemplate(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+        fetchAttachments,
+      });
+
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringContaining("Attachment fetch failed for team-1: GraphQL down"),
+      );
+      expect(lastRecordedRunState()).toMatchObject({ task: "team-1", state: "running" });
+      const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+      expect(prompt).toContain("*Attachment fetch failed: GraphQL down.");
+    });
+  });
+
   it("requires details from the caller (no Linear re-fetch)", () => {
     // Type-level test: SetupWorkspaceOptions.details is non-optional.
     type _DetailsRequired = SetupWorkspaceOptions["details"] extends TaskDetails ? true : never;
@@ -1969,6 +2140,7 @@ function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
     markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
     markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),
+    fetchAttachments: vi.fn<Board["fetchAttachments"]>().mockResolvedValue({ attachments: [] }),
   };
 }
 
@@ -2044,6 +2216,30 @@ describe(setupWorkspaceCli, () => {
     expect(firstInvocationOrder(runCommandMock)).toBeLessThan(
       firstInvocationOrder(defaultBoard.markInProgress),
     );
+  });
+
+  it("passes a Board-backed fetchAttachments closure when the source supports staging", async () => {
+    vi.mocked(sourceSupportsFetchAttachments).mockReturnValueOnce(true);
+    const launchDir = await mkdtemp(path.join(tmpdir(), "groundcrew-attach-cli-"));
+    createMock.mockImplementation(async () => ({ ...hostEntry(), dir: launchDir }));
+    try {
+      await setupWorkspaceCli("team-1");
+
+      expect(defaultBoard.fetchAttachments).toHaveBeenCalledWith({
+        issue: expect.objectContaining({ id: "linear:team-1" }),
+        stageDir: path.join(launchDir, ".groundcrew", "attachments"),
+        maxAttachmentBytes: 26_214_400,
+        maxTotalBytes: 104_857_600,
+      });
+    } finally {
+      await rm(launchDir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the fetch closure when the source lacks the fetchAttachments capability", async () => {
+    await setupWorkspaceCli("team-1");
+
+    expect(defaultBoard.fetchAttachments).not.toHaveBeenCalled();
   });
 
   it("does not provision or mark In Progress in dry-run mode", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
@@ -2041,6 +2041,49 @@ describe(setupWorkspace, () => {
       );
       expect(prompt).toContain('- "Related PR" - https://github.com/acme/widgets/pull/42');
       expect(prompt).toContain('- "huge.zip" - not staged');
+    });
+
+    it("refuses to stage through a symlinked .groundcrew and still launches", async () => {
+      const escapeTarget = await mkdtemp(path.join(tmpdir(), "groundcrew-escape-"));
+      await symlink(escapeTarget, path.join(launchDir, ".groundcrew"));
+      const fetchAttachmentsMock = vi
+        .fn<(stageDir: string) => Promise<AttachmentFetchResult>>()
+        .mockResolvedValue({ attachments: [] });
+      try {
+        await setupWorkspace(configWithAttachmentsTemplate(), {
+          task: "team-1",
+          repository: "repo-a",
+          agent: "claude",
+          details: { title: "Test Title", description: "Body" },
+          fetchAttachments: fetchAttachmentsMock,
+        });
+
+        expect(fetchAttachmentsMock).not.toHaveBeenCalled();
+        expect(lastRecordedRunState()).toMatchObject({ task: "team-1", state: "running" });
+        const prompt = writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt");
+        expect(prompt).toContain("*Attachment fetch failed:");
+        await expect(access(path.join(escapeTarget, "attachments"))).rejects.toThrow(/ENOENT/);
+      } finally {
+        await rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
+    it("keeps placeholder-like text inside substituted values literal", async () => {
+      const config: ResolvedConfig = {
+        ...makeConfig(),
+        prompts: { initial: "{{title}}|{{description}}{{attachments}}" },
+      };
+
+      await setupWorkspace(config, {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        details: { title: "T {{description}} T", description: "D" },
+      });
+
+      expect(writtenFileContent("/tmp/groundcrew-team-1-x/prompt.txt")).toBe(
+        "T {{description}} T|D",
+      );
     });
 
     it("absorbs the placeholder's blank line when attachments render empty", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -67,13 +67,9 @@ export interface SetupWorkspaceOptions {
  * exists after worktree creation, so the closure threads Board access into
  * `setupWorkspace` without coupling it to Board/Issue.
  *
- * As of the core-plumbing slice every source kind reports
- * `fetchAttachments: false` (see `sourceCapabilities.ts`), so this returns
- * `undefined` for all configured sources until a producing-adapter slice
- * flips its kind on. Note the gate reads config (`rawSources`) while
- * `board.fetchAttachments` routes by built-adapter name; if those ever
- * diverge, the closure soft-fails at call time as a prompt `fetchError`
- * rather than aborting the dispatch.
+ * The gate reads config (`rawSources`) while `board.fetchAttachments` routes
+ * by built-adapter name; if those ever diverge, the closure soft-fails at
+ * call time as a prompt `fetchError` rather than aborting the dispatch.
  */
 export function buildFetchAttachmentsClosure(arguments_: {
   config: ResolvedConfig;

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -138,8 +138,15 @@ async function stageAttachments(arguments_: {
   try {
     const groundcrewDir = path.join(launchDir, ".groundcrew");
     const stageDir = path.join(groundcrewDir, "attachments");
+    const gitignorePath = path.join(groundcrewDir, ".gitignore");
+    // A branch can ship `.groundcrew` (or pieces of it) as symlinks pointing
+    // outside the worktree, and these writes run in the orchestrator process
+    // (not the agent sandbox) — refuse to follow rather than write through.
+    assertNotSymlink(groundcrewDir);
+    assertNotSymlink(stageDir);
+    assertNotSymlink(gitignorePath);
     mkdirSync(stageDir, { recursive: true });
-    writeFileSync(path.join(groundcrewDir, ".gitignore"), "*\n");
+    writeFileSync(gitignorePath, "*\n");
     result = await options.fetchAttachments(stageDir);
   } catch (error) {
     result = { attachments: [], fetchError: errorMessage(error) };
@@ -148,6 +155,13 @@ async function stageAttachments(arguments_: {
     log(`Attachment fetch failed for ${options.task}: ${result.fetchError}`);
   }
   return result;
+}
+
+function assertNotSymlink(target: string): void {
+  const stats = lstatSync(target, { throwIfNoEntry: false });
+  if (stats !== undefined && stats.isSymbolicLink()) {
+    throw new Error(`refusing to stage attachments: ${target} is a symlink`);
+  }
 }
 
 export async function setupWorkspace(

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -1,4 +1,5 @@
-import { rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
@@ -8,15 +9,23 @@ import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
-import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
 import {
+  sourceSupportsFetchAttachments,
+  sourceSupportsMarkDone,
+} from "../lib/sourceCapabilities.ts";
+import {
+  renderAttachments,
   stageBuildSecrets,
   stagePromptFromTemplate,
   stageWorkspaceLaunchCommand,
   type StagedPrompt,
 } from "../lib/stagedLaunch.ts";
 import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
-import { naturalIdFromCanonical } from "../lib/taskSource.ts";
+import {
+  type AttachmentFetchResult,
+  type Issue,
+  naturalIdFromCanonical,
+} from "../lib/taskSource.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import {
@@ -42,6 +51,47 @@ export interface SetupWorkspaceOptions {
   repository: string;
   agent: string;
   details: TaskDetails;
+  /**
+   * Present when the caller can fetch attachments for this task (a
+   * Board-backed closure from `buildFetchAttachmentsClosure`). Callers that
+   * omit it get no `.groundcrew/` directory and an empty attachments section.
+   */
+  fetchAttachments?: (stageDir: string) => Promise<AttachmentFetchResult>;
+}
+
+/**
+ * Build the `SetupWorkspaceOptions.fetchAttachments` closure for an issue, or
+ * `undefined` when its source lacks the capability — the capability gate is
+ * what keeps non-implementing sources at zero behavior change (no
+ * `.groundcrew/` directory is ever created for them). The stage dir only
+ * exists after worktree creation, so the closure threads Board access into
+ * `setupWorkspace` without coupling it to Board/Issue.
+ *
+ * As of the core-plumbing slice every source kind reports
+ * `fetchAttachments: false` (see `sourceCapabilities.ts`), so this returns
+ * `undefined` for all configured sources until a producing-adapter slice
+ * flips its kind on. Note the gate reads config (`rawSources`) while
+ * `board.fetchAttachments` routes by built-adapter name; if those ever
+ * diverge, the closure soft-fails at call time as a prompt `fetchError`
+ * rather than aborting the dispatch.
+ */
+export function buildFetchAttachmentsClosure(arguments_: {
+  config: ResolvedConfig;
+  board: Board;
+  issue: Issue;
+  rawSources: readonly unknown[];
+}): ((stageDir: string) => Promise<AttachmentFetchResult>) | undefined {
+  const { config, board, issue, rawSources } = arguments_;
+  if (!sourceSupportsFetchAttachments({ rawSources, sourceName: issue.source })) {
+    return undefined;
+  }
+  return async (stageDir: string) =>
+    await board.fetchAttachments({
+      issue,
+      stageDir,
+      maxAttachmentBytes: config.attachments.maxAttachmentBytes,
+      maxTotalBytes: config.attachments.maxTotalBytes,
+    });
 }
 
 export interface SetupWorkspaceRunOptions {
@@ -54,6 +104,7 @@ function stagePrompt(input: {
   taskDetails: TaskDetails;
   worktreeName: string;
   workspaceContinuationInstruction: string;
+  attachmentResult: AttachmentFetchResult;
 }): StagedPrompt {
   return stagePromptFromTemplate({
     config: input.config,
@@ -65,8 +116,42 @@ function stagePrompt(input: {
       title: input.taskDetails.title,
       description: input.taskDetails.description,
       workspaceContinuationInstruction: input.workspaceContinuationInstruction,
+      attachments: renderAttachments(input.attachmentResult),
     },
   });
+}
+
+/**
+ * Create `<launchDir>/.groundcrew/attachments`, hide it from git, and run the
+ * caller's fetch closure. Best-effort by contract: any failure — the closure
+ * throwing, or even directory creation — degrades to a `fetchError` the
+ * prompt surfaces as a notice, never a failed workspace. (`.git` is a file in
+ * linked worktrees and `info/exclude` lives in the common git dir, so a
+ * directory-local gitignore is the only safe per-worktree exclusion.)
+ */
+async function stageAttachments(arguments_: {
+  config: ResolvedConfig;
+  options: SetupWorkspaceOptions;
+  launchDir: string;
+}): Promise<AttachmentFetchResult> {
+  const { config, options, launchDir } = arguments_;
+  if (!config.attachments.enabled || options.fetchAttachments === undefined) {
+    return { attachments: [] };
+  }
+  let result: AttachmentFetchResult;
+  try {
+    const groundcrewDir = path.join(launchDir, ".groundcrew");
+    const stageDir = path.join(groundcrewDir, "attachments");
+    mkdirSync(stageDir, { recursive: true });
+    writeFileSync(path.join(groundcrewDir, ".gitignore"), "*\n");
+    result = await options.fetchAttachments(stageDir);
+  } catch (error) {
+    result = { attachments: [], fetchError: errorMessage(error) };
+  }
+  if (result.fetchError !== undefined) {
+    log(`Attachment fetch failed for ${options.task}: ${result.fetchError}`);
+  }
+  return result;
 }
 
 export async function setupWorkspace(
@@ -126,7 +211,12 @@ export async function setupWorkspace(
     await assertLaunchReady(readinessPromise);
 
     const taskDetails = options.details;
-    const accessHint = await workspaces.accessHint(config, task, signal);
+    // Independent: the workspace-adapter probe and the attachment fetch share
+    // no state, and the fetch becomes network-bound once real adapters land.
+    const [accessHint, attachmentResult] = await Promise.all([
+      workspaces.accessHint(config, task, signal),
+      stageAttachments({ config, options, launchDir }),
+    ]);
 
     const stagedPrompt = stagePrompt({
       config,
@@ -134,6 +224,7 @@ export async function setupWorkspace(
       taskDetails,
       worktreeName,
       workspaceContinuationInstruction: renderWorkspaceContinuationInstruction(accessHint),
+      attachmentResult,
     });
     promptDir = stagedPrompt.directory;
 
@@ -465,6 +556,12 @@ export async function setupWorkspaceCli(
   }
 
   const naturalId = naturalIdFromCanonical(resolved.id);
+  const fetchAttachments = buildFetchAttachmentsClosure({
+    config,
+    board,
+    issue: resolved,
+    rawSources,
+  });
 
   await setupWorkspace(config, {
     task: naturalId,
@@ -480,6 +577,7 @@ export async function setupWorkspaceCli(
       description: resolved.description,
       ...(resolved.url === undefined ? {} : { url: resolved.url }),
     },
+    ...(fetchAttachments === undefined ? {} : { fetchAttachments }),
   });
   await board.markInProgress(resolved);
 }

--- a/src/commands/source.test.ts
+++ b/src/commands/source.test.ts
@@ -43,6 +43,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -148,7 +148,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -148,6 +148,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/task.test.ts
+++ b/src/commands/task.test.ts
@@ -75,6 +75,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/commands/teardownReporter.test.ts
+++ b/src/commands/teardownReporter.test.ts
@@ -220,6 +220,7 @@ function makeConfig(): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -37,7 +37,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -64,7 +64,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -64,6 +64,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -29,7 +29,12 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
-    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
+    attachments: {
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+      ...overrides.attachments,
+    },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -29,6 +29,7 @@ function makeConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
       sessionLimitPercentage: 85,
       ...overrides.orchestrator,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/attachmentStaging.test.ts
+++ b/src/lib/attachmentStaging.test.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+
+import {
+  createCapAccountant,
+  resolveInsideStageDir,
+  sanitizeAttachmentFilename,
+} from "./attachmentStaging.ts";
+
+describe(sanitizeAttachmentFilename, () => {
+  it("keeps a safe title verbatim, preserving spaces, case, and punctuation", () => {
+    const input = { title: "Mockup v3 (final).PNG", fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("Mockup v3 (final).PNG");
+  });
+
+  it("falls back to attachment-<id-prefix> for an empty title", () => {
+    const input = { title: "", fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("attachment-abc123de");
+  });
+
+  it("falls back for a title containing a forward slash", () => {
+    const input = { title: "notes/../../etc/passwd", fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("attachment-abc123de");
+  });
+
+  it("falls back for a title containing a backslash", () => {
+    const input = { title: String.raw`evil\name.txt`, fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("attachment-abc123de");
+  });
+
+  it("falls back for dot and dot-dot titles", () => {
+    const dotInput = { title: ".", fallbackId: "abc123def456" };
+    const dotDotInput = { title: "..", fallbackId: "abc123def456" };
+
+    expect(sanitizeAttachmentFilename(dotInput)).toBe("attachment-abc123de");
+    expect(sanitizeAttachmentFilename(dotDotInput)).toBe("attachment-abc123de");
+  });
+
+  it("falls back for a title containing a NUL byte", () => {
+    const input = { title: "evil\0.txt", fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("attachment-abc123de");
+  });
+
+  it("falls back for an over-long title", () => {
+    const input = { title: "a".repeat(256), fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("attachment-abc123de");
+  });
+
+  it("keeps a title exactly at the length limit", () => {
+    const input = { title: "a".repeat(255), fallbackId: "abc123def456" };
+
+    const actual = sanitizeAttachmentFilename(input);
+
+    expect(actual).toBe("a".repeat(255));
+  });
+});
+
+describe(resolveInsideStageDir, () => {
+  const stageDir = "/work/repo-a-team-1/.groundcrew/attachments";
+
+  it("resolves a plain filename to an absolute path inside the stage dir", () => {
+    const actual = resolveInsideStageDir({ stageDir, filename: "mockup.png" });
+
+    expect(actual).toBe(path.join(stageDir, "mockup.png"));
+  });
+
+  it("rejects a traversal filename that escapes the stage dir", () => {
+    const actual = resolveInsideStageDir({ stageDir, filename: "../escape.txt" });
+
+    expect(actual).toBeUndefined();
+  });
+
+  it("rejects an absolute filename", () => {
+    const actual = resolveInsideStageDir({ stageDir, filename: "/etc/passwd" });
+
+    expect(actual).toBeUndefined();
+  });
+
+  it("rejects a nested path (stage dir is flat)", () => {
+    const actual = resolveInsideStageDir({ stageDir, filename: "nested/file.txt" });
+
+    expect(actual).toBeUndefined();
+  });
+
+  it("rejects dot and empty filenames that resolve to the stage dir itself", () => {
+    expect(resolveInsideStageDir({ stageDir, filename: "." })).toBeUndefined();
+    expect(resolveInsideStageDir({ stageDir, filename: "" })).toBeUndefined();
+  });
+});
+
+describe(createCapAccountant, () => {
+  it("admits files within both caps and accumulates their sizes", () => {
+    const accountant = createCapAccountant({ maxAttachmentBytes: 100, maxTotalBytes: 250 });
+
+    expect(accountant.admit(100)).toEqual({ admitted: true });
+    expect(accountant.admit(100)).toEqual({ admitted: true });
+    expect(accountant.admit(50)).toEqual({ admitted: true });
+  });
+
+  it("rejects a single file over the per-file cap", () => {
+    const accountant = createCapAccountant({ maxAttachmentBytes: 100, maxTotalBytes: 250 });
+
+    const actual = accountant.admit(101);
+
+    expect(actual).toEqual({ admitted: false, reason: "exceeds-per-file-cap" });
+  });
+
+  it("rejects the file that would push the running total over the total cap", () => {
+    const accountant = createCapAccountant({ maxAttachmentBytes: 100, maxTotalBytes: 250 });
+
+    accountant.admit(100);
+    accountant.admit(100);
+
+    expect(accountant.admit(51)).toEqual({ admitted: false, reason: "exceeds-per-task-cap" });
+  });
+
+  it("does not count rejected files toward the running total", () => {
+    const accountant = createCapAccountant({ maxAttachmentBytes: 100, maxTotalBytes: 150 });
+
+    accountant.admit(100);
+    expect(accountant.admit(100)).toEqual({ admitted: false, reason: "exceeds-per-task-cap" });
+
+    expect(accountant.admit(50)).toEqual({ admitted: true });
+  });
+
+  it("prefers the per-file reason when a file exceeds both caps", () => {
+    const accountant = createCapAccountant({ maxAttachmentBytes: 100, maxTotalBytes: 250 });
+
+    accountant.admit(100);
+    accountant.admit(100);
+
+    expect(accountant.admit(200)).toEqual({ admitted: false, reason: "exceeds-per-file-cap" });
+  });
+});

--- a/src/lib/attachmentStaging.ts
+++ b/src/lib/attachmentStaging.ts
@@ -1,0 +1,110 @@
+/**
+ * Filename-safety and byte-cap primitives for staging task attachments into a
+ * worktree. Consumed by the producing adapters (Linear download, shell
+ * reconcile) as they land in follow-up slices. Dependency-free (Node builtins
+ * only) so it stays extraction-ready.
+ */
+
+import path from "node:path";
+
+/** Longest filename accepted verbatim; longer titles fall back to the stable form. */
+const MAX_FILENAME_LENGTH = 255;
+
+/** Characters of the source id kept in the `attachment-<id-prefix>` fallback name. */
+const FALLBACK_ID_PREFIX_LENGTH = 8;
+
+export interface SanitizeAttachmentFilenameArguments {
+  /** Source-side display title, kept verbatim when it is a safe single path segment. */
+  title: string;
+  /** Stable source id used for the `attachment-<id-prefix>` fallback name. */
+  fallbackId: string;
+}
+
+/**
+ * Keep the source title verbatim when it is a safe single path segment
+ * (spaces, capitalization, punctuation preserved); otherwise fall back to a
+ * stable `attachment-<id-prefix>` name. Unsafe: empty, `.`/`..`, path
+ * separators, NUL bytes, over-long.
+ */
+export function sanitizeAttachmentFilename(
+  arguments_: SanitizeAttachmentFilenameArguments,
+): string {
+  const { title, fallbackId } = arguments_;
+  if (isSafeFilename(title)) {
+    return title;
+  }
+  return `attachment-${fallbackId.slice(0, FALLBACK_ID_PREFIX_LENGTH)}`;
+}
+
+export interface ResolveInsideStageDirArguments {
+  /** Absolute path of the stage directory. */
+  stageDir: string;
+  /** Filename reported by a source; must be a single path segment. */
+  filename: string;
+}
+
+/**
+ * Resolve `filename` to its absolute path directly inside `stageDir`, or
+ * `undefined` when the name escapes it (traversal, absolute path, nested
+ * path, or a name resolving to the stage dir itself). The stage dir is flat:
+ * subdirectories are never scanned, so nested paths are rejected outright.
+ */
+export function resolveInsideStageDir(
+  arguments_: ResolveInsideStageDirArguments,
+): string | undefined {
+  const { stageDir, filename } = arguments_;
+  const resolved = path.resolve(stageDir, filename);
+  if (path.dirname(resolved) !== path.resolve(stageDir)) {
+    return undefined;
+  }
+  return resolved;
+}
+
+type CapAdmission =
+  | { admitted: true }
+  | { admitted: false; reason: "exceeds-per-file-cap" | "exceeds-per-task-cap" };
+
+export interface CreateCapAccountantArguments {
+  maxAttachmentBytes: number;
+  maxTotalBytes: number;
+}
+
+export interface CapAccountant {
+  /** Admit or reject one file by size; admitted sizes accumulate toward the total cap. */
+  admit: (sizeBytes: number) => CapAdmission;
+}
+
+/**
+ * Central cap enforcement, one accountant per fetch: the per-file cap is
+ * checked first (so an oversize file reports `exceeds-per-file-cap` even when
+ * the total cap is also blown), and only admitted files count toward the
+ * running total.
+ */
+export function createCapAccountant(arguments_: CreateCapAccountantArguments): CapAccountant {
+  const { maxAttachmentBytes, maxTotalBytes } = arguments_;
+  let totalBytes = 0;
+  return {
+    admit(sizeBytes: number): CapAdmission {
+      if (sizeBytes > maxAttachmentBytes) {
+        return { admitted: false, reason: "exceeds-per-file-cap" };
+      }
+      if (totalBytes + sizeBytes > maxTotalBytes) {
+        return { admitted: false, reason: "exceeds-per-task-cap" };
+      }
+      totalBytes += sizeBytes;
+      return { admitted: true };
+    },
+  };
+}
+
+function isSafeFilename(title: string): boolean {
+  return (
+    title.length > 0 &&
+    title.length <= MAX_FILENAME_LENGTH &&
+    title !== "." &&
+    title !== ".." &&
+    !title.includes("/") &&
+    !title.includes("\\") &&
+    !title.includes("\0")
+  );
+}

--- a/src/lib/attachmentStaging.ts
+++ b/src/lib/attachmentStaging.ts
@@ -1,8 +1,8 @@
 /**
  * Filename-safety and byte-cap primitives for staging task attachments into a
- * worktree. Consumed by the producing adapters (Linear download, shell
- * reconcile) as they land in follow-up slices. Dependency-free (Node builtins
- * only) so it stays extraction-ready.
+ * worktree — the helpers the `TaskSource.fetchAttachments` implementer
+ * contract points producing adapters at. Dependency-free (Node builtins only)
+ * so it stays extraction-ready.
  */
 
 import path from "node:path";

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -1,5 +1,7 @@
 import { createBoard } from "./board.ts";
 import type {
+  Attachment,
+  FetchAttachmentsArguments,
   Issue,
   MarkDoneResult,
   MarkInReviewResult,
@@ -359,5 +361,80 @@ describe("Board.markDone", () => {
     await expect(board.markDone(fakeIssue("nope:1", "nope"))).rejects.toThrow(
       /unknown source.*nope/,
     );
+  });
+});
+
+function fetchArguments(issue: Issue): FetchAttachmentsArguments {
+  return {
+    issue,
+    stageDir: "/work/repo-a-team-1/.groundcrew/attachments",
+    maxAttachmentBytes: 100,
+    maxTotalBytes: 250,
+  };
+}
+
+describe("Board.fetchAttachments", () => {
+  it("returns an empty result when the source does not implement fetchAttachments", async () => {
+    const board = createBoard([fakeSource("a")]);
+
+    const actual = await board.fetchAttachments(fetchArguments(fakeIssue("a:1", "a")));
+
+    expect(actual).toStrictEqual({ attachments: [] });
+  });
+
+  it("routes to the adapter named by issue.source and wraps its attachments", async () => {
+    const expected: Attachment[] = [
+      {
+        kind: "file",
+        filename: "mockup.png",
+        relativePath: ".groundcrew/attachments/mockup.png",
+        title: "mockup.png",
+        url: "https://example.test/mockup.png",
+        sizeBytes: 10,
+      },
+    ];
+    const aFetch = vi
+      .fn<(arguments_: FetchAttachmentsArguments) => Promise<readonly Attachment[]>>()
+      .mockResolvedValue(expected);
+    const board = createBoard([fakeSource("a", { fetchAttachments: aFetch }), fakeSource("b")]);
+    const input = fetchArguments(fakeIssue("a:1", "a"));
+
+    const actual = await board.fetchAttachments(input);
+
+    expect(actual).toStrictEqual({ attachments: expected });
+    expect(aFetch).toHaveBeenCalledWith(input);
+  });
+
+  it("wraps an adapter throw into fetchError instead of rejecting", async () => {
+    const aFetch = vi
+      .fn<(arguments_: FetchAttachmentsArguments) => Promise<readonly Attachment[]>>()
+      .mockRejectedValue(new Error("GraphQL down"));
+    const board = createBoard([fakeSource("a", { fetchAttachments: aFetch })]);
+
+    const actual = await board.fetchAttachments(fetchArguments(fakeIssue("a:1", "a")));
+
+    expect(actual).toStrictEqual({
+      attachments: [],
+      fetchError: "GraphQL down",
+    });
+  });
+
+  it("stringifies a non-Error adapter rejection into fetchError", async () => {
+    const aFetch = vi
+      .fn<(arguments_: FetchAttachmentsArguments) => Promise<readonly Attachment[]>>()
+      .mockRejectedValue("no good");
+    const board = createBoard([fakeSource("a", { fetchAttachments: aFetch })]);
+
+    const actual = await board.fetchAttachments(fetchArguments(fakeIssue("a:1", "a")));
+
+    expect(actual).toStrictEqual({ attachments: [], fetchError: "no good" });
+  });
+
+  it("throws when issue.source names an unknown source", async () => {
+    const board = createBoard([fakeSource("a")]);
+
+    await expect(
+      board.fetchAttachments(fetchArguments(fakeIssue("nope:1", "nope"))),
+    ).rejects.toThrow(/unknown source.*nope/);
   });
 });

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -7,7 +7,9 @@
 
 import {
   AmbiguousTaskError,
+  type AttachmentFetchResult,
   type BoardState,
+  type FetchAttachmentsArguments,
   type Issue,
   type MarkDoneResult,
   type MarkInReviewResult,
@@ -15,6 +17,7 @@ import {
   type TaskSource,
 } from "./taskSource.ts";
 import { resolveTaskIdMatches, type TaskResolutionMatches } from "./taskResolution.ts";
+import { errorMessage } from "./util.ts";
 
 export interface Board {
   verify: () => Promise<void>;
@@ -39,6 +42,15 @@ export interface Board {
    * optional `markDone` return `unsupported` (see `TaskSource.markDone`).
    */
   markDone: (issue: Issue) => Promise<MarkDoneResult>;
+  /**
+   * Stages attachments for `arguments_.issue` on the adapter whose `name`
+   * matches `issue.source`. Unknown source throws. Never rejects otherwise:
+   * a source without the optional `fetchAttachments` yields an empty result,
+   * and an adapter throw is wrapped into `fetchError` — so an adapter-level
+   * failure never fails a dispatch (`setupWorkspace` still guards its own
+   * stage-dir I/O separately).
+   */
+  fetchAttachments: (arguments_: FetchAttachmentsArguments) => Promise<AttachmentFetchResult>;
 }
 
 async function callVerify(source: TaskSource): Promise<void> {
@@ -173,6 +185,18 @@ export function createBoard(sources: readonly TaskSource[]): Board {
         };
       }
       return await source.markDone(issue);
+    },
+
+    async fetchAttachments(arguments_: FetchAttachmentsArguments): Promise<AttachmentFetchResult> {
+      const source = routeWriteback(byName, arguments_.issue);
+      if (source.fetchAttachments === undefined) {
+        return { attachments: [] };
+      }
+      try {
+        return { attachments: await source.fetchAttachments(arguments_) };
+      } catch (error) {
+        return { attachments: [], fetchError: errorMessage(error) };
+      }
     },
   };
 }

--- a/src/lib/config.paths.test.ts
+++ b/src/lib/config.paths.test.ts
@@ -18,6 +18,7 @@ function resolvedConfigWithWorkspace(
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -124,6 +124,91 @@ describe("loadConfig", () => {
     expect(actual.sources).toStrictEqual([]);
   });
 
+  it("applies attachment defaults (enabled, 25 MiB per file, 100 MiB total) when the block is omitted", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({ workspace: VALID_WORKSPACE(temporary) }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.attachments).toStrictEqual({
+      enabled: true,
+      maxAttachmentBytes: 26_214_400,
+      maxTotalBytes: 104_857_600,
+    });
+  });
+
+  it("merges a partial attachments block over the defaults", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        attachments: { enabled: false, maxAttachmentBytes: 1024 },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+    const actual = await loadConfig();
+
+    expect(actual.attachments).toStrictEqual({
+      enabled: false,
+      maxAttachmentBytes: 1024,
+      maxTotalBytes: 104_857_600,
+    });
+  });
+
+  it("fails when attachments.maxAttachmentBytes is not a positive integer", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        attachments: { maxAttachmentBytes: 0 },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(
+      /attachments\.maxAttachmentBytes must be an integer ≥ 1/,
+    );
+  });
+
+  it("fails when attachments.maxTotalBytes is not a positive integer", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      validConfigSource({
+        workspace: VALID_WORKSPACE(temporary),
+        attachments: { maxTotalBytes: -5 },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/attachments\.maxTotalBytes must be an integer ≥ 1/);
+  });
+
+  it("fails when attachments.enabled is not a boolean", async () => {
+    const configPath = writeConfigFile(
+      temporary,
+      configSource({
+        workspace: VALID_WORKSPACE(temporary),
+        agents: { definitions: { claude: {} } },
+        attachments: { enabled: "yes" as unknown as boolean },
+      }),
+    );
+    setEnvironmentVariable("GROUNDCREW_CONFIG", configPath);
+
+    const { loadConfig } = await loadFreshConfig();
+
+    await expect(loadConfig()).rejects.toThrow(/attachments\.enabled must be a boolean/);
+  });
+
   it("ships a agent-agnostic unattended default prompt", async () => {
     const configPath = writeConfigFile(
       temporary,
@@ -143,6 +228,7 @@ describe("loadConfig", () => {
     expect(actual.prompts.initial).toContain("GROUNDCREW_COMPLETE");
     expect(actual.prompts.initial).toMatch(/no PR is needed/i);
     expect(actual.prompts.initial).toContain("{{workspaceContinuationInstruction}}");
+    expect(actual.prompts.initial).toContain("{{attachments}}");
     expect(actual.prompts.initial).not.toContain("tmux attach -t groundcrew:{{task}}");
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -245,6 +245,19 @@ export interface KnownRepository {
   hooks?: HookCommands;
 }
 
+/**
+ * User-facing attachment staging knobs. Caps express worktree disk impact,
+ * not source identity, so the block is top-level and uniform across sources.
+ */
+export interface AttachmentConfig {
+  /** Default true; false skips attachment fetching entirely. */
+  enabled?: boolean;
+  /** Per-file byte cap. Default 26_214_400 (25 MiB). */
+  maxAttachmentBytes?: number;
+  /** Per-task cumulative byte cap. Default 104_857_600 (100 MiB). */
+  maxTotalBytes?: number;
+}
+
 export interface Config {
   /**
    * Additional pluggable task sources beyond the built-in Linear adapter
@@ -296,6 +309,8 @@ export interface Config {
     pollIntervalMilliseconds?: number;
     sessionLimitPercentage?: number;
   };
+  /** Attachment staging for dispatched tasks. Omitted means enabled with default caps. */
+  attachments?: AttachmentConfig;
   agents?: {
     default?: string;
     /**
@@ -410,6 +425,12 @@ export interface ResolvedConfig {
     pollIntervalMilliseconds: number;
     sessionLimitPercentage: number;
   };
+  /** Resolved attachment staging knobs; always present with defaults applied. */
+  attachments: {
+    enabled: boolean;
+    maxAttachmentBytes: number;
+    maxTotalBytes: number;
+  };
   agents: {
     default: string;
     definitions: Record<string, AgentDefinition>;
@@ -491,7 +512,12 @@ const DEFAULT_LOCAL_READ_ONLY_DIRS: readonly string[] = ["~/.config/tfenv"];
 
 function normalizeLocal(
   userLocal:
-    | { runner?: unknown; networkEgress?: unknown; safehouse?: unknown; readOnlyDirs?: unknown }
+    | {
+        runner?: unknown;
+        networkEgress?: unknown;
+        safehouse?: unknown;
+        readOnlyDirs?: unknown;
+      }
     | undefined,
 ): ResolvedConfig["local"] {
   return {
@@ -517,6 +543,12 @@ const DEFAULT_ORCHESTRATOR: ResolvedConfig["orchestrator"] = {
   maximumInProgress: 4,
   pollIntervalMilliseconds: 120_000,
   sessionLimitPercentage: 85,
+};
+
+const DEFAULT_ATTACHMENTS: ResolvedConfig["attachments"] = {
+  enabled: true,
+  maxAttachmentBytes: 26_214_400, // 25 MiB
+  maxTotalBytes: 104_857_600, // 100 MiB
 };
 
 const BUILT_IN_AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
@@ -603,6 +635,8 @@ const DEFAULT_PROMPT_INITIAL = [
   "{{description}}",
   "</task_description>",
   "",
+  "{{attachments}}",
+  "",
   "## Operating mode",
   "",
   "There is no human watching this session. Do not stop to ask clarifying questions. When the task is ambiguous or incomplete, choose the simplest reasonable interpretation consistent with the task and the codebase, then document that choice in the output.",
@@ -623,6 +657,7 @@ const ALLOWED_PROMPT_PLACEHOLDERS = new Set([
   "{{title}}",
   "{{description}}",
   "{{workspaceContinuationInstruction}}",
+  "{{attachments}}",
 ]);
 const PROMPT_PLACEHOLDER_RE = /{{[^{}]*}}/g;
 
@@ -1315,6 +1350,7 @@ function applyDefaults(user: Config, configDir: string): ResolvedConfig {
     workspace: normalizeWorkspace(user.workspace),
     defaults: normalizeDefaults((user as { defaults?: unknown }).defaults),
     orchestrator: { ...DEFAULT_ORCHESTRATOR, ...user.orchestrator },
+    attachments: { ...DEFAULT_ATTACHMENTS, ...user.attachments },
     agents: {
       default: user.agents?.default ?? "claude",
       definitions: mergeDefinitions(user.agents?.definitions),
@@ -1372,6 +1408,14 @@ function validate(config: ResolvedConfig): void {
   );
 
   requirePercent(config.orchestrator.sessionLimitPercentage, "orchestrator.sessionLimitPercentage");
+
+  if (typeof config.attachments.enabled !== "boolean") {
+    fail(
+      `attachments.enabled must be a boolean (got ${JSON.stringify(config.attachments.enabled)})`,
+    );
+  }
+  requirePositiveInt(config.attachments.maxAttachmentBytes, "attachments.maxAttachmentBytes");
+  requirePositiveInt(config.attachments.maxTotalBytes, "attachments.maxTotalBytes");
 
   const { definitions } = config.agents;
   if (Object.keys(definitions).length === 0) {

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -28,6 +28,7 @@ function makeConfig(stateRoot: string): ResolvedConfig {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: { claude: { cmd: "claude", color: "#fff" } },

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import type { DiscoveredManifest } from "./adapters/shell/discovery.ts";
-import { sourceSupportsMarkDone, taskSupportsCompletionCommand } from "./sourceCapabilities.ts";
+import {
+  sourceSupportsFetchAttachments,
+  sourceSupportsMarkDone,
+  summarizeSource,
+  taskSupportsCompletionCommand,
+} from "./sourceCapabilities.ts";
 
 describe(sourceSupportsMarkDone, () => {
   it("continues past non-matching sources before returning the markDone capability", () => {
@@ -75,6 +80,44 @@ describe(sourceSupportsMarkDone, () => {
       vi.doUnmock("./adapters/shell/discovery.ts");
       vi.resetModules();
     }
+  });
+});
+
+describe(sourceSupportsFetchAttachments, () => {
+  it("reports false for every built-in kind (no producing adapter ships in this slice)", () => {
+    const rawSources = [
+      { kind: "linear" },
+      { kind: "shell", name: "plans", commands: { listTasks: "plans list" } },
+      {
+        kind: "todo-txt",
+        name: "todo",
+        todoPath: "todo.txt",
+        tasksDir: ".tasks",
+        idPrefix: "GC",
+        timezone: "UTC",
+      },
+    ];
+
+    expect(sourceSupportsFetchAttachments({ rawSources, sourceName: "linear" })).toBe(false);
+    expect(sourceSupportsFetchAttachments({ rawSources, sourceName: "plans" })).toBe(false);
+    expect(sourceSupportsFetchAttachments({ rawSources, sourceName: "todo" })).toBe(false);
+  });
+
+  it("reports false for a source name no configured source claims", () => {
+    const actual = sourceSupportsFetchAttachments({
+      rawSources: [{ kind: "linear" }],
+      sourceName: "nope",
+    });
+
+    expect(actual).toBe(false);
+  });
+});
+
+describe(summarizeSource, () => {
+  it("includes a fetchAttachments capability flag on every summary", () => {
+    const actual = summarizeSource({ kind: "linear" });
+
+    expect(actual.capabilities.fetchAttachments).toBe(false);
   });
 });
 

--- a/src/lib/sourceCapabilities.test.ts
+++ b/src/lib/sourceCapabilities.test.ts
@@ -6,7 +6,6 @@ import type { DiscoveredManifest } from "./adapters/shell/discovery.ts";
 import {
   sourceSupportsFetchAttachments,
   sourceSupportsMarkDone,
-  summarizeSource,
   taskSupportsCompletionCommand,
 } from "./sourceCapabilities.ts";
 
@@ -110,14 +109,6 @@ describe(sourceSupportsFetchAttachments, () => {
     });
 
     expect(actual).toBe(false);
-  });
-});
-
-describe(summarizeSource, () => {
-  it("includes a fetchAttachments capability flag on every summary", () => {
-    const actual = summarizeSource({ kind: "linear" });
-
-    expect(actual.capabilities.fetchAttachments).toBe(false);
   });
 });
 

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -13,6 +13,12 @@ interface SourceCapabilities {
   markInReview: boolean;
   markDone: boolean;
   validate: boolean;
+  /**
+   * Whether the source can stage task attachments. False for every kind in
+   * this slice; producing adapters (Linear, shell `commands.fetchAttachments`)
+   * flip their kinds on in follow-up slices.
+   */
+  fetchAttachments: boolean;
 }
 
 export interface SourceSummary {
@@ -43,6 +49,7 @@ const LINEAR_CAPABILITIES: SourceCapabilities = {
   markInReview: true,
   markDone: false,
   validate: false,
+  fetchAttachments: false,
 };
 
 const UNKNOWN_KIND_CAPABILITIES: SourceCapabilities = {
@@ -54,6 +61,7 @@ const UNKNOWN_KIND_CAPABILITIES: SourceCapabilities = {
   markInReview: false,
   markDone: false,
   validate: false,
+  fetchAttachments: false,
 };
 
 function shellCapabilities(raw: unknown): SourceCapabilities {
@@ -68,6 +76,7 @@ function shellCapabilities(raw: unknown): SourceCapabilities {
     markInReview: commands.markInReview !== undefined,
     markDone: commands.markDone !== undefined,
     validate: commands.validate !== undefined,
+    fetchAttachments: false,
   };
 }
 
@@ -83,6 +92,7 @@ function manifestCapabilities(arguments_: ManifestCapabilitiesArguments): Source
     markInReview: commands.markInReview !== undefined,
     markDone: commands.markDone !== undefined,
     validate: commands.validate !== undefined,
+    fetchAttachments: false,
   };
 }
 
@@ -113,6 +123,7 @@ const TODO_TXT_CAPABILITIES: SourceCapabilities = {
   markInReview: true,
   markDone: true,
   validate: true,
+  fetchAttachments: false,
 };
 
 export function summarizeSource(raw: unknown): SourceSummary {
@@ -143,6 +154,25 @@ export function sourceSupportsMarkDone(arguments_: {
     const source = summarizeSource(rawSource);
     if (source.name === sourceName) {
       return source.capabilities.markDone;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether the named source can stage task attachments. Dispatch gates the
+ * `setupWorkspace` fetch closure on this so a source without the capability
+ * causes zero behavior change (no `.groundcrew/` directory is ever created).
+ */
+export function sourceSupportsFetchAttachments(arguments_: {
+  rawSources: readonly unknown[];
+  sourceName: string;
+}): boolean {
+  const { rawSources, sourceName } = arguments_;
+  for (const rawSource of rawSources) {
+    const source = summarizeSource(rawSource);
+    if (source.name === sourceName) {
+      return source.capabilities.fetchAttachments;
     }
   }
   return false;

--- a/src/lib/sourceCapabilities.ts
+++ b/src/lib/sourceCapabilities.ts
@@ -14,9 +14,9 @@ interface SourceCapabilities {
   markDone: boolean;
   validate: boolean;
   /**
-   * Whether the source can stage task attachments. False for every kind in
-   * this slice; producing adapters (Linear, shell `commands.fetchAttachments`)
-   * flip their kinds on in follow-up slices.
+   * Whether the source kind can stage task attachments into the workspace
+   * (`TaskSource.fetchAttachments`). Dispatch builds the fetch closure only
+   * when this is true.
    */
   fetchAttachments: boolean;
 }

--- a/src/lib/stagedLaunch.test.ts
+++ b/src/lib/stagedLaunch.test.ts
@@ -104,9 +104,7 @@ describe(renderAttachments, () => {
 
   it("omits the Attached files section when only links are present", () => {
     const actual = renderAttachments({
-      attachments: [
-        { kind: "link", title: "Spec", url: "https://example.test/spec", sourceType: undefined },
-      ],
+      attachments: [{ kind: "link", title: "Spec", url: "https://example.test/spec" }],
     });
 
     expect(actual).toContain("## References");

--- a/src/lib/stagedLaunch.test.ts
+++ b/src/lib/stagedLaunch.test.ts
@@ -3,7 +3,124 @@ import os from "node:os";
 import path from "node:path";
 
 import { BUILD_SECRET_NAMES } from "./config.ts";
-import { stageBuildSecrets } from "./stagedLaunch.ts";
+import type { AttachmentFetchResult } from "./taskSource.ts";
+import { renderAttachments, stageBuildSecrets } from "./stagedLaunch.ts";
+
+function stagedFile(
+  overrides: Partial<Extract<AttachmentFetchResult["attachments"][number], { kind: "file" }>> = {},
+) {
+  return {
+    kind: "file" as const,
+    filename: "Mockup v3.png",
+    relativePath: ".groundcrew/attachments/Mockup v3.png",
+    title: "Mockup v3.png",
+    url: "https://example.test/mockup",
+    sizeBytes: 10,
+    ...overrides,
+  };
+}
+
+describe(renderAttachments, () => {
+  it("renders an empty string for an empty result with no fetch error", () => {
+    const actual = renderAttachments({ attachments: [] });
+
+    expect(actual).toBe("");
+  });
+
+  it("renders a staged file as a backticked relative path under Attached files", () => {
+    const actual = renderAttachments({ attachments: [stagedFile()] });
+
+    expect(actual).toContain("## Attached files");
+    expect(actual).toContain("- `.groundcrew/attachments/Mockup v3.png`");
+    expect(actual).not.toContain("## References");
+  });
+
+  it("appends the original title when disambiguation renamed the file", () => {
+    const actual = renderAttachments({
+      attachments: [
+        stagedFile({
+          filename: "Mockup (2).png",
+          relativePath: ".groundcrew/attachments/Mockup (2).png",
+          title: "Mockup.png",
+        }),
+      ],
+    });
+
+    expect(actual).toContain(
+      '- `.groundcrew/attachments/Mockup (2).png` - originally "Mockup.png"',
+    );
+  });
+
+  it("renders a skipped attachment with reason, detail, and url sub-bullets", () => {
+    const actual = renderAttachments({
+      attachments: [
+        {
+          kind: "skipped",
+          title: "huge-dataset.zip",
+          url: "https://example.test/huge",
+          reason: "exceeds-per-file-cap",
+          detail: "89 MiB exceeds 25 MiB cap",
+        },
+      ],
+    });
+
+    expect(actual).toContain('- "huge-dataset.zip" - not staged');
+    expect(actual).toContain("  - reason: exceeds-per-file-cap - 89 MiB exceeds 25 MiB cap");
+    expect(actual).toContain("  - url: https://example.test/huge");
+  });
+
+  it("omits the url sub-bullet when the skipped attachment has no url", () => {
+    const actual = renderAttachments({
+      attachments: [
+        {
+          kind: "skipped",
+          title: "phantom.bin",
+          reason: "download-failed",
+          detail: "reported by source but not found in stage dir",
+        },
+      ],
+    });
+
+    expect(actual).toContain('- "phantom.bin" - not staged');
+    expect(actual).not.toContain("- url:");
+  });
+
+  it("renders reference links under a References section after Attached files", () => {
+    const actual = renderAttachments({
+      attachments: [
+        stagedFile(),
+        {
+          kind: "link",
+          title: "Related PR",
+          url: "https://github.com/acme/widgets/pull/42",
+          sourceType: "github",
+        },
+      ],
+    });
+
+    expect(actual).toContain('- "Related PR" - https://github.com/acme/widgets/pull/42');
+    expect(actual.indexOf("## Attached files")).toBeLessThan(actual.indexOf("## References"));
+  });
+
+  it("omits the Attached files section when only links are present", () => {
+    const actual = renderAttachments({
+      attachments: [
+        { kind: "link", title: "Spec", url: "https://example.test/spec", sourceType: undefined },
+      ],
+    });
+
+    expect(actual).toContain("## References");
+    expect(actual).not.toContain("## Attached files");
+  });
+
+  it("renders a fetch-failure notice when the whole fetch failed", () => {
+    const actual = renderAttachments({ attachments: [], fetchError: "GraphQL down" });
+
+    expect(actual).toBe(
+      "*Attachment fetch failed: GraphQL down. The task may have attachments that are not available here.*",
+    );
+  });
+});
 
 describe(stageBuildSecrets, () => {
   let promptDir: string;

--- a/src/lib/stagedLaunch.ts
+++ b/src/lib/stagedLaunch.ts
@@ -28,22 +28,42 @@ interface PromptTemplateVariables {
 }
 
 function renderPromptTemplate(template: string, variables: PromptTemplateVariables): string {
-  return (
-    template
-      .replaceAll(
-        "{{workspaceContinuationInstruction}}",
-        variables.workspaceContinuationInstruction,
-      )
-      .replaceAll("{{attachments}}", variables.attachments)
-      // The two optional placeholders above leave stacked blank lines behind
-      // when they render empty; collapse BEFORE user-authored content (title,
-      // description) is substituted so task text is never reflowed.
-      .replaceAll(/\n{3,}/g, "\n\n")
-      .replaceAll("{{task}}", variables.task)
-      .replaceAll("{{worktree}}", variables.worktree)
-      .replaceAll("{{title}}", variables.title)
-      .replaceAll("{{description}}", variables.description)
-  );
+  const withOptionals = replaceOptionalPlaceholder({
+    template: replaceOptionalPlaceholder({
+      template,
+      placeholder: "{{workspaceContinuationInstruction}}",
+      value: variables.workspaceContinuationInstruction,
+    }),
+    placeholder: "{{attachments}}",
+    value: variables.attachments,
+  });
+  return withOptionals
+    .replaceAll("{{task}}", variables.task)
+    .replaceAll("{{worktree}}", variables.worktree)
+    .replaceAll("{{title}}", variables.title)
+    .replaceAll("{{description}}", variables.description);
+}
+
+/**
+ * Substitute an optional placeholder. Non-empty values replace verbatim; an
+ * empty value also absorbs the placeholder's own line (and one adjacent blank
+ * line) so the template doesn't render stacked blank lines. Scoped to the
+ * placeholder site on purpose: the template body is user-authored config and
+ * must never be reflowed.
+ */
+function replaceOptionalPlaceholder(arguments_: {
+  template: string;
+  placeholder: string;
+  value: string;
+}): string {
+  const { template, placeholder, value } = arguments_;
+  if (value !== "") {
+    return template.replaceAll(placeholder, value);
+  }
+  return template
+    .replaceAll(`\n${placeholder}\n\n`, "\n")
+    .replaceAll(`\n${placeholder}\n`, "\n")
+    .replaceAll(placeholder, "");
 }
 
 /**

--- a/src/lib/stagedLaunch.ts
+++ b/src/lib/stagedLaunch.ts
@@ -4,6 +4,12 @@ import path from "node:path";
 
 import { BUILD_SECRET_NAMES, type ResolvedConfig } from "./config.ts";
 import { shellSingleQuote } from "./launchCommand.ts";
+import type {
+  AttachmentFetchResult,
+  ReferenceLinkAttachment,
+  SkippedAttachment,
+  StagedFileAttachment,
+} from "./taskSource.ts";
 import { readEnvironmentVariable } from "./util.ts";
 
 export interface StagedPrompt {
@@ -17,15 +23,87 @@ interface PromptTemplateVariables {
   title: string;
   description: string;
   workspaceContinuationInstruction: string;
+  /** Rendered `renderAttachments` output; "" when the task has none. */
+  attachments: string;
 }
 
 function renderPromptTemplate(template: string, variables: PromptTemplateVariables): string {
-  return template
-    .replaceAll("{{task}}", variables.task)
-    .replaceAll("{{worktree}}", variables.worktree)
-    .replaceAll("{{title}}", variables.title)
-    .replaceAll("{{description}}", variables.description)
-    .replaceAll("{{workspaceContinuationInstruction}}", variables.workspaceContinuationInstruction);
+  return (
+    template
+      .replaceAll(
+        "{{workspaceContinuationInstruction}}",
+        variables.workspaceContinuationInstruction,
+      )
+      .replaceAll("{{attachments}}", variables.attachments)
+      // The two optional placeholders above leave stacked blank lines behind
+      // when they render empty; collapse BEFORE user-authored content (title,
+      // description) is substituted so task text is never reflowed.
+      .replaceAll(/\n{3,}/g, "\n\n")
+      .replaceAll("{{task}}", variables.task)
+      .replaceAll("{{worktree}}", variables.worktree)
+      .replaceAll("{{title}}", variables.title)
+      .replaceAll("{{description}}", variables.description)
+  );
+}
+
+/**
+ * Render an attachment fetch result into the `{{attachments}}` prompt
+ * section: an "Attached files" section (staged files as backticked
+ * launchDir-relative paths, plus visible skips), then a "References" section
+ * (URL-only links). Each section is omitted when empty; an empty result
+ * renders the empty string. A wholesale fetch failure renders a notice line
+ * so the agent knows attachments may exist that it cannot see.
+ */
+export function renderAttachments(result: AttachmentFetchResult): string {
+  const sections: string[] = [];
+  if (result.fetchError !== undefined) {
+    sections.push(
+      `*Attachment fetch failed: ${result.fetchError}. The task may have attachments that are not available here.*`,
+    );
+  }
+
+  const attachedLines = result.attachments.flatMap((attachment) => {
+    if (attachment.kind === "file") {
+      return [stagedFileLine(attachment)];
+    }
+    if (attachment.kind === "skipped") {
+      return skippedAttachmentLines(attachment);
+    }
+    return [];
+  });
+  if (attachedLines.length > 0) {
+    sections.push(["## Attached files", "", ...attachedLines].join("\n"));
+  }
+
+  const referenceLines = result.attachments
+    .filter((attachment) => attachment.kind === "link")
+    .map((link) => referenceLinkLine(link));
+  if (referenceLines.length > 0) {
+    sections.push(["## References", "", ...referenceLines].join("\n"));
+  }
+
+  return sections.join("\n\n");
+}
+
+function stagedFileLine(attachment: StagedFileAttachment): string {
+  const renamed =
+    attachment.filename === attachment.title ? "" : ` - originally "${attachment.title}"`;
+  return `- \`${attachment.relativePath}\`${renamed}`;
+}
+
+function referenceLinkLine(link: ReferenceLinkAttachment): string {
+  return `- "${link.title}" - ${link.url}`;
+}
+
+function skippedAttachmentLines(attachment: SkippedAttachment): string[] {
+  const lines = [
+    `- "${attachment.title}" - not staged`,
+    `  - reason: ${attachment.reason} - ${attachment.detail}`,
+  ];
+  if (attachment.url !== undefined) {
+    lines.push(`  - url: ${attachment.url}`);
+  }
+  return lines;
 }
 
 export function stagePromptText(input: {

--- a/src/lib/stagedLaunch.ts
+++ b/src/lib/stagedLaunch.ts
@@ -27,38 +27,50 @@ interface PromptTemplateVariables {
   attachments: string;
 }
 
+const PROMPT_SUBSTITUTION_RE =
+  /\{\{(?:task|worktree|title|description|workspaceContinuationInstruction|attachments)\}\}/g;
+
 function renderPromptTemplate(template: string, variables: PromptTemplateVariables): string {
-  const withOptionals = replaceOptionalPlaceholder({
-    template: replaceOptionalPlaceholder({
+  const withOptionals = absorbEmptyOptionalPlaceholder(
+    absorbEmptyOptionalPlaceholder(
       template,
-      placeholder: "{{workspaceContinuationInstruction}}",
-      value: variables.workspaceContinuationInstruction,
-    }),
-    placeholder: "{{attachments}}",
-    value: variables.attachments,
-  });
-  return withOptionals
-    .replaceAll("{{task}}", variables.task)
-    .replaceAll("{{worktree}}", variables.worktree)
-    .replaceAll("{{title}}", variables.title)
-    .replaceAll("{{description}}", variables.description);
+      "{{workspaceContinuationInstruction}}",
+      variables.workspaceContinuationInstruction,
+    ),
+    "{{attachments}}",
+    variables.attachments,
+  );
+  const substitutions: ReadonlyMap<string, string> = new Map([
+    ["{{task}}", variables.task],
+    ["{{worktree}}", variables.worktree],
+    ["{{title}}", variables.title],
+    ["{{description}}", variables.description],
+    ["{{workspaceContinuationInstruction}}", variables.workspaceContinuationInstruction],
+    ["{{attachments}}", variables.attachments],
+  ]);
+  // Single pass over the template so substituted values are never re-scanned:
+  // task text (or an attachment title) containing "{{title}}" stays literal.
+  return withOptionals.replaceAll(
+    PROMPT_SUBSTITUTION_RE,
+    /* v8 ignore next @preserve -- the regex alternation guarantees every match is a map key, so the ?? fallback is unreachable */
+    (match) => substitutions.get(match) ?? match,
+  );
 }
 
 /**
- * Substitute an optional placeholder. Non-empty values replace verbatim; an
- * empty value also absorbs the placeholder's own line (and one adjacent blank
- * line) so the template doesn't render stacked blank lines. Scoped to the
- * placeholder site on purpose: the template body is user-authored config and
- * must never be reflowed.
+ * When an optional placeholder renders empty, absorb its own line (and one
+ * adjacent blank line) so the template doesn't render stacked blank lines.
+ * Scoped to the placeholder site on purpose: the template body is
+ * user-authored config and must never be reflowed. Non-empty values are left
+ * for the single-pass substitution.
  */
-function replaceOptionalPlaceholder(arguments_: {
-  template: string;
-  placeholder: string;
-  value: string;
-}): string {
-  const { template, placeholder, value } = arguments_;
+function absorbEmptyOptionalPlaceholder(
+  template: string,
+  placeholder: string,
+  value: string,
+): string {
   if (value !== "") {
-    return template.replaceAll(placeholder, value);
+    return template;
   }
   return template
     .replaceAll(`\n${placeholder}\n\n`, "\n")

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -143,7 +143,7 @@ export interface ReferenceLinkAttachment {
   title: string;
   url: string;
   /** Linear's sourceType ("github", "figma", ...) when known. */
-  sourceType: string | undefined;
+  sourceType?: string;
 }
 
 export interface SkippedAttachment {

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -119,6 +119,61 @@ export interface BoardState {
   parentSkips: readonly ParentSkip[];
 }
 
+/**
+ * One attachment surfaced to the launched agent: a file staged into the
+ * worktree, a URL-only reference to chase, or a known-but-unstaged skip.
+ */
+export type Attachment = StagedFileAttachment | ReferenceLinkAttachment | SkippedAttachment;
+
+export interface StagedFileAttachment {
+  kind: "file";
+  /** Final on-disk name (post sanitize/disambiguate). */
+  filename: string;
+  /** Path the prompt prints, relative to the agent's working directory (launchDir). */
+  relativePath: string;
+  /** Source-side display title (pre-disambiguation). */
+  title: string;
+  /** Source URL when known; omitted for script-staged files with no reported URL. */
+  url?: string;
+  sizeBytes: number;
+}
+
+export interface ReferenceLinkAttachment {
+  kind: "link";
+  title: string;
+  url: string;
+  /** Linear's sourceType ("github", "figma", ...) when known. */
+  sourceType: string | undefined;
+}
+
+export interface SkippedAttachment {
+  kind: "skipped";
+  title: string;
+  /** Source URL when known, so the agent can still try its own tooling. */
+  url?: string;
+  reason: "exceeds-per-file-cap" | "exceeds-per-task-cap" | "download-failed" | "invalid-filename";
+  /** Human-readable detail, e.g. "87 MiB exceeds 25 MiB cap", "HTTP 503", script-provided text. */
+  detail: string;
+}
+
+export interface FetchAttachmentsArguments {
+  issue: Issue;
+  /**
+   * Absolute path to `<launchDir>/.groundcrew/attachments`; the caller
+   * creates it before the call. The layout is fixed, so a staged file's
+   * `relativePath` is always `.groundcrew/attachments/<filename>`.
+   */
+  stageDir: string;
+  maxAttachmentBytes: number;
+  maxTotalBytes: number;
+}
+
+export interface AttachmentFetchResult {
+  attachments: readonly Attachment[];
+  /** Present iff the adapter call itself failed wholesale (network, GraphQL, script crash/timeout). */
+  fetchError?: string;
+}
+
 export type MarkInReviewResult =
   | { outcome: "applied" }
   | { outcome: "unsupported"; reason: string };
@@ -209,6 +264,23 @@ export interface TaskSource {
    * Unlike `verify()`, this never throws — errors are returned as an array.
    */
   validate?: () => Promise<string[]>;
+
+  /**
+   * Optional. Stage downloadable files into `stageDir`, collect URL-only
+   * references, report known-but-unstaged attachments. Implementer contract:
+   *
+   * - Enforce `maxAttachmentBytes` / `maxTotalBytes` yourself — Board does
+   *   not. Files the caps reject become `SkippedAttachment` entries with the
+   *   matching `exceeds-*` reason; `createCapAccountant`
+   *   (`./attachmentStaging.ts`) does the accounting.
+   * - Guard filenames yourself: `sanitizeAttachmentFilename` and
+   *   `resolveInsideStageDir` (same module) handle unsafe titles and
+   *   stage-dir containment.
+   * - Per-file failures become `SkippedAttachment` entries. Throwing is
+   *   reserved for wholesale failure; Board wraps it into
+   *   `AttachmentFetchResult.fetchError`.
+   */
+  fetchAttachments?: (arguments_: FetchAttachmentsArguments) => Promise<readonly Attachment[]>;
 }
 
 export class RepositoryResolutionError extends Error {

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -57,6 +57,7 @@ function makeConfig(
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "codex",
       definitions: definitions ?? {

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -92,6 +92,7 @@ function makeConfig(workspaceKind: WorkspaceKindSetting = "auto"): ResolvedConfi
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: {
       default: "claude",
       definitions: {

--- a/src/lib/worktrees.create.test.ts
+++ b/src/lib/worktrees.create.test.ts
@@ -72,6 +72,7 @@ function makeConfig(overrides: {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: { default: "claude", definitions: agents },
     prompts: { initial: "x" },
     workspaceKind: "auto",

--- a/src/lib/worktrees.open.test.ts
+++ b/src/lib/worktrees.open.test.ts
@@ -62,6 +62,7 @@ function makeConfig(overrides: {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: { default: "claude", definitions: { claude: { cmd: "claude", color: "#fff" } } },
     prompts: { initial: "x" },
     workspaceKind: "auto",

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -88,6 +88,7 @@ function makeConfig(overrides: {
       pollIntervalMilliseconds: 1000,
       sessionLimitPercentage: 85,
     },
+    attachments: { enabled: true, maxAttachmentBytes: 26_214_400, maxTotalBytes: 104_857_600 },
     agents: { default: "claude", definitions: agents },
     prompts: { initial: "x" },
     workspaceKind: "auto",

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -1,5 +1,10 @@
 import type { Board } from "../lib/board.ts";
-import type { BoardState, MarkDoneResult, MarkInReviewResult } from "../lib/taskSource.ts";
+import type {
+  AttachmentFetchResult,
+  BoardState,
+  MarkDoneResult,
+  MarkInReviewResult,
+} from "../lib/taskSource.ts";
 
 export function makeBoard(overrides: Partial<Board> = {}): Board {
   return {
@@ -14,6 +19,9 @@ export function makeBoard(overrides: Partial<Board> = {}): Board {
       .fn<() => Promise<MarkInReviewResult>>()
       .mockResolvedValue({ outcome: "applied" }),
     markDone: vi.fn<() => Promise<MarkDoneResult>>().mockResolvedValue({ outcome: "applied" }),
+    fetchAttachments: vi
+      .fn<() => Promise<AttachmentFetchResult>>()
+      .mockResolvedValue({ attachments: [] }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## What this is

Slice 1 of 4 of the task-attachments feature (source plan: `2026-07-18-task-attachments-01-core-plumbing`, plan-3324440482, from the task-attachments v2 design): the complete consumer path for ticket attachments, with no producing adapter yet. Follow-up slices add the producers (02 Linear adapter, 03 shell protocol, 04 JIRA bundle).

## Requirements

- Any task source implementing the new optional `TaskSource.fetchAttachments` gets its files staged into `<launchDir>/.groundcrew/attachments/` and surfaced in the agent prompt (staged files, URL-only references, and visible skips with reasons).
- Attachment fetching can never block or fail a dispatch: any failure degrades to a prompt notice.
- A source without the capability is byte-for-byte unchanged - no `.groundcrew/` directory, no prompt section.
- `attachments: { enabled, maxAttachmentBytes, maxTotalBytes }` config block, defaults on / 25 MiB / 100 MiB; `enabled: false` skips fetching entirely.
- Staged files stay invisible to git so `git status` in the worktree stays clean, and staging refuses to write through symlinked `.groundcrew` paths (the writes run in the orchestrator process, outside the agent sandbox).
- Non-goals (later slices / deliberate): producing adapters, filename disambiguation, resume re-fetch, per-source cap overrides.

## Architecture

Task attachments flow through one source-agnostic seam: `Board.fetchAttachments` routes an issue to its adapter's optional `fetchAttachments`, the dispatcher threads that into `setupWorkspace` as a capability-gated closure, and a `{{attachments}}` prompt placeholder renders the result. Before this, nothing about a ticket's attachments reached the launched agent - the prompt carried title and description only, and there was no seam an adapter could implement.

```text
dispatcher / crew setup
  └─ buildFetchAttachmentsClosure(board, issue, caps)   [only when the source's
       │                                                 capability flag is on]
       ▼
setupWorkspace ── mkdir .groundcrew/attachments + .gitignore("*")
       │          closure(stageDir) ──► Board.fetchAttachments ──► adapter
       ▼
stagePrompt ── renderAttachments(result) ──► {{attachments}} section
```

Load-bearing decisions:

- **The fetch is a closure on `SetupWorkspaceOptions`, built by the dispatcher/CLI from Board.** The stage dir only exists after worktree creation, so the fetch must run inside `setupWorkspace` - the closure threads Board access in without coupling `setupWorkspace` to Board/Issue.
- **Never-block is layered.** Board wraps adapter throws into `AttachmentFetchResult.fetchError` (its documented contract for all callers); `setupWorkspace` separately guards its own stage-dir I/O, including refusing symlinked `.groundcrew`/`attachments`/`.gitignore` paths a branch could ship. Either failure becomes a prompt notice, never a failed workspace.
- **Git invisibility via a directory-local `.groundcrew/.gitignore` containing `*`.** In a linked worktree `.git` is a file and `info/exclude` lives in the common git dir (it would leak into every checkout), so an ignore file inside the ignored directory is the only per-worktree-safe exclusion.
- **The capability gate reads config, not the built adapter.** `sourceCapabilities.fetchAttachments` is false for every kind in this slice, so the entire path is dormant in production until a producer flips its kind on - which is what guarantees the zero-change requirement for existing sources.

What deliberately did not change: dispatch behavior for every existing source and every existing prompt template (covered by the full suite plus explicit no-closure / `enabled: false` tests). Prompt rendering is now a single pass, so placeholder-like text inside task titles, descriptions, or attachment content stays literal, and an optional placeholder that renders empty (`{{workspaceContinuationInstruction}}`, now `{{attachments}}`) absorbs its own line instead of leaving a blank line; user-authored template content is never reflowed.

## Interface changes

New optional top-level `attachments` block in the crew config (omitted means enabled with these defaults):

```ts
// crew.config.ts
export default {
  // ...existing config
  attachments: {
    enabled: true, // false skips attachment fetching entirely
    maxAttachmentBytes: 26_214_400, // 25 MiB per file
    maxTotalBytes: 104_857_600, // 100 MiB per task
  },
};
```

New `{{attachments}}` placeholder for prompt templates. The default template gains it automatically; custom `prompts.initial` / `promptFile` users opt in by adding it where the section should render:

```text
## Task description

<task_description>
{{description}}
</task_description>

{{attachments}}
```

## Data / contract model

`Attachment` is a discriminated union: `file` (staged, prompt prints its launchDir-relative path), `link` (URL-only reference), `skipped` (known but not staged, with reason `exceeds-per-file-cap | exceeds-per-task-cap | download-failed | invalid-filename` and freeform detail). `fetchError` on the envelope means the whole fetch failed; the prompt then carries a notice so the agent knows attachments may exist that it cannot see. Cap enforcement and filename safety are the implementer's job (helpers in `attachmentStaging.ts`); Board only routes and wraps.

## Testing

TDD throughout: unit tests for the staging primitives (sanitization, traversal containment, cap accounting), the renderer (every bullet shape, both sections, fetch-error notice), config resolution/validation, Board routing, and capability flags; integration tests drive `setupWorkspace` against real temp dirs (staged file on disk, `.gitignore` written, prompt content, throwing closure still launches, `enabled: false` short-circuits, symlinked `.groundcrew` refused without failing the launch, placeholder-like text in substituted values stays literal); one composed end-to-end test runs a stub `TaskSource` through a real `createBoard` into `setupWorkspaceCli` and asserts the staged file exists exactly where the reported `relativePath` claims. `node --run verify` green (2134 tests).

## Decisions

- `StagedFileAttachment.url` is optional here where the design doc specified required-with-`""`-sentinel: two independent review passes flagged the inconsistent spelling of absence across the union (`SkippedAttachment.url?`), so absence is uniformly `undefined`; slice 03's reconcile should emit no `url` instead of `""`. Same for `ReferenceLinkAttachment.sourceType?`.
- Cancellation/timeout for the fetch is deliberately deferred to the slices that introduce real I/O (shell command timeouts, the Linear downloader); threading `AbortSignal` through `FetchAttachmentsArguments` now would freeze a field with no producer or consumer, and adding it later is additive and non-breaking.
- The design's "Zod validation" for the config block became the config loader's existing hand-rolled `requirePositiveInt`/`fail` pattern - the file has no Zod and the resolved-block convention is uniform there.
- The `attachments` fixture literal now appears in ~20 per-file test `makeConfig` helpers (the established per-file-fixture pattern); overrides-capable helpers merge `overrides.attachments`, and a shared `ResolvedConfig` fixture builder is a worthwhile follow-up but out of scope here.
- Repo AGENTS.md references a `core:go` skill for code changes; it is not installed in this environment, so the repo's documented TDD + `node --run verify` workflow was followed directly.
- Two oxlint `max-lines` caps were bumped (`setupWorkspace.test.ts` 2200→2600, `config.test.ts` 2200→2400) rather than splitting files whose header comments explain why they must stay together.