### PR TITLE
fix: keep cmux Codex hooks valid under Safehouse

### DIFF
--- a/src/lib/cmuxAgentHookInstall.test.ts
+++ b/src/lib/cmuxAgentHookInstall.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { installCmuxAgentHooks } from "./cmuxAgentHookInstall.ts";
 
 const runCommandMock = vi.hoisted(() =>
@@ -50,6 +54,39 @@ describe(installCmuxAgentHooks, () => {
       "cmux-agent-hooks-install",
       expect.objectContaining({ agent: "codex", outcome: "installed" }),
     );
+  });
+
+  it("gives installed hook commands a writable Foundation cache home", () => {
+    const configDir = mkdtempSync(path.join(os.tmpdir(), "cmux-hook-install-"));
+    const hooksPath = path.join(configDir, "hooks.json");
+    const originalCommand = '"$cmux_cli" hooks feed --source codex --event PreToolUse';
+    writeFileSync(
+      hooksPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command: originalCommand }] }],
+        },
+      }),
+    );
+
+    try {
+      installCmuxAgentHooks({ agent: "codex", configDir });
+
+      const installedHooks = readFileSync(hooksPath, "utf8");
+      expect(installedHooks).toContain(`export CFFIXED_USER_HOME='${configDir}'`);
+      expect(installedHooks).toContain("export CMUX_CLI_SENTRY_DISABLED=1");
+      expect(JSON.parse(installedHooks)).toMatchObject({
+        hooks: {
+          PreToolUse: [
+            {
+              hooks: [{ command: expect.stringContaining(originalCommand) }],
+            },
+          ],
+        },
+      });
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
   });
 
   it("swallows a failing install (non-zero exit / missing cmux CLI) and logs outcome=error", () => {

--- a/src/lib/cmuxAgentHookInstall.test.ts
+++ b/src/lib/cmuxAgentHookInstall.test.ts
@@ -56,15 +56,24 @@ describe(installCmuxAgentHooks, () => {
     );
   });
 
-  it("gives installed hook commands a writable Foundation cache home", () => {
+  it("gives cmux-owned hooks a writable Foundation cache home without changing other hooks", () => {
     const configDir = mkdtempSync(path.join(os.tmpdir(), "cmux-hook-install-"));
     const hooksPath = path.join(configDir, "hooks.json");
-    const originalCommand = '"$cmux_cli" hooks feed --source codex --event PreToolUse';
+    const cmuxCommand = `cmux_cli="\${CMUX_BUNDLED_CLI_PATH:-}"; "$cmux_cli" hooks feed --source codex --event PreToolUse`;
+    const userCommand = "./scripts/user-hook.sh";
     writeFileSync(
       hooksPath,
       JSON.stringify({
         hooks: {
-          PreToolUse: [{ hooks: [{ type: "command", command: originalCommand }] }],
+          PreToolUse: [
+            {
+              hooks: [
+                { type: "command", command: cmuxCommand },
+                { type: "command", command: userCommand },
+                { type: "prompt", prompt: "Review this tool call" },
+              ],
+            },
+          ],
         },
       }),
     );
@@ -79,11 +88,40 @@ describe(installCmuxAgentHooks, () => {
         hooks: {
           PreToolUse: [
             {
-              hooks: [{ command: expect.stringContaining(originalCommand) }],
+              hooks: [
+                { command: expect.stringContaining(cmuxCommand) },
+                { command: userCommand },
+                { type: "prompt", prompt: "Review this tool call" },
+              ],
             },
           ],
         },
       });
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not duplicate the Safehouse compatibility prefix", () => {
+    const configDir = mkdtempSync(path.join(os.tmpdir(), "cmux-hook-install-"));
+    const hooksPath = path.join(configDir, "hooks.json");
+    const prefix = `export CFFIXED_USER_HOME='${configDir}'; export CMUX_CLI_SENTRY_DISABLED=1; `;
+    const cmuxCommand = `cmux_cli="\${CMUX_BUNDLED_CLI_PATH:-}"; "$cmux_cli" hooks codex stop`;
+    writeFileSync(
+      hooksPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: "command", command: `${prefix}${cmuxCommand}` }] }],
+        },
+      }),
+    );
+
+    try {
+      installCmuxAgentHooks({ agent: "codex", configDir });
+
+      const installedHooks = readFileSync(hooksPath, "utf8");
+      expect(installedHooks.match(/CFFIXED_USER_HOME/g)).toHaveLength(1);
+      expect(installedHooks.match(/CMUX_CLI_SENTRY_DISABLED/g)).toHaveLength(1);
     } finally {
       rmSync(configDir, { recursive: true, force: true });
     }

--- a/src/lib/cmuxAgentHookInstall.ts
+++ b/src/lib/cmuxAgentHookInstall.ts
@@ -12,16 +12,17 @@ const CMUX_HOOKS_INSTALL_EVENT = "cmux-agent-hooks-install";
 const CMUX_HOOKS_INSTALL_TIMEOUT_MS = 10_000;
 const CMUX_HOOKS_FILE_NAME = "hooks.json";
 
