### PR TITLE
feat: link cmux tasks to source issues (TG-4209)

### DIFF
--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -126,7 +126,11 @@ const createMock = vi.mocked(worktrees.create);
 
 type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
 type FetchResolvedIssueInput = Parameters<typeof fetchResolvedIssue>[0];
-type IssueLookup = (id: string) => Promise<{ title: string; description?: string | undefined }>;
+type IssueLookup = (id: string) => Promise<{
+  title: string;
+  description?: string | undefined;
+  url?: string | undefined;
+}>;
 
 function lastRecordedRunState(): RecordedRunState {
   const input = recordRunStateMock.mock.calls.at(-1)?.[0];
@@ -288,6 +292,42 @@ describe(resumeWorkspace, () => {
       agentCommandName: "claude",
       launchDir: "/work/repo-a-team-1",
     });
+  });
+
+  it("reuses the exact task URL cached in run state", async () => {
+    readRunStateMock.mockReturnValue(
+      makeRunState({ url: "https://linear.app/example/issue/TEAM-1/source-slug" }),
+    );
+
+    await resumeWorkspace(config, { task: "team-1" });
+
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        name: "team-1",
+        url: "https://linear.app/example/issue/TEAM-1/source-slug",
+      }),
+    );
+  });
+
+  it("uses the source URL fetched for legacy run state without one", async () => {
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockResolvedValue({
+        title: "Title",
+        description: "Body",
+        url: "https://linear.app/example/issue/TEAM-1/fetched-slug",
+      }),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(config, { task: "team-1" });
+
+    expect(workspacesOpenMock).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        name: "team-1",
+        url: "https://linear.app/example/issue/TEAM-1/fetched-slug",
+      }),
+    );
   });
 
   function resumeArgsConfig(): ResolvedConfig {
@@ -529,7 +569,10 @@ describe(resumeWorkspace, () => {
     expect(fetchInput.client).toBeDefined();
     expect(workspacesOpenMock).toHaveBeenCalledWith(
       config,
-      expect.objectContaining({ name: "team-1" }),
+      expect.objectContaining({
+        name: "team-1",
+        url: "https://linear.app/example/issue/TEAM-1",
+      }),
     );
   });
 

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -330,6 +330,36 @@ describe(resumeWorkspace, () => {
     );
   });
 
