### PR TITLE
feat(status): publish cost-tiered JSON snapshots for external monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ crew status --json --local-only   # local tier only; never touches the network
 `--local-only` is a guarantee about that invocation, not a computed outcome, so
 a monitor's fast loop cannot stall on a slow board or a `gh` timeout.
 
-Two rules a reader must honor:
+Three rules a reader must honor:
 
 - **Subtract locally.** `status-remote.json` ships board classification without
   the local worktree subtraction. Remove tasks present in the local document

--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ Two rules a reader must honor:
   from `inProgress`, `queueReady`, and `queueBlocked` yourself. Precomputing
   that join would report a just-dispatched task as still queued until the next
   slow poll, which is a false statement rather than stale data.
+- **Join pull requests on the worktree directory.** `pullRequestsByWorktree` is
+  keyed by absolute worktree path, not by task, because a task with two
+  worktrees has two branches. An empty or missing entry means no pull requests
+  were found, or the `gh` lookup for that worktree failed; the two are not
+  distinguishable.
 - **Read the right timestamp.** `payload.capturedAt` describes the last
   successful fetch; `lastAttemptAt` describes the most recent try. Read
   `lastAttemptStatus` to answer "is the board healthy", and `capturedAt` to

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or i
 crew task create "Title" --source <name> [--agent <name>] # create a source task
 crew task done <TASK> [--allow-dirty]                    # mark a no-PR task done
 crew task validate [<source>]                            # validate task content
-crew status [<TASK>]                                   # inspect current state or one task
+crew status [<TASK>] [--json [--local-only]]           # inspect current state, or emit it as JSON
 crew run [--watch]                                       # one-shot or --watch forever
 crew start <TASK>                                      # provision + launch one task now
 crew stop <TASK> [--reason <text>]                     # stop workspace, keep worktree
