### PR TITLE
feat(preLaunch): guard preLaunchEnv against silent empty exports

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -940,4 +940,33 @@ describe(doctor, () => {
     expect(lines).toMatch(/requested=cmux/);
     expect(lines).toContain("cmux binary is not on PATH");
   });
+
+  it("emits an advisory line for each agent with a non-empty preLaunchEnv", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "claude",
+        definitions: {
+          claude: {
+            cmd: "claude",
+            color: "#fff",
+            preLaunchEnv: ["JIRA_API_TOKEN", "GITHUB_TOKEN"],
+          },
+          codex: { cmd: "codex", color: "#3267e3" },
+        },
+      }),
+    );
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const lines = consoleLog.output();
+    // Advisory renders with the `[ok]` tag (ok=true, required=false) — same
+    // pattern as `local runner (none)`. The informational nature is carried by
+    // the wording (`forwards N var(s): …`), not by a fail tag.
+    expect(lines).toMatch(/\[ok]\s*preLaunchEnv: claude/);
+    expect(lines).toContain("JIRA_API_TOKEN");
+    expect(lines).toContain("GITHUB_TOKEN");
+    // Agent without preLaunchEnv must not appear as an advisory line.
+    expect(lines).not.toMatch(/preLaunchEnv: codex/);
+  });
 });

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -949,6 +949,7 @@ describe(doctor, () => {
           claude: {
             cmd: "claude",
             color: "#fff",
+            preLaunch: 'export JIRA_API_TOKEN="tok"',
             preLaunchEnv: ["JIRA_API_TOKEN", "GITHUB_TOKEN"],
           },
           codex: { cmd: "codex", color: "#3267e3" },
@@ -963,6 +964,29 @@ describe(doctor, () => {
     expect(lines).toMatch(/\[ok]\s*preLaunchEnv: claude/);
     expect(lines).toContain("JIRA_API_TOKEN");
     expect(lines).toContain("GITHUB_TOKEN");
+    expect(lines).toContain("empty values are warned at launch");
     expect(lines).not.toMatch(/preLaunchEnv: codex/);
+  });
+
+  it("warns in the preLaunchEnv advisory when preLaunch is absent", async () => {
+    loadConfigMock.mockResolvedValue(
+      makeConfig({
+        default: "claude",
+        definitions: {
+          claude: {
+            cmd: "claude",
+            color: "#fff",
+            preLaunchEnv: ["JIRA_API_TOKEN"],
+          },
+        },
+      }),
+    );
+
+    const actual = await doctor();
+
+    expect(actual).toBe(true);
+    const lines = consoleLog.output();
+    expect(lines).toMatch(/\[ok]\s*preLaunchEnv: claude/);
+    expect(lines).toContain("no preLaunch is set, so empty values are NOT checked at launch");
   });
 });

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -960,13 +960,9 @@ describe(doctor, () => {
 
     expect(actual).toBe(true);
     const lines = consoleLog.output();
-    // Advisory renders with the `[ok]` tag (ok=true, required=false) — same
-    // pattern as `local runner (none)`. The informational nature is carried by
-    // the wording (`forwards N var(s): …`), not by a fail tag.
     expect(lines).toMatch(/\[ok]\s*preLaunchEnv: claude/);
     expect(lines).toContain("JIRA_API_TOKEN");
     expect(lines).toContain("GITHUB_TOKEN");
-    // Agent without preLaunchEnv must not appear as an advisory line.
     expect(lines).not.toMatch(/preLaunchEnv: codex/);
   });
 });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -246,6 +246,31 @@ function gatherToolTargets(config: ResolvedConfig): ToolCheckTarget[] {
   return [...all].map(([token, hint]) => (hint === undefined ? { token } : { token, hint }));
 }
 