+const commandHookSchema = z.looseObject({
+  type: z.literal("command"),
+  command: z.string(),
+});
+
 const cmuxHookSettingsSchema = z.looseObject({
   hooks: z.record(
     z.string(),
     z.array(
       z.looseObject({
-        hooks: z.array(
-          z.looseObject({
-            command: z.string(),
-          }),
-        ),
+        hooks: z.array(z.unknown()),
       }),
     ),
   ),
@@ -80,10 +81,24 @@ function hardenCmuxAgentHooks(input: { configDir: string }): void {
     "export CMUX_CLI_SENTRY_DISABLED=1; ";
   for (const groups of Object.values(settings.hooks)) {
     for (const group of groups) {
-      for (const hook of group.hooks) {
-        hook.command = `${commandPrefix}${hook.command}`;
-      }
+      group.hooks = group.hooks.map((hook) => hardenCmuxCommandHook({ hook, commandPrefix }));
     }
   }
   writeFileSync(hooksPath, `${JSON.stringify(settings, undefined, 2)}\n`);
+}
+
+function hardenCmuxCommandHook(input: { hook: unknown; commandPrefix: string }): unknown {
+  const parsed = commandHookSchema.safeParse(input.hook);
+  if (
+    !parsed.success ||
+    !isCmuxOwnedHookCommand(parsed.data.command) ||
+    parsed.data.command.startsWith(input.commandPrefix)
+  ) {
+    return input.hook;
+  }
+  return { ...parsed.data, command: `${input.commandPrefix}${parsed.data.command}` };
+}
+
+function isCmuxOwnedHookCommand(command: string): boolean {
+  return command.includes("CMUX_BUNDLED_CLI_PATH") && command.includes(" hooks ");
 }

--- a/src/lib/cmuxAgentHookInstall.ts
+++ b/src/lib/cmuxAgentHookInstall.ts
@@ -1,9 +1,31 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { z } from "zod";
+
 import { agentConfigRelocation } from "./codexConfigRelocation.ts";
 import { runCommand } from "./commandRunner.ts";
+import { shellSingleQuote } from "./shell.ts";
 import { errorMessage, logEvent, styleWarning, writeError } from "./util.ts";
 
 const CMUX_HOOKS_INSTALL_EVENT = "cmux-agent-hooks-install";
 const CMUX_HOOKS_INSTALL_TIMEOUT_MS = 10_000;
+const CMUX_HOOKS_FILE_NAME = "hooks.json";
+
+const cmuxHookSettingsSchema = z.looseObject({
+  hooks: z.record(
+    z.string(),
+    z.array(
+      z.looseObject({
+        hooks: z.array(
+          z.looseObject({
+            command: z.string(),
+          }),
+        ),
+      }),
+    ),
+  ),
+});
 
 /**
  * Best-effort `cmux hooks <agent> install --yes` against a relocated,
@@ -31,6 +53,7 @@ export function installCmuxAgentHooks(input: { agent: string; configDir: string 
       env: { ...process.env, [relocation.configDirEnv]: input.configDir },
       timeoutMs: CMUX_HOOKS_INSTALL_TIMEOUT_MS,
     });
+    hardenCmuxAgentHooks({ configDir: input.configDir });
     logEvent(CMUX_HOOKS_INSTALL_EVENT, { ...logContext, outcome: "installed" });
   } catch (error) {
     const message = errorMessage(error);
@@ -43,4 +66,24 @@ export function installCmuxAgentHooks(input: { agent: string; configDir: string 
       errorMessage: message,
     });
   }
+}
+
+function hardenCmuxAgentHooks(input: { configDir: string }): void {
+  const hooksPath = path.join(input.configDir, CMUX_HOOKS_FILE_NAME);
+  if (!existsSync(hooksPath)) {
+    return;
+  }
+
+  const settings = cmuxHookSettingsSchema.parse(JSON.parse(readFileSync(hooksPath, "utf8")));
+  const commandPrefix =
+    `export CFFIXED_USER_HOME=${shellSingleQuote(input.configDir)}; ` +
+    "export CMUX_CLI_SENTRY_DISABLED=1; ";
+  for (const groups of Object.values(settings.hooks)) {
+    for (const group of groups) {
+      for (const hook of group.hooks) {
+        hook.command = `${commandPrefix}${hook.command}`;
+      }
+    }
+  }
+  writeFileSync(hooksPath, `${JSON.stringify(settings, undefined, 2)}\n`);
 }


### PR DESCRIPTION
## Summary

- keep cmux-generated Codex hook output valid when the hook invokes cmux inside Safehouse
- redirect Foundation cache access to the already-staged writable Codex home and disable cmux CLI telemetry for those hook invocations
- leave user hooks and non-command hooks unchanged, and make the rewrite idempotent

## Why

#311 made sandboxed Codex load cmux hooks from Groundcrew’s relocated `CODEX_HOME`. Each lifecycle event then began launching the cmux CLI inside Safehouse. The Sentry Cocoa launch profiler initializes before cmux `main`, tries to access `~/Library/Caches/io.sentry`, and writes its cache failure diagnostics to stdout. That turns cmux’s valid `{}` hook response into invalid Codex hook JSON.

`CMUX_CLI_SENTRY_DISABLED` is cmux’s post-start telemetry switch, but it cannot prevent the pre-`main` launch-profiler cache lookup. `CFFIXED_USER_HOME` redirects that Foundation lookup into the writable staged home without granting the sandbox access to the user’s real cache directory. Both exports are scoped to commands generated by cmux.

The root fix belongs upstream in cmux: JSON hook commands should not initialize launch profiling or emit diagnostics on stdout. This PR is the compatibility fix for released cmux versions.

## Testing

- `node --run verify`
- 84 test files, 2,043 tests, 100% coverage
- manually reproduced the failure as `{}` followed by Sentry diagnostics and confirmed the hardened hook emits exactly `{}`