### PR TITLE
fix: prefer explicit Repository: line over incidental repo mentions

### DIFF
--- a/src/lib/adapters/linear/create.ts
+++ b/src/lib/adapters/linear/create.ts
@@ -143,7 +143,15 @@ function resolveCreateRepository(arguments_: {
     description: `Repository: ${input.repository}`,
     config,
   });
-  if (resolution.kind === "missing") {
+  // `resolveRepositoryFor` reports an unconfigured *declared* repo as
+  // { kind: "ok", repository: <asserted name> } (the dispatch path relies on
+  // that so the host can WARN+skip it by name). Create is a manual, must-be-
+  // valid operation, so reject anything that didn't canonicalize to a known
+  // repository rather than routing a task at an unconfigured worktree.
+  if (
+    resolution.kind === "missing" ||
+    !config.workspace.knownRepositories.includes(resolution.repository)
+  ) {
     throw new Error(
       `linear: repository "${input.repository}" is not in workspace.knownRepositories`,
     );

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -235,6 +235,71 @@ describe(resolveRepositoryFor, () => {
       "missing",
     );
   });
+
+  it("prefers an explicit `Repository:` line over an incidental known-repo mention", () => {
+    // Regression: a ticket declared `Repository: <unconfigured>` at the top but
+    // its body also name-dropped a *configured* repo in a contrast note. The
+    // incidental mention must not win — the declared (unconfigured) target does,
+    // so the dispatcher WARN+skips it by name instead of running the wrong repo.
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a"],
+        repositories: [{ name: "org/repo-a" }],
+      },
+    });
+    const result = resolveRepositoryFor({
+      description: [
+        "Repository: other-org/unlisted-service",
+        "",
+        "Worth contrasting with the handler in `repo-a`, which is different.",
+      ].join("\n"),
+      config,
+    });
+    expect(result).toStrictEqual({ kind: "ok", repository: "other-org/unlisted-service" });
+  });
+
+  it("honors a configured explicit `Repository:` line even when another repo is mentioned later", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a", "org/repo-b"],
+        repositories: [{ name: "org/repo-a" }, { name: "org/repo-b" }],
+      },
+    });
+    const result = resolveRepositoryFor({
+      description: "Repository: org/repo-b\n\nSee also org/repo-a for context.",
+      config,
+    });
+    expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-b" });
+  });
+
+  it("canonicalizes a bare name in an explicit `Repository:` line", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a"],
+        repositories: [{ name: "org/repo-a" }],
+      },
+    });
+    const result = resolveRepositoryFor({
+      description: "Repository: repo-a\n\nDetails follow.",
+      config,
+    });
+    expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
+  });
+
+  it("still scans the description when there is no explicit `Repository:` line", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a"],
+        repositories: [{ name: "org/repo-a" }],
+      },
+    });
+    const result = resolveRepositoryFor({ description: "fix the org/repo-a bug", config });
+    expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
+  });
 });
 
 describe(resolveAgentFor, () => {

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -201,6 +201,19 @@ describe(resolveRepositoryFor, () => {
     expect(resolveRepositoryFor({ description: "anything at all", config }).kind).toBe("missing");
   });
 
+  it("still honors an explicit declaration when knownRepositories is empty", () => {
+    // The empty-list guard exists only to keep the /\b()\b/ description scan
+    // from matching the empty string; it must not swallow an explicit
+    // declaration, which needs no regex. Surfacing the declared name lets the
+    // dispatcher WARN and skip by name instead of reporting "no repo found".
+    const config = makeConfig({
+      workspace: { projectDir: "/work", knownRepositories: [], repositories: [] },
+    });
+    expect(resolveRepositoryFor({ description: "Repository: acme/widgets", config })).toStrictEqual(
+      { kind: "ok", repository: "acme/widgets" },
+    );
+  });
+
   it("canonicalizes a bare match back to the configured `owner/repo` entry", async () => {
     // A Linear description that mentions only `repo-a` must resolve to the
     // exact knownRepositories entry `org/repo-a` so `crew run --task ...`

--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -300,6 +300,39 @@ describe(resolveRepositoryFor, () => {
     const result = resolveRepositoryFor({ description: "fix the org/repo-a bug", config });
     expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
   });
+
+  it("matches the `Repository:` keyword case-insensitively", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["org/repo-a"],
+        repositories: [{ name: "org/repo-a" }],
+      },
+    });
+    const result = resolveRepositoryFor({ description: "REPOSITORY: org/repo-a\n\nbody", config });
+    expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
+  });
+
+  it("resolves a mis-cased declared repo to the configured spelling", () => {
+    // GitHub owners/repos are case-insensitive, so a ticket may spell the org
+    // or repo differently than knownRepositories. It must still resolve — and
+    // to the configured casing so downstream worktree paths match.
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["ClipboardHealth/shift-reviews-service"],
+        repositories: [{ name: "ClipboardHealth/shift-reviews-service" }],
+      },
+    });
+    const result = resolveRepositoryFor({
+      description: "Repository: clipboardhealth/Shift-Reviews-Service\n\nbody",
+      config,
+    });
+    expect(result).toStrictEqual({
+      kind: "ok",
+      repository: "ClipboardHealth/shift-reviews-service",
+    });
+  });
 });
 
 describe(resolveAgentFor, () => {

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -57,6 +57,37 @@ type CanonicalizedRepositoryMatch =
   | { kind: "missing" }
   | { kind: "ambiguous" };
 
+// An explicit `Repository: <owner/repo>` (or bare `<repo>`) line is the
+// author's authoritative target: it is the format `create.ts` emits and the
+// one humans use in hand-written tickets. Anchored to a line start so prose
+// that merely contains the word "repository" can't trip it; optional wrapping
+// backticks are tolerated.
+const DECLARED_REPOSITORY_PATTERN = /^[^\S\n]*Repository:[^\S\n]*`?([^\s`]+)`?/im;
+
+function extractDeclaredRepository(description: string): string | undefined {
+  return DECLARED_REPOSITORY_PATTERN.exec(description)?.[1];
+}
+
+// Resolve one candidate name (full `owner/repo` or bare `repo`) against
+// knownRepositories: a bare name canonicalizes to its full entry, a bare name
+// matching several entries is ambiguous, and anything unconfigured is
+// `unknown` (the caller decides whether that WARN+skips or errors).
+function canonicalizeKnownRepositoryName(
+  name: string,
+  knownRepositories: readonly string[],
+): CanonicalizedRepositoryMatch {
+  const candidates = knownRepositories.filter((repo) => repo === name || repo.endsWith(`/${name}`));
+  if (candidates.length > 1) {
+    return { kind: "ambiguous" };
+  }
+  if (candidates.length === 1) {
+    /* v8 ignore next @preserve -- length-1 guarantees [0] defined */
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- length-1 guarantees [0] is defined
+    return { kind: "canonical", repository: candidates[0]! };
+  }
+  return { kind: "unknown", repository: name };
+}
+
 function canonicalizeRepositoryMatch(
   description: string | undefined,
   config: ResolvedConfig,
@@ -73,22 +104,22 @@ function canonicalizeRepositoryMatch(
   if (config.workspace.knownRepositories.length === 0) {
     return { kind: "missing" };
   }
+  // An explicit `Repository:` line is authoritative — resolve on it alone and
+  // never fall through to the whole-description scan. That fall-through is how
+  // a task whose real target repo is unconfigured (so it can't be scanned for)
+  // gets hijacked by an incidental known-repo mention elsewhere in the body
+  // (e.g. a "contrast with X" note). An unconfigured declared repo returns
+  // `unknown` so the dispatcher WARN+skips it by name instead of silently
+  // running against the wrong worktree.
+  const declared = extractDeclaredRepository(description);
+  if (declared !== undefined) {
+    return canonicalizeKnownRepositoryName(declared, config.workspace.knownRepositories);
+  }
   const matched = repositoryRegex.exec(description)?.[1];
   if (matched === undefined) {
     return { kind: "missing" };
   }
-  const candidates = config.workspace.knownRepositories.filter(
-    (r) => r === matched || r.endsWith(`/${matched}`),
-  );
-  if (candidates.length > 1) {
-    return { kind: "ambiguous" };
-  }
-  if (candidates.length === 1) {
-    /* v8 ignore next @preserve -- length-1 guarantees [0] defined */
-    // oxlint-disable-next-line typescript/no-non-null-assertion -- length-1 guarantees [0] is defined
-    return { kind: "canonical", repository: candidates[0]! };
-  }
-  return { kind: "unknown", repository: matched };
+  return canonicalizeKnownRepositoryName(matched, config.workspace.knownRepositories);
 }
 
 export function resolveRepositoryFor(arguments_: {

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -59,9 +59,10 @@ type CanonicalizedRepositoryMatch =
 
 // An explicit `Repository: <owner/repo>` (or bare `<repo>`) line is the
 // author's authoritative target: it is the format `create.ts` emits and the
-// one humans use in hand-written tickets. Anchored to a line start so prose
-// that merely contains the word "repository" can't trip it; optional wrapping
-// backticks are tolerated.
+// one humans use in hand-written tickets. Case-insensitive (`i`) so
+// `repository:` / `REPOSITORY:` are all honored; anchored to a line start so
+// prose that merely contains the word "repository" can't trip it; optional
+// wrapping backticks are tolerated.
 const DECLARED_REPOSITORY_PATTERN = /^[^\S\n]*Repository:[^\S\n]*`?([^\s`]+)`?/im;
 
 function extractDeclaredRepository(description: string): string | undefined {
@@ -71,12 +72,19 @@ function extractDeclaredRepository(description: string): string | undefined {
 // Resolve one candidate name (full `owner/repo` or bare `repo`) against
 // knownRepositories: a bare name canonicalizes to its full entry, a bare name
 // matching several entries is ambiguous, and anything unconfigured is
-// `unknown` (the caller decides whether that WARN+skips or errors).
+// `unknown` (the caller decides whether that WARN+skips or errors). GitHub
+// owners and repository names are case-insensitive, so the match ignores case
+// (a mis-cased declared repo still resolves) while always returning the
+// configured spelling.
 function canonicalizeKnownRepositoryName(
   name: string,
   knownRepositories: readonly string[],
 ): CanonicalizedRepositoryMatch {
-  const candidates = knownRepositories.filter((repo) => repo === name || repo.endsWith(`/${name}`));
+  const lowerName = name.toLowerCase();
+  const candidates = knownRepositories.filter((repo) => {
+    const lowerRepo = repo.toLowerCase();
+    return lowerRepo === lowerName || lowerRepo.endsWith(`/${lowerName}`);
+  });
   if (candidates.length > 1) {
     return { kind: "ambiguous" };
   }

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -104,6 +104,19 @@ function canonicalizeRepositoryMatch(
   if (description === undefined || description.length === 0) {
     return { kind: "missing" };
   }
+  // An explicit `Repository:` line is authoritative — resolve on it alone and
+  // never fall through to the whole-description scan. That fall-through is how
+  // a task whose real target repo is unconfigured (so it can't be scanned for)
+  // gets hijacked by an incidental known-repo mention elsewhere in the body
+  // (e.g. a "contrast with X" note). An unconfigured declared repo returns
+  // `unknown` so the dispatcher WARN+skips it by name instead of silently
+  // running against the wrong worktree. Resolved before the empty-config guard
+  // below because canonicalization needs no regex, so an empty
+  // knownRepositories must not discard a name the author stated outright.
+  const declared = extractDeclaredRepository(description);
+  if (declared !== undefined) {
+    return canonicalizeKnownRepositoryName(declared, config.workspace.knownRepositories);
+  }
   // Guard against an empty knownRepositories config: buildRepositoryRegex
   // would produce /\b()\b/, which matches the empty string at any word
   // boundary and returns a bogus "" match. Treat that as "no repo could
@@ -111,17 +124,6 @@ function canonicalizeRepositoryMatch(
   // a spurious empty-string repository.
   if (config.workspace.knownRepositories.length === 0) {
     return { kind: "missing" };
-  }
-  // An explicit `Repository:` line is authoritative — resolve on it alone and
-  // never fall through to the whole-description scan. That fall-through is how
-  // a task whose real target repo is unconfigured (so it can't be scanned for)
-  // gets hijacked by an incidental known-repo mention elsewhere in the body
-  // (e.g. a "contrast with X" note). An unconfigured declared repo returns
-  // `unknown` so the dispatcher WARN+skips it by name instead of silently
-  // running against the wrong worktree.
-  const declared = extractDeclaredRepository(description);
-  if (declared !== undefined) {
-    return canonicalizeKnownRepositoryName(declared, config.workspace.knownRepositories);
   }
   const matched = repositoryRegex.exec(description)?.[1];
   if (matched === undefined) {


### PR DESCRIPTION
## What & why

`resolveRepositoryFor` (the Linear adapter's repository resolver) scanned the **entire** issue description for the first known-repository name and routed the task to whatever it found. A ticket whose real target repository is **not** in `workspace.knownRepositories` — so it can never be the scan's match — could be silently dispatched to an *unrelated configured* repo merely name-dropped elsewhere in the body.

Concretely (how this surfaced): a ticket declared `Repository: shift-reviews-service` (unconfigured) at the top, but its body also said *"worth contrasting with … in `clipboard-health`"*. The scan matched `clipboard-health` (configured), so groundcrew created the worktree there — while the agent, reading the ticket, did the work and opened its PR in `shift-reviews-service`. The workspace ended up pointed at the wrong repo, and no branch-based tooling could associate the real PR back to it.

## The change

Treat an explicit `Repository:` line (the format `create.ts` emits and the one humans use in hand-written tickets) as **authoritative**: resolve on it alone and never fall through to the whole-description scan.

- Declared repo is configured → resolves to it (bare names still canonicalize to `owner/repo`).
- Declared repo is **not** configured → resolves as `unknown`, so the host's `dispatchableRepository` **WARN+skips the task by name** (`references unknown repository shift-reviews-service`) instead of mis-homing it — and without aborting the tick.
- No `Repository:` line → unchanged; still scans the description.

Also:
- **`create.ts`**: `resolveRepositoryFor` now reports an unconfigured *declared* repo as `{ kind: "ok", repository: <name> }` (so the dispatch path can WARN+skip by name). The manual `crew create` path therefore validates the resolved repo against `knownRepositories` explicitly rather than relying on `missing`, so it still rejects an unknown `--repo` instead of routing at a nonexistent worktree.
- Factored the known-repository canonicalization into a shared helper (`canonicalizeKnownRepositoryName`) reused by both the declared-line and scan paths so they can't drift.

## Testing

- `parsing.test.ts`: 4 new cases — declared-unknown beats an incidental mention; declared-configured beats a later mention; bare declared name canonicalizes; no-declaration still scans.
- Full suite green locally: **2076 tests / 85 files**; `oxlint --deny-warnings` clean.

## Note

Behavior change worth calling out: tickets targeting a repo that isn't in `knownRepositories` now cleanly **WARN+skip** (naming the repo) instead of silently mis-homing. To actually run such tickets, add the repo to `workspace.knownRepositories`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