+  it("does not attach a colliding Linear URL to a URL-less task from another source", async () => {
+    const multiSourceConfig: ResolvedConfig = {
+      ...config,
+      sources: [
+        { kind: "linear" },
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "todo.txt",
+          tasksDir: ".tasks",
+          idPrefix: "TEAM",
+          timezone: "UTC",
+        },
+      ],
+    };
+    readRunStateMock.mockReturnValue(makeRunState({ completionTaskId: "todo:team-1" }));
+    getLinearClientMock.mockReturnValue({
+      issue: vi.fn<IssueLookup>().mockResolvedValue({
+        title: "Unrelated Linear task",
+        description: "Body",
+        url: "https://linear.app/example/issue/TEAM-1/unrelated",
+      }),
+    } as unknown as ReturnType<typeof getLinearClient>);
+
+    await resumeWorkspace(multiSourceConfig, { task: "team-1" });
+
+    expect(workspacesOpenMock.mock.calls[0]?.[1]).not.toHaveProperty("url");
+    expect(lastRecordedRunState()).not.toHaveProperty("url");
+  });
+
   function resumeArgsConfig(): ResolvedConfig {
     return {
       ...config,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -36,6 +36,7 @@ export interface ResumeWorkspaceOptions {
 interface TaskDetails {
   title: string;
   description: string;
+  url?: string;
 }
 
 interface ResumeContext {
@@ -45,6 +46,7 @@ interface ResumeContext {
   worktree: WorktreeEntry;
   title: string;
   description: string;
+  url?: string;
   completionTaskId: string;
   completionMarkDoneSupported: boolean;
   reason?: string;
@@ -74,6 +76,7 @@ async function fetchTaskDetails(task: string): Promise<TaskDetails | undefined> 
     return {
       title: issue.title,
       description: issue.description ?? "",
+      url: issue.url,
     };
   } catch (error) {
     log(`Resume Linear detail lookup failed for ${task}: ${errorMessage(error)}`);
@@ -95,6 +98,7 @@ async function contextFromLinear(
     worktree,
     title: resolved.title,
     description: resolved.description,
+    url: resolved.url,
     completionTaskId,
     completionMarkDoneSupported: taskSupportsCompletionCommand({
       rawSources: sourcesFromConfig(config),
@@ -115,6 +119,7 @@ async function contextFromState(
   // enrich the prompt title/description (which falls back to the task id).
   const details = isLinearEnabled(config) ? await fetchTaskDetails(task) : undefined;
   const completionTaskId = state.completionTaskId ?? task;
+  const url = state.url ?? details?.url;
   return {
     task,
     repository: state.repository,
@@ -125,6 +130,7 @@ async function contextFromState(
     worktree: { ...worktree, branchName: state.branchName },
     title: details?.title ?? state.title ?? task.toUpperCase(),
     description: details?.description ?? "",
+    ...(url === undefined ? {} : { url }),
     completionTaskId,
     completionMarkDoneSupported: taskSupportsCompletionCommand({
       rawSources: sourcesFromConfig(config),
@@ -274,6 +280,7 @@ export async function resumeWorkspace(
       config,
       name: task,
       displayName: context.title,
+      ...(context.url === undefined ? {} : { url: context.url }),
       cwd: launchDir,
       command: launchCmd,
       agent: context.agent,
@@ -296,6 +303,7 @@ export async function resumeWorkspace(
       state: "resumed",
       resumeCount: context.resumeCount + 1,
       completionTaskId: context.completionTaskId,
+      ...(context.url === undefined ? {} : { url: context.url }),
       ...(context.reason === undefined ? {} : { reason: context.reason }),
     },
   });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/launchCommand.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
-import { taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
+import { summarizeSource, taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
 import {
   removeStagedPrompt,
   stageBuildSecrets,
@@ -119,7 +119,9 @@ async function contextFromState(
   // enrich the prompt title/description (which falls back to the task id).
   const details = isLinearEnabled(config) ? await fetchTaskDetails(task) : undefined;
   const completionTaskId = state.completionTaskId ?? task;
-  const url = state.url ?? details?.url;
+  const url =
+    state.url ??
+    (taskUsesLinearSource({ config, taskId: completionTaskId }) ? details?.url : undefined);
   return {
     task,
     repository: state.repository,
@@ -139,6 +141,25 @@ async function contextFromState(
     ...(state.reason === undefined ? {} : { reason: state.reason }),
     resumeCount: state.resumeCount,
   };
+}
+
+function taskUsesLinearSource(arguments_: { config: ResolvedConfig; taskId: string }): boolean {
+  const { config, taskId } = arguments_;
+  const rawSources = sourcesFromConfig(config);
+  const colonIndex = taskId.indexOf(":");
+  if (colonIndex === -1) {
+    const [singleSource] = rawSources;
+    return (
+      rawSources.length === 1 &&
+      singleSource !== undefined &&
+      summarizeSource(singleSource).kind === "linear"
+    );
+  }
+  const sourceName = taskId.slice(0, colonIndex);
+  return rawSources.some((rawSource) => {
+    const source = summarizeSource(rawSource);
+    return source.name === sourceName && source.kind === "linear";
+  });
 }
 
 async function buildResumeContext(config: ResolvedConfig, task: string): Promise<ResumeContext> {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -473,7 +473,7 @@ describe(setupWorkspace, () => {
       expect.arrayContaining([
         "set-status",
         "task",
-        "team-1",
+        "Linear ↗",
         "--url",
         "https://linear.app/example/issue/TEAM-1",
         "--workspace",

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -468,6 +468,18 @@ describe(setupWorkspace, () => {
       state: "running",
       url: "https://linear.app/example/issue/TEAM-1",
     });
+    expect(runCommandMock).toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining([
+        "set-status",
+        "task",
+        "team-1",
+        "--url",
+        "https://linear.app/example/issue/TEAM-1",
+        "--workspace",
+        "workspace:42",
+      ]),
+    );
   });
 
   it("grants matching todo-txt source paths to the worker completion sandbox", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -473,9 +473,7 @@ describe(setupWorkspace, () => {
       expect.arrayContaining([
         "set-status",
         "task",
-        "Linear ↗",
-        "--url",
-        "https://linear.app/example/issue/TEAM-1",
+        "[Linear ↗](https://linear.app/example/issue/TEAM-1)",
         "--workspace",
         "workspace:42",
       ]),

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -474,6 +474,8 @@ describe(setupWorkspace, () => {
         "set-status",
         "task",
         "[Linear ↗](https://linear.app/example/issue/TEAM-1)",
+        "--format",
+        "markdown",
         "--workspace",
         "workspace:42",
       ]),

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -196,6 +196,7 @@ export async function setupWorkspace(
       config,
       name: task,
       displayName: taskDetails.title,
+      url: taskDetails.url,
       cwd: launchDir,
       command: launchCmd,
       agent,

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -328,6 +328,7 @@ export async function openAgentWorkspace(input: {
   config: ResolvedConfig;
   name: string;
   displayName?: string;
+  url?: string | undefined;
   cwd: string;
   command: string;
   agent: string;
@@ -339,6 +340,7 @@ export async function openAgentWorkspace(input: {
   const spec = {
     name: input.name,
     ...(panelTitle === undefined ? {} : { displayName: panelTitle }),
+    ...(input.url === undefined ? {} : { url: input.url }),
     cwd: input.cwd,
     command: input.command,
     status: { text: input.agent, color: input.color, icon: "sparkle" },

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -48,7 +48,7 @@ export const cmuxAdapter: Adapter = {
       await applyCmuxStatusBestEffort({
         workspaceId,
         key: "task",
-        status: { text: spec.name },
+        status: { text: cmuxTaskLinkText(spec.url) },
         url: spec.url,
         workspaceName: spec.name,
         signal,
@@ -246,6 +246,14 @@ async function applyCmuxStatus(input: Omit<CmuxStatusInput, "workspaceName">): P
   }
   arguments_.push("--workspace", input.workspaceId);
   await runWorkspaceCommand("cmux", arguments_, input.signal);
+}
+
+function cmuxTaskLinkText(url: string): string {
+  try {
+    return new URL(url).hostname === "linear.app" ? "Linear ↗" : "Issue ↗";
+  } catch {
+    return "Issue ↗";
+  }
 }
 
 /**

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -44,17 +44,24 @@ export const cmuxAdapter: Adapter = {
       );
       throw new Error(`Unexpected cmux output: ${output}`);
     }
+    if (spec.url !== undefined) {
+      await applyCmuxStatusBestEffort({
+        workspaceId,
+        key: "task",
+        status: { text: spec.name },
+        url: spec.url,
+        workspaceName: spec.name,
+        signal,
+      });
+    }
     if (spec.status !== undefined) {
-      try {
-        await applyCmuxStatus(workspaceId, spec.status, signal);
-      } catch (error) {
-        // Status pills are best-effort. cmux v2+ dropped `set-status` entirely,
-        // so swallow that specific gap silently; surface anything else so a real
-        // regression doesn't hide behind the same swallow.
-        if (!isCmuxSetStatusUnsupported(error)) {
-          debug(`cmux set-status failed for ${spec.name} (continuing): ${errorMessage(error)}`);
-        }
-      }
+      await applyCmuxStatusBestEffort({
+        workspaceId,
+        key: "agent",
+        status: spec.status,
+        workspaceName: spec.name,
+        signal,
+      });
     }
   },
   async list(signal) {
@@ -201,20 +208,44 @@ function extractCmuxOpenId(output: string): string | undefined {
   return match ? match[0] : undefined;
 }
 
-async function applyCmuxStatus(
-  workspaceId: string,
-  status: WorkspaceStatus,
-  signal?: AbortSignal,
-): Promise<void> {
-  const arguments_ = ["set-status", "agent", status.text];
+interface CmuxStatusInput {
+  workspaceId: string;
+  key: "agent" | "task";
+  status: WorkspaceStatus;
+  url?: string;
+  workspaceName: string;
+  signal?: AbortSignal | undefined;
+}
+
+async function applyCmuxStatusBestEffort(input: CmuxStatusInput): Promise<void> {
+  try {
+    await applyCmuxStatus(input);
+  } catch (error) {
+    // Sidebar metadata is best-effort. cmux v2+ dropped `set-status` entirely,
+    // so swallow that specific gap silently; surface anything else so a real
+    // regression doesn't hide behind the same swallow.
+    if (!isCmuxSetStatusUnsupported(error)) {
+      debug(
+        `cmux set-status failed for ${input.workspaceName} (continuing): ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+async function applyCmuxStatus(input: Omit<CmuxStatusInput, "workspaceName">): Promise<void> {
+  const arguments_ = ["set-status", input.key, input.status.text];
+  const { status } = input;
   if (status.icon !== undefined) {
     arguments_.push("--icon", status.icon);
   }
   if (status.color !== undefined) {
     arguments_.push("--color", status.color);
   }
-  arguments_.push("--workspace", workspaceId);
-  await runWorkspaceCommand("cmux", arguments_, signal);
+  if (input.url !== undefined) {
+    arguments_.push("--url", input.url);
+  }
+  arguments_.push("--workspace", input.workspaceId);
+  await runWorkspaceCommand("cmux", arguments_, input.signal);
 }
 
 /**

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -255,7 +255,12 @@ function cmuxTaskLinkText(url: string): string {
   } catch {
     label = "Issue ↗";
   }
-  return `[${label}](${url})`;
+  const markdownUrl = url
+    .replaceAll("\\", "\\\\")
+    .replaceAll(")", "\\)")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  return `[${label}](${markdownUrl})`;
 }
 
 /**

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -49,6 +49,7 @@ export const cmuxAdapter: Adapter = {
         workspaceId,
         key: "task",
         status: { text: cmuxTaskLinkText(spec.url) },
+        format: "markdown",
         workspaceName: spec.name,
         signal,
       });
@@ -211,6 +212,7 @@ interface CmuxStatusInput {
   workspaceId: string;
   key: "agent" | "task";
   status: WorkspaceStatus;
+  format?: "plain" | "markdown";
   workspaceName: string;
   signal?: AbortSignal | undefined;
 }
@@ -238,6 +240,9 @@ async function applyCmuxStatus(input: Omit<CmuxStatusInput, "workspaceName">): P
   }
   if (status.color !== undefined) {
     arguments_.push("--color", status.color);
+  }
+  if (input.format !== undefined) {
+    arguments_.push("--format", input.format);
   }
   arguments_.push("--workspace", input.workspaceId);
   await runWorkspaceCommand("cmux", arguments_, input.signal);

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -49,7 +49,6 @@ export const cmuxAdapter: Adapter = {
         workspaceId,
         key: "task",
         status: { text: cmuxTaskLinkText(spec.url) },
-        url: spec.url,
         workspaceName: spec.name,
         signal,
       });
@@ -212,7 +211,6 @@ interface CmuxStatusInput {
   workspaceId: string;
   key: "agent" | "task";
   status: WorkspaceStatus;
-  url?: string;
   workspaceName: string;
   signal?: AbortSignal | undefined;
 }
@@ -241,19 +239,18 @@ async function applyCmuxStatus(input: Omit<CmuxStatusInput, "workspaceName">): P
   if (status.color !== undefined) {
     arguments_.push("--color", status.color);
   }
-  if (input.url !== undefined) {
-    arguments_.push("--url", input.url);
-  }
   arguments_.push("--workspace", input.workspaceId);
   await runWorkspaceCommand("cmux", arguments_, input.signal);
 }
 
 function cmuxTaskLinkText(url: string): string {
+  let label: string;
   try {
-    return new URL(url).hostname === "linear.app" ? "Linear ↗" : "Issue ↗";
+    label = new URL(url).hostname === "linear.app" ? "Linear ↗" : "Issue ↗";
   } catch {
-    return "Issue ↗";
+    label = "Issue ↗";
   }
+  return `[${label}](${url})`;
 }
 
 /**

--- a/src/lib/workspaceAdapter.ts
+++ b/src/lib/workspaceAdapter.ts
@@ -34,6 +34,8 @@ export interface OpenSpec {
   name: string;
   /** Optional cmux panel title; other adapters may ignore it. Cmux keeps `name` as the identity marker. */
   displayName?: string;
+  /** Optional source-provided URL used by cmux to link the task metadata. */
+  url?: string;
   /** Working directory the workspace runs in. */
   cwd: string;
   /** Shell string the workspace executes (host setup + agent exec). */

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -200,6 +200,42 @@ describe("workspaces.open (cmux)", () => {
     ]);
   });
 
+  it("links the task metadata to the exact source URL when provided", async () => {
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await workspaces.open(makeConfig(), {
+      name: "TEAM-1",
+      url: "https://linear.app/example/issue/TEAM-1/source-slug",
+      cwd: "/work/repo-a-TEAM-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-status",
+      "task",
+      "TEAM-1",
+      "--url",
+      "https://linear.app/example/issue/TEAM-1/source-slug",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("does not add task metadata when the source URL is absent", async () => {
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await workspaces.open(makeConfig(), {
+      name: "TEAM-1",
+      cwd: "/work/repo-a-TEAM-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).not.toHaveBeenCalledWith(
+      "cmux",
+      expect.arrayContaining(["set-status", "task"]),
+    );
+  });
+
   it("calls cmux set-status with status text, color, icon when status is provided", async () => {
     runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
 

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -213,9 +213,51 @@ describe("workspaces.open (cmux)", () => {
     expect(runMock).toHaveBeenCalledWith("cmux", [
       "set-status",
       "task",
-      "TEAM-1",
+      "Linear ↗",
       "--url",
       "https://linear.app/example/issue/TEAM-1/source-slug",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("uses a source-neutral label for non-Linear task URLs", async () => {
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await workspaces.open(makeConfig(), {
+      name: "ENG-1",
+      url: "https://acme.atlassian.net/browse/ENG-1",
+      cwd: "/work/repo-a-ENG-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-status",
+      "task",
+      "Issue ↗",
+      "--url",
+      "https://acme.atlassian.net/browse/ENG-1",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
+  it("uses a source-neutral label when a source provides a non-standard URL", async () => {
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await workspaces.open(makeConfig(), {
+      name: "CUSTOM-1",
+      url: "open-custom-issue",
+      cwd: "/work/repo-a-CUSTOM-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-status",
+      "task",
+      "Issue ↗",
+      "--url",
+      "open-custom-issue",
       "--workspace",
       "workspace:42",
     ]);

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -213,9 +213,7 @@ describe("workspaces.open (cmux)", () => {
     expect(runMock).toHaveBeenCalledWith("cmux", [
       "set-status",
       "task",
-      "Linear ↗",
-      "--url",
-      "https://linear.app/example/issue/TEAM-1/source-slug",
+      "[Linear ↗](https://linear.app/example/issue/TEAM-1/source-slug)",
       "--workspace",
       "workspace:42",
     ]);
@@ -234,9 +232,7 @@ describe("workspaces.open (cmux)", () => {
     expect(runMock).toHaveBeenCalledWith("cmux", [
       "set-status",
       "task",
-      "Issue ↗",
-      "--url",
-      "https://acme.atlassian.net/browse/ENG-1",
+      "[Issue ↗](https://acme.atlassian.net/browse/ENG-1)",
       "--workspace",
       "workspace:42",
     ]);
@@ -255,9 +251,7 @@ describe("workspaces.open (cmux)", () => {
     expect(runMock).toHaveBeenCalledWith("cmux", [
       "set-status",
       "task",
-      "Issue ↗",
-      "--url",
-      "open-custom-issue",
+      "[Issue ↗](open-custom-issue)",
       "--workspace",
       "workspace:42",
     ]);

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -214,6 +214,8 @@ describe("workspaces.open (cmux)", () => {
       "set-status",
       "task",
       "[Linear ↗](https://linear.app/example/issue/TEAM-1/source-slug)",
+      "--format",
+      "markdown",
       "--workspace",
       "workspace:42",
     ]);
@@ -233,6 +235,8 @@ describe("workspaces.open (cmux)", () => {
       "set-status",
       "task",
       "[Issue ↗](https://acme.atlassian.net/browse/ENG-1)",
+      "--format",
+      "markdown",
       "--workspace",
       "workspace:42",
     ]);
@@ -252,6 +256,8 @@ describe("workspaces.open (cmux)", () => {
       "set-status",
       "task",
       "[Issue ↗](open-custom-issue)",
+      "--format",
+      "markdown",
       "--workspace",
       "workspace:42",
     ]);

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -221,6 +221,43 @@ describe("workspaces.open (cmux)", () => {
     ]);
   });
 
+  it.each([
+    {
+      character: "closing parenthesis",
+      url: "https://linear.app/example/issue/TEAM-1/source)-slug",
+      expected: "[Linear ↗](https://linear.app/example/issue/TEAM-1/source\\)-slug)",
+    },
+    {
+      character: "backslash",
+      url: "https://linear.app/example/issue/TEAM-1/source\\slug",
+      expected: "[Linear ↗](https://linear.app/example/issue/TEAM-1/source\\\\slug)",
+    },
+    {
+      character: "line break",
+      url: "https://linear.app/example/issue/TEAM-1/source\nslug",
+      expected: "[Linear ↗](https://linear.app/example/issue/TEAM-1/source%0Aslug)",
+    },
+  ])("escapes a $character in the task URL Markdown destination", async ({ url, expected }) => {
+    runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
+
+    await workspaces.open(makeConfig(), {
+      name: "TEAM-1",
+      url,
+      cwd: "/work/repo-a-TEAM-1",
+      command: "exec claude",
+    });
+
+    expect(runMock).toHaveBeenCalledWith("cmux", [
+      "set-status",
+      "task",
+      expected,
+      "--format",
+      "markdown",
+      "--workspace",
+      "workspace:42",
+    ]);
+  });
+
   it("uses a source-neutral label for non-Linear task URLs", async () => {
     runMock.mockReturnValue(JSON.stringify({ ref: "workspace:42" }));
 


### PR DESCRIPTION
## Summary

- Propagate each task source's exact URL through workspace launch metadata on dispatch and resume.
- Show a compact `Linear ↗` link in cmux sidebar cards, with only the visible label acting as the click target.
- Leave URL-less tasks, workspace identity, cleanup, and non-cmux adapters unchanged.

## Why

Groundcrew already receives and persists the task source's direct URL, but cmux cards did not expose it. This makes the issue reachable from the card without constructing a URL from the task identifier or changing how workspaces are identified and managed.

## Validation

- `node --run verify` — all 9 checks passed; 85 test files and 2,079 tests passed with 100% coverage.
- Automated tests cover cmux metadata commands for tasks with and without a source URL.
- Resume tests verify cached URLs, legacy Linear URL recovery, and that URL-less tasks from other sources cannot inherit a colliding Linear URL.
- Live A/B smoke test with `TG-4273`:
  - the before state had no issue link;
  - the after state rendered `Linear ↗` as a hyperlink;
  - activating the label opened the exact source-provided Linear issue URL;
  - clicking the blank area to the right of the label did not open the link.

### Before

<img width="340" height="112" alt="cmux sidebar card before: no Linear issue link" src="https://github.com/user-attachments/assets/5dbb8e38-b8d5-41ec-bb22-b224f36f7ab2" />

### After

<img width="336" height="128" alt="cmux sidebar card after: compact Linear issue link" src="https://github.com/user-attachments/assets/78b9f0d4-dd58-47de-9cd6-62cbc20f1e33" />

## Notes

- cmux does not expose link metadata on its workspace-title row, so the issue link is a dedicated sidebar status row. This design was confirmed in the live smoke test.
- The exact source-provided URL is forwarded; no Linear URL is synthesized from the task identifier.
- This change and the Safehouse hook fix in #334 are independent and may merge in either order.

Closes tg-4209

Agent session: `019f9081-657e-7cb3-9f26-f4ef1263e855`

<sub>🤖 <code>cb-ship:updated v1</code></sub>
