### PR TITLE
fix: keep cmux Codex hooks inside Safehouse

### DIFF
--- a/src/lib/cmuxAgentHookInstall.test.ts
+++ b/src/lib/cmuxAgentHookInstall.test.ts
@@ -36,7 +36,10 @@ describe(installCmuxAgentHooks, () => {
       "cmux",
       ["hooks", "codex", "install", "--yes"],
       expect.objectContaining({
-        env: expect.objectContaining({ CODEX_HOME: "/tmp/gc-codex-home" }),
+        env: expect.objectContaining({
+          CODEX_HOME: "/tmp/gc-codex-home",
+          HOME: "/tmp/gc-codex-home",
+        }),
       }),
     );
   });

--- a/src/lib/cmuxAgentHookInstall.ts
+++ b/src/lib/cmuxAgentHookInstall.ts
@@ -27,8 +27,12 @@ export function installCmuxAgentHooks(input: { agent: string; configDir: string 
 
   try {
     runCommand("cmux", ["hooks", input.agent, "install", "--yes"], {
-      // oxlint-disable-next-line node/no-process-env -- the cmux CLI must inherit PATH etc.; only the agent's config-dir var is overridden
-      env: { ...process.env, [relocation.configDirEnv]: input.configDir },
+      env: {
+        // oxlint-disable-next-line node/no-process-env -- inherit PATH etc.; relocate HOME so generated hook scripts stay inside the granted config dir
+        ...process.env,
+        HOME: input.configDir,
+        [relocation.configDirEnv]: input.configDir,
+      },
       timeoutMs: CMUX_HOOKS_INSTALL_TIMEOUT_MS,
     });
     logEvent(CMUX_HOOKS_INSTALL_EVENT, { ...logContext, outcome: "installed" });


### PR DESCRIPTION
## Summary

Groundcrew relocates Codex configuration into a temporary `CODEX_HOME` for Safehouse launches, but cmux previously generated its hook scripts under the operator's real home. The staged `hooks.json` therefore referenced `~/.cmux/hooks` outside the sandbox grant, causing PreToolUse and PostToolUse commands to fail with exit 126.

Run `cmux hooks codex install` with `HOME` set to the relocated config directory as well as `CODEX_HOME`. This keeps generated hook scripts within the directory Groundcrew already grants to Safehouse while preserving cmux lifecycle reporting.

## Validation

- Regression test confirmed the previous environment retained the operator home
- `npx vitest run src/lib/cmuxAgentHookInstall.test.ts`
- `node --run verify` using Node 24.14.1 and npm 11.11.0 — 2,052 tests and all build/lint/format/architecture/package checks passed
- Pre-push `node --run verify` — passed

## Notes

Review focus: confirm relocating `HOME` only for the short-lived `cmux hooks ... install` subprocess is the preferred containment boundary.

Agent session: `codex resume 019fa8b2-78ab-7c00-8568-641ebfaf41e4`

<sub>🤖 <code>cb-ship:created v1 core@3.22.4</code></sub>