### PR TITLE
fix: allow OpenAI docs MCP egress (TG-4201)

### DIFF
--- a/clearance-allow-hosts
+++ b/clearance-allow-hosts
@@ -29,6 +29,7 @@ api.notion.com
 api.slack.com
 app.incident.io
 developers.notion.com
+developers.openai.com
 linear.app
 mcp-proxy.anthropic.com
 mcp.datadoghq.com

--- a/src/lib/clearanceAllowlist.test.ts
+++ b/src/lib/clearanceAllowlist.test.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 
+import { resolveAllowlist } from "@clipboard-health/clearance";
+
 import {
   clearanceAllowHostsFilesFromEnvironment,
   clearanceAllowHostsFilesValue,
@@ -61,5 +63,17 @@ describe(clearanceAllowHostsFilesFromEnvironment, () => {
     const actual = clearanceAllowHostsFilesFromEnvironment();
 
     expect(actual).toBe(`${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`);
+  });
+
+  it("allows OpenAI's hosted developer documentation MCP server", () => {
+    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");
+
+    const actual = resolveAllowlist({
+      env: {
+        CLEARANCE_ALLOW_HOSTS_FILES: clearanceAllowHostsFilesFromEnvironment(),
+      },
+    });
+
+    expect(actual.filter((host) => host === "developers.openai.com")).toHaveLength(1);
   });
 });

--- a/src/lib/clearanceAllowlist.test.ts
+++ b/src/lib/clearanceAllowlist.test.ts
@@ -1,7 +1,5 @@
 import path from "node:path";
 
-import { resolveAllowlist } from "@clipboard-health/clearance";
-
 import {
   clearanceAllowHostsFilesFromEnvironment,
   clearanceAllowHostsFilesValue,
@@ -63,17 +61,5 @@ describe(clearanceAllowHostsFilesFromEnvironment, () => {
     const actual = clearanceAllowHostsFilesFromEnvironment();
 
     expect(actual).toBe(`${bundledClearanceAllowHostsFile()}${path.delimiter}/tmp/personal-hosts`);
-  });
-
-  it("allows OpenAI's hosted developer documentation MCP server", () => {
-    vi.stubEnv("CLEARANCE_ALLOW_HOSTS_FILES", "");
-
-    const actual = resolveAllowlist({
-      env: {
-        CLEARANCE_ALLOW_HOSTS_FILES: clearanceAllowHostsFilesFromEnvironment(),
-      },
-    });
-
-    expect(actual.filter((host) => host === "developers.openai.com")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Codex tries to initialize the `openaiDeveloperDocs` MCP, but Clearance blocks `developers.openai.com`. This adds that exact host so Groundcrew sessions can use current OpenAI docs, which can improve Codex's accuracy on OpenAI-related work.

No wildcard or unrelated egress is added.

## Evidence

```text
⚠ MCP client for `openaiDeveloperDocs` failed to start
error sending request for url (https://developers.openai.com/mcp)
DENY method=CONNECT host=developers.openai.com port=443 reason=host not allowed
```

## Validation

- `node --run verify` (2,041 tests passed, 100% coverage)
- After installing, restart Clearance and confirm `openaiDeveloperDocs` initializes without the `DENY` above. This host-side check is pending.

Closes [TG-4201](https://linear.app/clipboard-health/issue/TG-4201)

Agent session: `codex resume 019f8b3d-e7cf-7003-9395-ebfb51a3ae36`

<sub>🤖 <code>cb-ship:created v1 core@3.22.4</code></sub>