@@ -126,6 +126,45 @@ crew completions <bash|zsh|fish>                        # print a shell completi
 ```
 
 See [command details](./docs/commands.md) for status output, doctor behavior, and the stop/resume workflow.
+
+### Status snapshots for external monitors
+
+`crew status --json` prints two documents and writes them beside the log file:
+
+```text
+<state-dir>/status-local.json     # worktrees, run states, sessions, git status
+<state-dir>/status-remote.json    # board, pull requests
+```
+
+The two are split by cost. The local tier is local subprocess work, so it is
+safe to poll every few seconds. The remote tier is network-bound and
+rate-limited, so poll it near your `pollIntervalMilliseconds`.
+
+```bash
+crew status --json                # both tiers
+crew status --json --local-only   # local tier only; never touches the network
+```
+
+`--local-only` is a guarantee about that invocation, not a computed outcome, so
+a monitor's fast loop cannot stall on a slow board or a `gh` timeout.
+
+Two rules a reader must honor:
+
+- **Subtract locally.** `status-remote.json` ships board classification without
+  the local worktree subtraction. Remove tasks present in the local document
+  from `inProgress`, `queueReady`, and `queueBlocked` yourself. Precomputing
+  that join would report a just-dispatched task as still queued until the next
+  slow poll, which is a false statement rather than stale data.
+- **Read the right timestamp.** `payload.capturedAt` describes the last
+  successful fetch; `lastAttemptAt` describes the most recent try. Read
+  `lastAttemptStatus` to answer "is the board healthy", and `capturedAt` to
+  answer "how old is this queue". A failed fetch keeps the previous payload, so
+  last-known-good data survives an outage while the document still says the
+  board is unreachable.
+
+Durations are never stored, only start instants, so a reader must derive
+elapsed time itself. A cached duration would show a frozen clock, which reads
+as "the agent stopped working" when it did not.
 
 ## Configuration
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,9 +84,18 @@ crew task done todo:flaky-triage-1
 
 `crew status <TASK>` prints a read-only snapshot for one task: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the task status from the configured task source.
 
-`crew status` with no task prints the current inventory: known worktrees with cached task metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. Local diagnostics are printed before task-source fetches complete. When the source fetch succeeds, status also prints any in-progress source tasks with no local worktree, slot usage, and Queue/Blocked sections for eligible Todo tasks. Worktree-less in-progress rows include the task title, URL when the source provides one, and repository when the source resolves one. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
+`crew status` with no task prints the current inventory: known worktrees with cached task metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. When the source fetch succeeds, status also prints any in-progress source tasks with no local worktree, slot usage, and Queue/Blocked sections for eligible Todo tasks. Worktree-less in-progress rows include the task title, URL when the source provides one, and repository when the source resolves one. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
 
 Status is informational only. Use `crew cleanup <TASK>` to tear down stale worktrees and `crew resume <TASK>` to reopen preserved work.
+
+`crew status --json` emits the same state as two JSON documents instead of text,
+and writes them beside the log file as `status-local.json` and
+`status-remote.json`. The split is by cost: the local document is subprocess
+work only, so an external monitor can poll it every few seconds, while the
+remote document holds the board fetch and PR lookups. `crew status --json
+--local-only` collects the local document alone and never touches the network.
+See [Status snapshots for external monitors](../README.md#status-snapshots-for-external-monitors)
+for the reader contract. Text mode writes nothing.
 
 <details>
 <summary>Sample task status output</summary>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,7 +190,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   status: {
     summary: "Print read-only groundcrew state, or one task's local/Linear status",
-    usage: "[<task>]",
+    usage: "[<task>] [--json [--local-only]]",
     invoke: statusCli,
   },
   cleanup: {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,4 +1,11 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -1413,6 +1420,87 @@ describe(status, () => {
 
       expect(actual.local.schemaVersion).toBe(1);
       expect(actual.remote?.lastAttemptStatus).toBe("ok");
+    });
+
+    it("timestamps each tier when its data collection starts", async () => {
+      const pollStartedAt = "2026-05-26T02:14:30.000Z";
+      const boardCapturedAt = "2026-05-26T02:15:00.000Z";
+      workspaceProbeMock.mockImplementation(async () => {
+        vi.setSystemTime(new Date(boardCapturedAt));
+        return { kind: "ok", names: new Set(["team-1"]) };
+      });
+      findPullRequestsMock.mockImplementation(async () => {
+        vi.setSystemTime(new Date("2026-05-26T02:16:00.000Z"));
+        return [];
+      });
+
+      await status(jsonConfig(), { json: true });
+
+      const actual = parseJsonOutput();
+      expect(actual.local.capturedAt).toBe(pollStartedAt);
+      expect(actual.remote?.lastAttemptAt).toBe(pollStartedAt);
+      expect(actual.remote?.payload?.capturedAt).toBe(boardCapturedAt);
+    });
+
+    it("publishes current source metadata for tasks outside queue states", async () => {
+      readRunStateMock.mockReturnValue(
+        runState({ title: "Title at dispatch", url: "https://example.test/old" }),
+      );
+      buildSourcesMock.mockResolvedValue([
+        fakeSource([
+          sourceIssue({
+            status: "done",
+            title: "Current source title",
+            url: "https://example.test/current",
+          }),
+        ]),
+      ]);
+
+      await status(jsonConfig(), { json: true });
+
+      const actual = parseJsonOutput();
+      expect(actual.remote?.payload?.sourceByTask["team-1"]).toMatchObject({
+        status: "done",
+        title: "Current source title",
+        url: "https://example.test/current",
+      });
+    });
+
+    it("publishes a task's recent lines even when they precede a large unrelated tail", async () => {
+      const config = jsonConfig();
+      const taskLine = "[09:00:00] team-1 dispatched";
+      const unrelatedTail = `${"x".repeat(200)}\n`.repeat(2000);
+      writeFileSync(config.logging.file, `${taskLine}\n${unrelatedTail}`);
+
+      await status(config, { json: true });
+
+      const actual = parseJsonOutput();
+      expect(actual.local.tasks[0]?.recentLogLines).toEqual([taskLine]);
+    });
+
+    it("extends cached task log history from the previous poll's cursor", async () => {
+      const config = jsonConfig();
+      const historicalLine = "[09:00:00] team-1 dispatched";
+      const appendedLine = "[09:15:00] team-1 resumed";
+      const unrelatedTail = `${"x".repeat(200)}\n`.repeat(2000);
+      writeFileSync(config.logging.file, `${historicalLine}\n${unrelatedTail}`);
+
+      await status(config, { json: true });
+
+      const first = parseJsonOutput();
+      const firstOffset = first.local.logCursor?.offset;
+      expect(firstOffset).toBeGreaterThan(0);
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
+      appendFileSync(config.logging.file, `${appendedLine}\n`);
+
+      await status(config, { json: true });
+
+      const second = parseJsonOutput();
+      expect(second.local.logCursor?.offset).toBe(
+        Buffer.byteLength(`${historicalLine}\n${unrelatedTail}${appendedLine}\n`),
+      );
+      expect(second.local.tasks[0]?.recentLogLines).toEqual([historicalLine, appendedLine]);
     });
 
     it("omits the remote key entirely with --local-only", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1385,6 +1385,26 @@ describe(status, () => {
     expect(output).not.toContain("session dead");
     expect(output).toContain("Workspace probe unavailable: cmux unavailable");
   });
+
+  // The snapshot document groups worktrees under one task while the inventory
+  // prints one row per worktree. This pins the flatten order across that
+  // regrouping.
+  it("prints one row per worktree, in list order, when a task has two", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ repository: "repo-a", dir: "/work/repo-a-team-1" }),
+      worktree({ repository: "repo-b", dir: "/work/repo-b-team-1" }),
+    ]);
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+
+    expect(output).toContain("/work/repo-a-team-1");
+    expect(output).toContain("/work/repo-b-team-1");
+    expect(output.indexOf("/work/repo-a-team-1")).toBeLessThan(
+      output.indexOf("/work/repo-b-team-1"),
+    );
+  });
 });
 
 describe(statusCli, () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1487,12 +1487,54 @@ describe(status, () => {
       expect(printed).toEqual(onDisk);
     });
 
+    it("prints exactly what it wrote to the local file", async () => {
+      const config = jsonConfig();
+
+      await status(config, { json: true });
+
+      const printed = parseJsonOutput().local;
+      const onDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
+      );
+
+      expect(printed).toEqual(onDisk);
+    });
+
+    it("prints exactly what it wrote when the board fetch fails", async () => {
+      const config = jsonConfig();
+      buildSourcesMock.mockRejectedValue(new Error("source down"));
+
+      await status(config, { json: true });
+
+      const printed = parseJsonOutput().remote;
+      const onDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
+      );
+
+      expect(printed).toEqual(onDisk);
+      expect(printed?.lastAttemptStatus).toBe("unavailable");
+    });
+
+    it("prints exactly what it wrote with --local-only", async () => {
+      const config = jsonConfig();
+
+      await status(config, { json: true, localOnly: true });
+
+      const printed = parseJsonOutput().local;
+      const onDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
+      );
+
+      expect(printed).toEqual(onDisk);
+    });
+
     it("writes no snapshot in text mode", async () => {
       const config = jsonConfig();
 
       await status(config);
 
       expect(existsSync(path.join(temporaryDirectory, "status-local.json"))).toBe(false);
+      expect(existsSync(path.join(temporaryDirectory, "status-remote.json"))).toBe(false);
     });
 
     it("rejects --json for a single task", async () => {
@@ -1500,6 +1542,23 @@ describe(status, () => {
         "crew status: --json is not supported for a single task",
       );
     });
+  });
+
+  it("still shows pull request links when the board fetch fails", async () => {
+    // The board and `gh` share no data, so losing one must not hide the other.
+    buildSourcesMock.mockRejectedValue(new Error("source down"));
+    stubPullRequestsByDirectory({
+      "/work/repo-a-team-1": [
+        { url: "https://example.test/a", number: 1, state: "open", title: "A" },
+      ],
+    });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+
+    expect(output).toContain("unavailable: source down");
+    expect(output).toContain("pr:        https://example.test/a (open)");
   });
 
   it("shows each worktree only its own pull requests when a task has two", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
+import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import type { LocalStatusDocument, RemoteStatusDocument } from "../lib/statusSnapshot.ts";
 import type { Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
@@ -179,6 +179,11 @@ function worktree(overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
     kind: "host",
     ...overrides,
   };
+}
+
+/** Each worktree directory gets its own pull requests; anything else gets none. */
+function stubPullRequestsByDirectory(prsByDirectory: Record<string, PullRequestSummary[]>): void {
+  findPullRequestsMock.mockImplementation(async ({ cwd }) => prsByDirectory[cwd] ?? []);
 }
 
 function runState(overrides: Partial<RunState> = {}): RunState {
@@ -1495,6 +1500,33 @@ describe(status, () => {
         "crew status: --json is not supported for a single task",
       );
     });
+  });
+
+  it("shows each worktree only its own pull requests when a task has two", async () => {
+    listWorktreesMock.mockReturnValue([
+      worktree({ repository: "repo-a", dir: "/work/repo-a-team-1" }),
+      worktree({ repository: "repo-b", dir: "/work/repo-b-team-1" }),
+    ]);
+    stubPullRequestsByDirectory({
+      "/work/repo-a-team-1": [
+        { url: "https://example.test/a", number: 1, state: "open", title: "A" },
+      ],
+      "/work/repo-b-team-1": [
+        { url: "https://example.test/b", number: 2, state: "open", title: "B" },
+      ],
+    });
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    const rowA = output.slice(output.indexOf("/work/repo-a-team-1"));
+    const rowB = output.slice(output.indexOf("/work/repo-b-team-1"));
+
+    expect(rowA).toContain("https://example.test/a");
+    expect(rowA.slice(0, rowA.indexOf("/work/repo-b-team-1"))).not.toContain(
+      "https://example.test/b",
+    );
+    expect(rowB).toContain("https://example.test/b");
   });
 
   // The snapshot document groups worktrees under one task while the inventory

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -6,6 +6,10 @@ import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
+import type {
+  LocalStatusDocument,
+  RemoteStatusDocument,
+} from "../lib/statusSnapshot.ts";
 import type { Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
@@ -1386,6 +1390,116 @@ describe(status, () => {
     expect(output).toContain("Workspace probe unavailable: cmux unavailable");
   });
 
+  describe("--json", () => {
+    function parseJsonOutput(): {
+      local: LocalStatusDocument;
+      remote?: RemoteStatusDocument;
+    } {
+      return JSON.parse(consoleLog.output());
+    }
+
+    // Every --json run persists two files beside the log, so each test needs
+    // its own directory or they read each other's snapshots.
+    function jsonConfig(): ResolvedConfig {
+      return makeConfig({ logging: { file: path.join(temporaryDirectory, "groundcrew.log") } });
+    }
+
+    it("prints both documents under one root", async () => {
+      await status(jsonConfig(), { json: true });
+
+      const actual = parseJsonOutput();
+
+      expect(actual.local.schemaVersion).toBe(1);
+      expect(actual.remote?.lastAttemptStatus).toBe("ok");
+    });
+
+    it("omits the remote key entirely with --local-only", async () => {
+      await status(jsonConfig(), { json: true, localOnly: true });
+
+      const actual = parseJsonOutput();
+
+      expect(actual.local.schemaVersion).toBe(1);
+      expect("remote" in actual).toBe(false);
+    });
+
+    it("never constructs a task source or looks up a pull request with --local-only", async () => {
+      await status(jsonConfig(), { json: true, localOnly: true });
+
+      expect(buildSourcesMock).not.toHaveBeenCalled();
+      expect(findPullRequestsMock).not.toHaveBeenCalled();
+    });
+
+    it("reports an unavailable board without failing the command", async () => {
+      buildSourcesMock.mockRejectedValue(new Error("source down"));
+
+      await status(jsonConfig(), { json: true });
+
+      const actual = parseJsonOutput();
+
+      expect(actual.remote?.lastAttemptStatus).toBe("unavailable");
+      expect(actual.remote?.lastAttemptError).toBe("source down");
+      expect(actual.remote?.payload).toBeUndefined();
+    });
+
+    it("carries the previous payload forward when a later fetch fails", async () => {
+      const config = jsonConfig();
+      await status(config, { json: true });
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
+      buildSourcesMock.mockRejectedValue(new Error("source down"));
+
+      await status(config, { json: true });
+
+      const actual = parseJsonOutput();
+
+      expect(actual.remote?.lastAttemptStatus).toBe("unavailable");
+      expect(actual.remote?.payload).toBeDefined();
+    });
+
+    it("writes both documents beside the log file", async () => {
+      const config = jsonConfig();
+
+      await status(config, { json: true });
+
+      const localOnDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
+      );
+      const remoteOnDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
+      );
+
+      expect(localOnDisk.schemaVersion).toBe(1);
+      expect(remoteOnDisk.lastAttemptStatus).toBe("ok");
+    });
+
+    it("prints exactly what it wrote to the remote file", async () => {
+      const config = jsonConfig();
+
+      await status(config, { json: true });
+
+      const printed = parseJsonOutput().remote;
+      const onDisk = JSON.parse(
+        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
+      );
+
+      expect(printed).toEqual(onDisk);
+    });
+
+    it("writes no snapshot in text mode", async () => {
+      const config = jsonConfig();
+
+      await status(config);
+
+      expect(existsSync(path.join(temporaryDirectory, "status-local.json"))).toBe(false);
+    });
+
+    it("rejects --json for a single task", async () => {
+      await expect(status(makeConfig(), { task: "team-1", json: true })).rejects.toThrow(
+        "crew status: --json is not supported for a single task",
+      );
+    });
+  });
+
   // The snapshot document groups worktrees under one task while the inventory
   // prints one row per worktree. This pins the flatten order across that
   // regrouping.
@@ -1453,6 +1567,20 @@ describe(statusCli, () => {
     await expect(statusCli(["--task", "TEAM-1"])).rejects.toThrow(/Usage: crew status/);
 
     expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects --local-only without --json", async () => {
+    await expect(statusCli(["--local-only"])).rejects.toThrow(
+      "crew status: --local-only requires --json",
+    );
+
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts --json and --local-only in either order", async () => {
+    await statusCli(["--local-only", "--json"]);
+
+    expect(loadConfigMock).toHaveBeenCalled();
   });
 
   it("rejects extra positional arguments", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -6,10 +6,7 @@ import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import type {
-  LocalStatusDocument,
-  RemoteStatusDocument,
-} from "../lib/statusSnapshot.ts";
+import type { LocalStatusDocument, RemoteStatusDocument } from "../lib/statusSnapshot.ts";
 import type { Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -285,10 +285,8 @@ function runDurationMs(input: {
   if (lifecycle !== "running" && lifecycle !== "resumed") {
     return undefined;
   }
-  if (startedAt === undefined) {
-    return undefined;
-  }
-  const created = Date.parse(startedAt);
+  /* v8 ignore next @preserve -- a running lifecycle always carries a run state, which always has createdAt */
+  const created = Date.parse(startedAt ?? "");
   if (Number.isNaN(created)) {
     return undefined;
   }
@@ -372,11 +370,7 @@ function writeInventoryWorktrees(joined: JoinedStatus, now: Date): void {
   }
 }
 
-function writeInventoryRow(input: {
-  task: JoinedTask;
-  worktree: StatusWorktree;
-  now: Date;
-}): void {
+function writeInventoryRow(input: { task: JoinedTask; worktree: StatusWorktree; now: Date }): void {
   const { task, worktree, now } = input;
   writeOutput(task.url === undefined ? task.task : `${task.task}  ${task.url}`);
   if (task.title !== undefined) {
@@ -430,7 +424,10 @@ function writeStraySessions(local: LocalStatusDocument): void {
 
 function describeOpenBlockers(issue: StatusBlockedIssue): string {
   return issue.blockedBy
-    .map((blocker) => `${naturalIdFromCanonical(blocker.id)} (${blocker.nativeStatus ?? blocker.status})`)
+    .map(
+      (blocker) =>
+        `${naturalIdFromCanonical(blocker.id)} (${blocker.nativeStatus ?? blocker.status})`,
+    )
     .join(", ");
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -9,11 +9,14 @@ import { type JoinedStatus, type JoinedTask, joinStatus } from "../lib/statusJoi
 import {
   buildRemoteDocument,
   type LocalStatusDocument,
+  readRemoteSnapshot,
   type RemoteFetchResult,
   type StatusBlockedIssue,
   type StatusBoardIssue,
   type StatusQueueIssue,
   type StatusWorktree,
+  writeLocalSnapshot,
+  writeRemoteSnapshot,
 } from "../lib/statusSnapshot.ts";
 import {
   type CanonicalStatus,
@@ -35,9 +38,15 @@ import {
 
 export interface StatusOptions {
   task?: string;
+  /** Emit the snapshot documents as JSON and persist them. */
+  json?: boolean;
+  /** Collect the local tier only. Guarantees this run makes no network call. */
+  localOnly?: boolean;
 }
 
 const RECENT_LOG_LINE_COUNT = 10;
+
+const STATUS_USAGE = "Usage: crew status [<task>] [--json [--local-only]]";
 
 function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
@@ -48,11 +57,25 @@ function taskLinePattern(task: string): RegExp {
 }
 
 function parseArguments(argv: string[]): StatusOptions {
-  const [task, ...extras] = argv;
-  if (extras.length > 0 || task?.length === 0 || task?.startsWith("-") === true) {
-    throw new Error("Usage: crew status [<task>]");
+  const options: StatusOptions = {};
+  for (const argument of argv) {
+    if (argument === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (argument === "--local-only") {
+      options.localOnly = true;
+      continue;
+    }
+    if (argument.length === 0 || argument.startsWith("-") || options.task !== undefined) {
+      throw new Error(STATUS_USAGE);
+    }
+    options.task = argument.toLowerCase();
   }
-  return task === undefined ? {} : { task: task.toLowerCase() };
+  if (options.localOnly === true && options.json !== true) {
+    throw new Error("crew status: --local-only requires --json");
+  }
+  return options;
 }
 
 function writeSection(title: string): void {
@@ -529,8 +552,52 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
   writeQueueSections({ joined, result });
 }
 
+/**
+ * Emits the snapshot documents on stdout and persists them beside the log
+ * file. The persisted copies let a monitor start warm, and let any other
+ * reader see state without spawning a process.
+ *
+ * `--local-only` omits the `remote` key rather than setting it null: absent
+ * means "not collected", where null would mean "collected and empty".
+ */
+async function writeJsonStatus(input: {
+  config: ResolvedConfig;
+  localOnly: boolean;
+}): Promise<void> {
+  const { config, localOnly } = input;
+  const local = await collectLocalStatus({ config });
+  writeLocalSnapshot({ config, document: local });
+  if (localOnly) {
+    writeOutput(JSON.stringify({ local }, undefined, 2));
+    return;
+  }
+  const result = await collectRemoteStatus({
+    config,
+    pullRequestTargets: pullRequestTargetsOf(local),
+  });
+  // Print what landed on disk, not what we built. When the monotonic guard
+  // rejects our document because a concurrent run wrote a newer one, the two
+  // differ, and stdout must never contradict the file.
+  const remote = writeRemoteSnapshot({
+    config,
+    document: buildRemoteDocument({
+      previous: readRemoteSnapshot(config),
+      attemptAt: new Date().toISOString(),
+      result,
+    }),
+  });
+  writeOutput(JSON.stringify({ local, remote }, undefined, 2));
+}
+
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {
   const task = options.task?.trim();
+  if (options.json === true) {
+    if (task !== undefined) {
+      throw new Error("crew status: --json is not supported for a single task");
+    }
+    await writeJsonStatus({ config, localOnly: options.localOnly === true });
+    return;
+  }
   if (task === undefined) {
     await writeInventoryStatus(config);
     return;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -522,13 +522,14 @@ interface CollectedTiers {
  * read its guard uses, and the text path deliberately merges against nothing.
  */
 async function collectBothTiers(config: ResolvedConfig): Promise<CollectedTiers> {
+  const attemptAt = new Date().toISOString();
   const boardPromise = fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   const result = await collectRemoteStatus({
     board: await boardPromise,
     pullRequestTargets: pullRequestTargetsOf(local),
   });
-  return { local, attemptAt: new Date().toISOString(), result };
+  return { local, attemptAt, result };
 }
 
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,18 +1,37 @@
+/**
+ * Renderers for `crew status`. Three output modes share this file.
+ *
+ * With no task it renders the inventory: it calls the collectors in
+ * statusCollect.ts, joins the two tiers with joinStatus, and prints text.
+ * With a task it renders that one task, doing its own I/O rather than using
+ * the collectors, because it reads the whole log where they read a tail.
+ * With --json it prints and persists the wire documents from statusSnapshot.ts.
+ * Text mode persists nothing.
+ *
+ * @see README.md#status-snapshots-for-external-monitors for the reader contract.
+ */
+
 import { readFileSync } from "node:fs";
 
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import { type JoinedStatus, type JoinedTask, joinStatus } from "../lib/statusJoin.ts";
+import {
+  type JoinedStatus,
+  type JoinedTask,
+  type JoinedWorktree,
+  joinStatus,
+} from "../lib/statusJoin.ts";
 import {
   buildRemoteDocument,
   type LocalStatusDocument,
   readRemoteSnapshot,
+  type RemoteFetchResult,
+  type RemoteStatusDocument,
   type StatusBlockedIssue,
   type StatusLifecycle,
   type StatusBoardIssue,
   type StatusQueueIssue,
-  type StatusWorktree,
   writeLocalSnapshot,
   writeRemoteSnapshot,
 } from "../lib/statusSnapshot.ts";
@@ -337,7 +356,7 @@ function formatTaskStatus(canonicalStatus: CanonicalStatus): string {
 /** The document groups worktrees by task; rows are per worktree. */
 function writeInventoryWorktrees(joined: JoinedStatus, now: Date): void {
   writeSection("Worktrees");
-  const rows = joined.tasks.flatMap((task) =>
+  const rows: Array<{ task: JoinedTask; worktree: JoinedWorktree }> = joined.tasks.flatMap((task) =>
     task.worktrees.map((worktree) => ({ task, worktree })),
   );
   if (rows.length === 0) {
@@ -352,7 +371,7 @@ function writeInventoryWorktrees(joined: JoinedStatus, now: Date): void {
   }
 }
 
-function writeInventoryRow(input: { task: JoinedTask; worktree: StatusWorktree; now: Date }): void {
+function writeInventoryRow(input: { task: JoinedTask; worktree: JoinedWorktree; now: Date }): void {
   const { task, worktree, now } = input;
   writeOutput(task.url === undefined ? task.task : `${task.task}  ${task.url}`);
   if (task.title !== undefined) {
@@ -371,8 +390,8 @@ function writeInventoryRow(input: { task: JoinedTask; worktree: StatusWorktree; 
   if (task.attachCommand !== undefined) {
     writeOutput(inventoryField("attach", task.attachCommand));
   }
-  if (task.pullRequests.length > 0) {
-    writeOutput(inventoryField("pr", formatPullRequests(task.pullRequests)));
+  if (worktree.pullRequests.length > 0) {
+    writeOutput(inventoryField("pr", formatPullRequests(worktree.pullRequests)));
   }
   if (task.hint !== undefined) {
     writeOutput(inventoryField("hint", task.hint));
@@ -491,15 +510,25 @@ function writeInProgressWithoutWorktree(joined: JoinedStatus): void {
   }
 }
 
+interface CollectedTiers {
+  local: LocalStatusDocument;
+  remote: RemoteStatusDocument;
+  result: RemoteFetchResult;
+}
+
 /**
- * `previous: undefined` is deliberate. Carry-forward is a monitor concern: a
- * one-shot text run must report only what this attempt saw, or a failed fetch
- * would print a queue recovered from an old snapshot where it prints
- * "unavailable" today.
+ * Runs both tiers. The board fetch starts first because it needs nothing
+ * local; only the pull request lookups wait on resolved branches.
+ *
+ * `previous` carries a prior remote document forward when the fetch fails.
+ * Text mode passes undefined so a one-shot run reports only what it just saw,
+ * rather than a queue recovered from an old snapshot.
  */
-async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  // The board fetch needs nothing local, so start it before awaiting the
-  // local pass; only the pull request lookups depend on resolved branches.
+async function collectBothTiers(input: {
+  config: ResolvedConfig;
+  previous: RemoteStatusDocument | undefined;
+}): Promise<CollectedTiers> {
+  const { config, previous } = input;
   const boardPromise = fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   const result = await collectRemoteStatus({
@@ -508,10 +537,15 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
     pullRequestTargets: pullRequestTargetsOf(local),
   });
   const remote = buildRemoteDocument({
-    previous: undefined,
+    previous,
     attemptAt: new Date().toISOString(),
     result,
   });
+  return { local, remote, result };
+}
+
+async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
+  const { local, remote, result } = await collectBothTiers({ config, previous: undefined });
   const joined = joinStatus({ local, remote });
   const now = new Date();
 
@@ -538,30 +572,19 @@ async function writeJsonStatus(input: {
   localOnly: boolean;
 }): Promise<void> {
   const { config, localOnly } = input;
-  // Started only in the full form, so --local-only never touches the network.
-  const boardPromise = localOnly ? undefined : fetchBoardIssues(config);
-  const local = await collectLocalStatus({ config });
-  writeLocalSnapshot({ config, document: local });
-  if (boardPromise === undefined) {
+  // --local-only takes its own path rather than a flag inside collectBothTiers,
+  // so this branch provably never starts a board fetch.
+  if (localOnly) {
+    const local = writeLocalSnapshot({ config, document: await collectLocalStatus({ config }) });
     writeOutput(JSON.stringify({ local }, undefined, 2));
     return;
   }
-  const result = await collectRemoteStatus({
-    config,
-    board: await boardPromise,
-    pullRequestTargets: pullRequestTargetsOf(local),
-  });
-  // Print what landed on disk, not what we built. When the monotonic guard
+  const collected = await collectBothTiers({ config, previous: readRemoteSnapshot(config) });
+  // Print what landed on disk, not what we built. When a monotonic guard
   // rejects our document because a concurrent run wrote a newer one, the two
   // differ, and stdout must never contradict the file.
-  const remote = writeRemoteSnapshot({
-    config,
-    document: buildRemoteDocument({
-      previous: readRemoteSnapshot(config),
-      attemptAt: new Date().toISOString(),
-      result,
-    }),
-  });
+  const local = writeLocalSnapshot({ config, document: collected.local });
+  const remote = writeRemoteSnapshot({ config, document: collected.remote });
   writeOutput(JSON.stringify({ local, remote }, undefined, 2));
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -25,7 +25,6 @@ import {
 import {
   buildRemoteDocument,
   type LocalStatusDocument,
-  readRemoteSnapshot,
   type RemoteFetchResult,
   type RemoteStatusDocument,
   type StatusBlockedIssue,
@@ -485,7 +484,6 @@ function writeInProgressIssue(issue: StatusBoardIssue): void {
 function pullRequestTargetsOf(local: LocalStatusDocument): PullRequestTarget[] {
   return local.tasks.flatMap((task) =>
     task.worktrees.map((worktree) => ({
-      task: task.task,
       dir: worktree.dir,
       branch: worktree.branch,
     })),
@@ -513,6 +511,7 @@ function writeInProgressWithoutWorktree(joined: JoinedStatus): void {
 interface CollectedTiers {
   local: LocalStatusDocument;
   remote: RemoteStatusDocument;
+  attemptAt: string;
   result: RemoteFetchResult;
 }
 
@@ -532,20 +531,15 @@ async function collectBothTiers(input: {
   const boardPromise = fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   const result = await collectRemoteStatus({
-    config,
     board: await boardPromise,
     pullRequestTargets: pullRequestTargetsOf(local),
   });
-  const remote = buildRemoteDocument({
-    previous,
-    attemptAt: new Date().toISOString(),
-    result,
-  });
-  return { local, remote, result };
+  const attemptAt = new Date().toISOString();
+  return { local, remote: buildRemoteDocument({ previous, attemptAt, result }), attemptAt, result };
 }
 
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  const { local, remote, result } = await collectBothTiers({ config, previous: undefined });
+  const { local, remote } = await collectBothTiers({ config, previous: undefined });
   const joined = joinStatus({ local, remote });
   const now = new Date();
 
@@ -556,7 +550,7 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
     writeOutput();
     writeOutput(`slots: ${joined.slots.used}/${joined.slots.maximum} used`);
   }
-  writeQueueSections({ joined, boardError: result.kind === "error" ? result.message : undefined });
+  writeQueueSections({ joined, boardError: remote.lastAttemptError });
 }
 
 /**
@@ -579,12 +573,17 @@ async function writeJsonStatus(input: {
     writeOutput(JSON.stringify({ local }, undefined, 2));
     return;
   }
-  const collected = await collectBothTiers({ config, previous: readRemoteSnapshot(config) });
+  const collected = await collectBothTiers({ config, previous: undefined });
   // Print what landed on disk, not what we built. When a monotonic guard
   // rejects our document because a concurrent run wrote a newer one, the two
-  // differ, and stdout must never contradict the file.
+  // differ, and stdout must never contradict the file. writeRemoteSnapshot
+  // owns the carry-forward merge so it reads the file exactly once.
   const local = writeLocalSnapshot({ config, document: collected.local });
-  const remote = writeRemoteSnapshot({ config, document: collected.remote });
+  const remote = writeRemoteSnapshot({
+    config,
+    attemptAt: collected.attemptAt,
+    result: collected.result,
+  });
   writeOutput(JSON.stringify({ local, remote }, undefined, 2));
 }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,7 +1,5 @@
 import { readFileSync } from "node:fs";
 
-import { type Board, createBoard } from "../lib/board.ts";
-import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
@@ -10,8 +8,8 @@ import {
   buildRemoteDocument,
   type LocalStatusDocument,
   readRemoteSnapshot,
-  type RemoteFetchResult,
   type StatusBlockedIssue,
+  type StatusLifecycle,
   type StatusBoardIssue,
   type StatusQueueIssue,
   type StatusWorktree,
@@ -28,11 +26,15 @@ import { type WorkspaceAccessHint, type WorkspaceProbe, workspaces } from "../li
 import { type WorktreeDirtiness, worktrees } from "../lib/worktrees.ts";
 import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import {
+  buildBoard,
   collectLocalStatus,
   collectRemoteStatus,
+  disagreementLabel,
+  fetchBoardIssues,
   isWorkspaceExited,
+  probeDisagreement,
   type PullRequestTarget,
-  runProbeFlags,
+  recentTaskLogLines,
   workspaceProbeUnavailableText,
 } from "./statusCollect.ts";
 
@@ -44,17 +46,7 @@ export interface StatusOptions {
   localOnly?: boolean;
 }
 
-const RECENT_LOG_LINE_COUNT = 10;
-
 const STATUS_USAGE = "Usage: crew status [<task>] [--json [--local-only]]";
-
-function escapeRegExp(value: string): string {
-  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
-
-function taskLinePattern(task: string): RegExp {
-  return new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
-}
 
 function parseArguments(argv: string[]): StatusOptions {
   const options: StatusOptions = {};
@@ -71,9 +63,6 @@ function parseArguments(argv: string[]): StatusOptions {
       throw new Error(STATUS_USAGE);
     }
     options.task = argument.toLowerCase();
-  }
-  if (options.localOnly === true && options.json !== true) {
-    throw new Error("crew status: --local-only requires --json");
   }
   return options;
 }
@@ -143,25 +132,23 @@ function formatRunState(state: RunState | undefined, flags: readonly string[] = 
   return detail === undefined ? summary : `${summary}; ${detail}`;
 }
 
-function recentTaskLogLines(config: ResolvedConfig, task: string): string[] {
-  let raw: string;
+/**
+ * The one-shot per-task view reads the whole log rather than the bounded tail
+ * the pollable collector uses, so an old task still shows its history.
+ */
+function wholeLogLines(config: ResolvedConfig): string[] {
   try {
-    raw = readFileSync(config.logging.file, "utf8");
+    return readFileSync(config.logging.file, "utf8").split("\n");
   } catch {
     return [];
   }
-  const pattern = taskLinePattern(task);
-  return raw
-    .split("\n")
-    .filter((line) => pattern.test(line))
-    .slice(-RECENT_LOG_LINE_COUNT);
 }
 
 async function resolveTaskSource(
   config: ResolvedConfig,
   task: string,
 ): Promise<SourceIssue | undefined> {
-  const board = await buildBoardForStatus(config);
+  const board = await buildBoard(config);
   return await withLogOutputSuppressed(async () => await board.resolveOne(task));
 }
 
@@ -186,7 +173,7 @@ async function readTaskSourceStatus(
 }
 
 function writeRecentLogs(config: ResolvedConfig, task: string): void {
-  const logLines = recentTaskLogLines(config, task);
+  const logLines = recentTaskLogLines({ lines: wholeLogLines(config), task });
   if (logLines.length === 0) {
     return;
   }
@@ -258,8 +245,13 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
   const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
   writeOutput(formatTaskLine(task, runState, sourceStatus));
   writeTaskTitle(runState, sourceStatus);
+  const disagreement = probeDisagreement({
+    lifecycle: runState?.state ?? "idle",
+    probe: workspaceProbe,
+    task,
+  });
   writeOutput(
-    `run: ${formatRunState(runState, runProbeFlags({ runState, probe: workspaceProbe, task }))}`,
+    `run: ${formatRunState(runState, disagreement === undefined ? [] : [disagreementLabel(disagreement)])}`,
   );
   writeOutput(`workspace: ${taskWorkspaceText(workspaceProbe, task)}`);
   if (accessHint !== undefined) {
@@ -271,13 +263,11 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
 }
 
 /**
- * Wall-clock elapsed time since the run was first recorded (RunState.createdAt
- * is preserved across resume/interrupt). Returns undefined when the row isn't
- * actively running, when no run state exists, or when the timestamp cannot
- * be parsed.
+ * Wall-clock time since the run was first recorded. Undefined unless the row is
+ * actively running, so an idle or finished row shows no age.
  */
 function runDurationMs(input: {
-  lifecycle: string;
+  lifecycle: StatusLifecycle;
   startedAt: string | undefined;
   now: Date;
 }): number | undefined {
@@ -314,12 +304,7 @@ function formatDuration(ms: number): string {
   return hours === 0 ? `${days}d` : `${days}d ${hours}h`;
 }
 
-/**
- * Combined human-readable state for the inventory row. The collector already
- * resolved the lifecycle and the probe-disagreement flags; this appends the
- * elapsed wall-clock time, which is derived at render time so a row never
- * shows a frozen clock.
- */
+/** Elapsed time is derived here, never stored, so a row cannot show a stale age. */
 function inventoryStateText(task: JoinedTask, now: Date): string {
   const flags = [...task.flags];
   const duration = runDurationMs({ lifecycle: task.lifecycle, startedAt: task.startedAt, now });
@@ -349,10 +334,7 @@ function formatTaskStatus(canonicalStatus: CanonicalStatus): string {
   return canonicalStatus === "in-progress" ? "in-progress (slot held)" : canonicalStatus;
 }
 
-/**
- * One row per worktree. The joined document groups worktrees under their task,
- * so this flattens them back in collection order.
- */
+/** The document groups worktrees by task; rows are per worktree. */
 function writeInventoryWorktrees(joined: JoinedStatus, now: Date): void {
   writeSection("Worktrees");
   const rows = joined.tasks.flatMap((task) =>
@@ -438,16 +420,11 @@ function writeQueueIssue(issue: StatusQueueIssue): void {
   writeOutput(inventoryField("agent", issue.agent));
 }
 
-async function buildBoardForStatus(config: ResolvedConfig): Promise<Board> {
-  const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
-  return createBoard(sources);
-}
-
-function writeQueueSections(input: { joined: JoinedStatus; result: RemoteFetchResult }): void {
-  const { joined, result } = input;
-  if (result.kind === "error") {
+function writeQueueSections(input: { joined: JoinedStatus; boardError: string | undefined }): void {
+  const { joined, boardError } = input;
+  if (boardError !== undefined) {
     writeSection("Queue");
-    writeOutput(`unavailable: ${result.message}`);
+    writeOutput(`unavailable: ${boardError}`);
     return;
   }
 
@@ -485,10 +462,7 @@ function writeInProgressIssue(issue: StatusBoardIssue): void {
   }
 }
 
-/**
- * Pull request lookups reuse the branches the local pass already resolved, so
- * the remote pass never re-reads run state or re-resolves a branch.
- */
+/** Reuses the branches the local pass resolved, so the remote pass re-reads nothing. */
 function pullRequestTargetsOf(local: LocalStatusDocument): PullRequestTarget[] {
   return local.tasks.flatMap((task) =>
     task.worktrees.map((worktree) => ({
@@ -518,17 +492,19 @@ function writeInProgressWithoutWorktree(joined: JoinedStatus): void {
 }
 
 /**
- * Collects both tiers and renders the joined view.
- *
  * `previous: undefined` is deliberate. Carry-forward is a monitor concern: a
  * one-shot text run must report only what this attempt saw, or a failed fetch
  * would print a queue recovered from an old snapshot where it prints
  * "unavailable" today.
  */
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
+  // The board fetch needs nothing local, so start it before awaiting the
+  // local pass; only the pull request lookups depend on resolved branches.
+  const boardPromise = fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   const result = await collectRemoteStatus({
     config,
+    board: await boardPromise,
     pullRequestTargets: pullRequestTargetsOf(local),
   });
   const remote = buildRemoteDocument({
@@ -546,7 +522,7 @@ async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
     writeOutput();
     writeOutput(`slots: ${joined.slots.used}/${joined.slots.maximum} used`);
   }
-  writeQueueSections({ joined, result });
+  writeQueueSections({ joined, boardError: result.kind === "error" ? result.message : undefined });
 }
 
 /**
@@ -562,14 +538,17 @@ async function writeJsonStatus(input: {
   localOnly: boolean;
 }): Promise<void> {
   const { config, localOnly } = input;
+  // Started only in the full form, so --local-only never touches the network.
+  const boardPromise = localOnly ? undefined : fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   writeLocalSnapshot({ config, document: local });
-  if (localOnly) {
+  if (boardPromise === undefined) {
     writeOutput(JSON.stringify({ local }, undefined, 2));
     return;
   }
   const result = await collectRemoteStatus({
     config,
+    board: await boardPromise,
     pullRequestTargets: pullRequestTargetsOf(local),
   });
   // Print what landed on disk, not what we built. When the monotonic guard
@@ -586,12 +565,24 @@ async function writeJsonStatus(input: {
   writeOutput(JSON.stringify({ local, remote }, undefined, 2));
 }
 
+/**
+ * The option combinations the command refuses. Lives apart from
+ * `parseArguments` so the exported `status` enforces it too: a library caller
+ * passing `localOnly` without `json` must not silently get the text path.
+ */
+function assertSupportedOptions(options: StatusOptions): void {
+  if (options.localOnly === true && options.json !== true) {
+    throw new Error("crew status: --local-only requires --json");
+  }
+  if (options.json === true && options.task !== undefined) {
+    throw new Error("crew status: --json is not supported for a single task");
+  }
+}
+
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {
+  assertSupportedOptions(options);
   const task = options.task?.trim();
   if (options.json === true) {
-    if (task !== undefined) {
-      throw new Error("crew status: --json is not supported for a single task");
-    }
     await writeJsonStatus({ config, localOnly: options.localOnly === true });
     return;
   }
@@ -607,6 +598,8 @@ export async function status(config: ResolvedConfig, options: StatusOptions = {}
 
 export async function statusCli(argv: string[]): Promise<void> {
   const options = parseArguments(argv);
+  // Validate before loading config so a bad flag combination fails fast.
+  assertSupportedOptions(options);
   const config = await loadConfig();
   await status(config, options);
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -5,10 +5,18 @@ import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
+import { type JoinedStatus, type JoinedTask, joinStatus } from "../lib/statusJoin.ts";
+import {
+  buildRemoteDocument,
+  type LocalStatusDocument,
+  type RemoteFetchResult,
+  type StatusBlockedIssue,
+  type StatusBoardIssue,
+  type StatusQueueIssue,
+  type StatusWorktree,
+} from "../lib/statusSnapshot.ts";
 import {
   type CanonicalStatus,
-  type GroundcrewIssue,
-  isGroundcrewIssue,
   type Issue as SourceIssue,
   naturalIdFromCanonical,
 } from "../lib/taskSource.ts";
@@ -16,6 +24,14 @@ import { errorMessage, withLogOutputSuppressed, writeOutput } from "../lib/util.
 import { type WorkspaceAccessHint, type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, worktrees } from "../lib/worktrees.ts";
 import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
+import {
+  collectLocalStatus,
+  collectRemoteStatus,
+  isWorkspaceExited,
+  type PullRequestTarget,
+  runProbeFlags,
+  workspaceProbeUnavailableText,
+} from "./statusCollect.ts";
 
 export interface StatusOptions {
   task?: string;
@@ -82,26 +98,14 @@ async function writeTaskWorktrees(config: ResolvedConfig, task: string): Promise
   }
 }
 
-function workspaceProbeUnavailableLine(
-  probe: Extract<WorkspaceProbe, { kind: "unavailable" }>,
-): string {
-  return probe.error === undefined
-    ? "Workspace probe unavailable"
-    : `Workspace probe unavailable: ${errorMessage(probe.error)}`;
-}
-
 function taskWorkspaceText(probe: WorkspaceProbe, task: string): string {
   if (probe.kind === "unavailable") {
-    return workspaceProbeUnavailableLine(probe);
+    return workspaceProbeUnavailableText(probe);
   }
-  if (isWorkspaceExited(probe, task)) {
+  if (isWorkspaceExited({ probe, task })) {
     return "exited";
   }
   return probe.names.has(task) ? "live" : "not live";
-}
-
-function isWorkspaceExited(probe: WorkspaceProbe, task: string): boolean {
-  return probe.kind === "ok" && probe.exitedNames?.has(task) === true;
 }
 
 function formatRunState(state: RunState | undefined, flags: readonly string[] = []): string {
@@ -172,7 +176,7 @@ async function exitedWorkspaceAccessHint(
   probe: WorkspaceProbe,
   task: string,
 ): Promise<WorkspaceAccessHint | undefined> {
-  if (!isWorkspaceExited(probe, task)) {
+  if (!isWorkspaceExited({ probe, task })) {
     return undefined;
   }
   try {
@@ -231,7 +235,9 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
   const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
   writeOutput(formatTaskLine(task, runState, sourceStatus));
   writeTaskTitle(runState, sourceStatus);
-  writeOutput(`run: ${formatRunState(runState, runProbeFlags(runState, workspaceProbe, task))}`);
+  writeOutput(
+    `run: ${formatRunState(runState, runProbeFlags({ runState, probe: workspaceProbe, task }))}`,
+  );
   writeOutput(`workspace: ${taskWorkspaceText(workspaceProbe, task)}`);
   if (accessHint !== undefined) {
     writeOutput(`attach: ${accessHint.command}`);
@@ -247,14 +253,19 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
  * actively running, when no run state exists, or when the timestamp cannot
  * be parsed.
  */
-function runStateDurationMs(runState: RunState | undefined, now: Date): number | undefined {
-  if (runState === undefined) {
+function runDurationMs(input: {
+  lifecycle: string;
+  startedAt: string | undefined;
+  now: Date;
+}): number | undefined {
+  const { lifecycle, startedAt, now } = input;
+  if (lifecycle !== "running" && lifecycle !== "resumed") {
     return undefined;
   }
-  if (runState.state !== "running" && runState.state !== "resumed") {
+  if (startedAt === undefined) {
     return undefined;
   }
-  const created = Date.parse(runState.createdAt);
+  const created = Date.parse(startedAt);
   if (Number.isNaN(created)) {
     return undefined;
   }
@@ -283,95 +294,18 @@ function formatDuration(ms: number): string {
 }
 
 /**
- * Probe-reconciliation flags shared by the inventory row and the per-task
- * `run:` line. Flags the two interesting disagreements between the recorded
- * RunState lifecycle and the live workspace probe: a running/resumed dispatch
- * with a missing or exited session, and an idle row with a stray live or
- * exited session. `probe.kind === "unavailable"` is "we don't know" and yields
- * no flags. Excludes the duration token, which only the inventory row appends.
+ * Combined human-readable state for the inventory row. The collector already
+ * resolved the lifecycle and the probe-disagreement flags; this appends the
+ * elapsed wall-clock time, which is derived at render time so a row never
+ * shows a frozen clock.
  */
-function runProbeFlags(
-  runState: RunState | undefined,
-  probe: WorkspaceProbe,
-  task: string,
-): string[] {
-  if (probe.kind !== "ok") {
-    return [];
-  }
-  const lifecycle = runState?.state ?? "idle";
-  const sessionPresent = probe.names.has(task);
-  const sessionExited = isWorkspaceExited(probe, task);
-  const flags: string[] = [];
-  if (lifecycle === "idle" && sessionPresent) {
-    flags.push(sessionExited ? "stray exited session" : "stray session");
-  }
-  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
-    flags.push("session exited");
-  } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
-    flags.push("session dead");
-  }
-  return flags;
-}
-
-/**
- * Combined human-readable state for the inventory row. Surfaces RunState
- * lifecycle and flags the two interesting disagreements with the workspace
- * probe via `runProbeFlags`. When the row is actively running, appends the
- * elapsed wall-clock time since dispatch.
- */
-function inventoryStateText(
-  runState: RunState | undefined,
-  probe: WorkspaceProbe,
-  task: string,
-  now: Date,
-): string {
-  const lifecycle = runState?.state ?? "idle";
-  const flags = runProbeFlags(runState, probe, task);
-  const duration = runStateDurationMs(runState, now);
+function inventoryStateText(task: JoinedTask, now: Date): string {
+  const flags = [...task.flags];
+  const duration = runDurationMs({ lifecycle: task.lifecycle, startedAt: task.startedAt, now });
   if (duration !== undefined) {
     flags.push(formatDuration(duration));
   }
-  return flags.length === 0 ? lifecycle : `${lifecycle} (${flags.join(", ")})`;
-}
-
-/**
- * Hint command for inventory rows where the run-state and the workspace
- * probe disagree. Returned commands are safe defaults; the user is free to
- * ignore them and use `attach:` + `pr:` to investigate first.
- *
- * - Stray session (session present, no run-state record) -> `crew cleanup`
- *   to tear down the orphaned worktree and close the session.
- * - Session exited (run-state says running/resumed, kept dead tmux window)
- *   -> attach first so the failed command remains available for inspection.
- * - Session dead (run-state says running/resumed, no session present) ->
- *   `crew resume` to bring the agent back; the worktree is preserved.
- *
- * No hint when the probe is unavailable (we genuinely don't know whether
- * there's a disagreement) or when the row is healthy.
- */
-function inventoryHint(
-  runState: RunState | undefined,
-  probe: WorkspaceProbe,
-  task: string,
-): string | undefined {
-  if (probe.kind === "unavailable") {
-    return undefined;
-  }
-  const lifecycle = runState?.state ?? "idle";
-  const sessionPresent = probe.names.has(task);
-  const sessionExited = isWorkspaceExited(probe, task);
-  if (lifecycle === "idle" && sessionPresent) {
-    return sessionExited
-      ? `run 'crew cleanup ${task}' to clear this stray exited session`
-      : `run 'crew cleanup ${task}' to clear this stray session`;
-  }
-  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
-    return `attach to inspect scrollback, then run 'crew resume ${task}'`;
-  }
-  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
-    return `run 'crew resume ${task}' to bring the session back`;
-  }
-  return undefined;
+  return flags.length === 0 ? task.lifecycle : `${task.lifecycle} (${flags.join(", ")})`;
 }
 
 const INVENTORY_LABEL_WIDTH = "worktree:".length;
@@ -386,164 +320,99 @@ function formatPullRequests(prs: readonly PullRequestSummary[]): string {
 
 /**
  * Inventory `task:` value: the worktree's remote canonical status. Slots are
- * consumed solely by `in-progress` issues (see `inProgressCount`), so that one
- * status is spelled out as `slot held` to make the otherwise-implicit rule
- * legible on the row; every other status renders bare.
+ * consumed solely by `in-progress` issues, so that one status is spelled out as
+ * `slot held` to make the otherwise-implicit rule legible on the row; every
+ * other status renders bare.
  */
 function formatTaskStatus(canonicalStatus: CanonicalStatus): string {
   return canonicalStatus === "in-progress" ? "in-progress (slot held)" : canonicalStatus;
 }
 
-async function writeInventoryWorktrees(
-  config: ResolvedConfig,
-  probe: WorkspaceProbe,
-  statusByTask: ReadonlyMap<string, CanonicalStatus> | undefined,
-): Promise<void> {
+/**
+ * One row per worktree. The joined document groups worktrees under their task,
+ * so this flattens them back in collection order.
+ */
+function writeInventoryWorktrees(joined: JoinedStatus, now: Date): void {
   writeSection("Worktrees");
-  const entries = worktrees
-    .list(config)
-    .toSorted((left, right) => left.task.localeCompare(right.task));
-  if (entries.length === 0) {
+  const rows = joined.tasks.flatMap((task) =>
+    task.worktrees.map((worktree) => ({ task, worktree })),
+  );
+  if (rows.length === 0) {
     writeOutput("(none)");
     return;
   }
-  const runStates = new Map<string, RunState | undefined>();
-  for (const entry of entries) {
-    if (!runStates.has(entry.task)) {
-      runStates.set(entry.task, readRunState(config, entry.task));
-    }
-  }
-  const accessHints = await collectAccessHints(config, entries);
-  const pullRequests = await collectPullRequests(
-    await Promise.all(
-      entries.map(async (entry) => ({
-        dir: entry.dir,
-        branchName: await effectiveBranchNameFromRunState({
-          entry,
-          runState: runStates.get(entry.task),
-        }),
-      })),
-    ),
-  );
-  const now = new Date();
-  for (const [index, entry] of entries.entries()) {
-    const runState = runStates.get(entry.task);
-    const accessHint = accessHints.get(entry.task);
-    // `collectPullRequests` guarantees an entry for every worktree dir seen
-    // in `entries`; the lookup always returns the array.
-    /* v8 ignore next @preserve -- defensive fallback for a Map key that collectPullRequests always populates */
-    const prs = pullRequests.get(entry.dir) ?? [];
+  for (const [index, row] of rows.entries()) {
     if (index > 0) {
       writeOutput();
     }
-    writeOutput(runState?.url === undefined ? entry.task : `${entry.task}  ${runState.url}`);
-    if (runState?.title !== undefined) {
-      writeOutput(inventoryField("title", runState.title));
-    }
-    writeOutput(inventoryField("state", inventoryStateText(runState, probe, entry.task, now)));
-    // `state:` is the local run lifecycle; `task:` is the remote status that
-    // actually drives the slot count. They're sourced independently and can
-    // legitimately disagree, so they sit adjacent. Omitted when the board fetch
-    // failed (no map) or the task isn't in the fetched board.
-    const taskStatus = statusByTask?.get(entry.task);
-    if (taskStatus !== undefined) {
-      writeOutput(inventoryField("task", formatTaskStatus(taskStatus)));
-    }
-    writeOutput(inventoryField("repo", entry.repository));
-    writeOutput(inventoryField("worktree", entry.dir));
-    if (accessHint !== undefined) {
-      writeOutput(inventoryField("attach", accessHint.command));
-    }
-    if (prs.length > 0) {
-      writeOutput(inventoryField("pr", formatPullRequests(prs)));
-    }
-    const hint = inventoryHint(runState, probe, entry.task);
-    if (hint !== undefined) {
-      writeOutput(inventoryField("hint", hint));
-    }
+    writeInventoryRow({ ...row, now });
   }
 }
 
-async function collectAccessHints(
-  config: ResolvedConfig,
-  entries: ReadonlyArray<{ task: string }>,
-): Promise<Map<string, WorkspaceAccessHint | undefined>> {
-  const uniqueTasks = [...new Set(entries.map((entry) => entry.task))];
-  const results = await Promise.allSettled(
-    uniqueTasks.map(async (task) => await workspaces.accessHint(config, task)),
-  );
-  return new Map(
-    uniqueTasks.map((task, index) => {
-      const result = results[index];
-      return [task, result?.status === "fulfilled" ? result.value : undefined] as const;
-    }),
-  );
-}
-
-async function collectPullRequests(
-  entries: ReadonlyArray<{ dir: string; branchName: string }>,
-): Promise<Map<string, readonly PullRequestSummary[]>> {
-  // Each worktree dir is unique, so keying by dir collapses nothing in
-  // practice; the Map removes duplicates defensively if the same dir
-  // appears twice.
-  const uniqueByDir = new Map<string, { dir: string; branchName: string }>();
-  for (const entry of entries) {
-    uniqueByDir.set(entry.dir, { dir: entry.dir, branchName: entry.branchName });
+function writeInventoryRow(input: {
+  task: JoinedTask;
+  worktree: StatusWorktree;
+  now: Date;
+}): void {
+  const { task, worktree, now } = input;
+  writeOutput(task.url === undefined ? task.task : `${task.task}  ${task.url}`);
+  if (task.title !== undefined) {
+    writeOutput(inventoryField("title", task.title));
   }
-  const results = await Promise.allSettled(
-    [...uniqueByDir.entries()].map(async ([dir, { branchName }]) => {
-      const prs = await findPullRequestsForBranch({ cwd: dir, branchName });
-      return [dir, prs] as const;
-    }),
-  );
-  return new Map(
-    [...uniqueByDir.keys()].map((dir, index) => {
-      const result = results[index];
-      return [dir, result?.status === "fulfilled" ? result.value[1] : []] as const;
-    }),
-  );
+  writeOutput(inventoryField("state", inventoryStateText(task, now)));
+  // `state:` is the local run lifecycle; `task:` is the remote status that
+  // actually drives the slot count. They're sourced independently and can
+  // legitimately disagree, so they sit adjacent. Omitted when the board fetch
+  // failed or the task isn't in the fetched board.
+  if (task.boardStatus !== undefined) {
+    writeOutput(inventoryField("task", formatTaskStatus(task.boardStatus)));
+  }
+  writeOutput(inventoryField("repo", worktree.repository));
+  writeOutput(inventoryField("worktree", worktree.dir));
+  if (task.attachCommand !== undefined) {
+    writeOutput(inventoryField("attach", task.attachCommand));
+  }
+  if (task.pullRequests.length > 0) {
+    writeOutput(inventoryField("pr", formatPullRequests(task.pullRequests)));
+  }
+  if (task.hint !== undefined) {
+    writeOutput(inventoryField("hint", task.hint));
+  }
 }
 
 const ORPHANED_SESSIONS_HEADER = "Orphaned sessions (no matching worktree)";
 const ORPHANED_SESSIONS_ACTION =
   "What to do: run 'crew stop <task>' to close the session, or 'tmux kill-session -t <task>' if no run-state exists.";
 
-function writeStraySessions(probe: WorkspaceProbe, worktreeTasks: ReadonlySet<string>): void {
-  if (probe.kind === "unavailable") {
+function writeStraySessions(local: LocalStatusDocument): void {
+  if (local.workspaceProbe.status === "unavailable") {
     // Surface probe failures so the user knows we couldn't classify orphans
     // (silently dropping the section would hide that diagnostic). The action
     // hint is omitted here — there's no row to act on.
     writeSection(ORPHANED_SESSIONS_HEADER);
-    writeOutput(workspaceProbeUnavailableLine(probe));
+    writeOutput(
+      local.workspaceProbe.error === undefined
+        ? "Workspace probe unavailable"
+        : `Workspace probe unavailable: ${local.workspaceProbe.error}`,
+    );
     return;
   }
-  const strays = [...probe.names].filter((name) => !worktreeTasks.has(name)).toSorted();
-  if (strays.length === 0) {
+  if (local.orphanedSessions.length === 0) {
     return;
   }
   writeSection(ORPHANED_SESSIONS_HEADER);
   writeOutput(ORPHANED_SESSIONS_ACTION);
-  writeOutput(strays.join("\n"));
+  writeOutput(local.orphanedSessions.join("\n"));
 }
 
-function isTodoSourceIssue(issue: SourceIssue): boolean {
-  return issue.status === "todo";
-}
-
-function hasOpenBlocker(issue: SourceIssue): boolean {
-  return issue.blockers.some((b) => b.status !== "done");
-}
-
-function describeOpenBlockers(issue: SourceIssue): string {
-  return issue.blockers
-    .filter((b) => b.status !== "done")
-    .map((b) => `${naturalIdFromCanonical(b.id)} (${b.nativeStatus ?? b.status})`)
+function describeOpenBlockers(issue: StatusBlockedIssue): string {
+  return issue.blockedBy
+    .map((blocker) => `${naturalIdFromCanonical(blocker.id)} (${blocker.nativeStatus ?? blocker.status})`)
     .join(", ");
 }
 
-function writeQueueIssue(issue: GroundcrewIssue): void {
-  const naturalId = naturalIdFromCanonical(issue.id);
-  writeOutput(issue.url === undefined ? naturalId : `${naturalId}  ${issue.url}`);
+function writeQueueIssue(issue: StatusQueueIssue): void {
+  writeOutput(issue.url === undefined ? issue.naturalId : `${issue.naturalId}  ${issue.url}`);
   writeOutput(inventoryField("title", issue.title));
   writeOutput(inventoryField("repo", issue.repository));
   writeOutput(inventoryField("agent", issue.agent));
@@ -554,78 +423,18 @@ async function buildBoardForStatus(config: ResolvedConfig): Promise<Board> {
   return createBoard(sources);
 }
 
-type BoardFetchResult =
-  | { kind: "ok"; issues: readonly SourceIssue[] }
-  | { kind: "error"; error: unknown };
-
-/**
- * Single board fetch used by both the slot count header and the
- * Queue/Blocked sections. Failures (e.g., missing API key) are captured
- * and rendered later as `unavailable: ...` in the Queue section.
- */
-async function fetchBoardForStatus(config: ResolvedConfig): Promise<BoardFetchResult> {
-  try {
-    const board = await buildBoardForStatus(config);
-    const { issues } = await withLogOutputSuppressed(async () => await board.fetch());
-    return { kind: "ok", issues };
-  } catch (error) {
-    return { kind: "error", error };
-  }
-}
-
-/**
- * Maps each fetched issue's lowercased natural id to its canonical status when
- * exactly one fetched issue has that natural id, so the Worktrees section can
- * show a `task:` field per row without guessing across sources. The key
- * matches the lowercased `WorktreeEntry.task` (same join as
- * `inProgressWithoutWorktree`). `undefined` when the board fetch failed —
- * callers then omit the field rather than guess.
- */
-function statusByWorktreeTask(
-  boardResult: BoardFetchResult,
-): ReadonlyMap<string, CanonicalStatus> | undefined {
-  if (boardResult.kind !== "ok") {
-    return undefined;
-  }
-  const statuses = new Map<string, CanonicalStatus>();
-  const matchCounts = new Map<string, number>();
-  for (const issue of boardResult.issues) {
-    const task = naturalIdFromCanonical(issue.id).toLowerCase();
-    matchCounts.set(task, (matchCounts.get(task) ?? 0) + 1);
-    statuses.set(task, issue.status);
-  }
-  for (const [task, matchCount] of matchCounts) {
-    if (matchCount > 1) {
-      statuses.delete(task);
-    }
-  }
-  return statuses;
-}
-
-function writeQueueSections(
-  boardResult: BoardFetchResult,
-  worktreeTasks: ReadonlySet<string>,
-): void {
-  if (boardResult.kind === "error") {
+function writeQueueSections(input: { joined: JoinedStatus; result: RemoteFetchResult }): void {
+  const { joined, result } = input;
+  if (result.kind === "error") {
     writeSection("Queue");
-    writeOutput(`unavailable: ${errorMessage(boardResult.error)}`);
+    writeOutput(`unavailable: ${result.message}`);
     return;
   }
-  // Only groundcrew-eligible Todos are dispatchable; non-eligible ones lack
-  // a repo or agent, so `crew run` would skip them. Todos whose task already
-  // has a local worktree are omitted so a dispatched-but-not-yet-transitioned
-  // ticket doesn't show as both provisioning and queued.
-  const todos = boardResult.issues
-    .filter(isTodoSourceIssue)
-    .filter(isGroundcrewIssue)
-    .filter((i) => !worktreeTasks.has(naturalIdFromCanonical(i.id).toLowerCase()));
-  const ready = todos.filter((i) => !hasOpenBlocker(i));
-  const blocked = todos.filter(hasOpenBlocker);
 
   // Hide the section entirely when nothing's queued and nothing's blocked.
-  if (ready.length > 0) {
+  if (joined.queueReady.length > 0) {
     writeSection("Queue");
-    for (const [index, issue] of ready.entries()) {
+    for (const [index, issue] of joined.queueReady.entries()) {
       if (index > 0) {
         writeOutput();
       }
@@ -633,9 +442,9 @@ function writeQueueSections(
     }
   }
 
-  if (blocked.length > 0) {
+  if (joined.queueBlocked.length > 0) {
     writeSection("Blocked");
-    for (const [index, issue] of blocked.entries()) {
+    for (const [index, issue] of joined.queueBlocked.entries()) {
       if (index > 0) {
         writeOutput();
       }
@@ -645,57 +454,42 @@ function writeQueueSections(
   }
 }
 
-function inProgressCount(issues: readonly SourceIssue[]): number {
-  return issues.filter((issue) => issue.status === "in-progress").length;
-}
-
-/**
- * In-progress board issues that have no local worktree. These count toward the
- * `slots: N/M used` total but are absent from the Worktrees section (their
- * worktree was removed, or lives outside this config's projectDir /
- * knownRepositories), so without this they'd be counted yet invisible. Worktree
- * tasks are lowercased, so the natural id is lowercased before matching.
- */
-function inProgressWithoutWorktree(
-  issues: readonly SourceIssue[],
-  worktreeTasks: ReadonlySet<string>,
-): SourceIssue[] {
-  return issues
-    .filter((issue) => issue.status === "in-progress")
-    .filter((issue) => !worktreeTasks.has(naturalIdFromCanonical(issue.id).toLowerCase()))
-    .toSorted((left, right) => left.id.localeCompare(right.id));
-}
-
-function writeInProgressIssue(issue: SourceIssue): void {
-  const naturalId = naturalIdFromCanonical(issue.id);
-  writeOutput(issue.url === undefined ? naturalId : `${naturalId}  ${issue.url}`);
+function writeInProgressIssue(issue: StatusBoardIssue): void {
+  writeOutput(issue.url === undefined ? issue.naturalId : `${issue.naturalId}  ${issue.url}`);
   writeOutput(inventoryField("title", issue.title));
   // These are all in-progress by definition, but spell out the slot-held
   // status so every holder row reads the same whether or not it has a worktree.
-  writeOutput(inventoryField("task", formatTaskStatus(issue.status)));
+  writeOutput(inventoryField("task", formatTaskStatus("in-progress")));
   if (issue.repository !== undefined) {
     writeOutput(inventoryField("repo", issue.repository));
   }
+}
+
+/**
+ * Pull request lookups reuse the branches the local pass already resolved, so
+ * the remote pass never re-reads run state or re-resolves a branch.
+ */
+function pullRequestTargetsOf(local: LocalStatusDocument): PullRequestTarget[] {
+  return local.tasks.flatMap((task) =>
+    task.worktrees.map((worktree) => ({
+      task: task.task,
+      dir: worktree.dir,
+      branch: worktree.branch,
+    })),
+  );
 }
 
 const SLOT_HOLDERS_HEADER = "Slot holders with no local worktree";
 const SLOT_HOLDERS_ACTION =
   "What to do: transition the ticket off 'in-progress' on the board, or run 'crew run <task>' to recreate the worktree locally.";
 
-function writeInProgressWithoutWorktree(
-  boardResult: BoardFetchResult,
-  worktreeTasks: ReadonlySet<string>,
-): void {
-  if (boardResult.kind !== "ok") {
-    return;
-  }
-  const issues = inProgressWithoutWorktree(boardResult.issues, worktreeTasks);
-  if (issues.length === 0) {
+function writeInProgressWithoutWorktree(joined: JoinedStatus): void {
+  if (joined.inProgressWithoutWorktree.length === 0) {
     return;
   }
   writeSection(SLOT_HOLDERS_HEADER);
   writeOutput(SLOT_HOLDERS_ACTION);
-  for (const [index, issue] of issues.entries()) {
+  for (const [index, issue] of joined.inProgressWithoutWorktree.entries()) {
     if (index > 0) {
       writeOutput();
     }
@@ -703,28 +497,36 @@ function writeInProgressWithoutWorktree(
   }
 }
 
+/**
+ * Collects both tiers and renders the joined view.
+ *
+ * `previous: undefined` is deliberate. Carry-forward is a monitor concern: a
+ * one-shot text run must report only what this attempt saw, or a failed fetch
+ * would print a queue recovered from an old snapshot where it prints
+ * "unavailable" today.
+ */
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  // Banner ("groundcrew status\n=================") dropped: the command
-  // you just ran already tells you what report you're looking at, and the
-  // section headers (`Worktrees`, `Queue`, etc.) carry the visual anchors.
-  // The board fetch runs concurrently with the probe, but we await it before
-  // rendering: each Worktrees row carries the remote task status, so the
-  // inventory can't print until the source resolves. A failed fetch returns
-  // quickly and still renders rows (without the `task:` field).
-  const boardResultPromise = fetchBoardForStatus(config);
-  const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-  const boardResult = await boardResultPromise;
-  await writeInventoryWorktrees(config, probe, statusByWorktreeTask(boardResult));
-  const worktreeTasks = new Set(worktrees.list(config).map((entry) => entry.task));
-  writeStraySessions(probe, worktreeTasks);
+  const local = await collectLocalStatus({ config });
+  const result = await collectRemoteStatus({
+    config,
+    pullRequestTargets: pullRequestTargetsOf(local),
+  });
+  const remote = buildRemoteDocument({
+    previous: undefined,
+    attemptAt: new Date().toISOString(),
+    result,
+  });
+  const joined = joinStatus({ local, remote });
+  const now = new Date();
 
-  writeInProgressWithoutWorktree(boardResult, worktreeTasks);
-  if (boardResult.kind === "ok") {
-    const used = inProgressCount(boardResult.issues);
+  writeInventoryWorktrees(joined, now);
+  writeStraySessions(local);
+  writeInProgressWithoutWorktree(joined);
+  if (joined.slots !== undefined) {
     writeOutput();
-    writeOutput(`slots: ${used}/${config.orchestrator.maximumInProgress} used`);
+    writeOutput(`slots: ${joined.slots.used}/${joined.slots.maximum} used`);
   }
-  writeQueueSections(boardResult, worktreeTasks);
+  writeQueueSections({ joined, result });
 }
 
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -26,7 +26,6 @@ import {
   buildRemoteDocument,
   type LocalStatusDocument,
   type RemoteFetchResult,
-  type RemoteStatusDocument,
   type StatusBlockedIssue,
   type StatusLifecycle,
   type StatusBoardIssue,
@@ -510,7 +509,6 @@ function writeInProgressWithoutWorktree(joined: JoinedStatus): void {
 
 interface CollectedTiers {
   local: LocalStatusDocument;
-  remote: RemoteStatusDocument;
   attemptAt: string;
   result: RemoteFetchResult;
 }
@@ -519,27 +517,26 @@ interface CollectedTiers {
  * Runs both tiers. The board fetch starts first because it needs nothing
  * local; only the pull request lookups wait on resolved branches.
  *
- * `previous` carries a prior remote document forward when the fetch fails.
- * Text mode passes undefined so a one-shot run reports only what it just saw,
- * rather than a queue recovered from an old snapshot.
+ * Returns the raw result rather than a built document: the JSON path needs
+ * `writeRemoteSnapshot` to do the carry-forward merge against the same file
+ * read its guard uses, and the text path deliberately merges against nothing.
  */
-async function collectBothTiers(input: {
-  config: ResolvedConfig;
-  previous: RemoteStatusDocument | undefined;
-}): Promise<CollectedTiers> {
-  const { config, previous } = input;
+async function collectBothTiers(config: ResolvedConfig): Promise<CollectedTiers> {
   const boardPromise = fetchBoardIssues(config);
   const local = await collectLocalStatus({ config });
   const result = await collectRemoteStatus({
     board: await boardPromise,
     pullRequestTargets: pullRequestTargetsOf(local),
   });
-  const attemptAt = new Date().toISOString();
-  return { local, remote: buildRemoteDocument({ previous, attemptAt, result }), attemptAt, result };
+  return { local, attemptAt: new Date().toISOString(), result };
 }
 
 async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  const { local, remote } = await collectBothTiers({ config, previous: undefined });
+  const { local, attemptAt, result } = await collectBothTiers(config);
+  // `previous: undefined` on purpose: a one-shot run reports only what this
+  // attempt saw, so a failed fetch prints "unavailable" rather than a queue
+  // recovered from an old snapshot.
+  const remote = buildRemoteDocument({ previous: undefined, attemptAt, result });
   const joined = joinStatus({ local, remote });
   const now = new Date();
 
@@ -573,7 +570,7 @@ async function writeJsonStatus(input: {
     writeOutput(JSON.stringify({ local }, undefined, 2));
     return;
   }
-  const collected = await collectBothTiers({ config, previous: undefined });
+  const collected = await collectBothTiers(config);
   // Print what landed on disk, not what we built. When a monotonic guard
   // rejects our document because a concurrent run wrote a newer one, the two
   // differ, and stdout must never contradict the file. writeRemoteSnapshot

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -295,7 +295,7 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual.kind).toBe("ok");
     if (actual.kind !== "ok") {
@@ -309,7 +309,10 @@ describe("collectRemoteStatus", () => {
   it("keeps an in-progress issue in the payload even when it has a local worktree", async () => {
     mockBoardFetch([makeIssue({ id: "linear:eng-220", status: "in-progress" })]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: ["eng-220"] });
+    const actual = await collectRemoteStatus({
+      config: mockConfig,
+      pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
+    });
 
     expect(actual.kind === "ok" && actual.payload.inProgress).toHaveLength(1);
   });
@@ -317,7 +320,7 @@ describe("collectRemoteStatus", () => {
   it("excludes a todo that no agent or repository can dispatch", async () => {
     mockBoardFetch([makeIssue({ id: "linear:eng-225", status: "todo", agent: undefined })]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual.kind === "ok" && actual.payload.queueReady).toEqual([]);
   });
@@ -331,7 +334,7 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual.kind === "ok" && actual.payload.queueReady.map((issue) => issue.naturalId)).toEqual([
       "eng-225",
@@ -350,7 +353,7 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual.kind === "ok" && actual.payload.queueBlocked[0]?.blockedBy).toEqual([
       { id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" },
@@ -363,7 +366,7 @@ describe("collectRemoteStatus", () => {
       makeIssue({ id: "shell:eng-220", status: "todo", source: "shell" }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual.kind === "ok" && actual.payload.statusByTask["eng-220"]).toBeUndefined();
   });
@@ -374,7 +377,10 @@ describe("collectRemoteStatus", () => {
       { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: ["eng-220"] });
+    const actual = await collectRemoteStatus({
+      config: mockConfig,
+      pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
+    });
 
     expect(actual.kind === "ok" && actual.payload.pullRequestsByTask["eng-220"]).toHaveLength(1);
     expect(findPullRequestsForBranch).toHaveBeenCalledTimes(1);
@@ -383,7 +389,7 @@ describe("collectRemoteStatus", () => {
   it("skips pull request lookups entirely when no task has a worktree", async () => {
     mockBoardFetch([]);
 
-    await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(findPullRequestsForBranch).not.toHaveBeenCalled();
   });
@@ -391,7 +397,7 @@ describe("collectRemoteStatus", () => {
   it("returns an error result rather than throwing when the fetch fails", async () => {
     mockBoardFetchRejection(new Error("Linear: 401 unauthorized"));
 
-    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
 
     expect(actual).toEqual({ kind: "error", message: "Linear: 401 unauthorized" });
   });

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -9,7 +9,12 @@ import { readRunState, type RunState } from "../lib/runState.ts";
 import type { Blocker, Issue as SourceIssue } from "../lib/taskSource.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
-import { collectLocalStatus, collectRemoteStatus } from "./statusCollect.ts";
+import type { RemoteFetchResult, RemoteStatusPayload } from "../lib/statusSnapshot.ts";
+import {
+  collectLocalStatus,
+  collectRemoteStatus,
+  workspaceProbeUnavailableText,
+} from "./statusCollect.ts";
 
 vi.mock(import("../lib/board.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -127,7 +132,7 @@ describe("collectLocalStatus", () => {
     const actual = await collectLocalStatus({ config: mockConfig });
 
     expect(actual.tasks[0]?.startedAt).toBe("2026-08-04T02:00:00.000Z");
-    expect(Object.keys(actual.tasks[0] ?? {})).not.toContain("duration");
+    expect(actual.tasks[0]).not.toHaveProperty("duration");
   });
 
   it("groups multiple worktrees under one task in list order", async () => {
@@ -155,7 +160,9 @@ describe("collectLocalStatus", () => {
   });
 
   it("flags a worktree with no run state and a live session as stray", async () => {
-    vi.mocked(readRunState).mockReturnValue(undefined);
+    // An empty map misses, which yields undefined without writing it literally.
+    const statesByTask = new Map<string, RunState>();
+    vi.mocked(readRunState).mockImplementation((_config, task) => statesByTask.get(task));
 
     const actual = await collectLocalStatus({ config: mockConfig });
 
@@ -184,6 +191,17 @@ describe("collectLocalStatus", () => {
     expect(actual.tasks[0]?.session).toBe("unknown");
     expect(actual.tasks[0]?.flags).toEqual([]);
     expect(actual.tasks[0]?.hint).toBeUndefined();
+  });
+
+  it("carries the probe's failure reason into the document", async () => {
+    vi.mocked(workspaces.probe).mockResolvedValue({
+      kind: "unavailable",
+      error: new Error("cmux unavailable"),
+    });
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.workspaceProbe).toEqual({ status: "unavailable", error: "cmux unavailable" });
   });
 
   it("collects git dirtiness and branch for each worktree", async () => {
@@ -251,21 +269,56 @@ function makeBlocker(overrides: Partial<Blocker> & { id: string }): Blocker {
   return { title: "a blocker", status: "in-progress", ...overrides };
 }
 
+function mockBoard(fetch: Board["fetch"]): void {
+  vi.mocked(createBoard).mockReturnValue({ fetch } as Board);
+}
+
 function mockBoardFetch(issues: SourceIssue[]): void {
-  const mockBoard: Pick<Board, "fetch"> = {
-    fetch: vi.fn(async () => ({ timestamp: "2026-08-04T03:00:00.000Z", issues, parentSkips: [] })),
-  };
-  vi.mocked(createBoard).mockReturnValue(mockBoard as Board);
+  mockBoard(
+    vi.fn<Board["fetch"]>(async () => ({
+      timestamp: "2026-08-04T03:00:00.000Z",
+      issues,
+      parentSkips: [],
+    })),
+  );
 }
 
 function mockBoardFetchRejection(error: Error): void {
-  const mockBoard: Pick<Board, "fetch"> = {
-    fetch: vi.fn(async () => {
+  mockBoard(
+    vi.fn<Board["fetch"]>(async () => {
       throw error;
     }),
-  };
-  vi.mocked(createBoard).mockReturnValue(mockBoard as Board);
+  );
 }
+
+/**
+ * Narrows a fetch result to its payload so tests assert without branching.
+ * A failed fetch fails the test here rather than inside an `if`.
+ */
+function expectPayload(result: RemoteFetchResult): RemoteStatusPayload {
+  expect(result.kind).toBe("ok");
+  if (result.kind !== "ok") {
+    throw new Error("unreachable: the assertion above already failed");
+  }
+  return result.payload;
+}
+
+describe("workspaceProbeUnavailableText", () => {
+  it("names the failure when the probe reports one", () => {
+    const actual = workspaceProbeUnavailableText({
+      kind: "unavailable",
+      error: new Error("cmux unavailable"),
+    });
+
+    expect(actual).toBe("Workspace probe unavailable: cmux unavailable");
+  });
+
+  it("stays generic when the probe reports no reason", () => {
+    const actual = workspaceProbeUnavailableText({ kind: "unavailable", error: undefined });
+
+    expect(actual).toBe("Workspace probe unavailable");
+  });
+});
 
 describe("collectRemoteStatus", () => {
   beforeEach(() => {
@@ -275,8 +328,6 @@ describe("collectRemoteStatus", () => {
       orchestrator: { maximumInProgress: 4 },
       sources: [],
     } as unknown as ResolvedConfig;
-    vi.mocked(worktrees.list).mockReturnValue([makeEntry()]);
-    vi.mocked(readRunState).mockReturnValue(makeRunState());
   });
 
   afterEach(() => {
@@ -295,34 +346,36 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = expectPayload(
+      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+    );
 
-    expect(actual.kind).toBe("ok");
-    if (actual.kind !== "ok") {
-      return;
-    }
-    expect(actual.payload.inProgress.map((issue) => issue.naturalId)).toEqual(["eng-220"]);
-    expect(actual.payload.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
-    expect(actual.payload.queueBlocked.map((issue) => issue.naturalId)).toEqual(["eng-215"]);
+    expect(actual.inProgress.map((issue) => issue.naturalId)).toEqual(["eng-220"]);
+    expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
+    expect(actual.queueBlocked.map((issue) => issue.naturalId)).toEqual(["eng-215"]);
   });
 
   it("keeps an in-progress issue in the payload even when it has a local worktree", async () => {
     mockBoardFetch([makeIssue({ id: "linear:eng-220", status: "in-progress" })]);
 
-    const actual = await collectRemoteStatus({
-      config: mockConfig,
-      pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
-    });
+    const actual = expectPayload(
+      await collectRemoteStatus({
+        config: mockConfig,
+        pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
+      }),
+    );
 
-    expect(actual.kind === "ok" && actual.payload.inProgress).toHaveLength(1);
+    expect(actual.inProgress).toHaveLength(1);
   });
 
-  it("excludes a todo that no agent or repository can dispatch", async () => {
+  it("excludes a todo that no agent can dispatch", async () => {
     mockBoardFetch([makeIssue({ id: "linear:eng-225", status: "todo", agent: undefined })]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = expectPayload(
+      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+    );
 
-    expect(actual.kind === "ok" && actual.payload.queueReady).toEqual([]);
+    expect(actual.queueReady).toEqual([]);
   });
 
   it("treats a todo whose blockers are all done as ready", async () => {
@@ -334,11 +387,11 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = expectPayload(
+      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+    );
 
-    expect(actual.kind === "ok" && actual.payload.queueReady.map((issue) => issue.naturalId)).toEqual([
-      "eng-225",
-    ]);
+    expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
   });
 
   it("keeps only the open blockers on a blocked issue", async () => {
@@ -353,9 +406,11 @@ describe("collectRemoteStatus", () => {
       }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = expectPayload(
+      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+    );
 
-    expect(actual.kind === "ok" && actual.payload.queueBlocked[0]?.blockedBy).toEqual([
+    expect(actual.queueBlocked[0]?.blockedBy).toEqual([
       { id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" },
     ]);
   });
@@ -366,24 +421,42 @@ describe("collectRemoteStatus", () => {
       makeIssue({ id: "shell:eng-220", status: "todo", source: "shell" }),
     ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = expectPayload(
+      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+    );
 
-    expect(actual.kind === "ok" && actual.payload.statusByTask["eng-220"]).toBeUndefined();
+    expect(actual.statusByTask["eng-220"]).toBeUndefined();
   });
 
-  it("collects pull requests only for tasks with a local worktree", async () => {
+  it("looks up pull requests with the branch the local tier already resolved", async () => {
     mockBoardFetch([]);
     vi.mocked(findPullRequestsForBranch).mockResolvedValue([
       { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
     ]);
 
-    const actual = await collectRemoteStatus({
+    const actual = expectPayload(
+      await collectRemoteStatus({
+        config: mockConfig,
+        pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "adopted-branch" }],
+      }),
+    );
+
+    expect(actual.pullRequestsByTask["eng-220"]).toHaveLength(1);
+    expect(findPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: "/repos/eng-220",
+      branchName: "adopted-branch",
+    });
+  });
+
+  it("never reads run state, since the local tier already did", async () => {
+    mockBoardFetch([]);
+
+    await collectRemoteStatus({
       config: mockConfig,
       pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
     });
 
-    expect(actual.kind === "ok" && actual.payload.pullRequestsByTask["eng-220"]).toHaveLength(1);
-    expect(findPullRequestsForBranch).toHaveBeenCalledTimes(1);
+    expect(readRunState).not.toHaveBeenCalled();
   });
 
   it("skips pull request lookups entirely when no task has a worktree", async () => {

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -13,6 +13,7 @@ import type { RemoteFetchResult, RemoteStatusPayload } from "../lib/statusSnapsh
 import {
   collectLocalStatus,
   collectRemoteStatus,
+  decodeLogTail,
   fetchBoardIssues,
   type PullRequestTarget,
   workspaceProbeUnavailableText,
@@ -338,6 +339,25 @@ async function collectWithBoard(
     pullRequestTargets,
   });
 }
+
+describe("decodeLogTail", () => {
+  it("decodes only the bytes read, so a shrunken log yields no NUL padding", () => {
+    const buffer = Buffer.alloc(64);
+    const bytesRead = buffer.write("[10:00:00] eng-220 line\n", "utf8");
+
+    const actual = decodeLogTail({ buffer, bytesRead, startedMidFile: false });
+
+    expect(actual).toEqual(["[10:00:00] eng-220 line", ""]);
+  });
+
+  it("drops the partial line a mid-file read starts inside", () => {
+    const buffer = Buffer.from("ragment\n[10:00:00] eng-220 line\n", "utf8");
+
+    const actual = decodeLogTail({ buffer, bytesRead: buffer.length, startedMidFile: true });
+
+    expect(actual).toEqual(["[10:00:00] eng-220 line", ""]);
+  });
+});
 
 describe("workspaceProbeUnavailableText", () => {
   it("names the failure when the probe reports one", () => {

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -13,7 +13,6 @@ import type { RemoteFetchResult, RemoteStatusPayload } from "../lib/statusSnapsh
 import {
   collectLocalStatus,
   collectRemoteStatus,
-  decodeLogTail,
   fetchBoardIssues,
   type PullRequestTarget,
   workspaceProbeUnavailableText,
@@ -243,19 +242,16 @@ describe("collectLocalStatus", () => {
     expect(actual.tasks[0]?.recentLogLines).toEqual(["[10:00:00] eng-220 dispatched"]);
   });
 
-  it("reads only the tail of a log larger than the bound", async () => {
+  it("finds a task's recent line before a large unrelated tail", async () => {
     const filler = `${"x".repeat(200)}\n`.repeat(2000);
     writeFileSync(mockConfig.logging.file, `[09:00:00] eng-220 ancient\n${filler}`);
 
     const actual = await collectLocalStatus({ config: mockConfig });
 
-    expect(actual.tasks[0]?.recentLogLines).toEqual([]);
+    expect(actual.tasks[0]?.recentLogLines).toEqual(["[09:00:00] eng-220 ancient"]);
   });
 
-  it("discards the partial line a tail read starts in the middle of", async () => {
-    // The cut lands inside this line, and its tail fragment mentions the task.
-    // Treating that fragment as a log line would attribute text to eng-220
-    // that was never written about it.
+  it("reassembles a matching line split across scan chunks", async () => {
     const oversizedLine = `${"x".repeat(300_000)} eng-220 fragment`;
     writeFileSync(
       mockConfig.logging.file,
@@ -264,7 +260,10 @@ describe("collectLocalStatus", () => {
 
     const actual = await collectLocalStatus({ config: mockConfig });
 
-    expect(actual.tasks[0]?.recentLogLines).toEqual(["[10:00:00] eng-220 real line"]);
+    expect(actual.tasks[0]?.recentLogLines).toEqual([
+      oversizedLine,
+      "[10:00:00] eng-220 real line",
+    ]);
   });
 
   it("survives a missing log file", async () => {
@@ -339,25 +338,6 @@ async function collectWithBoard(
     pullRequestTargets,
   });
 }
-
-describe("decodeLogTail", () => {
-  it("decodes only the bytes read, so a shrunken log yields no NUL padding", () => {
-    const buffer = Buffer.alloc(64);
-    const bytesRead = buffer.write("[10:00:00] eng-220 line\n", "utf8");
-
-    const actual = decodeLogTail({ buffer, bytesRead, startedMidFile: false });
-
-    expect(actual).toEqual(["[10:00:00] eng-220 line", ""]);
-  });
-
-  it("drops the partial line a mid-file read starts inside", () => {
-    const buffer = Buffer.from("ragment\n[10:00:00] eng-220 line\n", "utf8");
-
-    const actual = decodeLogTail({ buffer, bytesRead: buffer.length, startedMidFile: true });
-
-    expect(actual).toEqual(["[10:00:00] eng-220 line", ""]);
-  });
-});
 
 describe("workspaceProbeUnavailableText", () => {
   it("names the failure when the probe reports one", () => {
@@ -468,7 +448,7 @@ describe("collectRemoteStatus", () => {
     ]);
   });
 
-  it("omits an ambiguous natural id from statusByTask", async () => {
+  it("omits an ambiguous natural id from sourceByTask", async () => {
     const actual = expectPayload(
       await collectWithBoard([
         makeIssue({ id: "linear:eng-220", status: "in-progress" }),
@@ -476,7 +456,7 @@ describe("collectRemoteStatus", () => {
       ]),
     );
 
-    expect(actual.statusByTask["eng-220"]).toBeUndefined();
+    expect(actual.sourceByTask["eng-220"]).toBeUndefined();
   });
 
   it("looks up pull requests with the branch the local tier already resolved", async () => {

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -465,7 +465,7 @@ describe("collectRemoteStatus", () => {
       }),
     );
 
-    expect(actual.pullRequestsByTask["eng-220"]).toHaveLength(1);
+    expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toHaveLength(1);
     expect(findPullRequestsForBranch).toHaveBeenCalledWith({
       cwd: "/repos/eng-220",
       branchName: "adopted-branch",

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -2,12 +2,32 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import { type Board, createBoard } from "../lib/board.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
+import type { Blocker, Issue as SourceIssue } from "../lib/taskSource.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
-import { collectLocalStatus } from "./statusCollect.ts";
+import { collectLocalStatus, collectRemoteStatus } from "./statusCollect.ts";
 
+vi.mock(import("../lib/board.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, createBoard: vi.fn<typeof actual.createBoard>() };
+});
+vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]) };
+});
+vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    findPullRequestsForBranch: vi
+      .fn<typeof actual.findPullRequestsForBranch>()
+      .mockResolvedValue([]),
+  };
+});
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readRunState: vi.fn<typeof readRunState>() };
@@ -207,5 +227,172 @@ describe("collectLocalStatus", () => {
     const actual = await collectLocalStatus({ config: mockConfig });
 
     expect(actual.tasks[0]?.recentLogLines).toEqual([]);
+  });
+});
+
+function makeIssue(overrides: Partial<SourceIssue> & { id: string }): SourceIssue {
+  return {
+    source: "linear",
+    title: "a title",
+    description: "",
+    status: "todo",
+    repository: "groundcrew",
+    agent: "opus",
+    assignee: "paul",
+    updatedAt: "2026-08-04T03:00:00.000Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    sourceRef: undefined,
+    ...overrides,
+  };
+}
+
+function makeBlocker(overrides: Partial<Blocker> & { id: string }): Blocker {
+  return { title: "a blocker", status: "in-progress", ...overrides };
+}
+
+function mockBoardFetch(issues: SourceIssue[]): void {
+  const mockBoard: Pick<Board, "fetch"> = {
+    fetch: vi.fn(async () => ({ timestamp: "2026-08-04T03:00:00.000Z", issues, parentSkips: [] })),
+  };
+  vi.mocked(createBoard).mockReturnValue(mockBoard as Board);
+}
+
+function mockBoardFetchRejection(error: Error): void {
+  const mockBoard: Pick<Board, "fetch"> = {
+    fetch: vi.fn(async () => {
+      throw error;
+    }),
+  };
+  vi.mocked(createBoard).mockReturnValue(mockBoard as Board);
+}
+
+describe("collectRemoteStatus", () => {
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "gc-remote-"));
+    mockConfig = {
+      logging: { file: path.join(directory, "groundcrew.log") },
+      orchestrator: { maximumInProgress: 4 },
+      sources: [],
+    } as unknown as ResolvedConfig;
+    vi.mocked(worktrees.list).mockReturnValue([makeEntry()]);
+    vi.mocked(readRunState).mockReturnValue(makeRunState());
+  });
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true });
+    vi.clearAllMocks();
+  });
+
+  it("classifies board issues without subtracting local worktrees", async () => {
+    mockBoardFetch([
+      makeIssue({ id: "linear:eng-220", status: "in-progress" }),
+      makeIssue({ id: "linear:eng-225", status: "todo" }),
+      makeIssue({
+        id: "linear:eng-215",
+        status: "todo",
+        blockers: [makeBlocker({ id: "linear:eng-201" })],
+      }),
+    ]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual.kind).toBe("ok");
+    if (actual.kind !== "ok") {
+      return;
+    }
+    expect(actual.payload.inProgress.map((issue) => issue.naturalId)).toEqual(["eng-220"]);
+    expect(actual.payload.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
+    expect(actual.payload.queueBlocked.map((issue) => issue.naturalId)).toEqual(["eng-215"]);
+  });
+
+  it("keeps an in-progress issue in the payload even when it has a local worktree", async () => {
+    mockBoardFetch([makeIssue({ id: "linear:eng-220", status: "in-progress" })]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: ["eng-220"] });
+
+    expect(actual.kind === "ok" && actual.payload.inProgress).toHaveLength(1);
+  });
+
+  it("excludes a todo that no agent or repository can dispatch", async () => {
+    mockBoardFetch([makeIssue({ id: "linear:eng-225", status: "todo", agent: undefined })]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual.kind === "ok" && actual.payload.queueReady).toEqual([]);
+  });
+
+  it("treats a todo whose blockers are all done as ready", async () => {
+    mockBoardFetch([
+      makeIssue({
+        id: "linear:eng-225",
+        status: "todo",
+        blockers: [makeBlocker({ id: "linear:eng-201", status: "done" })],
+      }),
+    ]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual.kind === "ok" && actual.payload.queueReady.map((issue) => issue.naturalId)).toEqual([
+      "eng-225",
+    ]);
+  });
+
+  it("keeps only the open blockers on a blocked issue", async () => {
+    mockBoardFetch([
+      makeIssue({
+        id: "linear:eng-215",
+        status: "todo",
+        blockers: [
+          makeBlocker({ id: "linear:eng-200", status: "done" }),
+          makeBlocker({ id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" }),
+        ],
+      }),
+    ]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual.kind === "ok" && actual.payload.queueBlocked[0]?.blockedBy).toEqual([
+      { id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" },
+    ]);
+  });
+
+  it("omits an ambiguous natural id from statusByTask", async () => {
+    mockBoardFetch([
+      makeIssue({ id: "linear:eng-220", status: "in-progress" }),
+      makeIssue({ id: "shell:eng-220", status: "todo", source: "shell" }),
+    ]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual.kind === "ok" && actual.payload.statusByTask["eng-220"]).toBeUndefined();
+  });
+
+  it("collects pull requests only for tasks with a local worktree", async () => {
+    mockBoardFetch([]);
+    vi.mocked(findPullRequestsForBranch).mockResolvedValue([
+      { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
+    ]);
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: ["eng-220"] });
+
+    expect(actual.kind === "ok" && actual.payload.pullRequestsByTask["eng-220"]).toHaveLength(1);
+    expect(findPullRequestsForBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips pull request lookups entirely when no task has a worktree", async () => {
+    mockBoardFetch([]);
+
+    await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(findPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
+  it("returns an error result rather than throwing when the fetch fails", async () => {
+    mockBoardFetchRejection(new Error("Linear: 401 unauthorized"));
+
+    const actual = await collectRemoteStatus({ config: mockConfig, localTasks: [] });
+
+    expect(actual).toEqual({ kind: "error", message: "Linear: 401 unauthorized" });
   });
 });

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -13,6 +13,8 @@ import type { RemoteFetchResult, RemoteStatusPayload } from "../lib/statusSnapsh
 import {
   collectLocalStatus,
   collectRemoteStatus,
+  fetchBoardIssues,
+  type PullRequestTarget,
   workspaceProbeUnavailableText,
 } from "./statusCollect.ts";
 
@@ -315,15 +317,26 @@ function mockBoardFetchRejection(error: Error): void {
 }
 
 /**
- * Narrows a fetch result to its payload so tests assert without branching.
- * A failed fetch fails the test here rather than inside an `if`.
+ * Narrows a fetch result to its board payload so tests assert without
+ * branching. A failed board fetch fails the test here, not inside an `if`.
  */
 function expectPayload(result: RemoteFetchResult): RemoteStatusPayload {
-  expect(result.kind).toBe("ok");
-  if (result.kind !== "ok") {
+  expect(result.board.kind).toBe("ok");
+  if (result.board.kind !== "ok") {
     throw new Error("unreachable: the assertion above already failed");
   }
-  return result.payload;
+  return result.board.payload;
+}
+
+async function collectWithBoard(
+  issues: SourceIssue[],
+  pullRequestTargets: PullRequestTarget[] = [],
+): Promise<RemoteFetchResult> {
+  mockBoardFetch(issues);
+  return await collectRemoteStatus({
+    board: await fetchBoardIssues(mockConfig),
+    pullRequestTargets,
+  });
 }
 
 describe("workspaceProbeUnavailableText", () => {
@@ -355,18 +368,16 @@ describe("collectRemoteStatus", () => {
   });
 
   it("classifies board issues without subtracting local worktrees", async () => {
-    mockBoardFetch([
-      makeIssue({ id: "linear:eng-220", status: "in-progress" }),
-      makeIssue({ id: "linear:eng-225", status: "todo" }),
-      makeIssue({
-        id: "linear:eng-215",
-        status: "todo",
-        blockers: [makeBlocker({ id: "linear:eng-201" })],
-      }),
-    ]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+      await collectWithBoard([
+        makeIssue({ id: "linear:eng-220", status: "in-progress" }),
+        makeIssue({ id: "linear:eng-225", status: "todo" }),
+        makeIssue({
+          id: "linear:eng-215",
+          status: "todo",
+          blockers: [makeBlocker({ id: "linear:eng-201" })],
+        }),
+      ]),
     );
 
     expect(actual.inProgress.map((issue) => issue.naturalId)).toEqual(["eng-220"]);
@@ -375,58 +386,56 @@ describe("collectRemoteStatus", () => {
   });
 
   it("keeps an in-progress issue in the payload even when it has a local worktree", async () => {
-    mockBoardFetch([makeIssue({ id: "linear:eng-220", status: "in-progress" })]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({
-        config: mockConfig,
-        pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
-      }),
+      await collectWithBoard(
+        [makeIssue({ id: "linear:eng-220", status: "in-progress" })],
+        [{ dir: "/repos/eng-220", branch: "eng-220" }],
+      ),
     );
 
     expect(actual.inProgress).toHaveLength(1);
   });
 
   it("excludes a todo that no agent can dispatch", async () => {
-    mockBoardFetch([makeIssue({ id: "linear:eng-225", status: "todo", agent: undefined })]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+      await collectWithBoard([
+        makeIssue({ id: "linear:eng-225", status: "todo", agent: undefined }),
+      ]),
     );
 
     expect(actual.queueReady).toEqual([]);
   });
 
   it("treats a todo whose blockers are all done as ready", async () => {
-    mockBoardFetch([
-      makeIssue({
-        id: "linear:eng-225",
-        status: "todo",
-        blockers: [makeBlocker({ id: "linear:eng-201", status: "done" })],
-      }),
-    ]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+      await collectWithBoard([
+        makeIssue({
+          id: "linear:eng-225",
+          status: "todo",
+          blockers: [makeBlocker({ id: "linear:eng-201", status: "done" })],
+        }),
+      ]),
     );
 
     expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
   });
 
   it("keeps only the open blockers on a blocked issue", async () => {
-    mockBoardFetch([
-      makeIssue({
-        id: "linear:eng-215",
-        status: "todo",
-        blockers: [
-          makeBlocker({ id: "linear:eng-200", status: "done" }),
-          makeBlocker({ id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" }),
-        ],
-      }),
-    ]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+      await collectWithBoard([
+        makeIssue({
+          id: "linear:eng-215",
+          status: "todo",
+          blockers: [
+            makeBlocker({ id: "linear:eng-200", status: "done" }),
+            makeBlocker({
+              id: "linear:eng-201",
+              status: "in-progress",
+              nativeStatus: "In Progress",
+            }),
+          ],
+        }),
+      ]),
     );
 
     expect(actual.queueBlocked[0]?.blockedBy).toEqual([
@@ -440,29 +449,24 @@ describe("collectRemoteStatus", () => {
   });
 
   it("omits an ambiguous natural id from statusByTask", async () => {
-    mockBoardFetch([
-      makeIssue({ id: "linear:eng-220", status: "in-progress" }),
-      makeIssue({ id: "shell:eng-220", status: "todo", source: "shell" }),
-    ]);
-
     const actual = expectPayload(
-      await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] }),
+      await collectWithBoard([
+        makeIssue({ id: "linear:eng-220", status: "in-progress" }),
+        makeIssue({ id: "shell:eng-220", status: "todo", source: "shell" }),
+      ]),
     );
 
     expect(actual.statusByTask["eng-220"]).toBeUndefined();
   });
 
   it("looks up pull requests with the branch the local tier already resolved", async () => {
-    mockBoardFetch([]);
     vi.mocked(findPullRequestsForBranch).mockResolvedValue([
       { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
     ]);
 
-    const actual = expectPayload(
-      await collectRemoteStatus({
-        config: mockConfig,
-        pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "adopted-branch" }],
-      }),
+    const actual = await collectWithBoard(
+      [],
+      [{ dir: "/repos/eng-220", branch: "adopted-branch" }],
     );
 
     expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toHaveLength(1);
@@ -473,29 +477,30 @@ describe("collectRemoteStatus", () => {
   });
 
   it("never reads run state, since the local tier already did", async () => {
-    mockBoardFetch([]);
-
-    await collectRemoteStatus({
-      config: mockConfig,
-      pullRequestTargets: [{ task: "eng-220", dir: "/repos/eng-220", branch: "eng-220" }],
-    });
+    await collectWithBoard([], [{ dir: "/repos/eng-220", branch: "eng-220" }]);
 
     expect(readRunState).not.toHaveBeenCalled();
   });
 
   it("skips pull request lookups entirely when no task has a worktree", async () => {
-    mockBoardFetch([]);
-
-    await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    await collectWithBoard([]);
 
     expect(findPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
-  it("returns an error result rather than throwing when the fetch fails", async () => {
+  // The board and `gh` share no data, so one failing must not hide the other.
+  it("still collects pull requests when the board fetch fails", async () => {
     mockBoardFetchRejection(new Error("Linear: 401 unauthorized"));
+    vi.mocked(findPullRequestsForBranch).mockResolvedValue([
+      { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
+    ]);
 
-    const actual = await collectRemoteStatus({ config: mockConfig, pullRequestTargets: [] });
+    const actual = await collectRemoteStatus({
+      board: await fetchBoardIssues(mockConfig),
+      pullRequestTargets: [{ dir: "/repos/eng-220", branch: "eng-220" }],
+    });
 
-    expect(actual).toEqual({ kind: "error", message: "Linear: 401 unauthorized" });
+    expect(actual.board).toEqual({ kind: "error", message: "Linear: 401 unauthorized" });
+    expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toHaveLength(1);
   });
 });

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { ResolvedConfig } from "../lib/config.ts";
+import { readRunState, type RunState } from "../lib/runState.ts";
+import { workspaces } from "../lib/workspaces.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { collectLocalStatus } from "./statusCollect.ts";
+
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, readRunState: vi.fn<typeof readRunState>() };
+});
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      probe: vi.fn<typeof actual.workspaces.probe>(),
+      accessHint: vi.fn<typeof actual.workspaces.accessHint>(),
+    },
+  };
+});
+vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    worktrees: {
+      ...actual.worktrees,
+      list: vi.fn<typeof actual.worktrees.list>(),
+      probeWorkingTree: vi.fn<typeof actual.worktrees.probeWorkingTree>(),
+    },
+  };
+});
+vi.mock(import("../lib/worktreeRunState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    effectiveBranchNameFromRunState: vi
+      .fn<typeof actual.effectiveBranchNameFromRunState>()
+      .mockResolvedValue("eng-220"),
+  };
+});
+
+let directory: string;
+let mockConfig: ResolvedConfig;
+
+function makeEntry(overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
+  return {
+    repository: "groundcrew",
+    task: "eng-220",
+    branchName: "eng-220",
+    dir: "/repos/eng-220",
+    kind: "host",
+    ...overrides,
+  };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    task: "eng-220",
+    repository: "groundcrew",
+    agent: "opus",
+    worktreeDir: "/repos/eng-220",
+    branchName: "eng-220",
+    workspaceName: "eng-220",
+    state: "running",
+    createdAt: "2026-08-04T02:00:00.000Z",
+    updatedAt: "2026-08-04T03:00:00.000Z",
+    resumeCount: 0,
+    title: "Some task",
+    ...overrides,
+  };
+}
+
+describe("collectLocalStatus", () => {
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "gc-collect-"));
+    mockConfig = {
+      logging: { file: path.join(directory, "groundcrew.log") },
+      orchestrator: { maximumInProgress: 4 },
+    } as ResolvedConfig;
+    vi.mocked(worktrees.list).mockReturnValue([makeEntry()]);
+    vi.mocked(worktrees.probeWorkingTree).mockResolvedValue({ kind: "clean" });
+    vi.mocked(workspaces.probe).mockResolvedValue({ kind: "ok", names: new Set(["eng-220"]) });
+    vi.mocked(workspaces.accessHint).mockResolvedValue({
+      kind: "attachCommand",
+      command: "cmux open eng-220",
+    });
+    vi.mocked(readRunState).mockReturnValue(makeRunState());
+  });
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true });
+    vi.clearAllMocks();
+  });
+
+  it("carries maximumInProgress from config, not from any fetch", async () => {
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.maximumInProgress).toBe(4);
+  });
+
+  it("records the run-state start instant rather than an elapsed duration", async () => {
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.startedAt).toBe("2026-08-04T02:00:00.000Z");
+    expect(Object.keys(actual.tasks[0] ?? {})).not.toContain("duration");
+  });
+
+  it("groups multiple worktrees under one task in list order", async () => {
+    vi.mocked(worktrees.list).mockReturnValue([
+      makeEntry({ repository: "groundcrew", dir: "/repos/a" }),
+      makeEntry({ repository: "emdash", dir: "/repos/b" }),
+    ]);
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks).toHaveLength(1);
+    expect(actual.tasks[0]?.worktrees.map((worktree) => worktree.dir)).toEqual([
+      "/repos/a",
+      "/repos/b",
+    ]);
+  });
+
+  it("flags a run-state that says running when the session is gone", async () => {
+    vi.mocked(workspaces.probe).mockResolvedValue({ kind: "ok", names: new Set() });
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.flags).toContain("session dead");
+    expect(actual.tasks[0]?.session).toBe("not-live");
+  });
+
+  it("flags a worktree with no run state and a live session as stray", async () => {
+    vi.mocked(readRunState).mockReturnValue(undefined);
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.lifecycle).toBe("idle");
+    expect(actual.tasks[0]?.flags).toContain("stray session");
+    expect(actual.tasks[0]?.hint).toContain("crew cleanup eng-220");
+  });
+
+  it("lists sessions with no worktree as orphaned", async () => {
+    vi.mocked(workspaces.probe).mockResolvedValue({
+      kind: "ok",
+      names: new Set(["eng-220", "eng-199"]),
+    });
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.orphanedSessions).toEqual(["eng-199"]);
+  });
+
+  it("reports an unavailable probe without failing the collection", async () => {
+    vi.mocked(workspaces.probe).mockResolvedValue({ kind: "unavailable", error: undefined });
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.workspaceProbe.status).toBe("unavailable");
+    expect(actual.tasks[0]?.session).toBe("unknown");
+    expect(actual.tasks[0]?.flags).toEqual([]);
+    expect(actual.tasks[0]?.hint).toBeUndefined();
+  });
+
+  it("collects git dirtiness and branch for each worktree", async () => {
+    vi.mocked(worktrees.probeWorkingTree).mockResolvedValue({
+      kind: "dirty",
+      modified: 2,
+      untracked: 1,
+    });
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.worktrees[0]?.git).toEqual({
+      kind: "dirty",
+      modified: 2,
+      untracked: 1,
+    });
+    expect(actual.tasks[0]?.worktrees[0]?.branch).toBe("eng-220");
+  });
+
+  it("attaches only log lines that mention the task", async () => {
+    writeFileSync(
+      mockConfig.logging.file,
+      ["[10:00:00] eng-220 dispatched", "[10:00:01] eng-999 dispatched"].join("\n"),
+    );
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.recentLogLines).toEqual(["[10:00:00] eng-220 dispatched"]);
+  });
+
+  it("reads only the tail of a log larger than the bound", async () => {
+    const filler = `${"x".repeat(200)}\n`.repeat(2000);
+    writeFileSync(mockConfig.logging.file, `[09:00:00] eng-220 ancient\n${filler}`);
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.recentLogLines).toEqual([]);
+  });
+
+  it("survives a missing log file", async () => {
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.recentLogLines).toEqual([]);
+  });
+});

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -72,6 +72,17 @@ vi.mock(import("../lib/worktreeRunState.ts"), async (importOriginal) => {
 let directory: string;
 let mockConfig: ResolvedConfig;
 
+// The collector reads only these three fields; everything else it receives is
+// passed straight to mocked collaborators. One assertion here beats scattering
+// partial fixtures across the describe blocks.
+function makeConfig(logDirectory: string): ResolvedConfig {
+  return {
+    sources: [],
+    logging: { file: path.join(logDirectory, "groundcrew.log") },
+    orchestrator: { maximumInProgress: 4 },
+  } as unknown as ResolvedConfig;
+}
+
 function makeEntry(overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
   return {
     repository: "groundcrew",
@@ -103,10 +114,7 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
 describe("collectLocalStatus", () => {
   beforeEach(() => {
     directory = mkdtempSync(path.join(tmpdir(), "gc-collect-"));
-    mockConfig = {
-      logging: { file: path.join(directory, "groundcrew.log") },
-      orchestrator: { maximumInProgress: 4 },
-    } as ResolvedConfig;
+    mockConfig = makeConfig(directory);
     vi.mocked(worktrees.list).mockReturnValue([makeEntry()]);
     vi.mocked(worktrees.probeWorkingTree).mockResolvedValue({ kind: "clean" });
     vi.mocked(workspaces.probe).mockResolvedValue({ kind: "ok", names: new Set(["eng-220"]) });
@@ -241,6 +249,21 @@ describe("collectLocalStatus", () => {
     expect(actual.tasks[0]?.recentLogLines).toEqual([]);
   });
 
+  it("discards the partial line a tail read starts in the middle of", async () => {
+    // The cut lands inside this line, and its tail fragment mentions the task.
+    // Treating that fragment as a log line would attribute text to eng-220
+    // that was never written about it.
+    const oversizedLine = `${"x".repeat(300_000)} eng-220 fragment`;
+    writeFileSync(
+      mockConfig.logging.file,
+      [oversizedLine, "[10:00:00] eng-220 real line"].join("\n"),
+    );
+
+    const actual = await collectLocalStatus({ config: mockConfig });
+
+    expect(actual.tasks[0]?.recentLogLines).toEqual(["[10:00:00] eng-220 real line"]);
+  });
+
   it("survives a missing log file", async () => {
     const actual = await collectLocalStatus({ config: mockConfig });
 
@@ -323,11 +346,7 @@ describe("workspaceProbeUnavailableText", () => {
 describe("collectRemoteStatus", () => {
   beforeEach(() => {
     directory = mkdtempSync(path.join(tmpdir(), "gc-remote-"));
-    mockConfig = {
-      logging: { file: path.join(directory, "groundcrew.log") },
-      orchestrator: { maximumInProgress: 4 },
-      sources: [],
-    } as unknown as ResolvedConfig;
+    mockConfig = makeConfig(directory);
   });
 
   afterEach(() => {
@@ -411,7 +430,12 @@ describe("collectRemoteStatus", () => {
     );
 
     expect(actual.queueBlocked[0]?.blockedBy).toEqual([
-      { id: "linear:eng-201", status: "in-progress", nativeStatus: "In Progress" },
+      {
+        id: "linear:eng-201",
+        naturalId: "eng-201",
+        status: "in-progress",
+        nativeStatus: "In Progress",
+      },
     ]);
   });
 

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -18,12 +18,14 @@ import {
   type StatusBlockedIssue,
   type StatusBoardIssue,
   type StatusLifecycle,
+  type StatusQueueIssue,
   type StatusSessionState,
   type StatusTask,
   type StatusWorktree,
 } from "../lib/statusSnapshot.ts";
 import {
   type CanonicalStatus,
+  type GroundcrewIssue,
   isGroundcrewIssue,
   type Issue as SourceIssue,
   naturalIdFromCanonical,
@@ -101,10 +103,21 @@ export async function collectLocalStatus(
   };
 }
 
+/** The subset of a collected worktree a pull request lookup needs. */
+export interface PullRequestTarget {
+  task: string;
+  dir: string;
+  branch: string;
+}
+
 export interface CollectRemoteStatusInput {
   config: ResolvedConfig;
-  /** Lowercased task ids with a local worktree, used only to scope PR lookups. */
-  localTasks: readonly string[];
+  /**
+   * Worktrees from the local tier. Passing the already-resolved branch keeps
+   * this collector from re-reading run state and re-resolving branches that
+   * the local pass just computed.
+   */
+  pullRequestTargets: readonly PullRequestTarget[];
 }
 
 /**
@@ -119,7 +132,7 @@ export interface CollectRemoteStatusInput {
 export async function collectRemoteStatus(
   input: CollectRemoteStatusInput,
 ): Promise<RemoteFetchResult> {
-  const { config, localTasks } = input;
+  const { config, pullRequestTargets } = input;
   let issues: readonly SourceIssue[];
   try {
     const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
@@ -139,13 +152,15 @@ export async function collectRemoteStatus(
     payload: {
       capturedAt: new Date().toISOString(),
       statusByTask: statusByTask(issues),
-      pullRequestsByTask: await collectPullRequests({ config, localTasks }),
+      pullRequestsByTask: await collectPullRequests(pullRequestTargets),
       inProgress: issues
         .filter((issue) => issue.status === "in-progress")
         .toSorted((left, right) => left.id.localeCompare(right.id))
         .map((issue) => toBoardIssue(issue)),
-      queueReady: todos.filter((issue) => !hasOpenBlocker(issue)).map((issue) => toBoardIssue(issue)),
-      queueBlocked: todos.filter((issue) => hasOpenBlocker(issue)).map((issue) => toBlockedIssue(issue)),
+      queueReady: todos.filter((issue) => !hasOpenBlocker(issue)).map((issue) => toQueueIssue(issue)),
+      queueBlocked: todos
+        .filter((issue) => hasOpenBlocker(issue))
+        .map((issue) => toBlockedIssue(issue)),
     },
   };
 }
@@ -356,9 +371,13 @@ function toBoardIssue(issue: SourceIssue): StatusBoardIssue {
   };
 }
 
-function toBlockedIssue(issue: SourceIssue): StatusBlockedIssue {
+function toQueueIssue(issue: GroundcrewIssue): StatusQueueIssue {
+  return { ...toBoardIssue(issue), repository: issue.repository, agent: issue.agent };
+}
+
+function toBlockedIssue(issue: GroundcrewIssue): StatusBlockedIssue {
   return {
-    ...toBoardIssue(issue),
+    ...toQueueIssue(issue),
     blockedBy: issue.blockers
       .filter((blocker) => blocker.status !== "done")
       .map((blocker) => ({
@@ -389,21 +408,17 @@ function statusByTask(issues: readonly SourceIssue[]): Record<string, CanonicalS
   return Object.fromEntries(statuses);
 }
 
-async function collectPullRequests(input: {
-  config: ResolvedConfig;
-  localTasks: readonly string[];
-}): Promise<Record<string, PullRequestSummary[]>> {
-  const { config, localTasks } = input;
-  const wanted = new Set(localTasks);
-  const entries = worktrees.list(config).filter((entry) => wanted.has(entry.task));
+async function collectPullRequests(
+  targets: readonly PullRequestTarget[],
+): Promise<Record<string, PullRequestSummary[]>> {
   const results = await Promise.allSettled(
-    entries.map(async (entry) => {
-      const branchName = await effectiveBranchNameFromRunState({
-        entry,
-        runState: readRunState(config, entry.task),
-      });
-      return [entry.task, await findPullRequestsForBranch({ cwd: entry.dir, branchName })] as const;
-    }),
+    targets.map(
+      async (target) =>
+        [
+          target.task,
+          await findPullRequestsForBranch({ cwd: target.dir, branchName: target.branch }),
+        ] as const,
+    ),
   );
   const byTask: Record<string, PullRequestSummary[]> = {};
   for (const result of results) {

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -4,9 +4,9 @@
  * the renderers, the join, and the wire format stay free of I/O.
  */
 
-import { readFileSync } from "node:fs";
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
 
-import { createBoard } from "../lib/board.ts";
+import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
@@ -51,9 +51,8 @@ export interface CollectLocalStatusInput {
 }
 
 /**
- * Local tier: worktrees, run states, sessions, git dirtiness, log lines. Every
- * call here is a local subprocess or file read, which is what makes this safe
- * to poll every few seconds.
+ * Every call in the local tier is a local subprocess or file read, which is
+ * what makes it safe for a monitor to poll every few seconds.
  */
 export async function collectLocalStatus(
   input: CollectLocalStatusInput,
@@ -62,27 +61,30 @@ export async function collectLocalStatus(
   const entries = worktrees
     .list(config)
     .toSorted((left, right) => left.task.localeCompare(right.task));
-  const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
-
   const uniqueTasks = [...new Set(entries.map((entry) => entry.task))];
   const runStates = new Map(uniqueTasks.map((task) => [task, readRunState(config, task)]));
-  const accessHints = await collectAccessHints({ config, tasks: uniqueTasks });
   const logLines = readLogTail(config);
-  const collected = await collectWorktreesByTask({ entries, runStates });
 
-  // Iterating the collected map rather than the task list keeps every task's
-  // repository and worktrees non-optional: the map was built from the entries
-  // those fields come from.
-  const tasks: StatusTask[] = [...collected].map(([task, group]) => {
+  // The probe and the git fan-out share no data, so overlap them. Access hints
+  // wait for the probe: resolving the workspace adapter is only cached after
+  // its first await, so racing them would re-probe host capabilities N times.
+  const [probe, collected] = await Promise.all([
+    withLogOutputSuppressed(async () => await workspaces.probe(config)),
+    collectWorktreesByTask({ entries, runStates }),
+  ]);
+  const accessHints = await collectAccessHints({ config, tasks: uniqueTasks });
+
+  const tasks: StatusTask[] = [...collected].map(([task, taskWorktrees]) => {
     const runState = runStates.get(task);
+    const lifecycle = lifecycleOf(runState);
+    const disagreement = probeDisagreement({ lifecycle, probe, task });
     return {
       task,
       title: runState?.title,
       url: runState?.url,
-      repository: group.repository,
       agent: runState?.agent,
-      lifecycle: lifecycleOf(runState),
-      flags: runProbeFlags({ runState, probe, task }),
+      lifecycle,
+      flags: disagreement === undefined ? [] : [disagreementLabel(disagreement)],
       startedAt: runState?.createdAt,
       updatedAt: runState?.updatedAt,
       resumeCount: runState?.resumeCount,
@@ -90,8 +92,8 @@ export async function collectLocalStatus(
       detail: runState?.detail,
       session: sessionState({ probe, task }),
       attachCommand: accessHints.get(task)?.command,
-      hint: inventoryHint({ runState, probe, task }),
-      worktrees: group.worktrees,
+      hint: disagreement === undefined ? undefined : disagreementHint({ disagreement, task }),
+      worktrees: taskWorktrees,
       recentLogLines: recentTaskLogLines({ lines: logLines, task }),
     };
   });
@@ -121,6 +123,8 @@ export interface CollectRemoteStatusInput {
    * the local pass just computed.
    */
   pullRequestTargets: readonly PullRequestTarget[];
+  /** A board fetch already in flight. Omit to fetch inline. */
+  board?: BoardFetch;
 }
 
 /**
@@ -132,19 +136,33 @@ export interface CollectRemoteStatusInput {
  * A failed fetch is a result, not a throw: the caller merges it into the
  * previous document so last-known-good data survives an outage.
  */
+export type BoardFetch =
+  | { kind: "ok"; issues: readonly SourceIssue[] }
+  | { kind: "error"; message: string };
+
+/**
+ * The board fetch on its own. Exposed separately because it depends on nothing
+ * local, so callers can start it before the local pass finishes.
+ */
+export async function fetchBoardIssues(config: ResolvedConfig): Promise<BoardFetch> {
+  try {
+    const board = await buildBoard(config);
+    const state = await withLogOutputSuppressed(async () => await board.fetch());
+    return { kind: "ok", issues: state.issues };
+  } catch (error) {
+    return { kind: "error", message: errorMessage(error) };
+  }
+}
+
 export async function collectRemoteStatus(
   input: CollectRemoteStatusInput,
 ): Promise<RemoteFetchResult> {
   const { config, pullRequestTargets } = input;
-  let issues: readonly SourceIssue[];
-  try {
-    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
-    const board = createBoard(sources);
-    const state = await withLogOutputSuppressed(async () => await board.fetch());
-    issues = state.issues;
-  } catch (error) {
-    return { kind: "error", message: errorMessage(error) };
+  const board = input.board ?? (await fetchBoardIssues(config));
+  if (board.kind === "error") {
+    return { kind: "error", message: board.message };
   }
+  const { issues } = board;
 
   // Only groundcrew-eligible todos are dispatchable; the rest lack a repo or
   // an agent, so `crew run` would skip them.
@@ -170,19 +188,9 @@ export async function collectRemoteStatus(
   };
 }
 
-function lifecycleOf(runState: RunState | undefined): StatusLifecycle {
-  return runState?.state ?? "idle";
-}
-
-function sessionState(input: { probe: WorkspaceProbe; task: string }): StatusSessionState {
-  const { probe, task } = input;
-  if (probe.kind !== "ok") {
-    return "unknown";
-  }
-  if (isWorkspaceExited({ probe, task })) {
-    return "exited";
-  }
-  return probe.names.has(task) ? "live" : "not-live";
+export async function buildBoard(config: ResolvedConfig): Promise<Board> {
+  const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+  return createBoard(sources);
 }
 
 export function isWorkspaceExited(input: { probe: WorkspaceProbe; task: string }): boolean {
@@ -191,64 +199,69 @@ export function isWorkspaceExited(input: { probe: WorkspaceProbe; task: string }
 }
 
 /**
- * Flags the two interesting disagreements between the recorded RunState
- * lifecycle and the live workspace probe: a running dispatch with a missing or
- * exited session, and an idle row with a stray session. An unavailable probe
- * means "we don't know" and yields no flags.
+ * The ways a recorded run lifecycle can disagree with the live session probe.
  */
-export function runProbeFlags(input: {
-  runState: RunState | undefined;
-  probe: WorkspaceProbe;
-  task: string;
-}): string[] {
-  const { runState, probe, task } = input;
-  if (probe.kind !== "ok") {
-    return [];
-  }
-  const lifecycle = lifecycleOf(runState);
-  const sessionPresent = probe.names.has(task);
-  const sessionExited = isWorkspaceExited({ probe, task });
-  const flags: string[] = [];
-  if (lifecycle === "idle" && sessionPresent) {
-    flags.push(sessionExited ? "stray exited session" : "stray session");
-  }
-  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
-    flags.push("session exited");
-  } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
-    flags.push("session dead");
-  }
-  return flags;
-}
+export type ProbeDisagreement =
+  | "stray-session"
+  | "stray-exited-session"
+  | "session-exited"
+  | "session-dead";
 
 /**
- * Recovery command for a row where the run-state and the probe disagree. No
- * hint when the probe is unavailable, since we genuinely don't know whether
- * there is a disagreement, or when the row is healthy.
+ * Classifies the disagreement between the recorded lifecycle and the live
+ * probe. An unavailable probe means "we don't know", which is not a
+ * disagreement.
+ *
+ * The row label and the recovery hint both derive from this one
+ * classification, so they cannot drift into describing different conditions.
  */
-function inventoryHint(input: {
-  runState: RunState | undefined;
+export function probeDisagreement(input: {
+  lifecycle: StatusLifecycle;
   probe: WorkspaceProbe;
   task: string;
-}): string | undefined {
-  const { runState, probe, task } = input;
-  if (probe.kind === "unavailable") {
+}): ProbeDisagreement | undefined {
+  const { lifecycle, probe, task } = input;
+  if (probe.kind !== "ok") {
     return undefined;
   }
-  const lifecycle = lifecycleOf(runState);
-  const sessionPresent = probe.names.has(task);
   const sessionExited = isWorkspaceExited({ probe, task });
-  if (lifecycle === "idle" && sessionPresent) {
-    return sessionExited
-      ? `run 'crew cleanup ${task}' to clear this stray exited session`
-      : `run 'crew cleanup ${task}' to clear this stray session`;
+  const sessionPresent = probe.names.has(task);
+  if (lifecycle === "idle") {
+    if (!sessionPresent) {
+      return undefined;
+    }
+    return sessionExited ? "stray-exited-session" : "stray-session";
   }
-  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
-    return `attach to inspect scrollback, then run 'crew resume ${task}'`;
+  if (lifecycle !== "running" && lifecycle !== "resumed") {
+    return undefined;
   }
-  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
-    return `run 'crew resume ${task}' to bring the session back`;
+  if (sessionExited) {
+    return "session-exited";
   }
-  return undefined;
+  return sessionPresent ? undefined : "session-dead";
+}
+
+const DISAGREEMENT_LABELS: Record<ProbeDisagreement, string> = {
+  "stray-session": "stray session",
+  "stray-exited-session": "stray exited session",
+  "session-exited": "session exited",
+  "session-dead": "session dead",
+};
+
+export function disagreementLabel(disagreement: ProbeDisagreement): string {
+  return DISAGREEMENT_LABELS[disagreement];
+}
+
+/** Recovery command for a row whose recorded state and live session disagree. */
+function disagreementHint(input: { disagreement: ProbeDisagreement; task: string }): string {
+  const { disagreement, task } = input;
+  const hints: Record<ProbeDisagreement, string> = {
+    "stray-session": `run 'crew cleanup ${task}' to clear this stray session`,
+    "stray-exited-session": `run 'crew cleanup ${task}' to clear this stray exited session`,
+    "session-exited": `attach to inspect scrollback, then run 'crew resume ${task}'`,
+    "session-dead": `run 'crew resume ${task}' to bring the session back`,
+  };
+  return hints[disagreement];
 }
 
 export function workspaceProbeUnavailableText(
@@ -269,23 +282,13 @@ function probeState(probe: WorkspaceProbe): LocalStatusDocument["workspaceProbe"
   };
 }
 
-interface CollectedTaskWorktrees {
-  repository: string;
-  worktrees: StatusWorktree[];
-}
-
-/**
- * Groups worktrees under their task, in worktree-list order. The renderer
- * flattens this back to one row per worktree, so the order must stay stable.
- * The task's repository comes from its first worktree, matching the row a
- * single-worktree task has always printed.
- */
+/** Worktree-list order is preserved: the renderer flattens this back to rows. */
 async function collectWorktreesByTask(input: {
   entries: readonly WorktreeEntry[];
   runStates: ReadonlyMap<string, RunState | undefined>;
-}): Promise<Map<string, CollectedTaskWorktrees>> {
+}): Promise<Map<string, StatusWorktree[]>> {
   const { entries, runStates } = input;
-  const byTask = new Map<string, CollectedTaskWorktrees>();
+  const byTask = new Map<string, StatusWorktree[]>();
   const collected = await Promise.all(
     entries.map(async (entry) => ({
       entry,
@@ -295,9 +298,9 @@ async function collectWorktreesByTask(input: {
   for (const { entry, worktree } of collected) {
     const existing = byTask.get(entry.task);
     if (existing === undefined) {
-      byTask.set(entry.task, { repository: entry.repository, worktrees: [worktree] });
+      byTask.set(entry.task, [worktree]);
     } else {
-      existing.worktrees.push(worktree);
+      existing.push(worktree);
     }
   }
   return byTask;
@@ -343,15 +346,31 @@ function orphanedSessions(input: {
   return [...probe.names].filter((name) => !worktreeTasks.has(name)).toSorted();
 }
 
+/**
+ * Reads at most the last `LOG_TAIL_BYTES` of the log. Seeking rather than
+ * reading the whole file and slicing is the point: the log grows without
+ * limit, and this runs on every poll.
+ */
 function readLogTail(config: ResolvedConfig): string[] {
-  let raw: string;
+  let handle: number;
   try {
-    raw = readFileSync(config.logging.file, "utf8");
+    handle = openSync(config.logging.file, "r");
   } catch {
     return [];
   }
-  const tail = raw.length > LOG_TAIL_BYTES ? raw.slice(-LOG_TAIL_BYTES) : raw;
-  return tail.split("\n");
+  try {
+    const { size } = fstatSync(handle);
+    const length = Math.min(size, LOG_TAIL_BYTES);
+    const start = size - length;
+    const buffer = Buffer.alloc(length);
+    readSync(handle, buffer, 0, length, start);
+    const lines = buffer.toString("utf8").split("\n");
+    // A bounded read starts mid-line, so the leading fragment is not a log
+    // line and must not be matched against a task id.
+    return start > 0 ? lines.slice(1) : lines;
+  } finally {
+    closeSync(handle);
+  }
 }
 
 function hasOpenBlocker(issue: SourceIssue): boolean {
@@ -380,6 +399,7 @@ function toBlockedIssue(issue: GroundcrewIssue): StatusBlockedIssue {
       .filter((blocker) => blocker.status !== "done")
       .map((blocker) => ({
         id: blocker.id,
+        naturalId: naturalIdFromCanonical(blocker.id),
         status: blocker.status,
         nativeStatus: blocker.nativeStatus,
       })),
@@ -433,8 +453,28 @@ function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
-function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
+/**
+ * The most recent log lines mentioning `task`. Callers supply the lines so the
+ * pollable collector can pass a bounded tail while the one-shot per-task view
+ * passes the whole file.
+ */
+export function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
   const { lines, task } = input;
   const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
   return lines.filter((line) => pattern.test(line)).slice(-RECENT_LOG_LINE_COUNT);
+}
+
+function lifecycleOf(runState: RunState | undefined): StatusLifecycle {
+  return runState?.state ?? "idle";
+}
+
+function sessionState(input: { probe: WorkspaceProbe; task: string }): StatusSessionState {
+  const { probe, task } = input;
+  if (probe.kind !== "ok") {
+    return "unknown";
+  }
+  if (isWorkspaceExited({ probe, task })) {
+    return "exited";
+  }
+  return probe.names.has(task) ? "live" : "not-live";
 }

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -16,18 +16,20 @@ import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullR
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type LocalStatusDocument,
+  readLocalSnapshot,
   type RemoteFetchResult,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
   type StatusBlockedIssue,
   type StatusBoardIssue,
   type StatusLifecycle,
+  type StatusLogCursor,
   type StatusQueueIssue,
   type StatusSessionState,
+  type StatusSourceIssue,
   type StatusTask,
   type StatusWorktree,
 } from "../lib/statusSnapshot.ts";
 import {
-  type CanonicalStatus,
   type GroundcrewIssue,
   isGroundcrewIssue,
   type Issue as SourceIssue,
@@ -42,14 +44,11 @@ import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 const RECENT_LOG_LINE_COUNT = 10;
 
 /**
- * Upper bound on how much of the append-only log the collector reads. The log
- * is shared across runs and grows without limit, and a monitor polls this
- * every few seconds, so reading it whole would make the fast path scale with
- * the log's lifetime. `crew status <task>` is a one-shot command and still
- * reads the whole file. 256 KiB holds several thousand lines, far past the ten
- * this keeps per task.
+ * Reverse-scan chunk size for the append-only shared log. Active tasks are
+ * normally found in the first chunk; older tasks make the scan continue only
+ * until their ten most recent matching lines have been found.
  */
-const LOG_TAIL_BYTES = 256 * 1024;
+const LOG_SCAN_CHUNK_BYTES = 256 * 1024;
 
 export interface CollectLocalStatusInput {
   config: ResolvedConfig;
@@ -63,12 +62,14 @@ export async function collectLocalStatus(
   input: CollectLocalStatusInput,
 ): Promise<LocalStatusDocument> {
   const { config } = input;
+  const capturedAt = new Date().toISOString();
+  const previous = readLocalSnapshot(config);
   const entries = worktrees
     .list(config)
     .toSorted((left, right) => left.task.localeCompare(right.task));
   const uniqueTasks = [...new Set(entries.map((entry) => entry.task))];
   const runStates = new Map(uniqueTasks.map((task) => [task, readRunState(config, task)]));
-  const logLines = readLogTail(config);
+  const recentLogs = readRecentLogLines({ config, previous, tasks: uniqueTasks });
 
   // The probe and the git fan-out share no data, so overlap them. Access hints
   // wait for the probe: resolving the workspace adapter is only cached after
@@ -99,13 +100,14 @@ export async function collectLocalStatus(
       attachCommand: accessHints.get(task)?.command,
       hint: disagreement === undefined ? undefined : disagreementHint({ disagreement, task }),
       worktrees: taskWorktrees,
-      recentLogLines: recentTaskLogLines({ lines: logLines, task }),
+      recentLogLines: recentLogs.linesByTask.get(task) ?? [],
     };
   });
 
   return {
     schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
-    capturedAt: new Date().toISOString(),
+    capturedAt,
+    logCursor: recentLogs.cursor,
     maximumInProgress: config.orchestrator.maximumInProgress,
     workspaceProbe: probeState(probe),
     tasks,
@@ -132,7 +134,7 @@ export interface CollectRemoteStatusInput {
 
 /** One board fetch attempt. A failure is a value here, never a throw. */
 export type BoardFetch =
-  | { kind: "ok"; issues: readonly SourceIssue[] }
+  | { kind: "ok"; capturedAt: string; issues: readonly SourceIssue[] }
   | { kind: "error"; message: string };
 
 /**
@@ -143,7 +145,7 @@ export async function fetchBoardIssues(config: ResolvedConfig): Promise<BoardFet
   try {
     const board = await buildBoard(config);
     const state = await withLogOutputSuppressed(async () => await board.fetch());
-    return { kind: "ok", issues: state.issues };
+    return { kind: "ok", capturedAt: state.timestamp, issues: state.issues };
   } catch (error) {
     return { kind: "error", message: errorMessage(error) };
   }
@@ -177,8 +179,8 @@ export async function collectRemoteStatus(
     board: {
       kind: "ok",
       payload: {
-        capturedAt: new Date().toISOString(),
-        statusByTask: statusByTask(issues),
+        capturedAt: board.capturedAt,
+        sourceByTask: sourceByTask(issues),
         inProgress: issues
           .filter((issue) => issue.status === "in-progress")
           .toSorted((left, right) => left.id.localeCompare(right.id))
@@ -352,28 +354,147 @@ function orphanedSessions(input: {
   return [...probe.names].filter((name) => !worktreeTasks.has(name)).toSorted();
 }
 
-/**
- * Reads at most the last `LOG_TAIL_BYTES` of the log. Seeking rather than
- * reading the whole file and slicing is the point: the log grows without
- * limit, and this runs on every poll.
- */
-function readLogTail(config: ResolvedConfig): string[] {
+interface RecentLogResult {
+  linesByTask: Map<string, string[]>;
+  cursor?: StatusLogCursor | undefined;
+}
+
+function readRecentLogLines(input: {
+  config: ResolvedConfig;
+  previous: LocalStatusDocument | undefined;
+  tasks: readonly string[];
+}): RecentLogResult {
+  const { config, previous, tasks } = input;
+  if (tasks.length === 0) {
+    return { linesByTask: new Map() };
+  }
   let handle: number;
   try {
     handle = openSync(config.logging.file, "r");
   } catch {
-    return [];
+    return { linesByTask: new Map() };
   }
   try {
-    const { size } = fstatSync(handle);
-    const length = Math.min(size, LOG_TAIL_BYTES);
-    const start = size - length;
-    const buffer = Buffer.alloc(length);
-    const bytesRead = readSync(handle, buffer, 0, length, start);
-    return decodeLogTail({ buffer, bytesRead, startedMidFile: start > 0 });
+    const stats = fstatSync(handle);
+    const cursor: StatusLogCursor = {
+      device: stats.dev,
+      inode: stats.ino,
+      offset: stats.size,
+    };
+    const previousCursor = previous?.logCursor;
+    const canResume =
+      previousCursor !== undefined &&
+      previousCursor.device === cursor.device &&
+      previousCursor.inode === cursor.inode &&
+      previousCursor.offset <= cursor.offset;
+    const previousTasks = new Map(previous?.tasks.map((task) => [task.task, task]) ?? []);
+    const reusableTasks = canResume ? tasks.filter((task) => previousTasks.has(task)) : [];
+    const tasksNeedingHistory = tasks.filter((task) => !reusableTasks.includes(task));
+    const appendedLines = scanRecentLogLines({
+      handle,
+      startOffset: previousCursor?.offset ?? 0,
+      endOffset: cursor.offset,
+      tasks: reusableTasks,
+    });
+    const historicalLines = scanRecentLogLines({
+      handle,
+      startOffset: 0,
+      endOffset: cursor.offset,
+      tasks: tasksNeedingHistory,
+    });
+    const linesByTask = new Map<string, string[]>();
+    for (const task of reusableTasks) {
+      const cached = requiredMapValue(previousTasks, task).recentLogLines;
+      linesByTask.set(
+        task,
+        [...cached, ...requiredMapValue(appendedLines, task)].slice(-RECENT_LOG_LINE_COUNT),
+      );
+    }
+    for (const task of tasksNeedingHistory) {
+      linesByTask.set(task, requiredMapValue(historicalLines, task));
+    }
+    return { linesByTask, cursor };
   } finally {
     closeSync(handle);
   }
+}
+
+function scanRecentLogLines(input: {
+  handle: number;
+  startOffset: number;
+  endOffset: number;
+  tasks: readonly string[];
+}): Map<string, string[]> {
+  const { handle, startOffset, endOffset, tasks } = input;
+  const matchers = tasks.map((task) => ({
+    task,
+    pattern: taskLogPattern(task),
+    linesNewestFirst: [] as string[],
+  }));
+  let startsAtLineBoundary = startOffset === 0;
+  if (startOffset > 0) {
+    const priorByte = Buffer.alloc(1);
+    startsAtLineBoundary =
+      readSync(handle, priorByte, 0, 1, startOffset - 1) === 1 && priorByte[0] === 10;
+  }
+  let leadingFragment: Buffer = Buffer.alloc(0);
+  let position = endOffset;
+
+  while (
+    position > startOffset &&
+    matchers.some((matcher) => matcher.linesNewestFirst.length < RECENT_LOG_LINE_COUNT)
+  ) {
+    const length = Math.min(position - startOffset, LOG_SCAN_CHUNK_BYTES);
+    const start = position - length;
+    const buffer = Buffer.alloc(length);
+    const bytesRead = readSync(handle, buffer, 0, length, start);
+    const split = splitLogBuffer(Buffer.concat([buffer.subarray(0, bytesRead), leadingFragment]));
+    const includeFirst = start === startOffset && startsAtLineBoundary;
+    const lines = includeFirst ? [split.first, ...split.rest] : split.rest;
+    leadingFragment = start > startOffset ? split.first : Buffer.alloc(0);
+
+    for (const lineBuffer of lines.toReversed()) {
+      const line = lineBuffer.toString("utf8");
+      for (const matcher of matchers) {
+        if (matcher.linesNewestFirst.length < RECENT_LOG_LINE_COUNT && matcher.pattern.test(line)) {
+          matcher.linesNewestFirst.push(line);
+        }
+      }
+    }
+    position = start;
+  }
+
+  return new Map(
+    matchers.map((matcher) => [matcher.task, matcher.linesNewestFirst.toReversed()] as const),
+  );
+}
+
+function requiredMapValue<Key, Value>(map: ReadonlyMap<Key, Value>, key: Key): Value {
+  const value = map.get(key);
+  /* v8 ignore next @preserve -- callers pass keys used to construct these maps */
+  if (value === undefined) {
+    throw new Error("Missing expected map value");
+  }
+  return value;
+}
+
+function splitLogBuffer(buffer: Buffer): {
+  first: Buffer;
+  rest: Buffer[];
+} {
+  const firstNewline = buffer.indexOf("\n");
+  if (firstNewline === -1) {
+    return { first: buffer, rest: [] };
+  }
+  const rest: Buffer[] = [];
+  let start = firstNewline + 1;
+  for (let newline = buffer.indexOf("\n", start); newline !== -1;) {
+    rest.push(buffer.subarray(start, newline));
+    start = newline + 1;
+    newline = buffer.indexOf("\n", start);
+  }
+  rest.push(buffer.subarray(start));
+  return { first: buffer.subarray(0, firstNewline), rest };
 }
 
 function hasOpenBlocker(issue: SourceIssue): boolean {
@@ -389,6 +510,10 @@ function toBoardIssue(issue: SourceIssue): StatusBoardIssue {
     repository: issue.repository,
     agent: issue.agent,
   };
+}
+
+function toSourceIssue(issue: SourceIssue): StatusSourceIssue {
+  return { ...toBoardIssue(issue), status: issue.status };
 }
 
 function toQueueIssue(issue: GroundcrewIssue): StatusQueueIssue {
@@ -413,20 +538,20 @@ function toBlockedIssue(issue: GroundcrewIssue): StatusBlockedIssue {
  * Lowercased natural id to canonical status, omitting any id claimed by more
  * than one source rather than guessing which one a worktree row means.
  */
-function statusByTask(issues: readonly SourceIssue[]): Record<string, CanonicalStatus> {
-  const statuses = new Map<string, CanonicalStatus>();
+function sourceByTask(issues: readonly SourceIssue[]): Record<string, StatusSourceIssue> {
+  const sources = new Map<string, StatusSourceIssue>();
   const matchCounts = new Map<string, number>();
   for (const issue of issues) {
     const task = naturalIdFromCanonical(issue.id).toLowerCase();
     matchCounts.set(task, (matchCounts.get(task) ?? 0) + 1);
-    statuses.set(task, issue.status);
+    sources.set(task, toSourceIssue(issue));
   }
   for (const [task, matchCount] of matchCounts) {
     if (matchCount > 1) {
-      statuses.delete(task);
+      sources.delete(task);
     }
   }
-  return Object.fromEntries(statuses);
+  return Object.fromEntries(sources);
 }
 
 async function collectPullRequests(
@@ -459,22 +584,8 @@ function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
-/**
- * Splits a tail read into log lines.
- *
- * Decodes only `bytesRead`: a log rotated between the stat and the read
- * returns fewer bytes than requested, and the rest of the buffer is still
- * zero-filled, which would publish NUL characters. A read that started
- * mid-file also starts mid-line, so its leading fragment is not a log line.
- */
-export function decodeLogTail(input: {
-  buffer: Buffer;
-  bytesRead: number;
-  startedMidFile: boolean;
-}): string[] {
-  const { buffer, bytesRead, startedMidFile } = input;
-  const lines = buffer.toString("utf8", 0, bytesRead).split("\n");
-  return startedMidFile ? lines.slice(1) : lines;
+function taskLogPattern(task: string): RegExp {
+  return new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
 }
 
 /**
@@ -486,7 +597,7 @@ export function recentTaskLogLines(input: { lines: readonly string[]; task: stri
   const { lines, task } = input;
   // The boundary class is not \b on purpose: task ids contain hyphens, and \b
   // counts `_` as a word character, so `\btask\b` would match inside `x_eng-220`.
-  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
+  const pattern = taskLogPattern(task);
   return lines.filter((line) => pattern.test(line)).slice(-RECENT_LOG_LINE_COUNT);
 }
 

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -1,0 +1,291 @@
+/**
+ * Gathers the two status tiers that `crew status` renders and that
+ * `crew status --json` publishes. Owns every subprocess and network call so
+ * the renderers, the join, and the wire format stay free of I/O.
+ */
+
+import { readFileSync } from "node:fs";
+
+import type { ResolvedConfig } from "../lib/config.ts";
+import { readRunState, type RunState } from "../lib/runState.ts";
+import {
+  type LocalStatusDocument,
+  STATUS_SNAPSHOT_SCHEMA_VERSION,
+  type StatusLifecycle,
+  type StatusSessionState,
+  type StatusTask,
+  type StatusWorktree,
+} from "../lib/statusSnapshot.ts";
+import { errorMessage, withLogOutputSuppressed } from "../lib/util.ts";
+import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
+import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
+import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+
+const RECENT_LOG_LINE_COUNT = 10;
+
+/**
+ * Upper bound on how much of the append-only log the collector reads. The log
+ * is shared across runs and grows without limit, and a monitor polls this
+ * every few seconds, so reading it whole would make the fast path scale with
+ * the log's lifetime. `crew status <task>` is a one-shot command and still
+ * reads the whole file.
+ */
+const LOG_TAIL_BYTES = 256 * 1024;
+
+export interface CollectLocalStatusInput {
+  config: ResolvedConfig;
+}
+
+/**
+ * Local tier: worktrees, run states, sessions, git dirtiness, log lines. Every
+ * call here is a local subprocess or file read, which is what makes this safe
+ * to poll every few seconds.
+ */
+export async function collectLocalStatus(
+  input: CollectLocalStatusInput,
+): Promise<LocalStatusDocument> {
+  const { config } = input;
+  const entries = worktrees
+    .list(config)
+    .toSorted((left, right) => left.task.localeCompare(right.task));
+  const probe = await withLogOutputSuppressed(async () => await workspaces.probe(config));
+
+  const uniqueTasks = [...new Set(entries.map((entry) => entry.task))];
+  const runStates = new Map(uniqueTasks.map((task) => [task, readRunState(config, task)]));
+  const accessHints = await collectAccessHints({ config, tasks: uniqueTasks });
+  const logLines = readLogTail(config);
+  const worktreesByTask = await collectWorktreesByTask({ entries, runStates });
+
+  const tasks: StatusTask[] = uniqueTasks.map((task) => {
+    const runState = runStates.get(task);
+    return {
+      task,
+      title: runState?.title,
+      url: runState?.url,
+      repository: repositoryForTask({ entries, task }),
+      agent: runState?.agent,
+      lifecycle: lifecycleOf(runState),
+      flags: runProbeFlags({ runState, probe, task }),
+      startedAt: runState?.createdAt,
+      updatedAt: runState?.updatedAt,
+      resumeCount: runState?.resumeCount,
+      reason: runState?.reason,
+      detail: runState?.detail,
+      session: sessionState({ probe, task }),
+      attachCommand: accessHints.get(task)?.command,
+      hint: inventoryHint({ runState, probe, task }),
+      worktrees: worktreesByTask.get(task) ?? [],
+      recentLogLines: recentTaskLogLines({ lines: logLines, task }),
+    };
+  });
+
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    capturedAt: new Date().toISOString(),
+    maximumInProgress: config.orchestrator.maximumInProgress,
+    workspaceProbe: probeState(probe),
+    tasks,
+    orphanedSessions: orphanedSessions({ probe, entries }),
+  };
+}
+
+export function lifecycleOf(runState: RunState | undefined): StatusLifecycle {
+  return runState?.state ?? "idle";
+}
+
+export function sessionState(input: {
+  probe: WorkspaceProbe;
+  task: string;
+}): StatusSessionState {
+  const { probe, task } = input;
+  if (probe.kind !== "ok") {
+    return "unknown";
+  }
+  if (isWorkspaceExited({ probe, task })) {
+    return "exited";
+  }
+  return probe.names.has(task) ? "live" : "not-live";
+}
+
+export function isWorkspaceExited(input: { probe: WorkspaceProbe; task: string }): boolean {
+  const { probe, task } = input;
+  return probe.kind === "ok" && probe.exitedNames?.has(task) === true;
+}
+
+/**
+ * Flags the two interesting disagreements between the recorded RunState
+ * lifecycle and the live workspace probe: a running dispatch with a missing or
+ * exited session, and an idle row with a stray session. An unavailable probe
+ * means "we don't know" and yields no flags.
+ */
+export function runProbeFlags(input: {
+  runState: RunState | undefined;
+  probe: WorkspaceProbe;
+  task: string;
+}): string[] {
+  const { runState, probe, task } = input;
+  if (probe.kind !== "ok") {
+    return [];
+  }
+  const lifecycle = lifecycleOf(runState);
+  const sessionPresent = probe.names.has(task);
+  const sessionExited = isWorkspaceExited({ probe, task });
+  const flags: string[] = [];
+  if (lifecycle === "idle" && sessionPresent) {
+    flags.push(sessionExited ? "stray exited session" : "stray session");
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
+    flags.push("session exited");
+  } else if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
+    flags.push("session dead");
+  }
+  return flags;
+}
+
+/**
+ * Recovery command for a row where the run-state and the probe disagree. No
+ * hint when the probe is unavailable, since we genuinely don't know whether
+ * there is a disagreement, or when the row is healthy.
+ */
+export function inventoryHint(input: {
+  runState: RunState | undefined;
+  probe: WorkspaceProbe;
+  task: string;
+}): string | undefined {
+  const { runState, probe, task } = input;
+  if (probe.kind === "unavailable") {
+    return undefined;
+  }
+  const lifecycle = lifecycleOf(runState);
+  const sessionPresent = probe.names.has(task);
+  const sessionExited = isWorkspaceExited({ probe, task });
+  if (lifecycle === "idle" && sessionPresent) {
+    return sessionExited
+      ? `run 'crew cleanup ${task}' to clear this stray exited session`
+      : `run 'crew cleanup ${task}' to clear this stray session`;
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && sessionExited) {
+    return `attach to inspect scrollback, then run 'crew resume ${task}'`;
+  }
+  if ((lifecycle === "running" || lifecycle === "resumed") && !sessionPresent) {
+    return `run 'crew resume ${task}' to bring the session back`;
+  }
+  return undefined;
+}
+
+export function workspaceProbeUnavailableText(
+  probe: Extract<WorkspaceProbe, { kind: "unavailable" }>,
+): string {
+  return probe.error === undefined
+    ? "Workspace probe unavailable"
+    : `Workspace probe unavailable: ${errorMessage(probe.error)}`;
+}
+
+function probeState(probe: WorkspaceProbe): LocalStatusDocument["workspaceProbe"] {
+  if (probe.kind === "ok") {
+    return { status: "ok", error: undefined };
+  }
+  return {
+    status: "unavailable",
+    error: probe.error === undefined ? undefined : errorMessage(probe.error),
+  };
+}
+
+/**
+ * One entry per task, in worktree-list order. The renderer flattens this back
+ * to one row per worktree, so the order must stay stable.
+ */
+async function collectWorktreesByTask(input: {
+  entries: readonly WorktreeEntry[];
+  runStates: ReadonlyMap<string, RunState | undefined>;
+}): Promise<Map<string, StatusWorktree[]>> {
+  const { entries, runStates } = input;
+  const collected = await Promise.all(
+    entries.map(
+      async (entry) => await collectWorktree({ entry, runState: runStates.get(entry.task) }),
+    ),
+  );
+  const byTask = new Map<string, StatusWorktree[]>();
+  for (const [index, entry] of entries.entries()) {
+    const worktree = collected[index];
+    /* v8 ignore next 3 @preserve -- Promise.all preserves index alignment with entries */
+    if (worktree === undefined) {
+      continue;
+    }
+    const existing = byTask.get(entry.task);
+    if (existing === undefined) {
+      byTask.set(entry.task, [worktree]);
+    } else {
+      existing.push(worktree);
+    }
+  }
+  return byTask;
+}
+
+async function collectWorktree(input: {
+  entry: WorktreeEntry;
+  runState: RunState | undefined;
+}): Promise<StatusWorktree> {
+  const { entry, runState } = input;
+  const [branch, git] = await Promise.all([
+    effectiveBranchNameFromRunState({ entry, runState }),
+    worktrees.probeWorkingTree({ worktreeDir: entry.dir }),
+  ]);
+  return { repository: entry.repository, kind: entry.kind, dir: entry.dir, branch, git };
+}
+
+async function collectAccessHints(input: {
+  config: ResolvedConfig;
+  tasks: readonly string[];
+}): Promise<Map<string, { command: string } | undefined>> {
+  const { config, tasks } = input;
+  const results = await Promise.allSettled(
+    tasks.map(async (task) => await workspaces.accessHint(config, task)),
+  );
+  return new Map(
+    tasks.map((task, index) => {
+      const result = results[index];
+      return [task, result?.status === "fulfilled" ? result.value : undefined] as const;
+    }),
+  );
+}
+
+function repositoryForTask(input: { entries: readonly WorktreeEntry[]; task: string }): string {
+  const { entries, task } = input;
+  const entry = entries.find((candidate) => candidate.task === task);
+  /* v8 ignore next @preserve -- tasks are derived from entries, so a match always exists */
+  return entry?.repository ?? "";
+}
+
+function orphanedSessions(input: {
+  probe: WorkspaceProbe;
+  entries: readonly WorktreeEntry[];
+}): string[] {
+  const { probe, entries } = input;
+  if (probe.kind !== "ok") {
+    return [];
+  }
+  const worktreeTasks = new Set(entries.map((entry) => entry.task));
+  return [...probe.names].filter((name) => !worktreeTasks.has(name)).toSorted();
+}
+
+function readLogTail(config: ResolvedConfig): string[] {
+  let raw: string;
+  try {
+    raw = readFileSync(config.logging.file, "utf8");
+  } catch {
+    return [];
+  }
+  const tail = raw.length > LOG_TAIL_BYTES ? raw.slice(-LOG_TAIL_BYTES) : raw;
+  return tail.split("\n");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
+  const { lines, task } = input;
+  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
+  return lines.filter((line) => pattern.test(line)).slice(-RECENT_LOG_LINE_COUNT);
+}

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -1,7 +1,10 @@
 /**
- * Gathers the two status tiers that `crew status` renders and that
- * `crew status --json` publishes. Owns every subprocess and network call so
- * the renderers, the join, and the wire format stay free of I/O.
+ * Gathers the two status tiers that the `crew status` inventory renders and
+ * that `crew status --json` publishes. Owns every subprocess and network call
+ * on that path, so the join and the wire format do no I/O.
+ *
+ * The per-task view in status.ts is deliberately not on this path: it reads
+ * its own state, because it reads the whole log where this reads a tail.
  */
 
 import { closeSync, fstatSync, openSync, readSync } from "node:fs";
@@ -35,6 +38,7 @@ import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
+// Enough lines to show what a task just did, short enough for a status row.
 const RECENT_LOG_LINE_COUNT = 10;
 
 /**
@@ -42,7 +46,8 @@ const RECENT_LOG_LINE_COUNT = 10;
  * is shared across runs and grows without limit, and a monitor polls this
  * every few seconds, so reading it whole would make the fast path scale with
  * the log's lifetime. `crew status <task>` is a one-shot command and still
- * reads the whole file.
+ * reads the whole file. 256 KiB holds several thousand lines, far past the ten
+ * this keeps per task.
  */
 const LOG_TAIL_BYTES = 256 * 1024;
 
@@ -127,15 +132,7 @@ export interface CollectRemoteStatusInput {
   board?: BoardFetch;
 }
 
-/**
- * Remote tier: the board fetch and the pull request lookups. Board-side
- * classification is applied here, but the local worktree subtraction
- * deliberately is not — `joinStatus` does that against the freshest local
- * document, because this tier refreshes far more slowly.
- *
- * A failed fetch is a result, not a throw: the caller merges it into the
- * previous document so last-known-good data survives an outage.
- */
+/** One board fetch attempt. A failure is a value here, never a throw. */
 export type BoardFetch =
   | { kind: "ok"; issues: readonly SourceIssue[] }
   | { kind: "error"; message: string };
@@ -154,6 +151,15 @@ export async function fetchBoardIssues(config: ResolvedConfig): Promise<BoardFet
   }
 }
 
+/**
+ * Remote tier: the board fetch and the pull request lookups. Board-side
+ * classification is applied here, but the local worktree subtraction
+ * deliberately is not — `joinStatus` does that against the freshest local
+ * document, because this tier refreshes far more slowly.
+ *
+ * A failed fetch is a result, not a throw: the caller merges it into the
+ * previous document so last-known-good data survives an outage.
+ */
 export async function collectRemoteStatus(
   input: CollectRemoteStatusInput,
 ): Promise<RemoteFetchResult> {
@@ -173,7 +179,7 @@ export async function collectRemoteStatus(
     payload: {
       capturedAt: new Date().toISOString(),
       statusByTask: statusByTask(issues),
-      pullRequestsByTask: await collectPullRequests(pullRequestTargets),
+      pullRequestsByWorktree: await collectPullRequests(pullRequestTargets),
       inProgress: issues
         .filter((issue) => issue.status === "in-progress")
         .toSorted((left, right) => left.id.localeCompare(right.id))
@@ -433,20 +439,20 @@ async function collectPullRequests(
     targets.map(
       async (target) =>
         [
-          target.task,
+          target.dir,
           await findPullRequestsForBranch({ cwd: target.dir, branchName: target.branch }),
         ] as const,
     ),
   );
-  const byTask: Record<string, PullRequestSummary[]> = {};
+  const byWorktree: Record<string, PullRequestSummary[]> = {};
   for (const result of results) {
     if (result.status !== "fulfilled") {
       continue;
     }
-    const [task, pullRequests] = result.value;
-    byTask[task] = [...(byTask[task] ?? []), ...pullRequests];
+    const [dir, pullRequests] = result.value;
+    byWorktree[dir] = [...pullRequests];
   }
-  return byTask;
+  return byWorktree;
 }
 
 function escapeRegExp(value: string): string {
@@ -460,6 +466,8 @@ function escapeRegExp(value: string): string {
  */
 export function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
   const { lines, task } = input;
+  // The boundary class is not \b on purpose: task ids contain hyphens, and \b
+  // counts `_` as a word character, so `\btask\b` would match inside `x_eng-220`.
   const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(task)}([^a-z0-9]|$)`, "i");
   return lines.filter((line) => pattern.test(line)).slice(-RECENT_LOG_LINE_COUNT);
 }

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -68,15 +68,18 @@ export async function collectLocalStatus(
   const runStates = new Map(uniqueTasks.map((task) => [task, readRunState(config, task)]));
   const accessHints = await collectAccessHints({ config, tasks: uniqueTasks });
   const logLines = readLogTail(config);
-  const worktreesByTask = await collectWorktreesByTask({ entries, runStates });
+  const collected = await collectWorktreesByTask({ entries, runStates });
 
-  const tasks: StatusTask[] = uniqueTasks.map((task) => {
+  // Iterating the collected map rather than the task list keeps every task's
+  // repository and worktrees non-optional: the map was built from the entries
+  // those fields come from.
+  const tasks: StatusTask[] = [...collected].map(([task, group]) => {
     const runState = runStates.get(task);
     return {
       task,
       title: runState?.title,
       url: runState?.url,
-      repository: repositoryForTask({ entries, task }),
+      repository: group.repository,
       agent: runState?.agent,
       lifecycle: lifecycleOf(runState),
       flags: runProbeFlags({ runState, probe, task }),
@@ -88,7 +91,7 @@ export async function collectLocalStatus(
       session: sessionState({ probe, task }),
       attachCommand: accessHints.get(task)?.command,
       hint: inventoryHint({ runState, probe, task }),
-      worktrees: worktreesByTask.get(task) ?? [],
+      worktrees: group.worktrees,
       recentLogLines: recentTaskLogLines({ lines: logLines, task }),
     };
   });
@@ -157,7 +160,9 @@ export async function collectRemoteStatus(
         .filter((issue) => issue.status === "in-progress")
         .toSorted((left, right) => left.id.localeCompare(right.id))
         .map((issue) => toBoardIssue(issue)),
-      queueReady: todos.filter((issue) => !hasOpenBlocker(issue)).map((issue) => toQueueIssue(issue)),
+      queueReady: todos
+        .filter((issue) => !hasOpenBlocker(issue))
+        .map((issue) => toQueueIssue(issue)),
       queueBlocked: todos
         .filter((issue) => hasOpenBlocker(issue))
         .map((issue) => toBlockedIssue(issue)),
@@ -165,14 +170,11 @@ export async function collectRemoteStatus(
   };
 }
 
-export function lifecycleOf(runState: RunState | undefined): StatusLifecycle {
+function lifecycleOf(runState: RunState | undefined): StatusLifecycle {
   return runState?.state ?? "idle";
 }
 
-export function sessionState(input: {
-  probe: WorkspaceProbe;
-  task: string;
-}): StatusSessionState {
+function sessionState(input: { probe: WorkspaceProbe; task: string }): StatusSessionState {
   const { probe, task } = input;
   if (probe.kind !== "ok") {
     return "unknown";
@@ -223,7 +225,7 @@ export function runProbeFlags(input: {
  * hint when the probe is unavailable, since we genuinely don't know whether
  * there is a disagreement, or when the row is healthy.
  */
-export function inventoryHint(input: {
+function inventoryHint(input: {
   runState: RunState | undefined;
   probe: WorkspaceProbe;
   task: string;
@@ -267,32 +269,35 @@ function probeState(probe: WorkspaceProbe): LocalStatusDocument["workspaceProbe"
   };
 }
 
+interface CollectedTaskWorktrees {
+  repository: string;
+  worktrees: StatusWorktree[];
+}
+
 /**
- * One entry per task, in worktree-list order. The renderer flattens this back
- * to one row per worktree, so the order must stay stable.
+ * Groups worktrees under their task, in worktree-list order. The renderer
+ * flattens this back to one row per worktree, so the order must stay stable.
+ * The task's repository comes from its first worktree, matching the row a
+ * single-worktree task has always printed.
  */
 async function collectWorktreesByTask(input: {
   entries: readonly WorktreeEntry[];
   runStates: ReadonlyMap<string, RunState | undefined>;
-}): Promise<Map<string, StatusWorktree[]>> {
+}): Promise<Map<string, CollectedTaskWorktrees>> {
   const { entries, runStates } = input;
+  const byTask = new Map<string, CollectedTaskWorktrees>();
   const collected = await Promise.all(
-    entries.map(
-      async (entry) => await collectWorktree({ entry, runState: runStates.get(entry.task) }),
-    ),
+    entries.map(async (entry) => ({
+      entry,
+      worktree: await collectWorktree({ entry, runState: runStates.get(entry.task) }),
+    })),
   );
-  const byTask = new Map<string, StatusWorktree[]>();
-  for (const [index, entry] of entries.entries()) {
-    const worktree = collected[index];
-    /* v8 ignore next 3 @preserve -- Promise.all preserves index alignment with entries */
-    if (worktree === undefined) {
-      continue;
-    }
+  for (const { entry, worktree } of collected) {
     const existing = byTask.get(entry.task);
     if (existing === undefined) {
-      byTask.set(entry.task, [worktree]);
+      byTask.set(entry.task, { repository: entry.repository, worktrees: [worktree] });
     } else {
-      existing.push(worktree);
+      existing.worktrees.push(worktree);
     }
   }
   return byTask;
@@ -324,13 +329,6 @@ async function collectAccessHints(input: {
       return [task, result?.status === "fulfilled" ? result.value : undefined] as const;
     }),
   );
-}
-
-function repositoryForTask(input: { entries: readonly WorktreeEntry[]; task: string }): string {
-  const { entries, task } = input;
-  const entry = entries.find((candidate) => candidate.task === task);
-  /* v8 ignore next @preserve -- tasks are derived from entries, so a match always exists */
-  return entry?.repository ?? "";
 }
 
 function orphanedSessions(input: {

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -6,16 +6,28 @@
 
 import { readFileSync } from "node:fs";
 
+import { createBoard } from "../lib/board.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
+import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type LocalStatusDocument,
+  type RemoteFetchResult,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
+  type StatusBlockedIssue,
+  type StatusBoardIssue,
   type StatusLifecycle,
   type StatusSessionState,
   type StatusTask,
   type StatusWorktree,
 } from "../lib/statusSnapshot.ts";
+import {
+  type CanonicalStatus,
+  isGroundcrewIssue,
+  type Issue as SourceIssue,
+  naturalIdFromCanonical,
+} from "../lib/taskSource.ts";
 import { errorMessage, withLogOutputSuppressed } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
@@ -86,6 +98,55 @@ export async function collectLocalStatus(
     workspaceProbe: probeState(probe),
     tasks,
     orphanedSessions: orphanedSessions({ probe, entries }),
+  };
+}
+
+export interface CollectRemoteStatusInput {
+  config: ResolvedConfig;
+  /** Lowercased task ids with a local worktree, used only to scope PR lookups. */
+  localTasks: readonly string[];
+}
+
+/**
+ * Remote tier: the board fetch and the pull request lookups. Board-side
+ * classification is applied here, but the local worktree subtraction
+ * deliberately is not — `joinStatus` does that against the freshest local
+ * document, because this tier refreshes far more slowly.
+ *
+ * A failed fetch is a result, not a throw: the caller merges it into the
+ * previous document so last-known-good data survives an outage.
+ */
+export async function collectRemoteStatus(
+  input: CollectRemoteStatusInput,
+): Promise<RemoteFetchResult> {
+  const { config, localTasks } = input;
+  let issues: readonly SourceIssue[];
+  try {
+    const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+    const board = createBoard(sources);
+    const state = await withLogOutputSuppressed(async () => await board.fetch());
+    issues = state.issues;
+  } catch (error) {
+    return { kind: "error", message: errorMessage(error) };
+  }
+
+  // Only groundcrew-eligible todos are dispatchable; the rest lack a repo or
+  // an agent, so `crew run` would skip them.
+  const todos = issues.filter((issue) => issue.status === "todo").filter(isGroundcrewIssue);
+
+  return {
+    kind: "ok",
+    payload: {
+      capturedAt: new Date().toISOString(),
+      statusByTask: statusByTask(issues),
+      pullRequestsByTask: await collectPullRequests({ config, localTasks }),
+      inProgress: issues
+        .filter((issue) => issue.status === "in-progress")
+        .toSorted((left, right) => left.id.localeCompare(right.id))
+        .map((issue) => toBoardIssue(issue)),
+      queueReady: todos.filter((issue) => !hasOpenBlocker(issue)).map((issue) => toBoardIssue(issue)),
+      queueBlocked: todos.filter((issue) => hasOpenBlocker(issue)).map((issue) => toBlockedIssue(issue)),
+    },
   };
 }
 
@@ -278,6 +339,81 @@ function readLogTail(config: ResolvedConfig): string[] {
   }
   const tail = raw.length > LOG_TAIL_BYTES ? raw.slice(-LOG_TAIL_BYTES) : raw;
   return tail.split("\n");
+}
+
+function hasOpenBlocker(issue: SourceIssue): boolean {
+  return issue.blockers.some((blocker) => blocker.status !== "done");
+}
+
+function toBoardIssue(issue: SourceIssue): StatusBoardIssue {
+  return {
+    id: issue.id,
+    naturalId: naturalIdFromCanonical(issue.id),
+    title: issue.title,
+    url: issue.url,
+    repository: issue.repository,
+    agent: issue.agent,
+  };
+}
+
+function toBlockedIssue(issue: SourceIssue): StatusBlockedIssue {
+  return {
+    ...toBoardIssue(issue),
+    blockedBy: issue.blockers
+      .filter((blocker) => blocker.status !== "done")
+      .map((blocker) => ({
+        id: blocker.id,
+        status: blocker.status,
+        nativeStatus: blocker.nativeStatus,
+      })),
+  };
+}
+
+/**
+ * Lowercased natural id to canonical status, omitting any id claimed by more
+ * than one source rather than guessing which one a worktree row means.
+ */
+function statusByTask(issues: readonly SourceIssue[]): Record<string, CanonicalStatus> {
+  const statuses = new Map<string, CanonicalStatus>();
+  const matchCounts = new Map<string, number>();
+  for (const issue of issues) {
+    const task = naturalIdFromCanonical(issue.id).toLowerCase();
+    matchCounts.set(task, (matchCounts.get(task) ?? 0) + 1);
+    statuses.set(task, issue.status);
+  }
+  for (const [task, matchCount] of matchCounts) {
+    if (matchCount > 1) {
+      statuses.delete(task);
+    }
+  }
+  return Object.fromEntries(statuses);
+}
+
+async function collectPullRequests(input: {
+  config: ResolvedConfig;
+  localTasks: readonly string[];
+}): Promise<Record<string, PullRequestSummary[]>> {
+  const { config, localTasks } = input;
+  const wanted = new Set(localTasks);
+  const entries = worktrees.list(config).filter((entry) => wanted.has(entry.task));
+  const results = await Promise.allSettled(
+    entries.map(async (entry) => {
+      const branchName = await effectiveBranchNameFromRunState({
+        entry,
+        runState: readRunState(config, entry.task),
+      });
+      return [entry.task, await findPullRequestsForBranch({ cwd: entry.dir, branchName })] as const;
+    }),
+  );
+  const byTask: Record<string, PullRequestSummary[]> = {};
+  for (const result of results) {
+    if (result.status !== "fulfilled") {
+      continue;
+    }
+    const [task, pullRequests] = result.value;
+    byTask[task] = [...(byTask[task] ?? []), ...pullRequests];
+  }
+  return byTask;
 }
 
 function escapeRegExp(value: string): string {

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -370,12 +370,7 @@ function readLogTail(config: ResolvedConfig): string[] {
     const start = size - length;
     const buffer = Buffer.alloc(length);
     const bytesRead = readSync(handle, buffer, 0, length, start);
-    // Decode only what was read: a log rotated between the stat and the read
-    // leaves the rest of the buffer zero-filled, which would publish NULs.
-    const lines = buffer.toString("utf8", 0, bytesRead).split("\n");
-    // A bounded read starts mid-line, so the leading fragment is not a log
-    // line and must not be matched against a task id.
-    return start > 0 ? lines.slice(1) : lines;
+    return decodeLogTail({ buffer, bytesRead, startedMidFile: start > 0 });
   } finally {
     closeSync(handle);
   }
@@ -469,6 +464,24 @@ function escapeRegExp(value: string): string {
  * pollable collector can pass a bounded tail while the one-shot per-task view
  * passes the whole file.
  */
+/**
+ * Splits a tail read into log lines.
+ *
+ * Decodes only `bytesRead`: a log rotated between the stat and the read
+ * returns fewer bytes than requested, and the rest of the buffer is still
+ * zero-filled, which would publish NUL characters. A read that started
+ * mid-file also starts mid-line, so its leading fragment is not a log line.
+ */
+export function decodeLogTail(input: {
+  buffer: Buffer;
+  bytesRead: number;
+  startedMidFile: boolean;
+}): string[] {
+  const { buffer, bytesRead, startedMidFile } = input;
+  const lines = buffer.toString("utf8", 0, bytesRead).split("\n");
+  return startedMidFile ? lines.slice(1) : lines;
+}
+
 export function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
   const { lines, task } = input;
   // The boundary class is not \b on purpose: task ids contain hyphens, and \b

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -115,21 +115,19 @@ export async function collectLocalStatus(
 
 /** The subset of a collected worktree a pull request lookup needs. */
 export interface PullRequestTarget {
-  task: string;
   dir: string;
   branch: string;
 }
 
 export interface CollectRemoteStatusInput {
-  config: ResolvedConfig;
+  /** The board fetch, started by the caller so it can overlap the local pass. */
+  board: BoardFetch;
   /**
    * Worktrees from the local tier. Passing the already-resolved branch keeps
    * this collector from re-reading run state and re-resolving branches that
    * the local pass just computed.
    */
   pullRequestTargets: readonly PullRequestTarget[];
-  /** A board fetch already in flight. Omit to fetch inline. */
-  board?: BoardFetch;
 }
 
 /** One board fetch attempt. A failure is a value here, never a throw. */
@@ -163,10 +161,10 @@ export async function fetchBoardIssues(config: ResolvedConfig): Promise<BoardFet
 export async function collectRemoteStatus(
   input: CollectRemoteStatusInput,
 ): Promise<RemoteFetchResult> {
-  const { config, pullRequestTargets } = input;
-  const board = input.board ?? (await fetchBoardIssues(config));
+  const { board, pullRequestTargets } = input;
+  const pullRequestsByWorktree = await collectPullRequests(pullRequestTargets);
   if (board.kind === "error") {
-    return { kind: "error", message: board.message };
+    return { board, pullRequestsByWorktree };
   }
   const { issues } = board;
 
@@ -175,21 +173,23 @@ export async function collectRemoteStatus(
   const todos = issues.filter((issue) => issue.status === "todo").filter(isGroundcrewIssue);
 
   return {
-    kind: "ok",
-    payload: {
-      capturedAt: new Date().toISOString(),
-      statusByTask: statusByTask(issues),
-      pullRequestsByWorktree: await collectPullRequests(pullRequestTargets),
-      inProgress: issues
-        .filter((issue) => issue.status === "in-progress")
-        .toSorted((left, right) => left.id.localeCompare(right.id))
-        .map((issue) => toBoardIssue(issue)),
-      queueReady: todos
-        .filter((issue) => !hasOpenBlocker(issue))
-        .map((issue) => toQueueIssue(issue)),
-      queueBlocked: todos
-        .filter((issue) => hasOpenBlocker(issue))
-        .map((issue) => toBlockedIssue(issue)),
+    pullRequestsByWorktree,
+    board: {
+      kind: "ok",
+      payload: {
+        capturedAt: new Date().toISOString(),
+        statusByTask: statusByTask(issues),
+        inProgress: issues
+          .filter((issue) => issue.status === "in-progress")
+          .toSorted((left, right) => left.id.localeCompare(right.id))
+          .map((issue) => toBoardIssue(issue)),
+        queueReady: todos
+          .filter((issue) => !hasOpenBlocker(issue))
+          .map((issue) => toQueueIssue(issue)),
+        queueBlocked: todos
+          .filter((issue) => hasOpenBlocker(issue))
+          .map((issue) => toBlockedIssue(issue)),
+      },
     },
   };
 }
@@ -369,8 +369,10 @@ function readLogTail(config: ResolvedConfig): string[] {
     const length = Math.min(size, LOG_TAIL_BYTES);
     const start = size - length;
     const buffer = Buffer.alloc(length);
-    readSync(handle, buffer, 0, length, start);
-    const lines = buffer.toString("utf8").split("\n");
+    const bytesRead = readSync(handle, buffer, 0, length, start);
+    // Decode only what was read: a log rotated between the stat and the read
+    // leaves the rest of the buffer zero-filled, which would publish NULs.
+    const lines = buffer.toString("utf8", 0, bytesRead).split("\n");
     // A bounded read starts mid-line, so the leading fragment is not a log
     // line and must not be matched against a task id.
     return start > 0 ? lines.slice(1) : lines;
@@ -435,6 +437,9 @@ function statusByTask(issues: readonly SourceIssue[]): Record<string, CanonicalS
 async function collectPullRequests(
   targets: readonly PullRequestTarget[],
 ): Promise<Record<string, PullRequestSummary[]>> {
+  // allSettled, not all: one worktree whose lookup throws must not take down
+  // the whole status run, which is what the base command guaranteed. An empty
+  // or missing entry therefore means "none found, or the lookup failed".
   const results = await Promise.allSettled(
     targets.map(
       async (target) =>

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -460,11 +460,6 @@ function escapeRegExp(value: string): string {
 }
 
 /**
- * The most recent log lines mentioning `task`. Callers supply the lines so the
- * pollable collector can pass a bounded tail while the one-shot per-task view
- * passes the whole file.
- */
-/**
  * Splits a tail read into log lines.
  *
  * Decodes only `bytesRead`: a log rotated between the stat and the read
@@ -482,6 +477,11 @@ export function decodeLogTail(input: {
   return startedMidFile ? lines.slice(1) : lines;
 }
 
+/**
+ * The most recent log lines mentioning `task`. Callers supply the lines so the
+ * pollable collector can pass a bounded tail while the one-shot per-task view
+ * passes the whole file.
+ */
 export function recentTaskLogLines(input: { lines: readonly string[]; task: string }): string[] {
   const { lines, task } = input;
   // The boundary class is not \b on purpose: task ids contain hyphens, and \b

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,21 @@
+import * as packageRoot from "./index.ts";
+
+// @ts-expect-error -- pull-request lookup results are intentionally not part of the package API.
+import type { PullRequestSummary } from "./index.ts";
+
+describe("package root", () => {
+  it("keeps status snapshot implementation details private", () => {
+    expect(packageRoot).not.toHaveProperty("STATUS_SNAPSHOT_SCHEMA_VERSION");
+    expect(packageRoot).not.toHaveProperty("joinStatus");
+    expect(packageRoot).not.toHaveProperty("readLocalSnapshot");
+    expect(packageRoot).not.toHaveProperty("readRemoteSnapshot");
+    expect(packageRoot).not.toHaveProperty("writeLocalSnapshot");
+    expect(packageRoot).not.toHaveProperty("writeRemoteSnapshot");
+  });
+
+  it("keeps pull-request lookup result types private", () => {
+    const internalTypeOnly = undefined as unknown as PullRequestSummary;
+
+    expect(internalTypeOnly).toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,29 @@ export {
   type RunState,
 } from "./lib/runState.ts";
 export {
+  type JoinedSlots,
+  type JoinedStatus,
+  type JoinedTask,
+  joinStatus,
+} from "./lib/statusJoin.ts";
+export {
+  type LocalStatusDocument,
+  localSnapshotPath,
+  readRemoteSnapshot,
+  type RemoteStatusDocument,
+  type RemoteStatusPayload,
+  remoteSnapshotPath,
+  STATUS_SNAPSHOT_SCHEMA_VERSION,
+  type StatusBlockedIssue,
+  type StatusBlocker,
+  type StatusBoardIssue,
+  type StatusLifecycle,
+  type StatusQueueIssue,
+  type StatusSessionState,
+  type StatusTask,
+  type StatusWorktree,
+} from "./lib/statusSnapshot.ts";
+export {
   fetchBlockersForTask,
   fetchInProgressIssueCount,
   fetchRawLinearIssue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,39 +28,6 @@ export {
   type RunLifecycleState,
   type RunState,
 } from "./lib/runState.ts";
-// The status snapshot contract. A separate monitor program imports these to
-// read status-local.json and status-remote.json, so removing or renaming any
-// of them is a breaking change, and a shape change needs a bump of
-// STATUS_SNAPSHOT_SCHEMA_VERSION plus a README update.
-export {
-  type JoinedSlots,
-  type JoinedStatus,
-  type JoinedTask,
-  joinStatus,
-} from "./lib/statusJoin.ts";
-export {
-  type AvailabilityStatus,
-  type BoardOutcome,
-  type RemoteFetchResult,
-  type LocalStatusDocument,
-  localSnapshotPath,
-  readLocalSnapshot,
-  readRemoteSnapshot,
-  type RemoteStatusDocument,
-  type RemoteStatusPayload,
-  remoteSnapshotPath,
-  STATUS_SNAPSHOT_SCHEMA_VERSION,
-  type StatusSchemaVersion,
-  type StatusProbeState,
-  type StatusBlockedIssue,
-  type StatusBlocker,
-  type StatusBoardIssue,
-  type StatusLifecycle,
-  type StatusQueueIssue,
-  type StatusSessionState,
-  type StatusTask,
-  type StatusWorktree,
-} from "./lib/statusSnapshot.ts";
 export {
   fetchBlockersForTask,
   fetchInProgressIssueCount,
@@ -79,7 +46,6 @@ export {
   type AgentResolution,
   type RepositoryResolution,
 } from "./lib/adapters/linear/parsing.ts";
-export { type PullRequestSummary } from "./lib/pullRequests.ts";
 export { getUsageByAgent, type UsageByAgent } from "./lib/usage.ts";
 export { type Board, createBoard } from "./lib/board.ts";
 export { buildSources, buildSourcesWith } from "./lib/buildSources.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export {
   type AgentResolution,
   type RepositoryResolution,
 } from "./lib/adapters/linear/parsing.ts";
+export { type PullRequestSummary } from "./lib/pullRequests.ts";
 export { getUsageByAgent, type UsageByAgent } from "./lib/usage.ts";
 export { type Board, createBoard } from "./lib/board.ts";
 export { buildSources, buildSourcesWith } from "./lib/buildSources.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export {
 } from "./lib/statusJoin.ts";
 export {
   type AvailabilityStatus,
+  type BoardOutcome,
+  type RemoteFetchResult,
   type LocalStatusDocument,
   localSnapshotPath,
   readLocalSnapshot,

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ export {
   type RunLifecycleState,
   type RunState,
 } from "./lib/runState.ts";
+// The status snapshot contract. A separate monitor program imports these to
+// read status-local.json and status-remote.json, so removing or renaming any
+// of them is a breaking change, and a shape change needs a bump of
+// STATUS_SNAPSHOT_SCHEMA_VERSION plus a README update.
 export {
   type JoinedSlots,
   type JoinedStatus,
@@ -35,13 +39,17 @@ export {
   joinStatus,
 } from "./lib/statusJoin.ts";
 export {
+  type AvailabilityStatus,
   type LocalStatusDocument,
   localSnapshotPath,
+  readLocalSnapshot,
   readRemoteSnapshot,
   type RemoteStatusDocument,
   type RemoteStatusPayload,
   remoteSnapshotPath,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
+  type StatusSchemaVersion,
+  type StatusProbeState,
   type StatusBlockedIssue,
   type StatusBlocker,
   type StatusBoardIssue,

--- a/src/lib/atomicJson.test.ts
+++ b/src/lib/atomicJson.test.ts
@@ -1,0 +1,29 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { writeJsonAtomic } from "./atomicJson.ts";
+
+describe(writeJsonAtomic, () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = mkdtempSync(path.join(tmpdir(), "groundcrew-atomic-json-"));
+  });
+
+  afterEach(() => {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it("removes the temporary file when atomic replacement fails", () => {
+    const targetPath = path.join(temporaryDirectory, "target");
+    const temporaryPath = `${targetPath}.${process.pid}.tmp`;
+    mkdirSync(targetPath);
+
+    expect(() => {
+      writeJsonAtomic(targetPath, { ok: true });
+    }).toThrow(/EISDIR|ENOTDIR/);
+
+    expect(existsSync(temporaryPath)).toBe(false);
+  });
+});

--- a/src/lib/atomicJson.test.ts
+++ b/src/lib/atomicJson.test.ts
@@ -22,7 +22,7 @@ describe(writeJsonAtomic, () => {
 
     expect(() => {
       writeJsonAtomic(targetPath, { ok: true });
-    }).toThrow(/EISDIR|ENOTDIR/);
+    }).toThrow(expect.objectContaining({ syscall: "rename" }));
 
     expect(existsSync(temporaryPath)).toBe(false);
   });

--- a/src/lib/atomicJson.ts
+++ b/src/lib/atomicJson.ts
@@ -1,9 +1,9 @@
 /**
- * Crash-safe JSON file writes. Callers persist state that another process may
- * read at any moment, so a partially written file must never be observable.
+ * Atomic JSON file replacement. Callers persist state that another process
+ * may read at any moment, so a partially written file must never be observable.
  */
 
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 /**
@@ -19,5 +19,14 @@ export function writeJsonAtomic(filePath: string, value: unknown): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
   const temporaryPath = `${filePath}.${process.pid}.tmp`;
   writeFileSync(temporaryPath, `${JSON.stringify(value, undefined, 2)}\n`, { mode: 0o600 });
-  renameSync(temporaryPath, filePath);
+  try {
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      rmSync(temporaryPath, { force: true });
+    } catch {
+      // Cleanup is best-effort; preserve the original replacement failure.
+    }
+    throw error;
+  }
 }

--- a/src/lib/atomicJson.ts
+++ b/src/lib/atomicJson.ts
@@ -1,0 +1,23 @@
+/**
+ * Crash-safe JSON file writes. Callers persist state that another process may
+ * read at any moment, so a partially written file must never be observable.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Writes `value` as pretty JSON to `filePath`, creating parent directories.
+ *
+ * The write lands in a sibling temp file and is then renamed, which is atomic
+ * on POSIX, so a concurrent reader sees either the old file or the new one and
+ * never a half-written document. The pid in the temp name keeps two processes
+ * writing the same target from clobbering each other's temp file. Mode 0600
+ * matches the rest of groundcrew's state, which can carry task titles.
+ */
+export function writeJsonAtomic(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(value, undefined, 2)}\n`, { mode: 0o600 });
+  renameSync(temporaryPath, filePath);
+}

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -1,5 +1,7 @@
-import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import path from "node:path";
+
+import { writeJsonAtomic } from "./atomicJson.ts";
 
 import type { ResolvedConfig } from "./config.ts";
 import { normalizePlainTaskId } from "./taskId.ts";
@@ -174,11 +176,7 @@ function parseRunState(value: unknown): RunState | undefined {
 }
 
 function writeState(config: ResolvedConfig, state: RunState): void {
-  const statePath = runStatePath(config, state.task);
-  mkdirSync(path.dirname(statePath), { recursive: true });
-  const tmpPath = `${statePath}.${process.pid}.tmp`;
-  writeFileSync(tmpPath, `${JSON.stringify(state, undefined, 2)}\n`, { mode: 0o600 });
-  renameSync(tmpPath, statePath);
+  writeJsonAtomic(runStatePath(config, state.task), state);
 }
 
 export function readRunState(config: ResolvedConfig, task: string): RunState | undefined {

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -22,7 +22,15 @@ function makeTask(task: string): StatusTask {
     session: "live",
     attachCommand: undefined,
     hint: undefined,
-    worktrees: [],
+    worktrees: [
+      {
+        repository: "groundcrew",
+        kind: "host",
+        dir: "/work/eng-220",
+        branch: "eng-220",
+        git: { kind: "clean" },
+      },
+    ],
     recentLogLines: [],
   };
 }
@@ -47,8 +55,8 @@ function makeRemote(): RemoteStatusDocument {
     payload: {
       capturedAt: "2026-08-04T03:15:00.000Z",
       statusByTask: { "eng-220": "in-progress" },
-      pullRequestsByTask: {
-        "eng-220": [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
+      pullRequestsByWorktree: {
+        "/work/eng-220": [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
       },
       inProgress: [
         {
@@ -113,7 +121,7 @@ describe("joinStatus", () => {
     const actual = joinStatus({ local: makeLocal([makeTask("eng-220")]), remote: makeRemote() });
 
     expect(actual.tasks[0]?.boardStatus).toBe("in-progress");
-    expect(actual.tasks[0]?.pullRequests).toHaveLength(1);
+    expect(actual.tasks[0]?.worktrees[0]?.pullRequests).toHaveLength(1);
   });
 
   it("removes tasks with a local worktree from every board list", () => {
@@ -165,7 +173,7 @@ describe("joinStatus", () => {
     expect(actual.slots).toBeUndefined();
     expect(actual.queueReady).toEqual([]);
     expect(actual.tasks[0]?.boardStatus).toBeUndefined();
-    expect(actual.tasks[0]?.pullRequests).toEqual([]);
+    expect(actual.tasks[0]?.worktrees[0]?.pullRequests).toEqual([]);
   });
 
   it("treats an absent remote document the same as an empty payload", () => {

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -11,7 +11,6 @@ function makeTask(task: string): StatusTask {
     task,
     title: undefined,
     url: undefined,
-    repository: "groundcrew",
     agent: undefined,
     lifecycle: "running",
     flags: [],
@@ -95,7 +94,14 @@ function makeRemote(): RemoteStatusDocument {
           url: undefined,
           repository: "groundcrew",
           agent: "opus",
-          blockedBy: [{ id: "linear:eng-201", status: "in-progress", nativeStatus: undefined }],
+          blockedBy: [
+            {
+              id: "linear:eng-201",
+              naturalId: "eng-201",
+              status: "in-progress",
+              nativeStatus: undefined,
+            },
+          ],
         },
       ],
     },
@@ -135,7 +141,12 @@ describe("joinStatus", () => {
     const actual = joinStatus({ local: makeLocal([]), remote: makeRemote() });
 
     expect(actual.queueBlocked[0]?.blockedBy).toEqual([
-      { id: "linear:eng-201", status: "in-progress", nativeStatus: undefined },
+      {
+        id: "linear:eng-201",
+        naturalId: "eng-201",
+        status: "in-progress",
+        nativeStatus: undefined,
+      },
     ]);
   });
 

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -57,7 +57,14 @@ function makeRemote(): RemoteStatusDocument {
     },
     payload: {
       capturedAt: "2026-08-04T03:15:00.000Z",
-      statusByTask: { "eng-220": "in-progress" },
+      sourceByTask: {
+        "eng-220": {
+          id: "linear:eng-220",
+          naturalId: "eng-220",
+          title: "A task",
+          status: "in-progress",
+        },
+      },
       inProgress: [
         {
           id: "linear:eng-220",

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -52,12 +52,12 @@ function makeRemote(): RemoteStatusDocument {
     lastAttemptAt: "2026-08-04T03:15:00.000Z",
     lastAttemptStatus: "ok",
     lastAttemptError: undefined,
+    pullRequestsByWorktree: {
+      "/work/eng-220": [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
+    },
     payload: {
       capturedAt: "2026-08-04T03:15:00.000Z",
       statusByTask: { "eng-220": "in-progress" },
-      pullRequestsByWorktree: {
-        "/work/eng-220": [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
-      },
       inProgress: [
         {
           id: "linear:eng-220",
@@ -167,6 +167,7 @@ describe("joinStatus", () => {
         lastAttemptStatus: "unavailable",
         lastAttemptError: "no api key",
         payload: undefined,
+        pullRequestsByWorktree: {},
       },
     });
 

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -1,0 +1,166 @@
+import { joinStatus } from "./statusJoin.ts";
+import {
+  type LocalStatusDocument,
+  type RemoteStatusDocument,
+  STATUS_SNAPSHOT_SCHEMA_VERSION,
+  type StatusTask,
+} from "./statusSnapshot.ts";
+
+function makeTask(task: string): StatusTask {
+  return {
+    task,
+    title: undefined,
+    url: undefined,
+    repository: "groundcrew",
+    agent: undefined,
+    lifecycle: "running",
+    flags: [],
+    startedAt: undefined,
+    updatedAt: undefined,
+    resumeCount: undefined,
+    reason: undefined,
+    detail: undefined,
+    session: "live",
+    attachCommand: undefined,
+    hint: undefined,
+    worktrees: [],
+    recentLogLines: [],
+  };
+}
+
+function makeLocal(tasks: StatusTask[]): LocalStatusDocument {
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    capturedAt: "2026-08-04T03:16:00.000Z",
+    maximumInProgress: 4,
+    workspaceProbe: { status: "ok", error: undefined },
+    tasks,
+    orphanedSessions: [],
+  };
+}
+
+function makeRemote(): RemoteStatusDocument {
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    lastAttemptAt: "2026-08-04T03:15:00.000Z",
+    lastAttemptStatus: "ok",
+    lastAttemptError: undefined,
+    payload: {
+      capturedAt: "2026-08-04T03:15:00.000Z",
+      statusByTask: { "eng-220": "in-progress" },
+      pullRequestsByTask: {
+        "eng-220": [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
+      },
+      inProgress: [
+        {
+          id: "linear:eng-220",
+          naturalId: "ENG-220",
+          title: "a",
+          url: undefined,
+          repository: "groundcrew",
+          agent: "opus",
+        },
+        {
+          id: "linear:eng-217",
+          naturalId: "ENG-217",
+          title: "b",
+          url: undefined,
+          repository: "groundcrew",
+          agent: "opus",
+        },
+      ],
+      queueReady: [
+        {
+          id: "linear:eng-225",
+          naturalId: "ENG-225",
+          title: "c",
+          url: undefined,
+          repository: "groundcrew",
+          agent: "opus",
+        },
+        {
+          id: "linear:eng-220",
+          naturalId: "ENG-220",
+          title: "a",
+          url: undefined,
+          repository: "groundcrew",
+          agent: "opus",
+        },
+      ],
+      queueBlocked: [
+        {
+          id: "linear:eng-215",
+          naturalId: "ENG-215",
+          title: "d",
+          url: undefined,
+          repository: "groundcrew",
+          agent: "opus",
+          blockedBy: [{ id: "linear:eng-201", status: "in-progress", nativeStatus: undefined }],
+        },
+      ],
+    },
+  };
+}
+
+describe("joinStatus", () => {
+  it("attaches board status and pull requests to each task", () => {
+    const actual = joinStatus({ local: makeLocal([makeTask("eng-220")]), remote: makeRemote() });
+
+    expect(actual.tasks[0]?.boardStatus).toBe("in-progress");
+    expect(actual.tasks[0]?.pullRequests).toHaveLength(1);
+  });
+
+  it("removes tasks with a local worktree from every board list", () => {
+    const actual = joinStatus({ local: makeLocal([makeTask("eng-220")]), remote: makeRemote() });
+
+    expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["ENG-225"]);
+    expect(actual.inProgressWithoutWorktree.map((issue) => issue.naturalId)).toEqual(["ENG-217"]);
+  });
+
+  it("counts every in-progress issue toward slots, including ones with worktrees", () => {
+    const actual = joinStatus({ local: makeLocal([makeTask("eng-220")]), remote: makeRemote() });
+
+    expect(actual.slots).toEqual({ used: 2, maximum: 4 });
+  });
+
+  it("subtracts against the local document even when the remote one is older", () => {
+    const mockFresh = makeLocal([makeTask("eng-220"), makeTask("eng-225")]);
+
+    const actual = joinStatus({ local: mockFresh, remote: makeRemote() });
+
+    expect(actual.queueReady).toEqual([]);
+  });
+
+  it("keeps a blocked issue's blockers intact through the subtraction", () => {
+    const actual = joinStatus({ local: makeLocal([]), remote: makeRemote() });
+
+    expect(actual.queueBlocked[0]?.blockedBy).toEqual([
+      { id: "linear:eng-201", status: "in-progress", nativeStatus: undefined },
+    ]);
+  });
+
+  it("yields empty board lists and no slots when no fetch has ever succeeded", () => {
+    const actual = joinStatus({
+      local: makeLocal([makeTask("eng-220")]),
+      remote: {
+        schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+        lastAttemptAt: "2026-08-04T03:15:00.000Z",
+        lastAttemptStatus: "unavailable",
+        lastAttemptError: "no api key",
+        payload: undefined,
+      },
+    });
+
+    expect(actual.slots).toBeUndefined();
+    expect(actual.queueReady).toEqual([]);
+    expect(actual.tasks[0]?.boardStatus).toBeUndefined();
+    expect(actual.tasks[0]?.pullRequests).toEqual([]);
+  });
+
+  it("treats an absent remote document the same as an empty payload", () => {
+    const actual = joinStatus({ local: makeLocal([makeTask("eng-220")]), remote: undefined });
+
+    expect(actual.slots).toBeUndefined();
+    expect(actual.inProgressWithoutWorktree).toEqual([]);
+  });
+});

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -1,0 +1,85 @@
+/**
+ * Combines the local and remote status tiers at read time. Lives apart from
+ * the collectors because an external monitor reimplements this step against
+ * the published documents, and the text renderer consumes its output.
+ */
+
+import type { PullRequestSummary } from "./pullRequests.ts";
+import type {
+  LocalStatusDocument,
+  RemoteStatusDocument,
+  StatusBlockedIssue,
+  StatusBoardIssue,
+  StatusTask,
+} from "./statusSnapshot.ts";
+import type { CanonicalStatus } from "./taskSource.ts";
+
+export interface JoinedTask extends StatusTask {
+  boardStatus: CanonicalStatus | undefined;
+  pullRequests: PullRequestSummary[];
+}
+
+export interface JoinedSlots {
+  used: number;
+  maximum: number;
+}
+
+export interface JoinedStatus {
+  tasks: JoinedTask[];
+  /** In-progress board issues with no local worktree. */
+  inProgressWithoutWorktree: StatusBoardIssue[];
+  queueReady: StatusBoardIssue[];
+  queueBlocked: StatusBlockedIssue[];
+  /** Undefined when no board fetch has ever succeeded. */
+  slots: JoinedSlots | undefined;
+}
+
+export interface JoinStatusInput {
+  local: LocalStatusDocument;
+  remote: RemoteStatusDocument | undefined;
+}
+
+/**
+ * The board lists arrive unsubtracted, so this is where the local worktree set
+ * is removed from them. Doing it here rather than at fetch time is what keeps
+ * a fast local poll paired with a slow board poll from reporting a
+ * just-dispatched task as still queued.
+ */
+export function joinStatus(input: JoinStatusInput): JoinedStatus {
+  const { local, remote } = input;
+  const payload = remote?.payload;
+
+  const tasks: JoinedTask[] = local.tasks.map((task) => ({
+    ...task,
+    boardStatus: payload?.statusByTask[task.task],
+    pullRequests: payload?.pullRequestsByTask[task.task] ?? [],
+  }));
+
+  if (payload === undefined) {
+    return {
+      tasks,
+      inProgressWithoutWorktree: [],
+      queueReady: [],
+      queueBlocked: [],
+      slots: undefined,
+    };
+  }
+
+  const localTasks = new Set(local.tasks.map((task) => task.task));
+  return {
+    tasks,
+    inProgressWithoutWorktree: withoutLocalWorktree(payload.inProgress, localTasks),
+    queueReady: withoutLocalWorktree(payload.queueReady, localTasks),
+    queueBlocked: withoutLocalWorktree(payload.queueBlocked, localTasks),
+    // Every in-progress issue holds a slot, including ones that do have a
+    // local worktree, so this counts the unsubtracted list.
+    slots: { used: payload.inProgress.length, maximum: local.maximumInProgress },
+  };
+}
+
+function withoutLocalWorktree<T extends StatusBoardIssue>(
+  issues: readonly T[],
+  localTasks: ReadonlySet<string>,
+): T[] {
+  return issues.filter((issue) => !localTasks.has(issue.naturalId.toLowerCase()));
+}

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -25,7 +25,7 @@ export interface JoinedTask extends Omit<StatusTask, "worktrees"> {
   worktrees: JoinedWorktree[];
 }
 
-export interface JoinedSlots {
+interface JoinedSlots {
   used: number;
   maximum: number;
 }
@@ -55,14 +55,17 @@ export function joinStatus(input: JoinStatusInput): JoinedStatus {
   const { local, remote } = input;
   const payload = remote?.payload;
 
-  const tasks: JoinedTask[] = local.tasks.map((task) => ({
-    ...task,
-    boardStatus: ownProperty(payload?.statusByTask, task.task),
-    worktrees: task.worktrees.map((worktree) => ({
-      ...worktree,
-      pullRequests: ownProperty(remote?.pullRequestsByWorktree, worktree.dir) ?? [],
-    })),
-  }));
+  const tasks: JoinedTask[] = local.tasks.map((task) => {
+    const source = ownProperty(payload?.sourceByTask, task.task);
+    return {
+      ...task,
+      boardStatus: source?.status,
+      worktrees: task.worktrees.map((worktree) => ({
+        ...worktree,
+        pullRequests: ownProperty(remote?.pullRequestsByWorktree, worktree.dir) ?? [],
+      })),
+    };
+  });
 
   if (payload === undefined) {
     return {

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -57,10 +57,10 @@ export function joinStatus(input: JoinStatusInput): JoinedStatus {
 
   const tasks: JoinedTask[] = local.tasks.map((task) => ({
     ...task,
-    boardStatus: payload?.statusByTask[task.task],
+    boardStatus: ownProperty(payload?.statusByTask, task.task),
     worktrees: task.worktrees.map((worktree) => ({
       ...worktree,
-      pullRequests: remote?.pullRequestsByWorktree[worktree.dir] ?? [],
+      pullRequests: ownProperty(remote?.pullRequestsByWorktree, worktree.dir) ?? [],
     })),
   }));
 
@@ -84,6 +84,18 @@ export function joinStatus(input: JoinStatusInput): JoinedStatus {
     // local worktree, so this counts the unsubtracted list.
     slots: { used: payload.inProgress.length, maximum: local.maximumInProgress },
   };
+}
+
+/**
+ * These records arrive from JSON, so they carry Object.prototype. A task named
+ * "constructor" would otherwise resolve to a prototype member rather than a
+ * miss, and the renderer would print it.
+ */
+function ownProperty<T>(record: Record<string, T> | undefined, key: string): T | undefined {
+  if (record === undefined || !Object.hasOwn(record, key)) {
+    return undefined;
+  }
+  return record[key];
 }
 
 function withoutLocalWorktree<T extends StatusBoardIssue>(

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -10,6 +10,7 @@ import type {
   RemoteStatusDocument,
   StatusBlockedIssue,
   StatusBoardIssue,
+  StatusQueueIssue,
   StatusTask,
 } from "./statusSnapshot.ts";
 import type { CanonicalStatus } from "./taskSource.ts";
@@ -28,7 +29,7 @@ export interface JoinedStatus {
   tasks: JoinedTask[];
   /** In-progress board issues with no local worktree. */
   inProgressWithoutWorktree: StatusBoardIssue[];
-  queueReady: StatusBoardIssue[];
+  queueReady: StatusQueueIssue[];
   queueBlocked: StatusBlockedIssue[];
   /** Undefined when no board fetch has ever succeeded. */
   slots: JoinedSlots | undefined;

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -12,12 +12,17 @@ import type {
   StatusBoardIssue,
   StatusQueueIssue,
   StatusTask,
+  StatusWorktree,
 } from "./statusSnapshot.ts";
 import type { CanonicalStatus } from "./taskSource.ts";
 
-export interface JoinedTask extends StatusTask {
-  boardStatus: CanonicalStatus | undefined;
+export interface JoinedWorktree extends StatusWorktree {
   pullRequests: PullRequestSummary[];
+}
+
+export interface JoinedTask extends Omit<StatusTask, "worktrees"> {
+  boardStatus: CanonicalStatus | undefined;
+  worktrees: JoinedWorktree[];
 }
 
 export interface JoinedSlots {
@@ -53,7 +58,10 @@ export function joinStatus(input: JoinStatusInput): JoinedStatus {
   const tasks: JoinedTask[] = local.tasks.map((task) => ({
     ...task,
     boardStatus: payload?.statusByTask[task.task],
-    pullRequests: payload?.pullRequestsByTask[task.task] ?? [],
+    worktrees: task.worktrees.map((worktree) => ({
+      ...worktree,
+      pullRequests: payload?.pullRequestsByWorktree[worktree.dir] ?? [],
+    })),
   }));
 
   if (payload === undefined) {

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -60,7 +60,7 @@ export function joinStatus(input: JoinStatusInput): JoinedStatus {
     boardStatus: payload?.statusByTask[task.task],
     worktrees: task.worktrees.map((worktree) => ({
       ...worktree,
-      pullRequests: payload?.pullRequestsByWorktree[worktree.dir] ?? [],
+      pullRequests: remote?.pullRequestsByWorktree[worktree.dir] ?? [],
     })),
   }));
 

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -27,7 +27,14 @@ function makeConfig(directory: string): LoggingConfig {
 function makePayload(capturedAt: string): RemoteStatusPayload {
   return {
     capturedAt,
-    statusByTask: { "eng-220": "in-progress" },
+    sourceByTask: {
+      "eng-220": {
+        id: "linear:eng-220",
+        naturalId: "eng-220",
+        title: "A task",
+        status: "in-progress",
+      },
+    },
     inProgress: [],
     queueReady: [],
     queueBlocked: [],
@@ -322,7 +329,7 @@ describe("writeRemoteSnapshot", () => {
         pullRequestsByWorktree: {},
         payload: {
           capturedAt: "2026-08-04T03:00:00.000Z",
-          statusByTask: {},
+          sourceByTask: {},
           inProgress: "nope",
           queueReady: [],
           queueBlocked: [],

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { ResolvedConfig } from "./config.ts";
+import {
+  buildRemoteDocument,
+  readRemoteSnapshot,
+  type RemoteStatusDocument,
+  type RemoteStatusPayload,
+  remoteSnapshotPath,
+  STATUS_SNAPSHOT_SCHEMA_VERSION,
+  writeRemoteSnapshot,
+} from "./statusSnapshot.ts";
+
+type LoggingConfig = Pick<ResolvedConfig, "logging">;
+
+function makeConfig(directory: string): LoggingConfig {
+  return { logging: { file: path.join(directory, "groundcrew.log") } };
+}
+
+function makePayload(capturedAt: string): RemoteStatusPayload {
+  return {
+    capturedAt,
+    statusByTask: { "eng-220": "in-progress" },
+    pullRequestsByTask: {},
+    inProgress: [],
+    queueReady: [],
+    queueBlocked: [],
+  };
+}
+
+function makeDocument(overrides: Partial<RemoteStatusDocument> = {}): RemoteStatusDocument {
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    lastAttemptAt: "2026-08-04T03:00:00.000Z",
+    lastAttemptStatus: "ok",
+    lastAttemptError: undefined,
+    payload: makePayload("2026-08-04T03:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("buildRemoteDocument", () => {
+  it("replaces the payload on a successful attempt", () => {
+    const input = makePayload("2026-08-04T03:00:00.000Z");
+
+    const actual = buildRemoteDocument({
+      previous: undefined,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: { kind: "ok", payload: input },
+    });
+
+    expect(actual.lastAttemptStatus).toBe("ok");
+    expect(actual.lastAttemptError).toBeUndefined();
+    expect(actual.payload).toEqual(input);
+  });
+
+  it("keeps the previous payload when the attempt fails", () => {
+    const mockPrevious = makeDocument();
+
+    const actual = buildRemoteDocument({
+      previous: mockPrevious,
+      attemptAt: "2026-08-04T03:05:00.000Z",
+      result: { kind: "error", message: "Linear: 401 unauthorized" },
+    });
+
+    expect(actual.lastAttemptAt).toBe("2026-08-04T03:05:00.000Z");
+    expect(actual.lastAttemptStatus).toBe("unavailable");
+    expect(actual.lastAttemptError).toBe("Linear: 401 unauthorized");
+    expect(actual.payload?.capturedAt).toBe("2026-08-04T03:00:00.000Z");
+  });
+
+  it("leaves the payload undefined when the first attempt ever fails", () => {
+    const actual = buildRemoteDocument({
+      previous: undefined,
+      attemptAt: "2026-08-04T03:05:00.000Z",
+      result: { kind: "error", message: "no api key" },
+    });
+
+    expect(actual.payload).toBeUndefined();
+    expect(actual.lastAttemptStatus).toBe("unavailable");
+  });
+});
+
+describe("writeRemoteSnapshot", () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "gc-snapshot-"));
+  });
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true });
+  });
+
+  it("round-trips a document through disk", () => {
+    const config = makeConfig(directory);
+    const input = makeDocument();
+
+    writeRemoteSnapshot({ config, document: input });
+    const actual = readRemoteSnapshot(config);
+
+    expect(actual).toEqual(input);
+  });
+
+  it("returns the document it wrote", () => {
+    const config = makeConfig(directory);
+    const input = makeDocument();
+
+    const actual = writeRemoteSnapshot({ config, document: input });
+
+    expect(actual).toEqual(input);
+  });
+
+  it("discards a write whose attempt is older than the file's", () => {
+    const config = makeConfig(directory);
+    const mockNewer = makeDocument({ lastAttemptAt: "2026-08-04T03:05:00.000Z" });
+    writeRemoteSnapshot({ config, document: mockNewer });
+
+    const actual = writeRemoteSnapshot({
+      config,
+      document: makeDocument({
+        lastAttemptAt: "2026-08-04T03:00:00.000Z",
+        lastAttemptStatus: "unavailable",
+        lastAttemptError: "stale writer",
+        payload: undefined,
+      }),
+    });
+
+    expect(readRemoteSnapshot(config)).toEqual(mockNewer);
+    expect(actual).toEqual(mockNewer);
+  });
+
+  it("returns undefined for a missing file", () => {
+    const config = makeConfig(directory);
+
+    expect(readRemoteSnapshot(config)).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable file", () => {
+    const config = makeConfig(directory);
+    writeRemoteSnapshot({ config, document: makeDocument() });
+    writeFileSync(remoteSnapshotPath(config), "not json");
+
+    expect(readRemoteSnapshot(config)).toBeUndefined();
+  });
+
+  it("returns undefined for a document from an unknown schema version", () => {
+    const config = makeConfig(directory);
+    writeRemoteSnapshot({ config, document: makeDocument() });
+    writeFileSync(
+      remoteSnapshotPath(config),
+      JSON.stringify({ ...makeDocument(), schemaVersion: 999 }),
+    );
+
+    expect(readRemoteSnapshot(config)).toBeUndefined();
+  });
+
+  it("leaves no temp file behind", () => {
+    const config = makeConfig(directory);
+
+    writeRemoteSnapshot({ config, document: makeDocument() });
+
+    const actual = readFileSync(remoteSnapshotPath(config), "utf8");
+
+    expect(JSON.parse(actual).schemaVersion).toBe(STATUS_SNAPSHOT_SCHEMA_VERSION);
+  });
+});

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -5,11 +5,15 @@ import path from "node:path";
 import type { ResolvedConfig } from "./config.ts";
 import {
   buildRemoteDocument,
+  type LocalStatusDocument,
+  localSnapshotPath,
+  readLocalSnapshot,
   readRemoteSnapshot,
   type RemoteStatusDocument,
   type RemoteStatusPayload,
   remoteSnapshotPath,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
+  writeLocalSnapshot,
   writeRemoteSnapshot,
 } from "./statusSnapshot.ts";
 
@@ -23,10 +27,21 @@ function makePayload(capturedAt: string): RemoteStatusPayload {
   return {
     capturedAt,
     statusByTask: { "eng-220": "in-progress" },
-    pullRequestsByTask: {},
+    pullRequestsByWorktree: {},
     inProgress: [],
     queueReady: [],
     queueBlocked: [],
+  };
+}
+
+function makeLocal(capturedAt: string): LocalStatusDocument {
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    capturedAt,
+    maximumInProgress: 4,
+    workspaceProbe: { status: "ok" },
+    tasks: [],
+    orphanedSessions: [],
   };
 }
 
@@ -80,6 +95,46 @@ describe("buildRemoteDocument", () => {
 
     expect(actual.payload).toBeUndefined();
     expect(actual.lastAttemptStatus).toBe("unavailable");
+  });
+});
+
+describe("writeLocalSnapshot", () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "gc-local-"));
+  });
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true });
+  });
+
+  it("round-trips a document through disk", () => {
+    const config = makeConfig(directory);
+    const input = makeLocal("2026-08-04T03:00:00.000Z");
+
+    const actual = writeLocalSnapshot({ config, document: input });
+
+    expect(actual).toEqual(input);
+    expect(readLocalSnapshot(config)).toEqual(input);
+  });
+
+  it("discards a write captured earlier than the file's", () => {
+    const config = makeConfig(directory);
+    const mockNewer = makeLocal("2026-08-04T03:05:00.000Z");
+    writeLocalSnapshot({ config, document: mockNewer });
+
+    const actual = writeLocalSnapshot({ config, document: makeLocal("2026-08-04T03:00:00.000Z") });
+
+    expect(actual).toEqual(mockNewer);
+    expect(readLocalSnapshot(config)).toEqual(mockNewer);
+  });
+
+  it("returns undefined for a document that is not a local snapshot", () => {
+    const config = makeConfig(directory);
+    writeFileSync(localSnapshotPath(config), JSON.stringify({ schemaVersion: 1 }));
+
+    expect(readLocalSnapshot(config)).toBeUndefined();
   });
 });
 
@@ -148,6 +203,18 @@ describe("writeRemoteSnapshot", () => {
     expect(readRemoteSnapshot(config)?.lastAttemptStatus).toBe("unavailable");
   });
 
+  it("replaces a file whose attempt timestamp is not ISO-8601", () => {
+    const config = makeConfig(directory);
+    writeFileSync(
+      remoteSnapshotPath(config),
+      JSON.stringify({ ...makeDocument(), lastAttemptAt: "not a timestamp" }),
+    );
+
+    const actual = writeRemoteSnapshot({ config, document: makeDocument() });
+
+    expect(actual.lastAttemptAt).toBe("2026-08-04T03:00:00.000Z");
+  });
+
   it("returns undefined for a missing file", () => {
     const config = makeConfig(directory);
 
@@ -174,6 +241,31 @@ describe("writeRemoteSnapshot", () => {
         schemaVersion: 1,
         lastAttemptAt: "2026-08-04T03:00:00.000Z",
         lastAttemptStatus: "maybe",
+      }),
+    ],
+    [
+      "a document whose payload is not an object",
+      JSON.stringify({
+        schemaVersion: 1,
+        lastAttemptAt: "2026-08-04T03:00:00.000Z",
+        lastAttemptStatus: "ok",
+        payload: "nope",
+      }),
+    ],
+    [
+      "a document whose payload lists are not arrays",
+      JSON.stringify({
+        schemaVersion: 1,
+        lastAttemptAt: "2026-08-04T03:00:00.000Z",
+        lastAttemptStatus: "ok",
+        payload: {
+          capturedAt: "2026-08-04T03:00:00.000Z",
+          statusByTask: {},
+          pullRequestsByWorktree: {},
+          inProgress: "nope",
+          queueReady: [],
+          queueBlocked: [],
+        },
       }),
     ],
   ])("returns undefined for %s", (_label, contents) => {

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -162,6 +162,27 @@ describe("writeRemoteSnapshot", () => {
     expect(readRemoteSnapshot(config)).toBeUndefined();
   });
 
+  // A snapshot is a contract between two separately versioned programs, so
+  // anything that does not match the shape is rejected rather than misread.
+  it.each([
+    ["a JSON null", "null"],
+    ["a JSON scalar", "42"],
+    ["a document with no attempt timestamp", JSON.stringify({ schemaVersion: 1 })],
+    [
+      "a document with an unknown attempt status",
+      JSON.stringify({
+        schemaVersion: 1,
+        lastAttemptAt: "2026-08-04T03:00:00.000Z",
+        lastAttemptStatus: "maybe",
+      }),
+    ],
+  ])("returns undefined for %s", (_label, contents) => {
+    const config = makeConfig(directory);
+    writeFileSync(remoteSnapshotPath(config), contents);
+
+    expect(readRemoteSnapshot(config)).toBeUndefined();
+  });
+
   it("returns undefined for a document from an unknown schema version", () => {
     const config = makeConfig(directory);
     writeRemoteSnapshot({ config, document: makeDocument() });

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -199,8 +199,8 @@ describe("writeRemoteSnapshot", () => {
 
     writeRemoteSnapshot({ config, document: makeDocument() });
 
-    const actual = readFileSync(remoteSnapshotPath(config), "utf8");
+    const actual = readdirSync(directory);
 
-    expect(JSON.parse(actual).schemaVersion).toBe(STATUS_SNAPSHOT_SCHEMA_VERSION);
+    expect(actual).toEqual(["status-remote.json"]);
   });
 });

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { ResolvedConfig } from "./config.ts";
 import {
   buildRemoteDocument,
+  type RemoteFetchResult,
   type LocalStatusDocument,
   localSnapshotPath,
   readLocalSnapshot,
@@ -27,11 +28,21 @@ function makePayload(capturedAt: string): RemoteStatusPayload {
   return {
     capturedAt,
     statusByTask: { "eng-220": "in-progress" },
-    pullRequestsByWorktree: {},
     inProgress: [],
     queueReady: [],
     queueBlocked: [],
   };
+}
+
+function okResult(capturedAt: string): RemoteFetchResult {
+  return {
+    board: { kind: "ok", payload: makePayload(capturedAt) },
+    pullRequestsByWorktree: {},
+  };
+}
+
+function errorResult(message: string): RemoteFetchResult {
+  return { board: { kind: "error", message }, pullRequestsByWorktree: {} };
 }
 
 function makeLocal(capturedAt: string): LocalStatusDocument {
@@ -52,6 +63,7 @@ function makeDocument(overrides: Partial<RemoteStatusDocument> = {}): RemoteStat
     lastAttemptStatus: "ok",
     lastAttemptError: undefined,
     payload: makePayload("2026-08-04T03:00:00.000Z"),
+    pullRequestsByWorktree: {},
     ...overrides,
   };
 }
@@ -63,7 +75,7 @@ describe("buildRemoteDocument", () => {
     const actual = buildRemoteDocument({
       previous: undefined,
       attemptAt: "2026-08-04T03:00:00.000Z",
-      result: { kind: "ok", payload: input },
+      result: { board: { kind: "ok", payload: input }, pullRequestsByWorktree: {} },
     });
 
     expect(actual.lastAttemptStatus).toBe("ok");
@@ -77,7 +89,7 @@ describe("buildRemoteDocument", () => {
     const actual = buildRemoteDocument({
       previous: mockPrevious,
       attemptAt: "2026-08-04T03:05:00.000Z",
-      result: { kind: "error", message: "Linear: 401 unauthorized" },
+      result: errorResult("Linear: 401 unauthorized"),
     });
 
     expect(actual.lastAttemptAt).toBe("2026-08-04T03:05:00.000Z");
@@ -90,7 +102,7 @@ describe("buildRemoteDocument", () => {
     const actual = buildRemoteDocument({
       previous: undefined,
       attemptAt: "2026-08-04T03:05:00.000Z",
-      result: { kind: "error", message: "no api key" },
+      result: errorResult("no api key"),
     });
 
     expect(actual.payload).toBeUndefined();
@@ -151,36 +163,49 @@ describe("writeRemoteSnapshot", () => {
 
   it("round-trips a document through disk", () => {
     const config = makeConfig(directory);
-    const input = makeDocument();
 
-    writeRemoteSnapshot({ config, document: input });
-    const actual = readRemoteSnapshot(config);
+    const actual = writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
 
-    expect(actual).toEqual(input);
+    expect(actual).toEqual(makeDocument());
+    expect(readRemoteSnapshot(config)).toEqual(makeDocument());
   });
 
-  it("returns the document it wrote", () => {
+  // One read serves the merge and the guard, so a failure cannot reinstate a
+  // payload that a concurrent success already replaced.
+  it("merges against the file it guards on, not an earlier read", () => {
     const config = makeConfig(directory);
-    const input = makeDocument();
+    writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:05:00.000Z",
+      result: okResult("2026-08-04T03:05:00.000Z"),
+    });
 
-    const actual = writeRemoteSnapshot({ config, document: input });
+    const actual = writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:06:00.000Z",
+      result: errorResult("source down"),
+    });
 
-    expect(actual).toEqual(input);
+    expect(actual.lastAttemptStatus).toBe("unavailable");
+    expect(actual.payload?.capturedAt).toBe("2026-08-04T03:05:00.000Z");
   });
 
   it("discards a write whose attempt is older than the file's", () => {
     const config = makeConfig(directory);
-    const mockNewer = makeDocument({ lastAttemptAt: "2026-08-04T03:05:00.000Z" });
-    writeRemoteSnapshot({ config, document: mockNewer });
+    const mockNewer = writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:05:00.000Z",
+      result: okResult("2026-08-04T03:05:00.000Z"),
+    });
 
     const actual = writeRemoteSnapshot({
       config,
-      document: makeDocument({
-        lastAttemptAt: "2026-08-04T03:00:00.000Z",
-        lastAttemptStatus: "unavailable",
-        lastAttemptError: "stale writer",
-        payload: undefined,
-      }),
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: errorResult("stale writer"),
     });
 
     expect(readRemoteSnapshot(config)).toEqual(mockNewer);
@@ -189,18 +214,37 @@ describe("writeRemoteSnapshot", () => {
 
   it("accepts a write whose attempt matches the file's", () => {
     const config = makeConfig(directory);
-    writeRemoteSnapshot({ config, document: makeDocument() });
+    writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
 
     const actual = writeRemoteSnapshot({
       config,
-      document: makeDocument({
-        lastAttemptStatus: "unavailable",
-        lastAttemptError: "source down",
-      }),
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: errorResult("source down"),
     });
 
     expect(actual.lastAttemptStatus).toBe("unavailable");
     expect(readRemoteSnapshot(config)?.lastAttemptStatus).toBe("unavailable");
+  });
+
+  // Without an upper bound, one future-dated file pins the snapshot forever.
+  it("replaces a file dated in the future", () => {
+    const config = makeConfig(directory);
+    writeFileSync(
+      remoteSnapshotPath(config),
+      JSON.stringify(makeDocument({ lastAttemptAt: "2099-01-01T00:00:00.000Z" })),
+    );
+
+    const actual = writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
+
+    expect(actual.lastAttemptAt).toBe("2026-08-04T03:00:00.000Z");
   });
 
   it("replaces a file whose attempt timestamp is not ISO-8601", () => {
@@ -210,7 +254,11 @@ describe("writeRemoteSnapshot", () => {
       JSON.stringify({ ...makeDocument(), lastAttemptAt: "not a timestamp" }),
     );
 
-    const actual = writeRemoteSnapshot({ config, document: makeDocument() });
+    const actual = writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
 
     expect(actual.lastAttemptAt).toBe("2026-08-04T03:00:00.000Z");
   });
@@ -223,7 +271,11 @@ describe("writeRemoteSnapshot", () => {
 
   it("returns undefined for an unparseable file", () => {
     const config = makeConfig(directory);
-    writeRemoteSnapshot({ config, document: makeDocument() });
+    writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
     writeFileSync(remoteSnapshotPath(config), "not json");
 
     expect(readRemoteSnapshot(config)).toBeUndefined();
@@ -244,11 +296,20 @@ describe("writeRemoteSnapshot", () => {
       }),
     ],
     [
+      "a document with no pull request record",
+      JSON.stringify({
+        schemaVersion: 1,
+        lastAttemptAt: "2026-08-04T03:00:00.000Z",
+        lastAttemptStatus: "ok",
+      }),
+    ],
+    [
       "a document whose payload is not an object",
       JSON.stringify({
         schemaVersion: 1,
         lastAttemptAt: "2026-08-04T03:00:00.000Z",
         lastAttemptStatus: "ok",
+        pullRequestsByWorktree: {},
         payload: "nope",
       }),
     ],
@@ -258,10 +319,10 @@ describe("writeRemoteSnapshot", () => {
         schemaVersion: 1,
         lastAttemptAt: "2026-08-04T03:00:00.000Z",
         lastAttemptStatus: "ok",
+        pullRequestsByWorktree: {},
         payload: {
           capturedAt: "2026-08-04T03:00:00.000Z",
           statusByTask: {},
-          pullRequestsByWorktree: {},
           inProgress: "nope",
           queueReady: [],
           queueBlocked: [],
@@ -277,7 +338,6 @@ describe("writeRemoteSnapshot", () => {
 
   it("returns undefined for a document from an unknown schema version", () => {
     const config = makeConfig(directory);
-    writeRemoteSnapshot({ config, document: makeDocument() });
     writeFileSync(
       remoteSnapshotPath(config),
       JSON.stringify({ ...makeDocument(), schemaVersion: 999 }),
@@ -289,7 +349,11 @@ describe("writeRemoteSnapshot", () => {
   it("leaves no temp file behind", () => {
     const config = makeConfig(directory);
 
-    writeRemoteSnapshot({ config, document: makeDocument() });
+    writeRemoteSnapshot({
+      config,
+      attemptAt: "2026-08-04T03:00:00.000Z",
+      result: okResult("2026-08-04T03:00:00.000Z"),
+    });
 
     const actual = readdirSync(directory);
 

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -132,6 +132,22 @@ describe("writeRemoteSnapshot", () => {
     expect(actual).toEqual(mockNewer);
   });
 
+  it("accepts a write whose attempt matches the file's", () => {
+    const config = makeConfig(directory);
+    writeRemoteSnapshot({ config, document: makeDocument() });
+
+    const actual = writeRemoteSnapshot({
+      config,
+      document: makeDocument({
+        lastAttemptStatus: "unavailable",
+        lastAttemptError: "source down",
+      }),
+    });
+
+    expect(actual.lastAttemptStatus).toBe("unavailable");
+    expect(readRemoteSnapshot(config)?.lastAttemptStatus).toBe("unavailable");
+  });
+
   it("returns undefined for a missing file", () => {
     const config = makeConfig(directory);
 

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -26,10 +26,10 @@ export const STATUS_SNAPSHOT_SCHEMA_VERSION = 1;
  * value is `undefined`. So every `field?:` below is genuinely ABSENT on disk
  * rather than present-and-null, and a reader must treat absence as "not set".
  */
-export type StatusSchemaVersion = typeof STATUS_SNAPSHOT_SCHEMA_VERSION;
+type StatusSchemaVersion = typeof STATUS_SNAPSHOT_SCHEMA_VERSION;
 
 /** Two-state health verdict shared by the probe and the board attempt. */
-export type AvailabilityStatus = "ok" | "unavailable";
+type AvailabilityStatus = "ok" | "unavailable";
 
 export type StatusSessionState = "live" | "exited" | "not-live" | "unknown";
 
@@ -67,13 +67,20 @@ export interface StatusTask {
   hint?: string | undefined;
   worktrees: StatusWorktree[];
   /**
-   * Lines mentioning this task, from a bounded tail of the shared log. A line
-   * older than that tail is absent here but still shown by `crew status <task>`.
+   * The same ten most recent matching lines shown by `crew status <task>`.
    */
   recentLogLines: string[];
 }
 
-export interface StatusProbeState {
+export interface StatusLogCursor {
+  /** File identity, so a rotated log never reuses lines from its predecessor. */
+  device: number;
+  inode: number;
+  /** Exclusive byte offset covered by `tasks[].recentLogLines`. */
+  offset: number;
+}
+
+interface StatusProbeState {
   status: AvailabilityStatus;
   error?: string | undefined;
 }
@@ -89,6 +96,8 @@ export interface StatusProbeState {
 export interface LocalStatusDocument {
   schemaVersion: StatusSchemaVersion;
   capturedAt: string;
+  /** Incremental progress through the append-only shared log. */
+  logCursor?: StatusLogCursor | undefined;
   /** From config, never the network, so capacity renders before any fetch. */
   maximumInProgress: number;
   workspaceProbe: StatusProbeState;
@@ -105,6 +114,10 @@ export interface StatusBoardIssue {
   agent?: string | undefined;
 }
 
+export interface StatusSourceIssue extends StatusBoardIssue {
+  status: CanonicalStatus;
+}
+
 /**
  * A queued issue. Only groundcrew-eligible todos reach a queue, and
  * eligibility means both fields resolved, so they are required here.
@@ -114,7 +127,7 @@ export interface StatusQueueIssue extends StatusBoardIssue {
   agent: string;
 }
 
-export interface StatusBlocker {
+interface StatusBlocker {
   id: string;
   naturalId: string;
   status: CanonicalStatus;
@@ -137,8 +150,8 @@ export interface StatusBlockedIssue extends StatusQueueIssue {
  */
 export interface RemoteStatusPayload {
   capturedAt: string;
-  /** Lowercased natural id to canonical status. Ambiguous ids are omitted. */
-  statusByTask: Record<string, CanonicalStatus>;
+  /** Lowercased natural id to current source data. Ambiguous ids are omitted. */
+  sourceByTask: Record<string, StatusSourceIssue>;
   /** Every in-progress issue. Its length is the used slot count. */
   inProgress: StatusBoardIssue[];
   queueReady: StatusQueueIssue[];
@@ -165,7 +178,7 @@ export interface RemoteStatusDocument {
   pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
 }
 
-export type BoardOutcome =
+type BoardOutcome =
   | { kind: "ok"; payload: RemoteStatusPayload }
   | { kind: "error"; message: string };
 
@@ -257,9 +270,15 @@ function isLocalStatusDocument(value: unknown): value is LocalStatusDocument {
   if (!isRecord(value)) {
     return false;
   }
+  const logCursor = value["logCursor"];
   return (
     value["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
     typeof value["capturedAt"] === "string" &&
+    (logCursor === undefined ||
+      (isRecord(logCursor) &&
+        typeof logCursor["device"] === "number" &&
+        typeof logCursor["inode"] === "number" &&
+        typeof logCursor["offset"] === "number")) &&
     typeof value["maximumInProgress"] === "number" &&
     isRecord(value["workspaceProbe"]) &&
     Array.isArray(value["tasks"]) &&
@@ -347,7 +366,7 @@ function isRemoteStatusPayload(value: unknown): value is RemoteStatusPayload {
   }
   return (
     typeof value["capturedAt"] === "string" &&
-    isRecord(value["statusByTask"]) &&
+    isRecord(value["sourceByTask"]) &&
     Array.isArray(value["inProgress"]) &&
     Array.isArray(value["queueReady"]) &&
     Array.isArray(value["queueBlocked"])

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -1,0 +1,244 @@
+/**
+ * Wire format for the two status documents an external monitor reads, plus
+ * their atomic persistence. Knows nothing about boards, worktrees, or
+ * sessions — collectors build these shapes, `statusJoin` combines them.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { ResolvedConfig } from "./config.ts";
+import type { PullRequestSummary } from "./pullRequests.ts";
+import type { RunLifecycleState } from "./runState.ts";
+import type { CanonicalStatus } from "./taskSource.ts";
+import type { WorktreeDirtiness } from "./worktrees.ts";
+
+/**
+ * Contract version for both documents. Bump on any breaking shape change;
+ * readers refuse a version they don't know rather than misreading fields.
+ */
+export const STATUS_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export type StatusSessionState = "live" | "exited" | "not-live" | "unknown";
+
+export type StatusLifecycle = RunLifecycleState | "idle";
+
+export interface StatusWorktree {
+  repository: string;
+  kind: string;
+  dir: string;
+  branch: string;
+  git: WorktreeDirtiness;
+}
+
+export interface StatusTask {
+  /** Lowercased source task id, matching `WorktreeEntry.task`. */
+  task: string;
+  title: string | undefined;
+  url: string | undefined;
+  repository: string;
+  agent: string | undefined;
+  lifecycle: StatusLifecycle;
+  /** Probe-reconciliation flags, e.g. "session dead". Never a duration. */
+  flags: string[];
+  /** RunState.createdAt. Readers derive elapsed time; a stored duration in a
+   * cached document shows a frozen clock. */
+  startedAt: string | undefined;
+  updatedAt: string | undefined;
+  resumeCount: number | undefined;
+  reason: string | undefined;
+  detail: string | undefined;
+  session: StatusSessionState;
+  attachCommand: string | undefined;
+  hint: string | undefined;
+  worktrees: StatusWorktree[];
+  recentLogLines: string[];
+}
+
+export interface StatusProbeState {
+  status: "ok" | "unavailable";
+  error: string | undefined;
+}
+
+export interface LocalStatusDocument {
+  schemaVersion: number;
+  capturedAt: string;
+  /** From config, never the network, so capacity renders before any fetch. */
+  maximumInProgress: number;
+  workspaceProbe: StatusProbeState;
+  tasks: StatusTask[];
+  orphanedSessions: string[];
+}
+
+export interface StatusBoardIssue {
+  id: string;
+  naturalId: string;
+  title: string;
+  url: string | undefined;
+  repository: string | undefined;
+  agent: string | undefined;
+}
+
+export interface StatusBlocker {
+  id: string;
+  status: CanonicalStatus;
+  nativeStatus: string | undefined;
+}
+
+export interface StatusBlockedIssue extends StatusBoardIssue {
+  blockedBy: StatusBlocker[];
+}
+
+/**
+ * Board-derived facts only. Board-side classification is applied; the local
+ * worktree subtraction deliberately is not. Precomputing that join here would
+ * make the document assert something false as soon as a worktree appears,
+ * because the local tier refreshes far more often than this one.
+ */
+export interface RemoteStatusPayload {
+  capturedAt: string;
+  /** Lowercased natural id to canonical status. Ambiguous ids are omitted. */
+  statusByTask: Record<string, CanonicalStatus>;
+  pullRequestsByTask: Record<string, PullRequestSummary[]>;
+  /** Every in-progress issue. Its length is the used slot count. */
+  inProgress: StatusBoardIssue[];
+  queueReady: StatusBoardIssue[];
+  queueBlocked: StatusBlockedIssue[];
+}
+
+export interface RemoteStatusDocument {
+  schemaVersion: number;
+  /** The most recent attempt, successful or not. */
+  lastAttemptAt: string;
+  lastAttemptStatus: "ok" | "unavailable";
+  lastAttemptError: string | undefined;
+  /** The last successful fetch. Undefined when none has ever succeeded. */
+  payload: RemoteStatusPayload | undefined;
+}
+
+export type RemoteFetchResult =
+  | { kind: "ok"; payload: RemoteStatusPayload }
+  | { kind: "error"; message: string };
+
+export interface BuildRemoteDocumentInput {
+  previous: RemoteStatusDocument | undefined;
+  attemptAt: string;
+  result: RemoteFetchResult;
+}
+
+/**
+ * Merges an attempt into the previous document. A failure advances only the
+ * attempt fields, so last-known-good queue data survives an outage while the
+ * document still states plainly that the board is unreachable. Without that
+ * split a reader cannot tell "nobody polled" from "the board is down", and
+ * only the second is actionable.
+ */
+export function buildRemoteDocument(input: BuildRemoteDocumentInput): RemoteStatusDocument {
+  const { previous, attemptAt, result } = input;
+  if (result.kind === "ok") {
+    return {
+      schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+      lastAttemptAt: attemptAt,
+      lastAttemptStatus: "ok",
+      lastAttemptError: undefined,
+      payload: result.payload,
+    };
+  }
+  return {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
+    lastAttemptAt: attemptAt,
+    lastAttemptStatus: "unavailable",
+    lastAttemptError: result.message,
+    payload: previous?.payload,
+  };
+}
+
+type LoggingConfig = Pick<ResolvedConfig, "logging">;
+
+/** Both documents sit beside the log file and the per-task run states. */
+export function statusSnapshotDirectory(config: LoggingConfig): string {
+  return path.resolve(path.dirname(config.logging.file));
+}
+
+export function localSnapshotPath(config: LoggingConfig): string {
+  return path.resolve(statusSnapshotDirectory(config), "status-local.json");
+}
+
+export function remoteSnapshotPath(config: LoggingConfig): string {
+  return path.resolve(statusSnapshotDirectory(config), "status-remote.json");
+}
+
+export interface WriteLocalSnapshotInput {
+  config: LoggingConfig;
+  document: LocalStatusDocument;
+}
+
+export function writeLocalSnapshot(input: WriteLocalSnapshotInput): void {
+  const { config, document } = input;
+  writeDocument(localSnapshotPath(config), document);
+}
+
+export interface WriteRemoteSnapshotInput {
+  config: LoggingConfig;
+  document: RemoteStatusDocument;
+}
+
+/**
+ * Monotonic: refuses to write a document whose attempt predates the one on
+ * disk, so two concurrent runs interleaving read and write across processes
+ * can never move the remote tier backwards.
+ *
+ * Returns whatever is on disk afterwards, which is the caller's document
+ * unless the guard rejected it. Callers print the return value rather than
+ * their own document, so stdout can never disagree with the file.
+ */
+export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStatusDocument {
+  const { config, document } = input;
+  const existing = readRemoteSnapshot(config);
+  if (existing !== undefined && existing.lastAttemptAt >= document.lastAttemptAt) {
+    return existing;
+  }
+  writeDocument(remoteSnapshotPath(config), document);
+  return document;
+}
+
+/**
+ * Reads the persisted remote document, or undefined when it is missing,
+ * unreadable, corrupt, or written by an incompatible schema version. A
+ * missing snapshot is an ordinary first-run state, not an error.
+ */
+export function readRemoteSnapshot(config: LoggingConfig): RemoteStatusDocument | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(remoteSnapshotPath(config), "utf8");
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  return isRemoteStatusDocument(parsed) ? parsed : undefined;
+}
+
+function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate: Record<string, unknown> = { ...value };
+  return (
+    candidate["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
+    typeof candidate["lastAttemptAt"] === "string" &&
+    (candidate["lastAttemptStatus"] === "ok" || candidate["lastAttemptStatus"] === "unavailable")
+  );
+}
+
+function writeDocument(filePath: string, document: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  // Write-then-rename so a concurrent reader never observes a partial file.
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify(document, undefined, 2)}\n`, { mode: 0o600 });
+  renameSync(tmpPath, filePath);
+}

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -79,13 +79,22 @@ export interface StatusBoardIssue {
   agent: string | undefined;
 }
 
+/**
+ * A queued issue. Only groundcrew-eligible todos reach a queue, and
+ * eligibility means both fields resolved, so they are required here.
+ */
+export interface StatusQueueIssue extends StatusBoardIssue {
+  repository: string;
+  agent: string;
+}
+
 export interface StatusBlocker {
   id: string;
   status: CanonicalStatus;
   nativeStatus: string | undefined;
 }
 
-export interface StatusBlockedIssue extends StatusBoardIssue {
+export interface StatusBlockedIssue extends StatusQueueIssue {
   blockedBy: StatusBlocker[];
 }
 
@@ -102,7 +111,7 @@ export interface RemoteStatusPayload {
   pullRequestsByTask: Record<string, PullRequestSummary[]>;
   /** Every in-progress issue. Its length is the used slot count. */
   inProgress: StatusBoardIssue[];
-  queueReady: StatusBoardIssue[];
+  queueReady: StatusQueueIssue[];
   queueBlocked: StatusBlockedIssue[];
 }
 

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -139,9 +139,6 @@ export interface RemoteStatusPayload {
   capturedAt: string;
   /** Lowercased natural id to canonical status. Ambiguous ids are omitted. */
   statusByTask: Record<string, CanonicalStatus>;
-  /** Keyed by worktree dir. A task with two worktrees has two branches, and
-   * each can have its own pull requests. */
-  pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
   /** Every in-progress issue. Its length is the used slot count. */
   inProgress: StatusBoardIssue[];
   queueReady: StatusQueueIssue[];
@@ -154,13 +151,29 @@ export interface RemoteStatusDocument {
   lastAttemptAt: string;
   lastAttemptStatus: AvailabilityStatus;
   lastAttemptError?: string | undefined;
-  /** The last successful fetch. Undefined when none has ever succeeded. */
+  /** The last successful BOARD fetch. Undefined when none has ever succeeded. */
   payload?: RemoteStatusPayload | undefined;
+  /**
+   * Keyed by absolute worktree directory. A task with two worktrees has two
+   * branches, each with its own pull requests.
+   *
+   * Always from the current attempt, never carried forward: the lookups do not
+   * depend on the board, so a board outage must not freeze or hide them. An
+   * empty array means none were found OR the lookup failed; `gh` failures are
+   * not distinguishable here.
+   */
+  pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
 }
 
-export type RemoteFetchResult =
+export type BoardOutcome =
   | { kind: "ok"; payload: RemoteStatusPayload }
   | { kind: "error"; message: string };
+
+/** One remote pass: a board outcome plus pull requests, which succeed or fail apart. */
+export interface RemoteFetchResult {
+  board: BoardOutcome;
+  pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
+}
 
 export interface BuildRemoteDocumentInput {
   previous: RemoteStatusDocument | undefined;
@@ -177,20 +190,24 @@ export interface BuildRemoteDocumentInput {
  */
 export function buildRemoteDocument(input: BuildRemoteDocumentInput): RemoteStatusDocument {
   const { previous, attemptAt, result } = input;
-  if (result.kind === "ok") {
+  const shared = {
+    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION as StatusSchemaVersion,
+    lastAttemptAt: attemptAt,
+    // Never carried forward: these do not depend on the board.
+    pullRequestsByWorktree: result.pullRequestsByWorktree,
+  };
+  if (result.board.kind === "ok") {
     return {
-      schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
-      lastAttemptAt: attemptAt,
+      ...shared,
       lastAttemptStatus: "ok",
       lastAttemptError: undefined,
-      payload: result.payload,
+      payload: result.board.payload,
     };
   }
   return {
-    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
-    lastAttemptAt: attemptAt,
+    ...shared,
     lastAttemptStatus: "unavailable",
-    lastAttemptError: result.message,
+    lastAttemptError: result.board.message,
     payload: previous?.payload,
   };
 }
@@ -252,7 +269,8 @@ function isLocalStatusDocument(value: unknown): value is LocalStatusDocument {
 
 export interface WriteRemoteSnapshotInput {
   config: LoggingConfig;
-  document: RemoteStatusDocument;
+  attemptAt: string;
+  result: RemoteFetchResult;
 }
 
 /**
@@ -270,11 +288,15 @@ export interface WriteRemoteSnapshotInput {
  * their own document, so stdout can never disagree with the file.
  */
 export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStatusDocument {
-  const { config, document } = input;
+  const { config, attemptAt, result } = input;
+  // The merge and the guard share this one read. Reading twice let a failed
+  // run carry forward a payload that a concurrent success had already
+  // replaced, then write it back under a newer timestamp.
   const existing = readRemoteSnapshot(config);
-  if (existing !== undefined && isStrictlyNewer(existing.lastAttemptAt, document.lastAttemptAt)) {
+  if (existing !== undefined && isStrictlyNewer(existing.lastAttemptAt, attemptAt)) {
     return existing;
   }
+  const document = buildRemoteDocument({ previous: existing, attemptAt, result });
   writeJsonAtomic(remoteSnapshotPath(config), document);
   return document;
 }
@@ -295,12 +317,15 @@ function readJsonFile(filePath: string): unknown {
 
 /**
  * True when `existing` is a later instant than `candidate`. An unparseable
- * existing timestamp counts as older, so a file written by something that does
- * not use ISO-8601 gets replaced rather than silently winning forever.
+ * or future-dated existing timestamp counts as older, so neither a foreign
+ * timestamp format nor a clock that jumped forward can pin the file forever.
  */
 function isStrictlyNewer(existing: string, candidate: string): boolean {
   const existingMs = Date.parse(existing);
-  if (Number.isNaN(existingMs)) {
+  // A timestamp that is unparseable, or that this clock has not reached, is
+  // not evidence of a newer run. Without the upper bound one future-dated file
+  // pins the snapshot forever, with no command to clear it.
+  if (Number.isNaN(existingMs) || existingMs > Date.now()) {
     return false;
   }
   return existingMs > Date.parse(candidate);
@@ -311,10 +336,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Structural only: it checks the containers a reader walks, not every issue
- * inside them. That is the level that matters, because the shapes below are
- * what `joinStatus` indexes and iterates; a wrong field inside one issue
- * renders oddly, while a wrong container type throws.
+ * Structural only: it checks the containers a reader walks, not the elements
+ * inside them. That catches the corruption a single writer can plausibly
+ * produce. A hand-edited file with a malformed element still reaches the
+ * reader, so this is a sanity check, not a schema validator.
  */
 function isRemoteStatusPayload(value: unknown): value is RemoteStatusPayload {
   if (!isRecord(value)) {
@@ -323,7 +348,6 @@ function isRemoteStatusPayload(value: unknown): value is RemoteStatusPayload {
   return (
     typeof value["capturedAt"] === "string" &&
     isRecord(value["statusByTask"]) &&
-    isRecord(value["pullRequestsByWorktree"]) &&
     Array.isArray(value["inProgress"]) &&
     Array.isArray(value["queueReady"]) &&
     Array.isArray(value["queueBlocked"])
@@ -339,6 +363,9 @@ function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
     typeof value["lastAttemptAt"] !== "string" ||
     (value["lastAttemptStatus"] !== "ok" && value["lastAttemptStatus"] !== "unavailable")
   ) {
+    return false;
+  }
+  if (!isRecord(value["pullRequestsByWorktree"])) {
     return false;
   }
   const payload = value["payload"];

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -55,7 +55,7 @@ export interface StatusTask {
   recentLogLines: string[];
 }
 
-export interface StatusProbeState {
+interface StatusProbeState {
   status: "ok" | "unavailable";
   error: string | undefined;
 }
@@ -165,7 +165,7 @@ export function buildRemoteDocument(input: BuildRemoteDocumentInput): RemoteStat
 type LoggingConfig = Pick<ResolvedConfig, "logging">;
 
 /** Both documents sit beside the log file and the per-task run states. */
-export function statusSnapshotDirectory(config: LoggingConfig): string {
+function statusSnapshotDirectory(config: LoggingConfig): string {
   return path.resolve(path.dirname(config.logging.file));
 }
 

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -4,14 +4,16 @@
  * sessions — collectors build these shapes, `statusJoin` combines them.
  */
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+
+import { writeJsonAtomic } from "./atomicJson.ts";
 
 import type { ResolvedConfig } from "./config.ts";
 import type { PullRequestSummary } from "./pullRequests.ts";
 import type { RunLifecycleState } from "./runState.ts";
 import type { CanonicalStatus } from "./taskSource.ts";
-import type { WorktreeDirtiness } from "./worktrees.ts";
+import type { WorktreeDirtiness, WorktreeKind } from "./worktrees.ts";
 
 /**
  * Contract version for both documents. Bump on any breaking shape change;
@@ -25,7 +27,7 @@ export type StatusLifecycle = RunLifecycleState | "idle";
 
 export interface StatusWorktree {
   repository: string;
-  kind: string;
+  kind: WorktreeKind;
   dir: string;
   branch: string;
   git: WorktreeDirtiness;
@@ -36,13 +38,15 @@ export interface StatusTask {
   task: string;
   title: string | undefined;
   url: string | undefined;
-  repository: string;
   agent: string | undefined;
   lifecycle: StatusLifecycle;
   /** Probe-reconciliation flags, e.g. "session dead". Never a duration. */
   flags: string[];
-  /** RunState.createdAt. Readers derive elapsed time; a stored duration in a
-   * cached document shows a frozen clock. */
+  /**
+   * When the run was first recorded. Readers derive elapsed time themselves:
+   * a duration stored in a cached document shows a frozen clock, which reads
+   * as "the agent stopped working" when it did not.
+   */
   startedAt: string | undefined;
   updatedAt: string | undefined;
   resumeCount: number | undefined;
@@ -90,6 +94,7 @@ export interface StatusQueueIssue extends StatusBoardIssue {
 
 export interface StatusBlocker {
   id: string;
+  naturalId: string;
   status: CanonicalStatus;
   nativeStatus: string | undefined;
 }
@@ -184,7 +189,7 @@ export interface WriteLocalSnapshotInput {
 
 export function writeLocalSnapshot(input: WriteLocalSnapshotInput): void {
   const { config, document } = input;
-  writeDocument(localSnapshotPath(config), document);
+  writeJsonAtomic(localSnapshotPath(config), document);
 }
 
 export interface WriteRemoteSnapshotInput {
@@ -209,15 +214,11 @@ export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStat
   if (existing !== undefined && existing.lastAttemptAt > document.lastAttemptAt) {
     return existing;
   }
-  writeDocument(remoteSnapshotPath(config), document);
+  writeJsonAtomic(remoteSnapshotPath(config), document);
   return document;
 }
 
-/**
- * Reads the persisted remote document, or undefined when it is missing,
- * unreadable, corrupt, or written by an incompatible schema version. A
- * missing snapshot is an ordinary first-run state, not an error.
- */
+/** A missing or unreadable snapshot is an ordinary first-run state, not an error. */
 export function readRemoteSnapshot(config: LoggingConfig): RemoteStatusDocument | undefined {
   let raw: string;
   try {
@@ -234,22 +235,17 @@ export function readRemoteSnapshot(config: LoggingConfig): RemoteStatusDocument 
   return isRemoteStatusDocument(parsed) ? parsed : undefined;
 }
 
-function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const candidate: Record<string, unknown> = { ...value };
-  return (
-    candidate["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
-    typeof candidate["lastAttemptAt"] === "string" &&
-    (candidate["lastAttemptStatus"] === "ok" || candidate["lastAttemptStatus"] === "unavailable")
-  );
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function writeDocument(filePath: string, document: unknown): void {
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  // Write-then-rename so a concurrent reader never observes a partial file.
-  const tmpPath = `${filePath}.${process.pid}.tmp`;
-  writeFileSync(tmpPath, `${JSON.stringify(document, undefined, 2)}\n`, { mode: 0o600 });
-  renameSync(tmpPath, filePath);
+function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
+    typeof value["lastAttemptAt"] === "string" &&
+    (value["lastAttemptStatus"] === "ok" || value["lastAttemptStatus"] === "unavailable")
+  );
 }

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -21,6 +21,16 @@ import type { WorktreeDirtiness, WorktreeKind } from "./worktrees.ts";
  */
 export const STATUS_SNAPSHOT_SCHEMA_VERSION = 1;
 
+/**
+ * Optional fields are written by `JSON.stringify`, which omits a key whose
+ * value is `undefined`. So every `field?:` below is genuinely ABSENT on disk
+ * rather than present-and-null, and a reader must treat absence as "not set".
+ */
+export type StatusSchemaVersion = typeof STATUS_SNAPSHOT_SCHEMA_VERSION;
+
+/** Two-state health verdict shared by the probe and the board attempt. */
+export type AvailabilityStatus = "ok" | "unavailable";
+
 export type StatusSessionState = "live" | "exited" | "not-live" | "unknown";
 
 export type StatusLifecycle = RunLifecycleState | "idle";
@@ -36,9 +46,9 @@ export interface StatusWorktree {
 export interface StatusTask {
   /** Lowercased source task id, matching `WorktreeEntry.task`. */
   task: string;
-  title: string | undefined;
-  url: string | undefined;
-  agent: string | undefined;
+  title?: string | undefined;
+  url?: string | undefined;
+  agent?: string | undefined;
   lifecycle: StatusLifecycle;
   /** Probe-reconciliation flags, e.g. "session dead". Never a duration. */
   flags: string[];
@@ -47,25 +57,37 @@ export interface StatusTask {
    * a duration stored in a cached document shows a frozen clock, which reads
    * as "the agent stopped working" when it did not.
    */
-  startedAt: string | undefined;
-  updatedAt: string | undefined;
-  resumeCount: number | undefined;
-  reason: string | undefined;
-  detail: string | undefined;
+  startedAt?: string | undefined;
+  updatedAt?: string | undefined;
+  resumeCount?: number | undefined;
+  reason?: string | undefined;
+  detail?: string | undefined;
   session: StatusSessionState;
-  attachCommand: string | undefined;
-  hint: string | undefined;
+  attachCommand?: string | undefined;
+  hint?: string | undefined;
   worktrees: StatusWorktree[];
+  /**
+   * Lines mentioning this task, from a bounded tail of the shared log. A line
+   * older than that tail is absent here but still shown by `crew status <task>`.
+   */
   recentLogLines: string[];
 }
 
-interface StatusProbeState {
-  status: "ok" | "unavailable";
-  error: string | undefined;
+export interface StatusProbeState {
+  status: AvailabilityStatus;
+  error?: string | undefined;
 }
 
+/**
+ * The local tier. Every field here comes from a local subprocess or a file
+ * read, so a monitor can poll this document every few seconds.
+ *
+ * Placement rule for a new field: if producing it needs the network, it
+ * belongs in `RemoteStatusPayload`. `--local-only` is a promise about this
+ * whole document, and one network-backed field voids it.
+ */
 export interface LocalStatusDocument {
-  schemaVersion: number;
+  schemaVersion: StatusSchemaVersion;
   capturedAt: string;
   /** From config, never the network, so capacity renders before any fetch. */
   maximumInProgress: number;
@@ -78,9 +100,9 @@ export interface StatusBoardIssue {
   id: string;
   naturalId: string;
   title: string;
-  url: string | undefined;
-  repository: string | undefined;
-  agent: string | undefined;
+  url?: string | undefined;
+  repository?: string | undefined;
+  agent?: string | undefined;
 }
 
 /**
@@ -96,7 +118,7 @@ export interface StatusBlocker {
   id: string;
   naturalId: string;
   status: CanonicalStatus;
-  nativeStatus: string | undefined;
+  nativeStatus?: string | undefined;
 }
 
 export interface StatusBlockedIssue extends StatusQueueIssue {
@@ -104,6 +126,10 @@ export interface StatusBlockedIssue extends StatusQueueIssue {
 }
 
 /**
+ * The remote tier. Placement rule for a new field: it belongs here when
+ * producing it needs the network, because this tier polls slowly, near
+ * `pollIntervalMilliseconds`.
+ *
  * Board-derived facts only. Board-side classification is applied; the local
  * worktree subtraction deliberately is not. Precomputing that join here would
  * make the document assert something false as soon as a worktree appears,
@@ -113,7 +139,9 @@ export interface RemoteStatusPayload {
   capturedAt: string;
   /** Lowercased natural id to canonical status. Ambiguous ids are omitted. */
   statusByTask: Record<string, CanonicalStatus>;
-  pullRequestsByTask: Record<string, PullRequestSummary[]>;
+  /** Keyed by worktree dir. A task with two worktrees has two branches, and
+   * each can have its own pull requests. */
+  pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
   /** Every in-progress issue. Its length is the used slot count. */
   inProgress: StatusBoardIssue[];
   queueReady: StatusQueueIssue[];
@@ -121,13 +149,13 @@ export interface RemoteStatusPayload {
 }
 
 export interface RemoteStatusDocument {
-  schemaVersion: number;
+  schemaVersion: StatusSchemaVersion;
   /** The most recent attempt, successful or not. */
   lastAttemptAt: string;
-  lastAttemptStatus: "ok" | "unavailable";
-  lastAttemptError: string | undefined;
+  lastAttemptStatus: AvailabilityStatus;
+  lastAttemptError?: string | undefined;
   /** The last successful fetch. Undefined when none has ever succeeded. */
-  payload: RemoteStatusPayload | undefined;
+  payload?: RemoteStatusPayload | undefined;
 }
 
 export type RemoteFetchResult =
@@ -187,9 +215,39 @@ export interface WriteLocalSnapshotInput {
   document: LocalStatusDocument;
 }
 
-export function writeLocalSnapshot(input: WriteLocalSnapshotInput): void {
+/**
+ * Same monotonic rule as `writeRemoteSnapshot`, for the same reason: a slow
+ * run must not republish stale session state over a fresher poll. Returns what
+ * is on disk afterwards so callers print the file's true contents.
+ */
+export function writeLocalSnapshot(input: WriteLocalSnapshotInput): LocalStatusDocument {
   const { config, document } = input;
+  const existing = readLocalSnapshot(config);
+  if (existing !== undefined && isStrictlyNewer(existing.capturedAt, document.capturedAt)) {
+    return existing;
+  }
   writeJsonAtomic(localSnapshotPath(config), document);
+  return document;
+}
+
+/** A missing or unreadable snapshot is an ordinary first-run state, not an error. */
+export function readLocalSnapshot(config: LoggingConfig): LocalStatusDocument | undefined {
+  const parsed = readJsonFile(localSnapshotPath(config));
+  return isLocalStatusDocument(parsed) ? parsed : undefined;
+}
+
+function isLocalStatusDocument(value: unknown): value is LocalStatusDocument {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
+    typeof value["capturedAt"] === "string" &&
+    typeof value["maximumInProgress"] === "number" &&
+    isRecord(value["workspaceProbe"]) &&
+    Array.isArray(value["tasks"]) &&
+    Array.isArray(value["orphanedSessions"])
+  );
 }
 
 export interface WriteRemoteSnapshotInput {
@@ -198,11 +256,14 @@ export interface WriteRemoteSnapshotInput {
 }
 
 /**
- * Monotonic: refuses to write a document whose attempt is strictly older than
- * the one on disk, so two concurrent runs interleaving read and write across
- * processes can never move the remote tier backwards. Equal timestamps are
- * accepted — same-millisecond attempts are equally current, and rejecting them
- * would silently drop a legitimate result.
+ * Refuses to write a document whose attempt is strictly older than the one on
+ * disk. Equal timestamps are accepted: same-millisecond attempts are equally
+ * current, and rejecting them would drop a legitimate result.
+ *
+ * This narrows the race, it does not close it. The read and the rename are
+ * separate syscalls, so two processes can still interleave such that the older
+ * attempt lands last. Closing it would need a lock file, which is not worth it
+ * for a cache whose next poll corrects any regression.
  *
  * Returns whatever is on disk afterwards, which is the caller's document
  * unless the guard rejected it. Callers print the return value rather than
@@ -211,7 +272,7 @@ export interface WriteRemoteSnapshotInput {
 export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStatusDocument {
   const { config, document } = input;
   const existing = readRemoteSnapshot(config);
-  if (existing !== undefined && existing.lastAttemptAt > document.lastAttemptAt) {
+  if (existing !== undefined && isStrictlyNewer(existing.lastAttemptAt, document.lastAttemptAt)) {
     return existing;
   }
   writeJsonAtomic(remoteSnapshotPath(config), document);
@@ -220,32 +281,66 @@ export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStat
 
 /** A missing or unreadable snapshot is an ordinary first-run state, not an error. */
 export function readRemoteSnapshot(config: LoggingConfig): RemoteStatusDocument | undefined {
-  let raw: string;
-  try {
-    raw = readFileSync(remoteSnapshotPath(config), "utf8");
-  } catch {
-    return undefined;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
+  const parsed = readJsonFile(remoteSnapshotPath(config));
   return isRemoteStatusDocument(parsed) ? parsed : undefined;
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when `existing` is a later instant than `candidate`. An unparseable
+ * existing timestamp counts as older, so a file written by something that does
+ * not use ISO-8601 gets replaced rather than silently winning forever.
+ */
+function isStrictlyNewer(existing: string, candidate: string): boolean {
+  const existingMs = Date.parse(existing);
+  if (Number.isNaN(existingMs)) {
+    return false;
+  }
+  return existingMs > Date.parse(candidate);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
+/**
+ * Structural only: it checks the containers a reader walks, not every issue
+ * inside them. That is the level that matters, because the shapes below are
+ * what `joinStatus` indexes and iterates; a wrong field inside one issue
+ * renders oddly, while a wrong container type throws.
+ */
+function isRemoteStatusPayload(value: unknown): value is RemoteStatusPayload {
   if (!isRecord(value)) {
     return false;
   }
   return (
-    value["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
-    typeof value["lastAttemptAt"] === "string" &&
-    (value["lastAttemptStatus"] === "ok" || value["lastAttemptStatus"] === "unavailable")
+    typeof value["capturedAt"] === "string" &&
+    isRecord(value["statusByTask"]) &&
+    isRecord(value["pullRequestsByWorktree"]) &&
+    Array.isArray(value["inProgress"]) &&
+    Array.isArray(value["queueReady"]) &&
+    Array.isArray(value["queueBlocked"])
   );
+}
+
+function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (
+    value["schemaVersion"] !== STATUS_SNAPSHOT_SCHEMA_VERSION ||
+    typeof value["lastAttemptAt"] !== "string" ||
+    (value["lastAttemptStatus"] !== "ok" && value["lastAttemptStatus"] !== "unavailable")
+  ) {
+    return false;
+  }
+  const payload = value["payload"];
+  return payload === undefined || isRemoteStatusPayload(payload);
 }

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -193,9 +193,11 @@ export interface WriteRemoteSnapshotInput {
 }
 
 /**
- * Monotonic: refuses to write a document whose attempt predates the one on
- * disk, so two concurrent runs interleaving read and write across processes
- * can never move the remote tier backwards.
+ * Monotonic: refuses to write a document whose attempt is strictly older than
+ * the one on disk, so two concurrent runs interleaving read and write across
+ * processes can never move the remote tier backwards. Equal timestamps are
+ * accepted — same-millisecond attempts are equally current, and rejecting them
+ * would silently drop a legitimate result.
  *
  * Returns whatever is on disk afterwards, which is the caller's document
  * unless the guard rejected it. Callers print the return value rather than
@@ -204,7 +206,7 @@ export interface WriteRemoteSnapshotInput {
 export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStatusDocument {
   const { config, document } = input;
   const existing = readRemoteSnapshot(config);
-  if (existing !== undefined && existing.lastAttemptAt >= document.lastAttemptAt) {
+  if (existing !== undefined && existing.lastAttemptAt > document.lastAttemptAt) {
     return existing;
   }
   writeDocument(remoteSnapshotPath(config), document);

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -635,7 +635,10 @@ async function probeWorktreeDirtiness(
   try {
     output = await runCommandAsync(
       "git",
-      ["-C", worktreeDir, "status", "--porcelain"],
+      // --no-optional-locks: `crew status --json` is polled every few seconds,
+      // and without it each poll takes index.lock and rewrites the index,
+      // which can make a live agent's own git commands fail on the lock.
+      ["--no-optional-locks", "-C", worktreeDir, "status", "--porcelain"],
       signalProperty(signal),
     );
   } catch {


### PR DESCRIPTION
## Why

`crew status` previously exposed state only as human-readable text, forcing an external monitor to import groundcrew or parse presentation output. The monitor needs a language-independent JSON contract that can be polled locally without network work, while slower board and pull-request data refreshes independently.

The snapshot must also remain trustworthy under overlapping polls: readers need honest capture times, complete per-task fields, and atomic files rather than stale observations labeled as fresh.

## Summary

- Add `crew status --json` and `crew status --json --local-only`.
- Persist atomic mode-0600 `status-local.json` and `status-remote.json` documents beside the groundcrew log.
- Split local subprocess/file collection from network-bound board and pull-request collection, then join them for the unchanged text renderer.
- Preserve last-known-good board data across failed fetches while recording the latest attempt status and error.
- Key pull requests by absolute worktree path and keep board classifications unsubtracted so readers can join them against the freshest local snapshot.
- Order overlapping writes by poll start time and preserve the board's actual capture timestamp.
- Publish current source status/title/URL for every unambiguous task through `payload.sourceByTask`.
- Reverse-scan task history once, then persist a file-identity/offset cursor so later polls process only appended log bytes while retaining the same ten recent lines as `crew status <TASK>`.
- Keep the wire contract language-independent; snapshot implementation helpers are not exported from the npm package root.

`--local-only` never constructs a task source or invokes `gh`. Plain `crew status` writes no snapshot and retains its existing text output.

## Validation

- `node --run verify`
  - 2,150 tests passed.
  - 100% statement, branch, function, and line coverage.
  - Build, lint, formatting, knip, architecture, duplication, Markdown, and dependency checks passed.
- Focused status contract suite: 139 tests passed across `status`, collectors, join logic, and snapshot persistence.
- New public-seam tests cover poll timestamps, non-queue source metadata, complete and incrementally cached task logs, and the narrowed package-root API.

## Notes

- `payload.capturedAt` is the board's capture time; `lastAttemptAt` orders and describes the current polling attempt.
- `sourceByTask` is keyed by lowercase natural task ID. Ambiguous IDs returned by multiple sources are omitted rather than guessed.
- `inProgress`, `queueReady`, and `queueBlocked` remain unsubtracted; readers remove tasks represented in the local document.
- `pullRequestsByWorktree` is keyed by absolute worktree directory.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>
