### PR TITLE
fix: support bare configured repository names

### DIFF
--- a/src/lib/adapters/linear/parsing.test.ts
+++ b/src/lib/adapters/linear/parsing.test.ts
@@ -302,6 +302,23 @@ describe(resolveRepositoryFor, () => {
     expect(result).toStrictEqual({ kind: "ok", repository: "org/repo-a" });
   });
 
+  it("canonicalizes a full name in an explicit `Repository:` line to a configured bare name", () => {
+    const config = makeConfig({
+      workspace: {
+        projectDir: "/work",
+        knownRepositories: ["repo-a"],
+        repositories: [{ name: "repo-a" }],
+      },
+    });
+
+    const result = resolveRepositoryFor({
+      description: "Repository: org/repo-a\n\nDetails follow.",
+      config,
+    });
+
+    expect(result).toStrictEqual({ kind: "ok", repository: "repo-a" });
+  });
+
   it("still scans the description when there is no explicit `Repository:` line", () => {
     const config = makeConfig({
       workspace: {

--- a/src/lib/adapters/linear/parsing.ts
+++ b/src/lib/adapters/linear/parsing.ts
@@ -71,20 +71,27 @@ function extractDeclaredRepository(description: string): string | undefined {
 
 // Resolve one candidate name (full `owner/repo` or bare `repo`) against
 // knownRepositories: a bare name canonicalizes to its full entry, a bare name
-// matching several entries is ambiguous, and anything unconfigured is
-// `unknown` (the caller decides whether that WARN+skips or errors). GitHub
-// owners and repository names are case-insensitive, so the match ignores case
-// (a mis-cased declared repo still resolves) while always returning the
-// configured spelling.
+// matching several entries is ambiguous, a full name canonicalizes to a bare
+// configured entry, and anything unconfigured is `unknown` (the caller decides
+// whether that WARN+skips or errors). GitHub owners and repository names are
+// case-insensitive, so the match ignores case (a mis-cased declared repo still
+// resolves) while always returning the configured spelling.
 function canonicalizeKnownRepositoryName(
   name: string,
   knownRepositories: readonly string[],
 ): CanonicalizedRepositoryMatch {
   const lowerName = name.toLowerCase();
-  const candidates = knownRepositories.filter((repo) => {
+  const directCandidates = knownRepositories.filter((repo) => {
     const lowerRepo = repo.toLowerCase();
     return lowerRepo === lowerName || lowerRepo.endsWith(`/${lowerName}`);
   });
+  const candidates =
+    directCandidates.length > 0
+      ? directCandidates
+      : knownRepositories.filter((repo) => {
+          const lowerRepo = repo.toLowerCase();
+          return !lowerRepo.includes("/") && lowerName.endsWith(`/${lowerRepo}`);
+        });
   if (candidates.length > 1) {
     return { kind: "ambiguous" };
   }


### PR DESCRIPTION
## Why

PR #332 made explicit `Repository:` declarations authoritative, but its canonicalization only handled a bare ticket name against a full configured name. Existing installations that configure bare logical names now receive full `owner/repo` values from Linear, causing otherwise known repositories to be rejected and every affected task to be skipped.

This restores the documented backward-compatible bare-name configuration so operators can dispatch existing tickets without renaming local repository paths or rewriting ticket declarations.

## Summary

- Canonicalize a full declared repository name to a configured bare logical name when existing exact and bare-to-full matching finds no candidate.
- Preserve existing exact/full-name precedence and ambiguity behavior.
- Add a regression test for `Repository: org/repo-a` with `knownRepositories: ["repo-a"]`.

## Validation

- `npm exec vitest run src/lib/adapters/linear/parsing.test.ts` — 27 tests passed.
- `node --run verify` — all checks passed; 85 files, 2,091 tests, and 100% coverage.
- The pre-push hook reran the full verification successfully.

## Notes

Regression follow-up to #332.

Agent session: `codex resume 019fcf55-9c13-74f3-a754-7ddc0bb47ac7`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>
