### PR TITLE
chore: update Clipboard AI tooling packages

### DIFF
--- a/.rules/common/coreLibraries.md
+++ b/.rules/common/coreLibraries.md
@@ -30,12 +30,13 @@ When a bug traces into a `@clipboard-health/*` library, read the source code in 
 - **execution-context**: A lightweight Node.js utility for managing execution contexts and metadata aggregation using AsyncLocalStorage.
 - **json-api**: TypeScript-friendly utilities for adhering to the JSON:API specification.
 - **json-api-nestjs**: TypeScript-friendly utilities for adhering to the JSON:API specification with NestJS.
-- **mongo-jobs**: MongoDB-powered background jobs.
 - **notifications**: Send notifications through third-party providers.
 - **nx-plugin**: An Nx plugin with generators to manage libraries and applications.
 - **oxlint-config**: Shared Oxlint configuration for Clipboard Health repositories.
 - **phone-number**: Phone number utility functions.
+- **playwright-flake-linter**: Shared configurable checks for Playwright flake anti-patterns.
 - **playwright-reporter-llm**: Playwright reporter that outputs structured JSON for LLM agents. Minimal console output, flat schema, easy to filter to failures.
+- **playwright-toolkit**: Shared anti-flake primitives for Clipboard Health Playwright suites.
 - **rules-engine**: A pure functional rules engine to keep logic-dense code simple, reliable, understandable, and explainable.
 - **testing-core**: TypeScript-friendly testing utilities.
 - **util-ts**: TypeScript utilities.

--- a/.rules/common/typeScript.md
+++ b/.rules/common/typeScript.md
@@ -17,6 +17,7 @@ description: "Writing ANY TypeScript code"
 
 ## Core Rules
 
+- Do not add ticket or issue numbers (e.g. Linear, Jira IDs) to code, variable names, or comments unless explicitly asked
 - Avoid type assertions (`as`, `!`) unless absolutely necessary
 - Use `function` keyword for declarations, not `const`
 - Prefer `undefined` over `null`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@
 
 IMPORTANT: You MUST read the relevant rule files below before writing or reviewing code.
 
-| Rule                    | File                                  | When to Read                                                                                                           |
-| ----------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Configuration           | .rules/common/configuration.md        | Adding config, secrets, or third-party dependencies: SSM, LaunchDarkly, DB, NPM packages                               |
-| Core Libraries          | .rules/common/coreLibraries.md        | Adding dependencies, implementing functionality, or debugging errors involving a @clipboard-health/\* library          |
-| Feature Flags           | .rules/common/featureFlags.md         | Creating or managing feature flags: naming, lifecycle, SDK usage, Zod schemas                                          |
-| Git Workflow            | .rules/common/gitWorkflow.md          | Writing commit messages, PR titles, or reviewing pull requests                                                         |
-| Library Authoring       | .rules/common/libraryAuthoring.md     | Authoring shared library code: @clipboard-health/\* packages or shared library modules within services (e.g., src/lib) |
-| Logging & Observability | .rules/common/loggingObservability.md | Adding logging, metrics, monitoring, or observability: levels, context, PII, Datadog                                   |
-| Testing                 | .rules/common/testing.md              | Writing unit tests: conventions, naming, structure                                                                     |
-| TypeScript              | .rules/common/typeScript.md           | Writing ANY TypeScript code                                                                                            |
+| Rule                    | File                                  | When to Read                                                                                                          |
+| ----------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Configuration           | .rules/common/configuration.md        | Adding config, secrets, or third-party dependencies: SSM, LaunchDarkly, DB, NPM packages                              |
+| Core Libraries          | .rules/common/coreLibraries.md        | Adding dependencies, implementing functionality, or debugging errors involving a @clipboard-health/* library          |
+| Feature Flags           | .rules/common/featureFlags.md         | Creating or managing feature flags: naming, lifecycle, SDK usage, Zod schemas                                         |
+| Git Workflow            | .rules/common/gitWorkflow.md          | Writing commit messages, PR titles, or reviewing pull requests                                                        |
+| Library Authoring       | .rules/common/libraryAuthoring.md     | Authoring shared library code: @clipboard-health/* packages or shared library modules within services (e.g., src/lib) |
+| Logging & Observability | .rules/common/loggingObservability.md | Adding logging, metrics, monitoring, or observability: levels, context, PII, Datadog                                  |
+| Testing                 | .rules/common/testing.md              | Writing unit tests: conventions, naming, structure                                                                    |
+| TypeScript              | .rules/common/typeScript.md           | Writing ANY TypeScript code                                                                                           |
 
 ## Agent Skills
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "crew-clearance-ensure": "bin/crewClearanceEnsure.js"
       },
       "devDependencies": {
-        "@clipboard-health/ai-rules": "2.37.1",
+        "@clipboard-health/ai-rules": "2.43.4",
         "@clipboard-health/oxlint-config": "1.12.9",
         "@nx/js": "22.7.7",
         "@tsconfig/node24": "24.0.4",
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/@clipboard-health/ai-rules": {
-      "version": "2.37.1",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.37.1.tgz",
-      "integrity": "sha512-BjEqvWhT5ielHpXwhSQR3+L0cvcyVifpo0hp+HiSvKR46WzA0PFZkYu/wOlweUZUIETD0j46jKrYShmMrY/dRg==",
+      "version": "2.43.4",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.43.4.tgz",
+      "integrity": "sha512-gVFahggn9j8ptj8umEV9lLojIAp+9KlBcTdNXsQ5U9J+1BvaenIaM5oQYRvuQ0jiHnk/VC8Fj+/HGLCGI1gULg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@clipboard-health/ai-rules": "2.37.1",
+    "@clipboard-health/ai-rules": "2.43.4",
     "@clipboard-health/oxlint-config": "1.12.9",
     "@nx/js": "22.7.7",
     "@tsconfig/node24": "24.0.4",


### PR DESCRIPTION
Summary
===
Update the Clipboard AI tooling packages declared by this repository to their latest versions:

- @clipboard-health/ai-rules to v2.43.4
- @clipboard-health/playwright-flake-linter to v1.0.1
- @clipboard-health/playwright-reporter-llm to v2.8.0
- @clipboard-health/playwright-toolkit to v1.1.2

Run "npm install" and sync AI agent memory files (e.g., AGENTS.md, CLAUDE.md) where the sync script is available.

[_Created by Sourcegraph batch change `rockywarren/update-ai-rules-2.43.4`._](https://clipboardhealth.sourcegraphcloud.com/users/rockywarren/batch-changes/update-ai-rules-2.43.4)