+/**
+ * Advisory: one `[? ]` line per agent that has `preLaunchEnv` configured,
+ * naming the vars that will be forwarded. Empty values are caught at launch
+ * time (see `buildPreLaunchEmptyCheckLines` in
+ * `src/lib/preLaunchEmptyCheck.ts`) or at edit time via crew-config's TUI
+ * probe. Doctor does not run the hook itself — that would be slow,
+ * interactive, and side-effectful.
+ */
+function preLaunchEnvAdvisories(config: ResolvedConfig): Check[] {
+  const advisories: Check[] = [];
+  for (const [agentName, definition] of Object.entries(config.agents.definitions)) {
+    const names = definition.preLaunchEnv ?? [];
+    if (names.length === 0) {
+      continue;
+    }
+    advisories.push({
+      name: `preLaunchEnv: ${agentName}`,
+      ok: true,
+      required: false,
+      hint: `forwards ${names.length} var(s): ${names.join(", ")}. Empty values are warned at launch — verify with crew-config's preLaunchEnv editor probe before launching.`,
+    });
+  }
+  return advisories;
+}
+
 function agentCliHint(agentName: string, token: string): string | undefined {
   if (!isBuiltInAgentName(agentName)) {
     return undefined;
@@ -329,6 +354,10 @@ export async function doctor(): Promise<boolean> {
     const check = await checkCmd(token, required, required ? hint : "required for local runs");
     checks.push(check);
   }
+
+  // Advisory: operators see which agents will forward env vars from preLaunch.
+  // Runtime empty-value detection lives in `src/lib/preLaunchEmptyCheck.ts`.
+  checks.push(...preLaunchEnvAdvisories(config));
 
   const usageGatedAgents = gatedAgents(config);
   if (usageGatedAgents.length > 0) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -253,11 +253,19 @@ function preLaunchEnvAdvisories(config: ResolvedConfig): Check[] {
     if (names.length === 0) {
       continue;
     }
+    // The runtime empty-check is spliced only when `preLaunch` is present
+    // (see `hostPreLaunchSourceAndReadPrompt` / `preLaunchPromptAndExec` in
+    // `src/lib/launchCommand.ts`). Without `preLaunch`, forwarded values come
+    // straight from the parent shell and no launch-time guard runs.
+    const warnClause =
+      definition.preLaunch === undefined
+        ? "no preLaunch is set, so empty values are NOT checked at launch"
+        : "empty values are warned at launch";
     advisories.push({
       name: `preLaunchEnv: ${agentName}`,
       ok: true,
       required: false,
-      hint: `forwards ${names.length} var(s): ${names.join(", ")}. Empty values are warned at launch — verify with crew-config's preLaunchEnv editor probe before launching.`,
+      hint: `forwards ${names.length} var(s): ${names.join(", ")}. ${warnClause} — verify with crew-config's preLaunchEnv editor probe before launching.`,
     });
   }
   return advisories;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -246,14 +246,6 @@ function gatherToolTargets(config: ResolvedConfig): ToolCheckTarget[] {
   return [...all].map(([token, hint]) => (hint === undefined ? { token } : { token, hint }));
 }
 
-/**
- * Advisory: one `[? ]` line per agent that has `preLaunchEnv` configured,
- * naming the vars that will be forwarded. Empty values are caught at launch
- * time (see `buildPreLaunchEmptyCheckLines` in
- * `src/lib/preLaunchEmptyCheck.ts`) or at edit time via crew-config's TUI
- * probe. Doctor does not run the hook itself — that would be slow,
- * interactive, and side-effectful.
- */
 function preLaunchEnvAdvisories(config: ResolvedConfig): Check[] {
   const advisories: Check[] = [];
   for (const [agentName, definition] of Object.entries(config.agents.definitions)) {
@@ -355,8 +347,6 @@ export async function doctor(): Promise<boolean> {
     checks.push(check);
   }
 
-  // Advisory: operators see which agents will forward env vars from preLaunch.
-  // Runtime empty-value detection lives in `src/lib/preLaunchEmptyCheck.ts`.
   checks.push(...preLaunchEnvAdvisories(config));
 
   const usageGatedAgents = gatedAgents(config);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -265,7 +265,7 @@ function preLaunchEnvAdvisories(config: ResolvedConfig): Check[] {
       name: `preLaunchEnv: ${agentName}`,
       ok: true,
       required: false,
-      hint: `forwards ${names.length} var(s): ${names.join(", ")}. ${warnClause} — verify with crew-config's preLaunchEnv editor probe before launching.`,
+      hint: `forwards ${names.length} var(s): ${names.join(", ")}. ${warnClause}.`,
     });
   }
   return advisories;

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -912,6 +912,53 @@ describe(buildLaunchCommand, () => {
       }
     });
 
+    it("splices the empty-value check between preLaunch and the prompt read, one per preLaunchEnv name (safehouse)", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          runner: "safehouse",
+          definition: {
+            cmd: "claude",
+            color: "#fff",
+            preLaunch: "export JIRA_API_TOKEN=abc && export GITHUB_TOKEN=xyz",
+            preLaunchEnv: ["JIRA_API_TOKEN", "GITHUB_TOKEN"],
+          },
+        }),
+      );
+
+      // End-to-end behavior of the emitted snippet is covered by
+      // preLaunchEmptyCheck.test.ts under `sh -c`; here we assert the wiring:
+      // one check per name, ordered after preLaunch and before the prompt read.
+      const preLaunchIndex = out.indexOf("export JIRA_API_TOKEN=abc");
+      const jiraCheckIndex = out.indexOf(
+        "preLaunchEnv: JIRA_API_TOKEN is empty after preLaunch (value length 0)",
+      );
+      const githubCheckIndex = out.indexOf(
+        "preLaunchEnv: GITHUB_TOKEN is empty after preLaunch (value length 0)",
+      );
+      const promptReadIndex = out.indexOf("_p=$(cat");
+
+      expect(preLaunchIndex).toBeGreaterThan(-1);
+      expect(jiraCheckIndex).toBeGreaterThan(preLaunchIndex);
+      expect(githubCheckIndex).toBeGreaterThan(preLaunchIndex);
+      expect(promptReadIndex).toBeGreaterThan(jiraCheckIndex);
+      expect(promptReadIndex).toBeGreaterThan(githubCheckIndex);
+    });
+
+    it("emits no empty-value check when preLaunchEnv is absent (safehouse)", () => {
+      const out = buildLaunchCommand(
+        arguments_({
+          runner: "safehouse",
+          definition: {
+            cmd: "claude",
+            color: "#fff",
+            preLaunch: "true",
+          },
+        }),
+      );
+
+      expect(out).not.toContain("is empty after preLaunch");
+    });
+
     it("runs preLaunch without double-wrapping when cmd already starts with safehouse", () => {
       const out = buildLaunchCommand(
         arguments_({

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -959,6 +959,77 @@ describe(buildLaunchCommand, () => {
       expect(out).not.toContain("is empty after preLaunch");
     });
 
+    it("warns on stderr when a preLaunchEnv value is empty after preLaunch (runner=none, end-to-end)", () => {
+      const promptDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-"));
+      const promptFile = path.join(promptDir, "prompt.txt");
+      const worktreeDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-wt-"));
+      try {
+        writeFileSync(promptFile, "the prompt body\n");
+
+        const out = buildLaunchCommand(
+          arguments_({
+            runner: "none",
+            promptFile,
+            worktreeDir,
+            definition: {
+              // `echo` succeeds and exits 0, so we can run the whole chain past
+              // the empty-check without needing a wrapper — no `exit N` masking.
+              cmd: "echo TEST_MARKER_STDOUT",
+              color: "#fff",
+              // Motivating bug: `cat` on missing file inside `export` masks
+              // the substitution's non-zero status → JIRA_API_TOKEN is
+              // exported empty; `set -e` / exit-code checks miss it.
+              preLaunch: 'export JIRA_API_TOKEN="$(cat /this/path/does/not/exist 2>/dev/null)"',
+              preLaunchEnv: ["JIRA_API_TOKEN"],
+            },
+          }),
+        );
+
+        const actual = spawnSync("sh", ["-c", out], { env: { PATH: "/bin:/usr/bin" } });
+
+        expect(actual.status).toBe(0);
+        expect(actual.stdout.toString()).toContain("TEST_MARKER_STDOUT");
+        expect(actual.stderr.toString()).toContain(
+          "preLaunchEnv: JIRA_API_TOKEN is empty after preLaunch (value length 0)",
+        );
+      } finally {
+        rmSync(promptDir, { recursive: true, force: true });
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not warn when the preLaunchEnv value is non-empty after preLaunch (runner=none, end-to-end)", () => {
+      const promptDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-ok-"));
+      const promptFile = path.join(promptDir, "prompt.txt");
+      const worktreeDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-ok-wt-"));
+      try {
+        writeFileSync(promptFile, "the prompt body\n");
+
+        const out = buildLaunchCommand(
+          arguments_({
+            runner: "none",
+            promptFile,
+            worktreeDir,
+            definition: {
+              cmd: "echo TEST_MARKER_STDOUT",
+              color: "#fff",
+              preLaunch: 'export JIRA_API_TOKEN="real-value"',
+              preLaunchEnv: ["JIRA_API_TOKEN"],
+            },
+          }),
+        );
+
+        const actual = spawnSync("sh", ["-c", out], { env: { PATH: "/bin:/usr/bin" } });
+
+        expect(actual.status).toBe(0);
+        expect(actual.stdout.toString()).toContain("TEST_MARKER_STDOUT");
+        expect(actual.stderr.toString()).not.toContain("preLaunchEnv: JIRA_API_TOKEN is empty");
+      } finally {
+        rmSync(promptDir, { recursive: true, force: true });
+        rmSync(worktreeDir, { recursive: true, force: true });
+      }
+    });
+
     it("runs preLaunch without double-wrapping when cmd already starts with safehouse", () => {
       const out = buildLaunchCommand(
         arguments_({

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -998,38 +998,6 @@ describe(buildLaunchCommand, () => {
       }
     });
 
-    it("does not warn when the preLaunchEnv value is non-empty after preLaunch (runner=none, end-to-end)", () => {
-      const promptDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-ok-"));
-      const promptFile = path.join(promptDir, "prompt.txt");
-      const worktreeDir = mkdtempSync(path.join(tmpdir(), "groundcrew-empty-check-none-ok-wt-"));
-      try {
-        writeFileSync(promptFile, "the prompt body\n");
-
-        const out = buildLaunchCommand(
-          arguments_({
-            runner: "none",
-            promptFile,
-            worktreeDir,
-            definition: {
-              cmd: "echo TEST_MARKER_STDOUT",
-              color: "#fff",
-              preLaunch: 'export JIRA_API_TOKEN="real-value"',
-              preLaunchEnv: ["JIRA_API_TOKEN"],
-            },
-          }),
-        );
-
-        const actual = spawnSync("sh", ["-c", out], { env: { PATH: "/bin:/usr/bin" } });
-
-        expect(actual.status).toBe(0);
-        expect(actual.stdout.toString()).toContain("TEST_MARKER_STDOUT");
-        expect(actual.stderr.toString()).not.toContain("preLaunchEnv: JIRA_API_TOKEN is empty");
-      } finally {
-        rmSync(promptDir, { recursive: true, force: true });
-        rmSync(worktreeDir, { recursive: true, force: true });
-      }
-    });
-
     it("runs preLaunch without double-wrapping when cmd already starts with safehouse", () => {
       const out = buildLaunchCommand(
         arguments_({

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -162,9 +162,6 @@ function preLaunchPromptAndExec(arguments_: {
   if (arguments_.definition.preLaunch !== undefined) {
     lines.push(
       renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir),
-      // Warn (stderr, non-fatal) when a preLaunchEnv name resolves to empty
-      // after the hook. Mirrors hostPreLaunchSourceAndReadPrompt (safehouse
-      // chain); the unwrapped-host chain runs preLaunch here.
       ...buildPreLaunchEmptyCheckLines(arguments_.definition.preLaunchEnv ?? []),
     );
   }
@@ -216,13 +213,11 @@ function hostPreLaunchSourceAndReadPrompt(arguments_: {
 }): string[] {
   const lines: string[] = [];
   if (arguments_.definition.preLaunch !== undefined) {
+    const preLaunchEnv = arguments_.definition.preLaunchEnv ?? [];
     lines.push(
-      unsetEnvironmentLine([...BUILD_SECRET_NAMES, ...(arguments_.definition.preLaunchEnv ?? [])]),
+      unsetEnvironmentLine([...BUILD_SECRET_NAMES, ...preLaunchEnv]),
       renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir),
-      // Warn (stderr, non-fatal) when a preLaunchEnv name resolves to empty after
-      // the hook — catches the `export VAR="$(cat missing)"` failure mode that
-      // masks its substitution's exit status. See preLaunchEmptyCheck.ts.
-      ...buildPreLaunchEmptyCheckLines(arguments_.definition.preLaunchEnv ?? []),
+      ...buildPreLaunchEmptyCheckLines(preLaunchEnv),
     );
   }
   lines.push(

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -214,6 +214,8 @@ function hostPreLaunchSourceAndReadPrompt(arguments_: {
   const lines: string[] = [];
   if (arguments_.definition.preLaunch !== undefined) {
     const preLaunchEnv = arguments_.definition.preLaunchEnv ?? [];
+    // Order is load-bearing: unset scrubs inherited values so the empty-check
+    // reads what preLaunch actually produced, not what the parent shell leaked.
     lines.push(
       unsetEnvironmentLine([...BUILD_SECRET_NAMES, ...preLaunchEnv]),
       renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir),

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -9,6 +9,7 @@ import {
   type NetworkEgressSetting,
 } from "./config.ts";
 import { clearanceAllowHostsFilesFromEnvironment } from "./clearanceAllowlist.ts";
+import { buildPreLaunchEmptyCheckLines } from "./preLaunchEmptyCheck.ts";
 import { shellSingleQuote } from "./shell.ts";
 
 export { shellSingleQuote } from "./shell.ts";
@@ -212,6 +213,10 @@ function hostPreLaunchSourceAndReadPrompt(arguments_: {
     lines.push(
       unsetEnvironmentLine([...BUILD_SECRET_NAMES, ...(arguments_.definition.preLaunchEnv ?? [])]),
       renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir),
+      // Warn (stderr, non-fatal) when a preLaunchEnv name resolves to empty after
+      // the hook — catches the `export VAR="$(cat missing)"` failure mode that
+      // masks its substitution's exit status. See preLaunchEmptyCheck.ts.
+      ...buildPreLaunchEmptyCheckLines(arguments_.definition.preLaunchEnv ?? []),
     );
   }
   lines.push(

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -160,7 +160,13 @@ function preLaunchPromptAndExec(arguments_: {
 }): string[] {
   const lines: string[] = [];
   if (arguments_.definition.preLaunch !== undefined) {
-    lines.push(renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir));
+    lines.push(
+      renderPreLaunch(arguments_.definition.preLaunch, arguments_.worktreeDir),
+      // Warn (stderr, non-fatal) when a preLaunchEnv name resolves to empty
+      // after the hook. Mirrors hostPreLaunchSourceAndReadPrompt (safehouse
+      // chain); the unwrapped-host chain runs preLaunch here.
+      ...buildPreLaunchEmptyCheckLines(arguments_.definition.preLaunchEnv ?? []),
+    );
   }
   lines.push(
     `_p=$(cat ${shellSingleQuote(arguments_.promptFile)})`,

--- a/src/lib/preLaunchEmptyCheck.test.ts
+++ b/src/lib/preLaunchEmptyCheck.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import { buildPreLaunchEmptyCheckLines } from "./preLaunchEmptyCheck.ts";
+
+/**
+ * Run a `sh -c` script and return the exit code plus captured stderr.
+ * Uses `/bin/sh` — the same shell the launchCommand tests use — so the
+ * emitted snippet is proven to work under whatever `sh` the host provides
+ * (bash-in-POSIX-mode on macOS, dash on many Linux CIs).
+ *
+ * A hermetic env (`{}`) is intentional: inheriting `process.env` would let
+ * ambient state leak into assertions about "the var is unset".
+ */
+function runShell(script: string): { status: number; stderr: string } {
+  const result = spawnSync("sh", ["-c", script], { env: {} });
+  return { status: result.status ?? -1, stderr: result.stderr.toString() };
+}
+
+describe(buildPreLaunchEmptyCheckLines, () => {
+  it("returns [] for an empty name list", () => {
+    const actual = buildPreLaunchEmptyCheckLines([]);
+
+    expect(actual).toEqual([]);
+  });
+
+  it("deduplicates repeated names", () => {
+    const actual = buildPreLaunchEmptyCheckLines(["X", "X", "Y"]);
+
+    expect(actual).toHaveLength(2);
+  });
+
+  it("emits no diagnostic when the named var is set to a non-empty value", () => {
+    const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
+
+    const { status, stderr } = runShell(`TOKEN=abc; ${line}`);
+
+    expect(status).toBe(0);
+    expect(stderr).toBe("");
+  });
+
+  it("emits a stderr diagnostic when the named var is set to an empty string", () => {
+    const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
+
+    const { status, stderr } = runShell(`TOKEN=""; ${line}`);
+
+    expect(status).toBe(0);
+    expect(stderr).toContain("preLaunchEnv: TOKEN is empty after preLaunch (value length 0)");
+  });
+
+  it("emits a stderr diagnostic when the named var is unset", () => {
+    const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
+
+    const { status, stderr } = runShell(`${line}`);
+
+    expect(status).toBe(0);
+    expect(stderr).toContain("preLaunchEnv: TOKEN is empty after preLaunch (value length 0)");
+  });
+
+  it("emits one diagnostic per empty name and nothing for names that are set", () => {
+    const lines = buildPreLaunchEmptyCheckLines(["A", "B", "C"]);
+
+    const script = `B=ok; ${lines.join(" && ")}`;
+    const { status, stderr } = runShell(script);
+
+    expect(status).toBe(0);
+    expect(stderr).toContain("preLaunchEnv: A is empty after preLaunch (value length 0)");
+    expect(stderr).not.toContain("preLaunchEnv: B is empty");
+    expect(stderr).toContain("preLaunchEnv: C is empty after preLaunch (value length 0)");
+  });
+
+  it("participates in an `&&` chain so a failing preLaunch still short-circuits (grouped compound)", () => {
+    // The check must be a `{ …; }` group. A bare `if … fi` link would break
+    // `&&` short-circuit — `;` does not short-circuit `&&`, so the if would
+    // run regardless of the preceding link's exit status. If the check were
+    // not grouped, `echo REACHED` below would print because the check exits 0.
+    const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
+
+    const { status, stderr } = runShell(`false && ${line} && echo REACHED`);
+
+    expect(status).not.toBe(0);
+    expect(stderr).not.toContain("preLaunchEnv: TOKEN is empty");
+  });
+});

--- a/src/lib/preLaunchEmptyCheck.test.ts
+++ b/src/lib/preLaunchEmptyCheck.test.ts
@@ -31,15 +31,6 @@ describe(buildPreLaunchEmptyCheckLines, () => {
     expect(actual).toHaveLength(2);
   });
 
-  it("emits no diagnostic when the named var is set to a non-empty value", () => {
-    const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
-
-    const { status, stderr } = runShell(`TOKEN=abc; ${line}`);
-
-    expect(status).toBe(0);
-    expect(stderr).toBe("");
-  });
-
   it("emits a stderr diagnostic when the named var is set to an empty string", () => {
     const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
 
@@ -70,11 +61,7 @@ describe(buildPreLaunchEmptyCheckLines, () => {
     expect(stderr).toContain("preLaunchEnv: C is empty after preLaunch (value length 0)");
   });
 
-  it("participates in an `&&` chain so a failing preLaunch still short-circuits (grouped compound)", () => {
-    // The check must be a `{ …; }` group. A bare `if … fi` link would break
-    // `&&` short-circuit — `;` does not short-circuit `&&`, so the if would
-    // run regardless of the preceding link's exit status. If the check were
-    // not grouped, `echo REACHED` below would print because the check exits 0.
+  it("participates in an `&&` chain so a failing preLaunch still short-circuits", () => {
     const [line] = buildPreLaunchEmptyCheckLines(["TOKEN"]);
 
     const { status, stderr } = runShell(`false && ${line} && echo REACHED`);

--- a/src/lib/preLaunchEmptyCheck.ts
+++ b/src/lib/preLaunchEmptyCheck.ts
@@ -1,20 +1,12 @@
 /**
  * Emit POSIX-shell lines that warn (to stderr) when a `preLaunchEnv` name
  * resolves to an empty string after `preLaunch` runs. Length-0 is the
- * reliable tell for the `export VAR="$(cat missing-file)"` failure mode
- * (bash's `export` builtin masks the substitution's non-zero exit status,
- * so `set -e` and exit-code checks do not catch it).
+ * reliable tell for the `export VAR="$(cat missing-file)"` failure mode:
+ * `export` masks the substitution's non-zero exit status, so `set -e` and
+ * exit-code checks do not catch it.
  *
  * Returns `[]` for an empty input list so callers can splat unconditionally
  * into their `&&` chain.
- *
- * The generated snippet warns and continues — it never aborts. An opt-in
- * abort mode is a follow-up, not part of this contract.
- *
- * Each emitted line is a `{ …; }` compound so it participates properly in
- * the outer `&&` chain: a preceding `preLaunch` failure still short-circuits
- * the chain instead of falling through to the check (a bare `if … fi` link
- * would not — `;` does not short-circuit `&&`).
  *
  * Names must be POSIX identifiers (`[A-Za-z_][A-Za-z0-9_]*`); groundcrew's
  * `validatePreLaunchEnv` in `src/lib/config.ts` enforces that, so no shell
@@ -26,6 +18,6 @@ export function buildPreLaunchEmptyCheckLines(names: readonly string[]): string[
   }
   return [...new Set(names)].map(
     (name) =>
-      `{ if [ -z "\${${name}-}" ]; then echo "preLaunchEnv: ${name} is empty after preLaunch (value length 0)" >&2; fi; }`,
+      `if [ -z "\${${name}-}" ]; then echo "preLaunchEnv: ${name} is empty after preLaunch (value length 0)" >&2; fi`,
   );
 }

--- a/src/lib/preLaunchEmptyCheck.ts
+++ b/src/lib/preLaunchEmptyCheck.ts
@@ -1,12 +1,25 @@
 /**
- * Emit POSIX-shell lines that warn (to stderr) when a `preLaunchEnv` name
- * resolves to an empty string after `preLaunch` runs. Length-0 is the
- * reliable tell for the `export VAR="$(cat missing-file)"` failure mode:
- * `export` masks the substitution's non-zero exit status, so `set -e` and
- * exit-code checks do not catch it.
+ * Emit POSIX-shell lines that WARN (to stderr, never abort) when a
+ * `preLaunchEnv` name resolves to an empty string after `preLaunch` runs.
+ * Length-0 is the reliable tell for the `export VAR="$(cat missing-file)"`
+ * failure mode: `export` masks the substitution's non-zero exit status, so
+ * `set -e` and exit-code checks do not catch it.
+ *
+ * Warn-only is deliberate — a hard-abort mode is a separate opt-in, so the
+ * chain (prompt read, prompt-dir cleanup, exec) must not be short-circuited
+ * by an empty value here.
  *
  * Returns `[]` for an empty input list so callers can splat unconditionally
  * into their `&&` chain.
+ *
+ * Caveat: the check reads the shell's post-preLaunch view of the var. On the
+ * safehouse chain (`hostPreLaunchSourceAndReadPrompt`) the caller unsets each
+ * `preLaunchEnv` name before running `preLaunch`, so the check truly reflects
+ * what `preLaunch` produced. On the unwrapped-host chain
+ * (`preLaunchPromptAndExec`) no unset happens first, so a value inherited
+ * from the parent shell can survive `preLaunch` and mask a failed `export`.
+ * That asymmetry is a property of the runners; closing it requires an env
+ * scrub on the runner=none path, tracked as a follow-up.
  *
  * Names must be POSIX identifiers (`[A-Za-z_][A-Za-z0-9_]*`); groundcrew's
  * `validatePreLaunchEnv` in `src/lib/config.ts` enforces that, so no shell

--- a/src/lib/preLaunchEmptyCheck.ts
+++ b/src/lib/preLaunchEmptyCheck.ts
@@ -1,0 +1,31 @@
+/**
+ * Emit POSIX-shell lines that warn (to stderr) when a `preLaunchEnv` name
+ * resolves to an empty string after `preLaunch` runs. Length-0 is the
+ * reliable tell for the `export VAR="$(cat missing-file)"` failure mode
+ * (bash's `export` builtin masks the substitution's non-zero exit status,
+ * so `set -e` and exit-code checks do not catch it).
+ *
+ * Returns `[]` for an empty input list so callers can splat unconditionally
+ * into their `&&` chain.
+ *
+ * The generated snippet warns and continues — it never aborts. An opt-in
+ * abort mode is a follow-up, not part of this contract.
+ *
+ * Each emitted line is a `{ …; }` compound so it participates properly in
+ * the outer `&&` chain: a preceding `preLaunch` failure still short-circuits
+ * the chain instead of falling through to the check (a bare `if … fi` link
+ * would not — `;` does not short-circuit `&&`).
+ *
+ * Names must be POSIX identifiers (`[A-Za-z_][A-Za-z0-9_]*`); groundcrew's
+ * `validatePreLaunchEnv` in `src/lib/config.ts` enforces that, so no shell
+ * escaping is done here.
+ */
+export function buildPreLaunchEmptyCheckLines(names: readonly string[]): string[] {
+  if (names.length === 0) {
+    return [];
+  }
+  return [...new Set(names)].map(
+    (name) =>
+      `{ if [ -z "\${${name}-}" ]; then echo "preLaunchEnv: ${name} is empty after preLaunch (value length 0)" >&2; fi; }`,
+  );
+}


### PR DESCRIPTION
## What this is

groundcrew now injects a POSIX-shell empty-value guard between `preLaunch` and the launch chain, catching the silent failure where `export VAR="$(cmd)"` masks the substitution's non-zero exit status. Before this, a broken `preLaunch` (missing token file, failed `curl`, unset upstream env) left `VAR` empty, the launch proceeded, and the agent surfaced a downstream 401 with no trail back to preLaunch.

## Requirements

- Fire on the true failure mode — `export VAR="$(cmd)"` returning 0 with `VAR` empty. `set -e` and exit-code checks are already known to miss this.
- Non-aborting — preserve the existing launch-chain contract (prompt read, prompt-dir cleanup, exec must still run).
- POSIX-portable — the emitted shell must run under `/bin/sh` on macOS and `dash` on Linux CI.
- Named diagnostic — an operator reading launch stderr must see the offending variable's name.
- No new configuration surface.

Non-goals: aborting on non-zero `preLaunch` exit (dropped — doesn't catch the motivating bug); scrubbing inherited env on the runner=none path (would silently change runner=none semantics).

## The architecture

The launch chain now carries a per-forwarded-name empty-value probe right after `preLaunch` runs, so a broken export shows up as a stderr line before the launch chain proceeds. A new `preLaunchEmptyCheck` module owns the shell-snippet builder; `launchCommand.ts` splices it into both preLaunch composition sites; `doctor.ts` reflects the runtime gate back to the operator at config time.

Before:

```
unset preLaunchEnv vars → preLaunch → read prompt → exec agent
```

After:

```
unset preLaunchEnv vars → preLaunch → empty-check per name → read prompt → exec agent
```

Each name emits `if [ -z "${NAME-}" ]; then echo "preLaunchEnv: NAME is empty after preLaunch (value length 0)" >&2; fi`. `if…fi` returns 0, so the `&&` chain never short-circuits.

Load-bearing decisions:

- **Warn, don't abort.** Shipping an abort mode next to the warn suggests the operator is protected by two independent layers — they aren't, because the abort layer (non-zero exit) is exactly the case export-masking defeats. Warn-only is the honest scope.
- **Gate the runtime check on `preLaunch !== undefined`.** Listing `preLaunchEnv` names without a `preLaunch` is legal (per `validatePreLaunchEnv`) and means "forward what the parent shell already exported" — nothing this PR can guard. The doctor advisory calls that out explicitly rather than lying.
- **Emit at two splice sites, tolerate asymmetry.** The safehouse chain unsets forwarded names before running `preLaunch`, so the check reads what `preLaunch` produced. The runner=none chain does not unset — a parent-shell value can survive a broken export and hide the failure. Adding a scrub there would silently change runner=none semantics; the caveat is documented at the module and splice sites instead.

What deliberately did not change: launch-chain composition order (the guard slots between existing steps, doesn't replace any), sdx-runner rejection of `preLaunch` (still thrown upstream), `validatePreLaunchEnv` semantics. Safety here rides on the existing `launchCommand.test.ts` and `config.test.ts` suites staying green.

## Interface changes

`crew doctor` gains one `[ok]` advisory per agent with a non-empty `preLaunchEnv`:

After:

```
[ok] preLaunchEnv: claude — forwards 2 var(s): JIRA_API_TOKEN, GITHUB_TOKEN. empty values are warned at launch.
```

When `preLaunch` is unset, the second half switches to `no preLaunch is set, so empty values are NOT checked at launch`, so the copy tracks the runtime gate.

Launch stderr gains one line per empty forwarded var:

```
preLaunchEnv: JIRA_API_TOKEN is empty after preLaunch (value length 0)
```

## Testing

`preLaunchEmptyCheck.test.ts` roundtrips the emitted snippet through a hermetic `/bin/sh` to prove POSIX portability and correct empty/non-empty behavior. `launchCommand.test.ts` adds one composition test per splice site plus an end-to-end runner=none test that exercises the motivating `export VAR="$(cat missing)"` case through a real subshell and asserts the named diagnostic reaches stderr. `doctor.test.ts` covers both advisory copy branches. `node --run verify` passes.

## Follow-ups

Opt-in abort mode behind a config flag, scrubbing inherited env on runner=none to close the asymmetry, and threading the resolved runner into `doctor` so the advisory can suppress itself under sdx are all deferred.