### PR TITLE
fix: forward cmux Safehouse writable grants (TG-4209)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.49.2",
+  "version": "4.49.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.49.2",
+      "version": "4.49.3",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/clearance": "1.6.3",
+        "@clipboard-health/clearance": "1.6.6",
         "@linear/sdk": "89.0.0",
         "agent-trust": "1.0.0",
         "cosmiconfig": "9.0.2",
@@ -1595,9 +1595,9 @@
       "license": "MIT"
     },
     "node_modules/@clipboard-health/clearance": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.6.3.tgz",
-      "integrity": "sha512-/AEXdHQg4omWSxQxpjISXM3Nv4t4Bm4uSioCTX6N47iv5sBTTFldVcRvy+BRX4sqkjWbpRMYYoER6rFA6VvobA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.6.6.tgz",
+      "integrity": "sha512-ivIlc9AseWX2NhBCHtCZle7lPFqoGT6u/NIdWZ1zAvknVvztGk4gHmeoJ0LD4woabsH85CxVee4gAUwT/wnOGQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "verify": "node scripts/verifyAll.mts"
   },
   "dependencies": {
-    "@clipboard-health/clearance": "1.6.3",
+    "@clipboard-health/clearance": "1.6.6",
     "@linear/sdk": "89.0.0",
     "agent-trust": "1.0.0",
     "cosmiconfig": "9.0.2",

--- a/src/lib/agentLaunch.test.ts
+++ b/src/lib/agentLaunch.test.ts
@@ -183,6 +183,20 @@ describe(composeAgentLaunch, () => {
     expect(launchCommand).toContain('"$@"');
   });
 
+  it("adds cmux writable Safehouse grants supplied by clearance", () => {
+    resolveSafehouseCmuxIntegrationMock.mockReturnValue(
+      safehouseCmuxIntegrationFixture({
+        addDirs: ["/Users/dev/Library/Caches/io.sentry"],
+      }),
+    );
+
+    const launchCommand = compose();
+
+    expect(launchCommand).toContain(
+      "--add-dirs='/work/repo-a-team-1:/tmp/repo-a.git:/Users/dev/Library/Caches/io.sentry'",
+    );
+  });
+
   it("injects cmux activity-reporting hooks for a cmux-hosted Claude agent", () => {
     const launchCommand = compose();
 

--- a/src/lib/agentLaunch.ts
+++ b/src/lib/agentLaunch.ts
@@ -160,6 +160,10 @@ function safehouseAgentIntegrationFor(input: {
   });
 
   return {
+    addDirs: [
+      ...cmuxIntegration.addDirs,
+      ...(relocatedCmuxHooksHome === undefined ? [] : [relocatedCmuxHooksHome.configDir]),
+    ],
     addDirsReadOnly: cmuxIntegration.addDirsReadOnly,
     envPass: cmuxIntegration.envPass,
     commandPreludes: [
@@ -181,7 +185,6 @@ function safehouseAgentIntegrationFor(input: {
     ...(relocatedCmuxHooksHome === undefined
       ? {}
       : {
-          addDirs: [relocatedCmuxHooksHome.configDir],
           writeBackFiles: relocatedCmuxHooksHome.writeBackFiles,
           teardownPaths: [relocatedCmuxHooksHome.parentDir],
         }),

--- a/src/testHelpers/safehouseCmuxIntegration.ts
+++ b/src/testHelpers/safehouseCmuxIntegration.ts
@@ -4,6 +4,7 @@ export function safehouseCmuxIntegrationFixture(
   overrides: Partial<SafehouseCmuxIntegration> = {},
 ): SafehouseCmuxIntegration {
   return {
+    addDirs: [],
     addDirsReadOnly: ["/Applications/cmux.app", "/Users/dev/.local/state/cmux"],
     claudeCommandPrelude: "export CMUX_CUSTOM_CLAUDE_PATH=/Users/dev/.local/bin/claude",
     envPass: ["CMUX_SURFACE_ID", "CMUX_SOCKET_PATH"],


### PR DESCRIPTION
## Why

cmux 0.64.21+ runs Codex lifecycle hooks from `~/.cmux/hooks`, and its CLI initializes Sentry while producing the JSON those hooks return. Inside Groundcrew's Safehouse sandbox, cmux could not read the hook executables or write `~/Library/Caches/io.sentry`. That caused every lifecycle hook to fail, first with exit code 126 and then with invalid JSON when Sentry diagnostics contaminated stdout.

[core-utils #831](https://github.com/ClipboardHealth/core-utils/pull/831) added the required cmux paths to Clearance 1.6.6. Groundcrew must consume the new writable-path field for that fix to reach launched agents. This has no direct customer impact; it restores reliable cmux sidebar activity reporting for Groundcrew operators using Codex with Safehouse.

## Summary

- Upgrade `@clipboard-health/clearance` from 1.6.3 to 1.6.6.
- Forward Clearance's writable cmux paths into the agent Safehouse wrapper.
- Merge those paths with Groundcrew's existing staged `CODEX_HOME` grant.
- Cover the generated Safehouse command with a focused regression test.

## Validation

- Red: `npm exec vitest -- run src/lib/agentLaunch.test.ts` failed because `/Users/dev/Library/Caches/io.sentry` was absent from `--add-dirs`.
- Green: `npm exec vitest -- run src/lib/agentLaunch.test.ts src/lib/launchCommand.test.ts` — 108 tests passed.
- `node --run verify` — passed.
- Pre-push verification — passed.

Before the fix, a real Groundcrew-launched Codex session reported:

```text
SessionStart hook (failed)
error: hook exited with code 126

PreToolUse hook (failed)
error: hook returned invalid pre-tool-use JSON output

PostToolUse hook (failed)
error: hook returned invalid post-tool-use JSON output

Stop hook (failed)
error: hook exited with code 126
```

The minimized failing hook command showed why the JSON was invalid: cmux returned `{}` and then wrote Sentry cache errors to stdout, so `jq` exited 5.

```text
{}
[Sentry] [error] Can't create base path ... /Users/davidhuculak/Library/Caches/io.sentry ...
jq: parse error: Invalid numeric literal at line 2, column 8
json_exit=5
```

After applying the Clearance grants through Groundcrew, a fresh cmux/Codex smoke session ran the same read-only prompt without any hook failures:

```text
Ran printf 'hook smoke test\n'
  └ hook smoke test

Output: hook smoke test
No files changed and no PR opened.
```

## Notes

- Depends on merged [core-utils #831](https://github.com/ClipboardHealth/core-utils/pull/831).
- Related Linear issue: [TG-4209](https://linear.app/clipboardhealth/issue/TG-4209/link-cmux-sidebar-task-headings-to-their-linear-issues).
- This compatibility fix is intentionally separate from draft Groundcrew [#317](https://github.com/ClipboardHealth/groundcrew/pull/317). #317 will be rebased after this PR merges.

Agent session: `codex resume 019f9081-657e-7cb3-9f26-f4ef1263e855`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>
