### PR TITLE
feat: allow tasks to skip worktree preparation

### DIFF
--- a/docs/setup-hooks.md
+++ b/docs/setup-hooks.md
@@ -33,6 +33,20 @@ Hook failures are advisory. Groundcrew logs the non-zero exit and still launches
 the agent so a flaky package registry or stale lockfile does not block the
 session.
 
+## Task-level opt-out
+
+Some tasks need the repository checkout but not its dependency installation or
+code generation. Add the exact Linear label `groundcrew-skip-prepare` to skip
+worktree preparation for that task. Shell task sources can emit
+`"worktreePreparation": "skip"` in the issue JSON for the same behavior.
+
+The opt-out skips every preparation layer, including the operator-only
+`unsandboxedHooks.prepareWorktree` hook. Groundcrew still creates the worktree
+and launches the agent normally. This policy does not make the worktree
+read-only; it only skips preparation commands.
+
+Dry-run output includes `prepareWorktree skipped` when the policy applies.
+
 ## Precedence
 
 `prepareWorktree` resolves through three layers, highest priority first:

--- a/docs/task-sources.md
+++ b/docs/task-sources.md
@@ -69,12 +69,17 @@ declared paths. The `sdx` runner does not mount these host paths.
     "updatedAt": "2026-05-22T15:00:00Z",
     "blockers": [{ "id": "JIRA-122", "title": "Schema migration", "status": "done" }],
     "hasMoreBlockers": false,
+    "worktreePreparation": "skip",
     "sourceRef": { "nativeId": "10042" }
   }
 ]
 ```
 
 Allowed `status` values are `todo`, `in-progress`, `in-review`, `done`, and `other`. In shell-script JSON output, emit both `repository` and `agent`; use `null` when a task should not be groundcrew-eligible. `hasMoreBlockers` is optional and defaults to `false`; `sourceRef` is opaque data that groundcrew passes back to your writeback command.
+`worktreePreparation` is optional. Set it to `skip` when the task should create
+its worktree without running any configured `prepareWorktree` or
+`unsandboxedHooks.prepareWorktree` command; omission preserves the default
+preparation behavior.
 
 ## Todo.txt
 
@@ -143,6 +148,10 @@ crew task create "Fix cancellation retry race" \
 ```
 
 Created Linear issues are assigned to the API key's viewer, moved into a Todo workflow state, labeled with exactly one `agent-*` label, and given a description that includes `Repository: <repo>` near the top. Repeated `--dep <ISSUE>` values create Linear blocked-by relations when the dependency is a Linear issue id.
+
+Add the exact `groundcrew-skip-prepare` label to an existing Linear task when it
+should create a worktree without running configured worktree preparation hooks.
+The label does not make the worktree read-only.
 
 ## The `description` is the agent's prompt
 

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -164,6 +164,23 @@ describe(createDispatcher, () => {
       expect(setupCall?.[1]?.details.url).toBe("https://linear.app/example/issue/TEAM-1");
     });
 
+    it("forwards the task's worktree preparation policy", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue({ worktreePreparation: "skip" })]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(setupMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ worktreePreparation: "skip" }),
+      );
+    });
+
     it("logs `At capacity` when no slots remain", async () => {
       const config = makeConfig({
         orchestrator: {
@@ -686,6 +703,20 @@ describe(createDispatcher, () => {
       expect(setupMock).not.toHaveBeenCalled();
       expect(consoleLog.output()).toContain("[dry-run] Would start team-1");
       expect(consoleLog.output()).toContain("(claude)");
+    });
+
+    it("dry-run reports when prepareWorktree would be skipped", async () => {
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue({ worktreePreparation: "skip" })]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: true,
+      });
+
+      expect(consoleLog.output()).toContain("prepareWorktree skipped");
     });
 
     it("rethrows workspace probe failures after attaching a usage rejection handler", async () => {

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -111,9 +111,11 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     }
 
     if (dryRun) {
+      const preparationSuffix =
+        issue.worktreePreparation === "skip" ? "; prepareWorktree skipped" : "";
       log(
         /* v8 ignore next @preserve -- classifyTodo forces recovery=false in dry-run, so the resume branch can't fire here */
-        `[dry-run] Would ${recovery ? "resume" : "start"} ${taskId} in ${issue.repository} (${issue.agent})`,
+        `[dry-run] Would ${recovery ? "resume" : "start"} ${taskId} in ${issue.repository} (${issue.agent})${preparationSuffix}`,
       );
       logEvent("dispatch", {
         outcome: "skipped",
@@ -138,6 +140,9 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
             sourceName: issue.source,
           }),
           agent: issue.agent,
+          ...(issue.worktreePreparation === undefined
+            ? {}
+            : { worktreePreparation: issue.worktreePreparation }),
           details: {
             title: issue.title,
             description: issue.description,

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -5,7 +5,7 @@ import { ensureClearance } from "@clipboard-health/clearance";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { resolvePullRequest } from "../lib/pullRequests.ts";
-import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
+import { resolveRepositoryPreparationCommands } from "../lib/repositoryHooks.ts";
 import { readRunState, recordRunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
 import { workspaces } from "../lib/workspaces.ts";
@@ -52,7 +52,7 @@ vi.mock(import("../lib/repositoryHooks.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    resolvePrepareWorktreeCommand: vi.fn<typeof resolvePrepareWorktreeCommand>(),
+    resolveRepositoryPreparationCommands: vi.fn<typeof resolveRepositoryPreparationCommands>(),
   };
 });
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
@@ -114,7 +114,7 @@ const ensureClearanceMock = vi.mocked(ensureClearance);
 const loadConfigMock = vi.mocked(loadConfig);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const resolvePullRequestMock = vi.mocked(resolvePullRequest);
-const resolvePrepareWorktreeCommandMock = vi.mocked(resolvePrepareWorktreeCommand);
+const resolveRepositoryPreparationCommandsMock = vi.mocked(resolveRepositoryPreparationCommands);
 const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
 const workspacesOpenMock = vi.mocked(workspaces.open);
@@ -372,6 +372,10 @@ describe(openWorkspace, () => {
     });
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
     workspacesOpenMock.mockResolvedValue();
+    resolveRepositoryPreparationCommandsMock.mockReturnValue({
+      prepareWorktreeCommand: undefined,
+      prepareWorktreeUnsandboxedCommand: undefined,
+    });
     stubRunCommand();
     detectHostMock.mockResolvedValue(host());
     ensureClearanceMock.mockResolvedValue({
@@ -402,8 +406,11 @@ describe(openWorkspace, () => {
       config,
       expect.objectContaining({ name: "pr-42", cwd: "/work/acme/widgets-pr-42" }),
     );
-    expect(resolvePrepareWorktreeCommandMock).toHaveBeenCalledWith(
-      expect.objectContaining({ worktreeDir: "/work/acme/widgets-pr-42" }),
+    expect(resolveRepositoryPreparationCommandsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: "acme/widgets",
+        worktreeDir: "/work/acme/widgets-pr-42",
+      }),
     );
     expect(lastRecordedRunState()).toMatchObject({
       task: "pr-42",
@@ -523,7 +530,10 @@ describe(openWorkspace, () => {
   });
 
   it("stages the prepareWorktree hook into the launch when one is configured", async () => {
-    resolvePrepareWorktreeCommandMock.mockReturnValue("npm ci");
+    resolveRepositoryPreparationCommandsMock.mockReturnValue({
+      prepareWorktreeCommand: "npm ci",
+      prepareWorktreeUnsandboxedCommand: undefined,
+    });
 
     await openWorkspace(config, {
       input: { kind: "pr", pr: "42" },
@@ -534,12 +544,15 @@ describe(openWorkspace, () => {
     expect(stagedLaunchScript()).toContain("npm ci");
   });
 
-  it("forwards per-repo hooks to resolvePrepareWorktreeCommand when opening", async () => {
+  it("forwards repository context when resolving preparation commands", async () => {
     const repoConfig = makeConfigWithRepositories(["acme/widgets"]);
     repoConfig.workspace.repositories = [
       { name: "acme/widgets", hooks: { prepareWorktree: "npm ci" } },
     ];
-    resolvePrepareWorktreeCommandMock.mockReturnValue("npm ci");
+    resolveRepositoryPreparationCommandsMock.mockReturnValue({
+      prepareWorktreeCommand: "npm ci",
+      prepareWorktreeUnsandboxedCommand: undefined,
+    });
 
     await openWorkspace(repoConfig, {
       input: { kind: "pr", pr: "42" },
@@ -547,9 +560,11 @@ describe(openWorkspace, () => {
       promptText: "go",
     });
 
-    expect(resolvePrepareWorktreeCommandMock).toHaveBeenCalledWith(
-      expect.objectContaining({ perRepoHooks: { prepareWorktree: "npm ci" } }),
-    );
+    expect(resolveRepositoryPreparationCommandsMock).toHaveBeenCalledWith({
+      config: repoConfig,
+      repository: "acme/widgets",
+      worktreeDir: "/work/acme/widgets-pr-42",
+    });
   });
 
   it("runs a per-repo unsandboxedHooks.prepareWorktree command on the host when opening", async () => {
@@ -557,6 +572,10 @@ describe(openWorkspace, () => {
     repoConfig.workspace.repositories = [
       { name: "acme/widgets", unsandboxedHooks: { prepareWorktree: "bin/setup" } },
     ];
+    resolveRepositoryPreparationCommandsMock.mockReturnValue({
+      prepareWorktreeCommand: undefined,
+      prepareWorktreeUnsandboxedCommand: "bin/setup",
+    });
 
     await openWorkspace(repoConfig, {
       input: { kind: "pr", pr: "42" },
@@ -722,6 +741,10 @@ describe(openWorkspaceCli, () => {
 
   beforeEach(() => {
     loadConfigMock.mockResolvedValue(config);
+    resolveRepositoryPreparationCommandsMock.mockReturnValue({
+      prepareWorktreeCommand: undefined,
+      prepareWorktreeUnsandboxedCommand: undefined,
+    });
     mkdtempMock.mockReturnValue("/tmp/groundcrew-open-pr-42-x");
     existsSyncMock.mockReturnValue(true);
     resolvePullRequestMock.mockResolvedValue({

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -5,7 +5,7 @@ import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../l
 import { inferAgentCommandName } from "../lib/launchCommand.ts";
 import { loadConfig, repositoryBaseDir, type ResolvedConfig } from "../lib/config.ts";
 import { resolvePullRequest } from "../lib/pullRequests.ts";
-import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
+import { resolveRepositoryPreparationCommands } from "../lib/repositoryHooks.ts";
 import { recordRunState, readRunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
 import {
@@ -241,19 +241,12 @@ export async function openWorkspace(
   });
   let cleanupAgentLaunch: (() => void) | undefined;
   try {
-    const repositoryEntry = config.workspace.repositories.find(
-      (entry) => entry.name === repository,
-    );
-    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
-      worktreeDir: launchDir,
-      // Spread-conditional: exactOptionalPropertyTypes forbids an explicit
-      // `undefined` for an optional field, and the lookup yields undefined for
-      // repos with no hooks. Mirrors setupWorkspace so `crew open` honors the
-      // same per-repo operator hooks as `crew setup`.
-      ...(repositoryEntry?.hooks === undefined ? {} : { perRepoHooks: repositoryEntry.hooks }),
-      defaultHooks: config.defaults.hooks,
-    });
-    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.unsandboxedHooks?.prepareWorktree;
+    const { prepareWorktreeCommand, prepareWorktreeUnsandboxedCommand } =
+      resolveRepositoryPreparationCommands({
+        config,
+        repository,
+        worktreeDir: launchDir,
+      });
     const secretsFile =
       prepareWorktreeCommand === undefined && prepareWorktreeUnsandboxedCommand === undefined
         ? undefined

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -782,6 +782,46 @@ describe(setupWorkspace, () => {
     expect(launchScript).toContain('"$prepare_status" -ne 0');
   });
 
+  it("skips every prepareWorktree hook when the task policy opts out", async () => {
+    detectHostMock.mockResolvedValue(host());
+    const base = makeConfig({
+      definitions: {
+        claude: {
+          cmd: "claude --permission-mode auto",
+          color: "#fff",
+        },
+      },
+    });
+    const config: ResolvedConfig = {
+      ...base,
+      defaults: { hooks: { prepareWorktree: "npm ci" } },
+      workspace: {
+        ...base.workspace,
+        repositories: [
+          {
+            name: "repo-a",
+            unsandboxedHooks: { prepareWorktree: "bin/setup" },
+          },
+        ],
+      },
+    };
+    mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:42" }));
+
+    await setupWorkspace(config, {
+      task: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      worktreePreparation: "skip",
+      details: { title: "Test Title", description: "Body" },
+    });
+
+    const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(launchScript).not.toContain("npm ci");
+    expect(launchScript).not.toContain("bin/setup");
+    expect(logMock).toHaveBeenCalledWith("Skipping prepareWorktree for team-1 (task policy)");
+  });
+
   it("runs the per-repo operator prepareWorktree hook when defaults define none", async () => {
     detectHostMock.mockResolvedValue(host());
     const base = makeConfig({
@@ -1222,6 +1262,29 @@ describe(setupWorkspace, () => {
         task: "team-1",
         repository: "repo-a",
         agent: "claude",
+        details: { title: "Test Title", description: "Body" },
+      });
+
+      expect(writeFileMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("secrets.env"),
+        expect.anything(),
+        expect.anything(),
+      );
+      const launchScript = writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh");
+      expect(launchScript).not.toContain("secrets.env");
+      expect(launchScript).not.toContain("unset NPM_TOKEN");
+    });
+
+    it("skips secrets.env when task policy skips a configured prepareWorktree hook", async () => {
+      setEnvironmentVariable("NPM_TOKEN", "npm_test_token");
+      deleteEnvironmentVariable("BUF_TOKEN");
+      mockCmuxNewWorkspaceOutput(JSON.stringify({ ref: "workspace:1" }));
+
+      await setupWorkspace(makeConfigWithPrepareWorktree(), {
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        worktreePreparation: "skip",
         details: { title: "Test Title", description: "Body" },
       });
 
@@ -2024,6 +2087,24 @@ describe(setupWorkspaceCli, () => {
     expect(lastRecordedRunState().url).toBe("https://linear.app/example/issue/TEAM-1");
   });
 
+  it("forwards the resolved task's worktree preparation policy", async () => {
+    loadConfigMock.mockResolvedValue(makeConfigWithPrepareWorktree());
+    createBoardMock.mockReturnValue(
+      fakeBoard(
+        canonicalLinearIssue({
+          naturalId: "team-1",
+          repository: "repo-a",
+          agent: "claude",
+          worktreePreparation: "skip",
+        }),
+      ),
+    );
+
+    await setupWorkspaceCli("team-1");
+
+    expect(writtenFileContent("/tmp/groundcrew-team-1-x/launch.sh")).not.toContain("npm ci");
+  });
+
   it("marks the task In Progress via board.markInProgress after launching the workspace", async () => {
     await setupWorkspaceCli("team-1");
 
@@ -2041,6 +2122,24 @@ describe(setupWorkspaceCli, () => {
     expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
     const logged = logMock.mock.calls.map(([message]) => message).join("\n");
     expect(logged).toContain("[dry-run] Would launch team-1 in repo-a (claude)");
+  });
+
+  it("reports skipped worktree preparation in dry-run mode", async () => {
+    createBoardMock.mockReturnValue(
+      fakeBoard(
+        canonicalLinearIssue({
+          naturalId: "team-1",
+          repository: "repo-a",
+          agent: "claude",
+          worktreePreparation: "skip",
+        }),
+      ),
+    );
+
+    await setupWorkspaceCli("team-1", { dryRun: true });
+
+    const logged = logMock.mock.calls.map(([message]) => message).join("\n");
+    expect(logged).toContain("prepareWorktree skipped");
   });
 
   it("does not mark the task In Progress when workspace setup fails", async () => {

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -3,7 +3,7 @@ import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../l
 import { inferAgentCommandName, workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import { resolvePrepareWorktreeCommand } from "../lib/repositoryHooks.ts";
+import { resolveRepositoryPreparationCommands } from "../lib/repositoryHooks.ts";
 import { recordRunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
 import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
@@ -15,7 +15,7 @@ import {
   type StagedPrompt,
 } from "../lib/stagedLaunch.ts";
 import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
-import { naturalIdFromCanonical } from "../lib/taskSource.ts";
+import { naturalIdFromCanonical, type WorktreePreparation } from "../lib/taskSource.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import {
@@ -40,6 +40,8 @@ export interface SetupWorkspaceOptions {
   completionMarkDoneSupported?: boolean;
   repository: string;
   agent: string;
+  /** Set to `skip` to bypass configured prepareWorktree hooks. */
+  worktreePreparation?: WorktreePreparation;
   details: TaskDetails;
 }
 
@@ -136,19 +138,17 @@ export async function setupWorkspace(
     });
     promptDir = stagedPrompt.directory;
 
-    const repositoryEntry = config.workspace.repositories.find(
-      (entry) => entry.name === repository,
-    );
-    const perRepoHooks = repositoryEntry?.hooks;
-    const prepareWorktreeUnsandboxedCommand = repositoryEntry?.unsandboxedHooks?.prepareWorktree;
-    const prepareWorktreeCommand = resolvePrepareWorktreeCommand({
-      worktreeDir: launchDir,
-      // Spread-conditional rather than a direct assignment: under
-      // exactOptionalPropertyTypes an optional field can't take an explicit
-      // `undefined`, and the lookup yields undefined for repos with no hooks.
-      ...(perRepoHooks === undefined ? {} : { perRepoHooks }),
-      defaultHooks: config.defaults.hooks,
-    });
+    const shouldPrepareWorktree = options.worktreePreparation !== "skip";
+    const { prepareWorktreeCommand, prepareWorktreeUnsandboxedCommand } =
+      resolveTaskPreparationCommands({
+        config,
+        repository,
+        launchDir,
+        shouldPrepareWorktree,
+      });
+    if (!shouldPrepareWorktree) {
+      log(`Skipping prepareWorktree for ${task} (task policy)`);
+    }
     const secretsFile =
       prepareWorktreeCommand === undefined && prepareWorktreeUnsandboxedCommand === undefined
         ? undefined
@@ -228,6 +228,28 @@ export async function setupWorkspace(
     recordFailedToLaunch({ config, options, paths: { worktreeDir, branchName }, error });
     throw error;
   }
+}
+
+function resolveTaskPreparationCommands(arguments_: {
+  config: ResolvedConfig;
+  repository: string;
+  launchDir: string;
+  shouldPrepareWorktree: boolean;
+}): {
+  prepareWorktreeCommand: string | undefined;
+  prepareWorktreeUnsandboxedCommand: string | undefined;
+} {
+  if (!arguments_.shouldPrepareWorktree) {
+    return {
+      prepareWorktreeCommand: undefined,
+      prepareWorktreeUnsandboxedCommand: undefined,
+    };
+  }
+  return resolveRepositoryPreparationCommands({
+    config: arguments_.config,
+    repository: arguments_.repository,
+    worktreeDir: arguments_.launchDir,
+  });
 }
 
 /**
@@ -462,7 +484,11 @@ export async function setupWorkspaceCli(
   log(`Resolved ${task}: repository=${resolved.repository}, agent=${resolved.agent}`);
 
   if (options.dryRun === true) {
-    log(`[dry-run] Would launch ${task} in ${resolved.repository} (${resolved.agent})`);
+    const preparationSuffix =
+      resolved.worktreePreparation === "skip" ? "; prepareWorktree skipped" : "";
+    log(
+      `[dry-run] Would launch ${task} in ${resolved.repository} (${resolved.agent})${preparationSuffix}`,
+    );
     return;
   }
 
@@ -477,6 +503,9 @@ export async function setupWorkspaceCli(
     }),
     repository: resolved.repository,
     agent: resolved.agent,
+    ...(resolved.worktreePreparation === undefined
+      ? {}
+      : { worktreePreparation: resolved.worktreePreparation }),
     details: {
       title: resolved.title,
       description: resolved.description,

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -75,6 +75,9 @@ function linearIssue(overrides: Partial<LinearIssue> = {}): LinearIssue {
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
     url: overrides.url ?? "https://linear.app/example/issue/TEAM-1",
     priority: overrides.priority ?? 0,
+    ...(overrides.worktreePreparation === undefined
+      ? {}
+      : { worktreePreparation: overrides.worktreePreparation }),
   };
 }
 
@@ -347,6 +350,12 @@ describe(toCanonicalIssue, () => {
     expect(result.description).toBe("Body of the task.");
   });
 
+  it("preserves the worktree preparation policy", () => {
+    const result = toCanonicalIssue(linearIssue({ worktreePreparation: "skip" }), "linear");
+
+    expect(result.worktreePreparation).toBe("skip");
+  });
+
   it("source-prefixes blocker ids and canonicalizes their statuses via stateType", () => {
     const issue = linearIssue({
       blockers: [
@@ -597,6 +606,7 @@ describe(createLinearTaskSource, () => {
       hasMoreBlockers: false,
       url: "https://linear.app/example/issue/TEAM-1",
       priority: 0,
+      worktreePreparation: "skip",
     });
     const source = createLinearTaskSource({ kind: "linear" }, {
       globalConfig: makeConfig(),
@@ -608,6 +618,7 @@ describe(createLinearTaskSource, () => {
     expect(issue?.repository).toBe("repo-a");
     expect(issue?.agent).toBe("claude");
     expect(issue?.status).toBe("todo");
+    expect(issue?.worktreePreparation).toBe("skip");
   });
 
   it("getTask() returns a canonical Issue with description populated from fetchResolvedIssue", async () => {

--- a/src/lib/adapters/linear/factory.ts
+++ b/src/lib/adapters/linear/factory.ts
@@ -144,6 +144,9 @@ export function toCanonicalIssue(
     hasMoreBlockers: linearIssue.hasMoreBlockers,
     url: linearIssue.url,
     ...(linearIssue.priority === 0 ? {} : { priority: linearIssue.priority }),
+    ...(linearIssue.worktreePreparation === undefined
+      ? {}
+      : { worktreePreparation: linearIssue.worktreePreparation }),
     sourceRef,
   };
 }
@@ -225,6 +228,9 @@ export function createLinearTaskSource(
       hasMoreBlockers: resolved.hasMoreBlockers,
       url: resolved.url,
       ...(resolved.priority === 0 ? {} : { priority: resolved.priority }),
+      ...(resolved.worktreePreparation === undefined
+        ? {}
+        : { worktreePreparation: resolved.worktreePreparation }),
       sourceRef,
     };
   }

--- a/src/lib/adapters/linear/fetch.test.ts
+++ b/src/lib/adapters/linear/fetch.test.ts
@@ -296,6 +296,34 @@ describe(createBoardSource, () => {
       expect(issue?.agent).toBe("claude");
     });
 
+    it("maps the groundcrew-skip-prepare label to the skip preparation policy", async () => {
+      const node = issueNode({
+        identifier: "TEAM-1",
+        labels: {
+          nodes: [{ name: "agent-claude" }, { name: "groundcrew-skip-prepare" }],
+        },
+      });
+      const { source } = makeBoardSource(makeClient({ pages: [[node]] }));
+
+      const state = await source.fetch();
+
+      expect(state.issues[0]?.worktreePreparation).toBe("skip");
+    });
+
+    it("does not skip preparation for similar Linear labels", async () => {
+      const node = issueNode({
+        identifier: "TEAM-1",
+        labels: {
+          nodes: [{ name: "agent-claude" }, { name: "groundcrew-skip-prepare-later" }],
+        },
+      });
+      const { source } = makeBoardSource(makeClient({ pages: [[node]] }));
+
+      const state = await source.fetch();
+
+      expect(state.issues[0]?.worktreePreparation).toBeUndefined();
+    });
+
     it("skips parent tasks with children and surfaces them as parentSkips when unstarted", async () => {
       const parent = issueNode({
         identifier: "TEAM-1",
@@ -429,6 +457,30 @@ describe(fetchResolvedIssue, () => {
       task: "TEAM-1",
     });
     expect(resolved.agent).toBe("codex");
+  });
+
+  it("maps the skip preparation label during a single-task lookup", async () => {
+    const client = {
+      client: {
+        rawRequest: vi.fn<RawRequest>(async () => ({
+          data: {
+            issue: issueNode({
+              labels: {
+                nodes: [{ name: "agent-claude" }, { name: "groundcrew-skip-prepare" }],
+              },
+            }),
+          },
+        })),
+      },
+    };
+
+    const resolved = await fetchResolvedIssue({
+      client: client as unknown as LinearClient,
+      config: makeConfig(),
+      task: "TEAM-1",
+    });
+
+    expect(resolved.worktreePreparation).toBe("skip");
   });
 
   it("falls back to agents.default when the label refers to a built-in agent that is not enabled", async () => {

--- a/src/lib/adapters/linear/fetch.ts
+++ b/src/lib/adapters/linear/fetch.ts
@@ -11,12 +11,13 @@
 import type { LinearClient } from "@linear/sdk";
 
 import type { ResolvedConfig } from "../../config.ts";
-import { RepositoryResolutionError } from "../../taskSource.ts";
+import { RepositoryResolutionError, type WorktreePreparation } from "../../taskSource.ts";
 import { log, styleWarning } from "../../util.ts";
 import {
   AGENT_LABEL_PREFIX,
   resolveAgentFor,
   resolveRepositoryFor,
+  resolveWorktreePreparation,
   type AgentResolution,
 } from "./parsing.ts";
 
@@ -71,6 +72,7 @@ export interface Issue {
   url: string;
   /** Linear priority: 1=Urgent, 2=High, 3=Medium, 4=Low, 0=No priority. */
   priority: number;
+  worktreePreparation?: WorktreePreparation;
 }
 
 /**
@@ -336,6 +338,7 @@ function buildLinearIssue(input: {
   teamId: string;
   url: string;
   priority: number;
+  worktreePreparation: WorktreePreparation | undefined;
   inverseRelations: { nodes: IssueRelationNode[]; pageInfo: { hasNextPage: boolean } } | undefined;
 }): Issue {
   return {
@@ -356,6 +359,9 @@ function buildLinearIssue(input: {
     priority: input.priority,
     blockers: blockersFromRelations(input.inverseRelations?.nodes ?? []),
     hasMoreBlockers: input.inverseRelations?.pageInfo.hasNextPage ?? false,
+    ...(input.worktreePreparation === undefined
+      ? {}
+      : { worktreePreparation: input.worktreePreparation }),
   };
 }
 
@@ -389,6 +395,7 @@ function issueFromNode(node: IssueNode, config: ResolvedConfig): Issue {
     teamId: node.team?.id ?? "",
     url: node.url,
     priority: node.priority,
+    worktreePreparation: resolveWorktreePreparation({ labels: node.labels.nodes }),
     inverseRelations: node.inverseRelations,
   });
 }
@@ -409,6 +416,7 @@ interface ResolvedIssue {
   hasMoreBlockers: boolean;
   url: string;
   priority: number;
+  worktreePreparation?: WorktreePreparation;
 }
 
 const ISSUE_LABEL_PAGE_SIZE = 50;
@@ -656,6 +664,7 @@ export async function fetchResolvedIssue(arguments_: {
   } else if (agentResolution.kind === "not-enabled-fallback") {
     agent = agentResolution.fallbackAgent;
   }
+  const worktreePreparation = resolveWorktreePreparation({ labels: raw.labels });
   return {
     uuid: raw.uuid,
     title: raw.title,
@@ -672,6 +681,7 @@ export async function fetchResolvedIssue(arguments_: {
     hasMoreBlockers: raw.hasMoreBlockers,
     url: raw.url,
     priority: raw.priority,
+    ...(worktreePreparation === undefined ? {} : { worktreePreparation }),
   };
 }
 

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -4,9 +4,10 @@
  */
 
 import { AGENT_ANY, isBuiltInAgentNotEnabled, type ResolvedConfig } from "../../config.ts";
-import { RepositoryResolutionError } from "../../taskSource.ts";
+import { RepositoryResolutionError, type WorktreePreparation } from "../../taskSource.ts";
 
 export const AGENT_LABEL_PREFIX = "agent-";
+const SKIP_PREPARE_WORKTREE_LABEL = "groundcrew-skip-prepare";
 
 export type RepositoryResolution = { kind: "ok"; repository: string } | { kind: "missing" };
 
@@ -15,6 +16,14 @@ export type AgentResolution =
   | { kind: "no-label" }
   | { kind: "agent-any" }
   | { kind: "not-enabled-fallback"; requestedAgent: string; fallbackAgent: string };
+
+export function resolveWorktreePreparation(arguments_: {
+  labels: Array<{ name: string }>;
+}): WorktreePreparation | undefined {
+  return arguments_.labels.some((label) => label.name === SKIP_PREPARE_WORKTREE_LABEL)
+    ? "skip"
+    : undefined;
+}
 
 function escapeRegex(value: string): string {
   return value.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);

--- a/src/lib/adapters/shell/factory.test.ts
+++ b/src/lib/adapters/shell/factory.test.ts
@@ -51,6 +51,9 @@ function shellIssue(overrides: Partial<ShellIssue> = {}): ShellIssue {
     hasMoreBlockers: overrides.hasMoreBlockers ?? false,
     sourceRef: "sourceRef" in overrides ? overrides.sourceRef : { path: "/tmp/p.md" },
     ...("url" in overrides ? { url: overrides.url } : {}),
+    ...("worktreePreparation" in overrides
+      ? { worktreePreparation: overrides.worktreePreparation }
+      : {}),
   };
 }
 
@@ -100,6 +103,12 @@ describe(toCanonicalIssue, () => {
   it("omits the canonical url when the script's payload has none", () => {
     const result = toCanonicalIssue(shellIssue(), "jira");
     expect(result).not.toHaveProperty("url");
+  });
+
+  it("passes the worktree preparation policy through to the canonical Issue", () => {
+    const result = toCanonicalIssue(shellIssue({ worktreePreparation: "skip" }), "jira");
+
+    expect(result.worktreePreparation).toBe("skip");
   });
 
   it("source-prefixes blocker ids", () => {

--- a/src/lib/adapters/shell/factory.ts
+++ b/src/lib/adapters/shell/factory.ts
@@ -134,6 +134,9 @@ export function toCanonicalIssue(shellIssue: ShellIssue, sourceName: string): Ca
     blockers,
     hasMoreBlockers: shellIssue.hasMoreBlockers,
     ...(shellIssue.url === undefined ? {} : { url: shellIssue.url }),
+    ...(shellIssue.worktreePreparation === undefined
+      ? {}
+      : { worktreePreparation: shellIssue.worktreePreparation }),
     sourceRef: shellIssue.sourceRef,
   };
 }

--- a/src/lib/adapters/shell/schema.test.ts
+++ b/src/lib/adapters/shell/schema.test.ts
@@ -57,6 +57,42 @@ describe("shell issue schema", () => {
     expect(parsed.hasMoreBlockers).toBe(false);
   });
 
+  it("accepts the skip worktree preparation policy", () => {
+    const input = {
+      id: "x",
+      title: "t",
+      description: "",
+      status: "todo",
+      repository: "org/repo",
+      agent: "claude",
+      assignee: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [],
+      worktreePreparation: "skip",
+      sourceRef: null,
+    };
+
+    expect(shellIssueSchema.parse(input).worktreePreparation).toBe("skip");
+  });
+
+  it("rejects an explicit run worktree preparation policy", () => {
+    const input = {
+      id: "x",
+      title: "t",
+      description: "",
+      status: "todo",
+      repository: "org/repo",
+      agent: "claude",
+      assignee: "u",
+      updatedAt: "2026-01-01T00:00:00Z",
+      blockers: [],
+      worktreePreparation: "run",
+      sourceRef: null,
+    };
+
+    expect(() => shellIssueSchema.parse(input)).toThrow(/Invalid input/);
+  });
+
   it("validates blockers' canonical status field", () => {
     const issueWithBadBlocker = {
       id: "x",

--- a/src/lib/adapters/shell/schema.ts
+++ b/src/lib/adapters/shell/schema.ts
@@ -37,6 +37,7 @@ export const shellIssueSchema = z.object({
    * breaking; `crew status` falls back to displaying just the id.
    */
   url: z.url().optional(),
+  worktreePreparation: z.literal("skip").optional(),
   sourceRef: z.unknown(),
 });
 

--- a/src/lib/repositoryHooks.test.ts
+++ b/src/lib/repositoryHooks.test.ts
@@ -2,7 +2,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { resolvePrepareWorktreeCommand } from "./repositoryHooks.ts";
+import type { ResolvedConfig } from "./config.ts";
+import {
+  resolvePrepareWorktreeCommand,
+  resolveRepositoryPreparationCommands,
+} from "./repositoryHooks.ts";
 
 function temporaryWorktree(): string {
   return mkdtempSync(path.join(tmpdir(), "groundcrew-hooks-"));
@@ -15,6 +19,63 @@ function writeRepositoryConfig(worktreeDir: string, config: unknown): void {
     `${JSON.stringify(config, undefined, 2)}\n`,
   );
 }
+
+function preparationConfig(): ResolvedConfig {
+  return {
+    sources: [],
+    defaults: { hooks: { prepareWorktree: "npm ci" } },
+    git: { remote: "origin", defaultBranch: "main" },
+    workspace: {
+      projectDir: "/work",
+      knownRepositories: ["acme/widgets"],
+      repositories: [
+        {
+          name: "acme/widgets",
+          hooks: { prepareWorktree: "make setup" },
+          unsandboxedHooks: { prepareWorktree: "bin/setup" },
+        },
+      ],
+    },
+    orchestrator: {
+      maximumInProgress: 4,
+      pollIntervalMilliseconds: 1000,
+      sessionLimitPercentage: 85,
+    },
+    agents: {
+      default: "claude",
+      definitions: { claude: { cmd: "claude", color: "#fff" } },
+    },
+    prompts: { initial: "x" },
+    workspaceKind: "auto",
+    local: {
+      runner: "auto",
+      networkEgress: "allowlisted",
+      safehouse: { enable: [] },
+      readOnlyDirs: [],
+    },
+    logging: { file: "/tmp/groundcrew-test.log" },
+  };
+}
+
+describe(resolveRepositoryPreparationCommands, () => {
+  it("resolves sandboxed and unsandboxed commands for a repository", () => {
+    const worktreeDir = temporaryWorktree();
+    try {
+      expect(
+        resolveRepositoryPreparationCommands({
+          config: preparationConfig(),
+          repository: "acme/widgets",
+          worktreeDir,
+        }),
+      ).toStrictEqual({
+        prepareWorktreeCommand: "make setup",
+        prepareWorktreeUnsandboxedCommand: "bin/setup",
+      });
+    } finally {
+      rmSync(worktreeDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe(resolvePrepareWorktreeCommand, () => {
   it("returns undefined when neither repo config nor defaults define prepareWorktree", () => {

--- a/src/lib/repositoryHooks.ts
+++ b/src/lib/repositoryHooks.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-import type { HookCommands } from "./config.ts";
+import type { HookCommands, ResolvedConfig } from "./config.ts";
 
 const REPOSITORY_CONFIG_RELATIVE_PATH = ".groundcrew/config.json";
 
@@ -15,6 +15,33 @@ interface ResolvePrepareWorktreeCommandArguments {
    */
   perRepoHooks?: HookCommands;
   defaultHooks: HookCommands;
+}
+
+interface ResolveRepositoryPreparationCommandsArguments {
+  config: ResolvedConfig;
+  repository: string;
+  worktreeDir: string;
+}
+
+interface RepositoryPreparationCommands {
+  prepareWorktreeCommand: string | undefined;
+  prepareWorktreeUnsandboxedCommand: string | undefined;
+}
+
+export function resolveRepositoryPreparationCommands(
+  arguments_: ResolveRepositoryPreparationCommandsArguments,
+): RepositoryPreparationCommands {
+  const repositoryEntry = arguments_.config.workspace.repositories.find(
+    (entry) => entry.name === arguments_.repository,
+  );
+  return {
+    prepareWorktreeCommand: resolvePrepareWorktreeCommand({
+      worktreeDir: arguments_.worktreeDir,
+      ...(repositoryEntry?.hooks === undefined ? {} : { perRepoHooks: repositoryEntry.hooks }),
+      defaultHooks: arguments_.config.defaults.hooks,
+    }),
+    prepareWorktreeUnsandboxedCommand: repositoryEntry?.unsandboxedHooks?.prepareWorktree,
+  };
 }
 
 // Flat precedence cascade, highest priority first: the repo-committed

--- a/src/lib/taskSource.ts
+++ b/src/lib/taskSource.ts
@@ -23,6 +23,8 @@
  */
 export type CanonicalStatus = "todo" | "in-progress" | "in-review" | "done" | "other";
 
+export type WorktreePreparation = "skip";
+
 export interface Blocker {
   /** Canonical (source-prefixed) id of the blocking task. */
   id: string;
@@ -85,6 +87,8 @@ export interface Issue {
   priority?: number;
   /** Adapter-private. Consumers MUST NOT inspect; only the producing adapter reads it. */
   sourceRef: unknown;
+  /** Task-level opt-out from configured worktree preparation hooks. */
+  worktreePreparation?: WorktreePreparation;
 }
 
 export type Task = Issue;


### PR DESCRIPTION
## Summary

- Add a task-level worktree preparation opt-out
- Map the exact Linear label `groundcrew-skip-prepare` and shell issue value `"worktreePreparation": "skip"` to the policy
- Continue creating the worktree while skipping sandboxed and unsandboxed preparation hooks, build-secret staging, and surfacing the decision in launch and dry-run output

## Validation

- `node --run verify`
- 2,071 tests passed with 100% statement, branch, function, and line coverage
- Final committed-diff review found no actionable issues and confirmed the requirements are met

## Notes

This policy only skips preparation commands; it does not enforce a read-only worktree.

Agent session: `codex resume 019faf77-1932-7ba1-b86e-6ec8d287a864`

<sub>🤖 <code>cb-ship:created v1 core@3.22.4</code></sub>
