### PR TITLE
fix: remove backticks from shell hints in operator messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ If a referenced skill is missing or unreadable, run `npm ci` from the repository
 
 1. Use red, green, refactor test-driven development
 2. Validate changes with at least `node --run verify`
-3. Invoke core:go skill for ALL code changes
+3. Invoke cb-work skill for ALL code changes
 4. To exercise the `crew` CLI against the local checkout, run it via the npm script: `node --run crew -- <args>` (e.g. `node --run crew -- cleanup ENG-123`). The globally-installed `crew` binary runs the published version and will not reflect your in-progress changes. See [Development](./README.md#development) for the `crew:op` 1Password variant.
 
 ### Vitest coverage ignores

--- a/OVERLAY.md
+++ b/OVERLAY.md
@@ -4,7 +4,7 @@
 
 1. Use red, green, refactor test-driven development
 2. Validate changes with at least `node --run verify`
-3. Invoke core:go skill for ALL code changes
+3. Invoke cb-work skill for ALL code changes
 4. To exercise the `crew` CLI against the local checkout, run it via the npm script: `node --run crew -- <args>` (e.g. `node --run crew -- cleanup ENG-123`). The globally-installed `crew` binary runs the published version and will not reflect your in-progress changes. See [Development](./README.md#development) for the `crew:op` 1Password variant.
 
 ### Vitest coverage ignores

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jason/Documents/work/groundcrew/.claude/worktrees/main/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jason/Documents/work/groundcrew/.claude/worktrees/main/node_modules

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -193,8 +193,8 @@ describe(run, () => {
   it("hard-fails `sandbox <verb> [args...]` with the manual sbx workflow", async () => {
     await run(["sandbox", "auth", "claude"]);
 
-    expect(consoleError.output()).toContain("`crew sandbox` is no longer supported");
-    expect(consoleError.output()).toContain("manual `sbx` workflow");
+    expect(consoleError.output()).toContain("'crew sandbox' is no longer supported");
+    expect(consoleError.output()).toContain("manual 'sbx' workflow");
     expect(consoleError.output()).toContain("agents.definitions.<agent>.sandbox.agent");
     expect(process.exitCode).toBe(1);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,9 +24,9 @@ import {
 } from "./lib/util.ts";
 
 const REMOVED_SANDBOX_COMMAND_MESSAGE = [
-  "`crew sandbox` is no longer supported.",
+  "'crew sandbox' is no longer supported.",
   "Groundcrew now launches agents inside existing sbx sandboxes but does not list, create, regenerate, authenticate, or remove them.",
-  "Use the manual `sbx` workflow in README.md#docker-sandboxes-sdx-setup, then keep `agents.definitions.<agent>.sandbox.agent` in crew.config.ts so launches can address the existing sandbox.",
+  "Use the manual 'sbx' workflow in README.md#docker-sandboxes-sdx-setup, then keep 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts so launches can address the existing sandbox.",
 ].join("\n");
 
 interface PackageMetadata {
@@ -204,7 +204,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     invoke: interruptWorkspaceCli,
   },
   interrupt: {
-    summary: "Deprecated alias for `crew stop`",
+    summary: "Deprecated alias for 'crew stop'",
     usage: "<task> [--reason <text>]",
     deprecated: true,
     invoke: async (argv) => {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -670,7 +670,7 @@ describe(createDispatcher, () => {
 
       expect(setupMock).not.toHaveBeenCalled();
       expect(board.markInProgress).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("Run crew cleanup");
+      expect(consoleLog.output()).toContain("Run 'crew cleanup team-1'");
     });
 
     it("retries next iteration when the workspace list is unavailable", async () => {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -670,7 +670,7 @@ describe(createDispatcher, () => {
 
       expect(setupMock).not.toHaveBeenCalled();
       expect(board.markInProgress).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("Run `crew cleanup");
+      expect(consoleLog.output()).toContain("Run 'crew cleanup");
     });
 
     it("retries next iteration when the workspace list is unavailable", async () => {

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -670,7 +670,7 @@ describe(createDispatcher, () => {
 
       expect(setupMock).not.toHaveBeenCalled();
       expect(board.markInProgress).not.toHaveBeenCalled();
-      expect(consoleLog.output()).toContain("Run 'crew cleanup");
+      expect(consoleLog.output()).toContain("Run crew cleanup");
     });
 
     it("retries next iteration when the workspace list is unavailable", async () => {

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -670,7 +670,7 @@ describe(doctor, () => {
     expect(actual).toBe(true);
     expect(consoleLog.output()).toContain("local runner (safehouse)");
     expect(consoleLog.output()).toContain(
-      "safehouse runner requires macOS with `safehouse` on PATH",
+      "safehouse runner requires macOS with 'safehouse' on PATH",
     );
     expect(consoleLog.output().match(/local runner \(safehouse\)/g)).toHaveLength(1);
   });
@@ -694,7 +694,7 @@ describe(doctor, () => {
     expect(actual).toBe(true);
     expect(consoleLog.output()).toContain("requested: auto → resolved: sdx");
     expect(consoleLog.output()).toContain("local runner (sdx)");
-    expect(consoleLog.output()).not.toContain("sdx runner requires `sbx`");
+    expect(consoleLog.output()).not.toContain("sdx runner requires 'sbx'");
   });
 
   it("reports the sdx runner as missing when sbx is not on PATH", async () => {
@@ -715,7 +715,7 @@ describe(doctor, () => {
 
     expect(actual).toBe(true);
     expect(consoleLog.output()).toContain("local runner (sdx)");
-    expect(consoleLog.output()).toContain("sdx runner requires `sbx`");
+    expect(consoleLog.output()).toContain("sdx runner requires 'sbx'");
   });
 
   it("surfaces a WARNING when local.runner is configured to 'none'", async () => {
@@ -925,7 +925,7 @@ describe(doctor, () => {
     expect(actual).toBe(true);
     const lines = consoleLog.output();
     expect(lines).toContain("Local runner");
-    expect(lines).toContain("sdx runner requires `sbx`");
+    expect(lines).toContain("sdx runner requires 'sbx'");
     expect(lines).toMatch(/requested=auto, resolved=cmux/);
     expect(checkedCommands()).toContain("cmux");
     expect(checkedCommands()).not.toContain("tmux");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -400,7 +400,7 @@ function localCapabilityCheck(host: HostCapabilities, resolved: LocalRunner): Ch
       required: false,
       hint: ok
         ? "ready"
-        : "safehouse runner requires macOS with `safehouse` on PATH (install from https://agent-safehouse.dev/)",
+        : "safehouse runner requires macOS with 'safehouse' on PATH (install from https://agent-safehouse.dev/)",
     };
   }
   if (resolved === "sdx") {
@@ -411,7 +411,7 @@ function localCapabilityCheck(host: HostCapabilities, resolved: LocalRunner): Ch
       required: false,
       hint: ok
         ? "ready"
-        : "sdx runner requires `sbx` (Docker Sandboxes) on PATH (install from https://docs.docker.com/ai/sandboxes/)",
+        : "sdx runner requires 'sbx' (Docker Sandboxes) on PATH (install from https://docs.docker.com/ai/sandboxes/)",
     };
   }
   // resolved === "none"

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -322,7 +322,7 @@ describe(classifyEligibility, () => {
       expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
       // The suggested cleanup command must use the natural id so it is actually runnable.
       const { message } = verdicts[0] as SkipVerdict;
-      expect(message).toContain("Run crew cleanup team-1");
+      expect(message).toContain("Run 'crew cleanup team-1'");
       expect(message).not.toContain("`");
     });
 

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -322,7 +322,7 @@ describe(classifyEligibility, () => {
       expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
       // The suggested cleanup command must use the natural id so it is actually runnable.
       const { message } = verdicts[0] as SkipVerdict;
-      expect(message).toContain("Run 'crew cleanup team-1'");
+      expect(message).toContain("Run crew cleanup team-1");
       expect(message).not.toContain("`");
     });
 

--- a/src/commands/eligibility.test.ts
+++ b/src/commands/eligibility.test.ts
@@ -320,9 +320,10 @@ describe(classifyEligibility, () => {
       );
 
       expect(verdicts[0]).toMatchObject({ kind: "skip", eventReason: "workspace_missing" });
-      // The suggested `crew cleanup` command must use the natural id so it is actually runnable.
+      // The suggested cleanup command must use the natural id so it is actually runnable.
       const { message } = verdicts[0] as SkipVerdict;
-      expect(message).toMatch(/crew cleanup team-1/);
+      expect(message).toContain("Run 'crew cleanup team-1'");
+      expect(message).not.toContain("`");
     });
 
     it("emits `workspace_list_unavailable` when the workspace adapter probe failed", () => {

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -253,7 +253,7 @@ function classifyRecovery(
     return {
       kind: "skip",
       issue,
-      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run crew cleanup ${naturalId} to allow re-provisioning.`,
+      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run 'crew cleanup ${naturalId}' to allow re-provisioning.`,
       eventReason: "workspace_missing",
     };
   }

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -253,7 +253,7 @@ function classifyRecovery(
     return {
       kind: "skip",
       issue,
-      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run \`crew cleanup ${naturalId}\` to allow re-provisioning.`,
+      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run 'crew cleanup ${naturalId}' to allow re-provisioning.`,
       eventReason: "workspace_missing",
     };
   }

--- a/src/commands/eligibility.ts
+++ b/src/commands/eligibility.ts
@@ -253,7 +253,7 @@ function classifyRecovery(
     return {
       kind: "skip",
       issue,
-      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run 'crew cleanup ${naturalId}' to allow re-provisioning.`,
+      message: `Skipping ${issue.id}: worktree exists but no live workspace. Run crew cleanup ${naturalId} to allow re-provisioning.`,
       eventReason: "workspace_missing",
     };
   }

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1155,7 +1155,7 @@ describe(orchestrate, () => {
     expect(setupMock).not.toHaveBeenCalled();
     expect(client.updateIssue).not.toHaveBeenCalled();
     const out = consoleLog.output();
-    expect(out).toContain("Run `crew cleanup");
+    expect(out).toContain("Run 'crew cleanup");
   });
 
   it("skips a task when the workspace list is unavailable", async () => {

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1155,7 +1155,7 @@ describe(orchestrate, () => {
     expect(setupMock).not.toHaveBeenCalled();
     expect(client.updateIssue).not.toHaveBeenCalled();
     const out = consoleLog.output();
-    expect(out).toContain("Run 'crew cleanup");
+    expect(out).toContain("Run crew cleanup");
   });
 
   it("skips a task when the workspace list is unavailable", async () => {

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -1155,7 +1155,7 @@ describe(orchestrate, () => {
     expect(setupMock).not.toHaveBeenCalled();
     expect(client.updateIssue).not.toHaveBeenCalled();
     const out = consoleLog.output();
-    expect(out).toContain("Run crew cleanup");
+    expect(out).toContain("Run 'crew cleanup team-1'");
   });
 
   it("skips a task when the workspace list is unavailable", async () => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1409,7 +1409,7 @@ describe(setupWorkspace, () => {
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
       }),
-    ).rejects.toThrow(/sdx runner require `sbx`/);
+    ).rejects.toThrow(/sdx runner require 'sbx'/);
 
     expect(createMock).not.toHaveBeenCalled();
     expect(ensureClearanceMock).not.toHaveBeenCalled();
@@ -1584,7 +1584,7 @@ describe(setupWorkspace, () => {
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
       }),
-    ).rejects.toThrow(/require `safehouse` on PATH/);
+    ).rejects.toThrow(/require 'safehouse' on PATH/);
 
     expect(createMock).not.toHaveBeenCalled();
     expect(ensureClearanceMock).not.toHaveBeenCalled();

--- a/src/lib/adapters/linear/create.ts
+++ b/src/lib/adapters/linear/create.ts
@@ -206,7 +206,7 @@ function buildLinearDescription(arguments_: {
     "## Groundcrew",
     "",
     `Repository: ${repository}`,
-    "Implementation workflow: use the `core:go`/`go` skill when available. If that skill is unavailable, follow this repo's AGENTS.md/CLAUDE.md implementation workflow and run the documented verification.",
+    "Implementation workflow: use the `cb-work` skill. Follow this repo's AGENTS.md/CLAUDE.md implementation workflow and run the documented verification.",
     "",
     "## Task",
     "",

--- a/src/lib/adapters/linear/factory.test.ts
+++ b/src/lib/adapters/linear/factory.test.ts
@@ -759,6 +759,9 @@ describe(createLinearTaskSource, () => {
     });
     const createdInput = issueCreateInput(rawRequest.mock.calls);
     expect(createdInput["description"]).toContain("Repository: ClipboardHealth/api");
+    expect(createdInput["description"]).toContain(
+      "Implementation workflow: use the `cb-work` skill.",
+    );
     expect(createdInput["description"]).toContain("Projects: marketplace\nContexts: backend");
     expect(rawRequest.mock.calls[2]?.[1]).toStrictEqual({
       input: {

--- a/src/lib/cmuxAdapter.ts
+++ b/src/lib/cmuxAdapter.ts
@@ -40,7 +40,7 @@ export const cmuxAdapter: Adapter = {
     const workspaceId = extractCmuxOpenId(output);
     if (workspaceId === undefined) {
       log(
-        `cmux new-workspace returned unrecognized output for ${spec.name}; if a workspace was created, run \`cmux close-workspace\` manually.`,
+        `cmux new-workspace returned unrecognized output for ${spec.name}; if a workspace was created, run 'cmux close-workspace' manually.`,
       );
       throw new Error(`Unexpected cmux output: ${output}`);
     }
@@ -355,7 +355,7 @@ async function closeWorkspaceLeakedByFailedOpen(
     );
   } catch (closeError) {
     log(
-      `cmux new-workspace for ${name} exited non-zero and left workspace ${workspaceId}; automatic close failed (${errorMessage(closeError)}). Run \`cmux close-workspace --workspace ${workspaceId}\` by hand.`,
+      `cmux new-workspace for ${name} exited non-zero and left workspace ${workspaceId}; automatic close failed (${errorMessage(closeError)}). Run 'cmux close-workspace --workspace ${workspaceId}' by hand.`,
     );
   }
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -533,7 +533,7 @@ describe("loadConfig", () => {
       /agents\.definitions\.claude\.sandbox\.template is no longer supported/,
     );
     await expect(loadConfig()).rejects.toThrow(
-      /'sbx create --name groundcrew-<agent> <agent> <projectDir>'/,
+      /for example sbx create --name groundcrew-<agent> <agent> <projectDir>/,
     );
   });
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -533,7 +533,7 @@ describe("loadConfig", () => {
       /agents\.definitions\.claude\.sandbox\.template is no longer supported/,
     );
     await expect(loadConfig()).rejects.toThrow(
-      /for example sbx create --name groundcrew-<agent> <agent> <projectDir>/,
+      /for example 'sbx create --name groundcrew-<agent> <agent> <projectDir>'/,
     );
   });
 

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -532,7 +532,9 @@ describe("loadConfig", () => {
     await expect(loadConfig()).rejects.toThrow(
       /agents\.definitions\.claude\.sandbox\.template is no longer supported/,
     );
-    await expect(loadConfig()).rejects.toThrow(/sbx create --name groundcrew-<agent>/);
+    await expect(loadConfig()).rejects.toThrow(
+      /'sbx create --name groundcrew-<agent> <agent> <projectDir>'/,
+    );
   });
 
   it("rejects removed per-agent sandbox.kits with migration guidance", async () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -964,7 +964,7 @@ function normalizeSandbox(value: unknown, configKey: string): SandboxDefinition 
 function failRemovedConfigKey(configKey: string, reason: string): never {
   fail(
     `${configKey} is no longer supported: ${reason} ` +
-      "Provision and manage the sandbox yourself with `sbx` (for example `sbx create --name groundcrew-<agent> <agent> <projectDir>`), then keep only `agents.definitions.<agent>.sandbox.agent` in crew.config.ts.",
+      "Provision and manage the sandbox yourself with 'sbx' (for example 'sbx create --name groundcrew-<agent> <agent> <projectDir>'), then keep only 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts.",
   );
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -964,7 +964,7 @@ function normalizeSandbox(value: unknown, configKey: string): SandboxDefinition 
 function failRemovedConfigKey(configKey: string, reason: string): never {
   fail(
     `${configKey} is no longer supported: ${reason} ` +
-      "Provision and manage the sandbox yourself with 'sbx' (for example sbx create --name groundcrew-<agent> <agent> <projectDir>), then keep only 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts.",
+      "Provision and manage the sandbox yourself with 'sbx' (for example 'sbx create --name groundcrew-<agent> <agent> <projectDir>'), then keep only 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts.",
   );
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -964,7 +964,7 @@ function normalizeSandbox(value: unknown, configKey: string): SandboxDefinition 
 function failRemovedConfigKey(configKey: string, reason: string): never {
   fail(
     `${configKey} is no longer supported: ${reason} ` +
-      "Provision and manage the sandbox yourself with 'sbx' (for example 'sbx create --name groundcrew-<agent> <agent> <projectDir>'), then keep only 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts.",
+      "Provision and manage the sandbox yourself with 'sbx' (for example sbx create --name groundcrew-<agent> <agent> <projectDir>), then keep only 'agents.definitions.<agent>.sandbox.agent' in crew.config.ts.",
   );
 }
 

--- a/src/lib/launchCommand.test.ts
+++ b/src/lib/launchCommand.test.ts
@@ -1316,7 +1316,7 @@ describe(buildLaunchCommand, () => {
             },
           }),
         ),
-      ).toThrow(/preLaunchEnv cannot be injected when `cmd` starts with `safehouse`/);
+      ).toThrow(/preLaunchEnv cannot be injected when 'cmd' starts with 'safehouse'/);
     });
 
     it("throws when workerEnvironment is set with a cmd that already starts with safehouse", () => {
@@ -1330,7 +1330,7 @@ describe(buildLaunchCommand, () => {
             workerEnvironment: WORKER_ENVIRONMENT,
           }),
         ),
-      ).toThrow(/workerEnvironment cannot be injected when `cmd` starts with `safehouse`/);
+      ).toThrow(/workerEnvironment cannot be injected when 'cmd' starts with 'safehouse'/);
     });
 
     it("treats preLaunchEnv: [] as a no-op when cmd already starts with safehouse", () => {

--- a/src/lib/launchCommand.ts
+++ b/src/lib/launchCommand.ts
@@ -45,7 +45,7 @@ export function resolveSafehouseClearancePath(baseUrl: string = import.meta.url)
   } catch (error) {
     throw new Error(
       "@clipboard-health/clearance is required by @clipboard-health/groundcrew but could not be resolved. " +
-        "Install it alongside groundcrew (for example: `npm install -g @clipboard-health/clearance`).",
+        "Install it alongside groundcrew (for example: 'npm install -g @clipboard-health/clearance').",
       { cause: error },
     );
   }
@@ -569,12 +569,12 @@ export function buildLaunchCommand(arguments_: LaunchCommandArguments): string {
     // user owns env forwarding in that case, so there's no wrap flag for us to
     // inject into. Fail loudly instead of silently dropping the contract.
     throw new Error(
-      "preLaunchEnv cannot be injected when `cmd` starts with `safehouse` — your cmd owns the wrap, so add the names to its own `--env-pass=` flag, or drop the `safehouse` prefix from `cmd` to let groundcrew compose the flag for you.",
+      "preLaunchEnv cannot be injected when 'cmd' starts with 'safehouse' — your cmd owns the wrap, so add the names to its own '--env-pass=' flag, or drop the 'safehouse' prefix from 'cmd' to let groundcrew compose the flag for you.",
     );
   }
   if (arguments_.workerEnvironment !== undefined && arguments_.runner === "safehouse") {
     throw new Error(
-      "workerEnvironment cannot be injected when `cmd` starts with `safehouse` — your cmd owns the wrap, so add GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE to its own `--env-pass=` flag, or drop the `safehouse` prefix from `cmd` to let groundcrew compose the flag for you.",
+      "workerEnvironment cannot be injected when 'cmd' starts with 'safehouse' — your cmd owns the wrap, so add GROUNDCREW_TASK_ID,GROUNDCREW_COMPLETE to its own '--env-pass=' flag, or drop the 'safehouse' prefix from 'cmd' to let groundcrew compose the flag for you.",
     );
   }
   return buildUnwrappedHostLaunchCommand(arguments_);

--- a/src/lib/localRunner.test.ts
+++ b/src/lib/localRunner.test.ts
@@ -69,7 +69,7 @@ describe(assertLocalRunnerRequirements, () => {
   it("throws when safehouse is requested on macOS but the binary is missing", () => {
     expect(() => {
       assertLocalRunnerRequirements(host({ hasSafehouse: false }), "safehouse");
-    }).toThrow(/require `safehouse` on PATH/);
+    }).toThrow(/require 'safehouse' on PATH/);
   });
 
   it("returns silently when sdx is supported and sbx is on PATH", () => {
@@ -82,7 +82,7 @@ describe(assertLocalRunnerRequirements, () => {
   it("throws when sdx is requested but sbx is missing", () => {
     expect(() => {
       assertLocalRunnerRequirements(host(), "sdx");
-    }).toThrow(/sdx runner require `sbx`/);
+    }).toThrow(/sdx runner require 'sbx'/);
   });
 
   it("throws when sdx is requested on an unsupported platform", () => {

--- a/src/lib/localRunner.ts
+++ b/src/lib/localRunner.ts
@@ -43,7 +43,7 @@ export function assertLocalRunnerRequirements(host: HostCapabilities, runner: Lo
     }
     if (!host.hasSafehouse) {
       throw new Error(
-        "Local groundcrew runs require `safehouse` on PATH. Install Safehouse from https://agent-safehouse.dev/ and retry.",
+        "Local groundcrew runs require 'safehouse' on PATH. Install Safehouse from https://agent-safehouse.dev/ and retry.",
       );
     }
     return;
@@ -54,7 +54,7 @@ export function assertLocalRunnerRequirements(host: HostCapabilities, runner: Lo
     }
     if (!host.hasSbx) {
       throw new Error(
-        "Local groundcrew runs with the sdx runner require `sbx` (Docker Sandboxes) on PATH. Install from https://docs.docker.com/ai/sandboxes/ and retry.",
+        "Local groundcrew runs with the sdx runner require 'sbx' (Docker Sandboxes) on PATH. Install from https://docs.docker.com/ai/sandboxes/ and retry.",
       );
     }
     return;

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -537,9 +537,10 @@ describe("workspaces.open (cmux)", () => {
       workspaces.open(makeConfig(), { name: "TEAM-1", cwd: "/cwd", command: "x" }),
     ).rejects.toThrow(/Command failed: cmux/);
 
-    expect(logMock).toHaveBeenCalledWith(
-      expect.stringContaining("cmux close-workspace --workspace leaked-id"),
-    );
+    const actual = logMock.mock.calls.map(([message]) => message).join("\n");
+
+    expect(actual).toContain("Run 'cmux close-workspace --workspace leaked-id' by hand.");
+    expect(actual).not.toContain("`");
   });
 
   it("caches the resolved adapter per config so detectHostCapabilities is not re-run", async () => {
@@ -1835,13 +1836,12 @@ describe("workspaces tmux session-per-task env", () => {
       command: "x",
     });
 
-    expect(writeErrorMock).toHaveBeenCalledWith(
-      expect.stringContaining("tmux session-per-task mode will become the default soon"),
-    );
-    expect(writeErrorMock).toHaveBeenCalledWith(
-      expect.stringContaining("GROUNDCREW_TMUX_SESSION_PER_TASK=1"),
-    );
-    expect(writeErrorMock).toHaveBeenCalledWith(expect.stringContaining("tmux attach -t <task>"));
+    const actual = writeErrorMock.mock.calls.map(([message]) => message).join("\n");
+
+    expect(actual).toContain("tmux session-per-task mode will become the default soon");
+    expect(actual).toContain("GROUNDCREW_TMUX_SESSION_PER_TASK=1");
+    expect(actual).toContain("'tmux attach -t <task>'");
+    expect(actual).not.toContain("`");
   });
 
   it("does not warn auto users when auto resolves to cmux", async () => {

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -87,7 +87,7 @@ const TMUX_SESSION_PER_TASK_ENV = "GROUNDCREW_TMUX_SESSION_PER_TASK";
 const TMUX_SESSION_DEFAULT_WARNING = [
   "WARNING: tmux window mode is deprecated; tmux session-per-task mode will become the default soon.",
   `Opt in now with ${TMUX_SESSION_PER_TASK_ENV}=1.`,
-  "Migration: attach with `tmux attach -t <task>` instead of `tmux attach -t groundcrew:<task>`; each task gets its own tmux session; `crew stop` and `crew cleanup` close that managed session; set GROUNDCREW_KEEP_DEAD_WINDOWS=1 to keep exited scrollback.",
+  "Migration: attach with 'tmux attach -t <task>' instead of 'tmux attach -t groundcrew:<task>'; each task gets its own tmux session; 'crew stop' and 'crew cleanup' close that managed session; set GROUNDCREW_KEEP_DEAD_WINDOWS=1 to keep exited scrollback.",
 ].join("\n");
 
 const ADAPTER_LOADER_BY_KIND: Record<WorkspaceKind, () => Promise<Adapter>> = {

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -837,41 +837,15 @@ describe(remove, () => {
       });
     };
 
-    await expect(callRemove()).rejects.toThrow(/2 modified files and 2 untracked files/);
-    await expect(callRemove()).rejects.toThrow(/Run 'crew cleanup --force team-1'/);
-    await expect(callRemove()).rejects.toThrow(
+    const actual = await callRemove().then(() => "", String);
+
+    expect(actual).toMatch(/2 modified files and 2 untracked files/);
+    expect(actual).toContain("Run 'crew cleanup --force team-1'");
+    expect(actual).toMatch(
       new RegExp(
         `commit/stash in ${path.join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`,
       ),
     );
-  });
-
-  it("renders the dirty-worktree cleanup hint without shell-substituting backticks", async () => {
-    mkdirSync(path.join(projectDir, "repo-a"));
-    mkdirSync(path.join(projectDir, "repo-a-team-1"));
-    const config = makeConfig({ projectDir });
-
-    runCommandMock.mockImplementation((_command, arguments_) => {
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status --porcelain reports a dirty tree.
-      if (hasArguments(arguments_, "worktree", "remove")) {
-        throw new Error("Command failed: git worktree remove\nExit status: 128");
-      }
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "status", "--porcelain")) {
-        return " M src/foo.ts\n";
-      }
-      return "";
-    });
-
-    const actual = await remove(config, {
-      repository: "repo-a",
-      task: "team-1",
-      branchName: "dev-team-1",
-      dir: path.join(projectDir, "repo-a-team-1"),
-      kind: "host",
-    }).then(() => "", String);
-
-    expect(actual).toContain("Run 'crew cleanup --force team-1'");
     expect(actual).not.toContain("`");
   });
 
@@ -970,48 +944,16 @@ describe(remove, () => {
       });
     };
 
-    await expect(callRemove()).rejects.toThrow(
-      /directory exists but is not a registered git worktree/,
-    );
-    await expect(callRemove()).rejects.toThrow(/Run 'crew cleanup --force team-1'/);
-    await expect(callRemove()).rejects.toThrow(
+    const actual = await callRemove().then(() => "", String);
+
+    expect(actual).toMatch(/directory exists but is not a registered git worktree/);
+    expect(actual).toContain("Run 'crew cleanup --force team-1'");
+    expect(actual).toMatch(
       new RegExp(
         `remove ${path.join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`,
       ),
     );
-    await expect(callRemove()).rejects.toThrow(/inspect it first/);
-  });
-
-  it("renders the orphan-worktree cleanup hint without shell-substituting backticks", async () => {
-    mkdirSync(path.join(projectDir, "repo-a"));
-    mkdirSync(path.join(projectDir, "repo-a-team-1"));
-    const config = makeConfig({ projectDir });
-
-    runCommandMock.mockImplementation((_command, arguments_) => {
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status fails because the dir has no .git.
-      if (hasArguments(arguments_, "worktree", "remove")) {
-        throw new Error("Command failed: git worktree remove\nExit status: 128");
-      }
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "status", "--porcelain")) {
-        throw new Error("not a git repository");
-      }
-      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
-      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
-        return `worktree ${path.join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n`;
-      }
-      return "";
-    });
-
-    const actual = await remove(config, {
-      repository: "repo-a",
-      task: "team-1",
-      branchName: "dev-team-1",
-      dir: path.join(projectDir, "repo-a-team-1"),
-      kind: "host",
-    }).then(() => "", String);
-
-    expect(actual).toContain("Run 'crew cleanup --force team-1'");
+    expect(actual).toMatch(/inspect it first/);
     expect(actual).not.toContain("`");
   });
 

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -410,7 +410,7 @@ describe(remove, () => {
         dir: worktreeDir,
         kind: "host",
       }),
-    ).rejects.toThrow(/crew cleanup --force team-220/);
+    ).rejects.toThrow(/Run 'crew cleanup --force team-220'/);
 
     // The remove template never ran.
     expect(runCommandMock).not.toHaveBeenCalledWith("sh", expect.anything(), expect.anything());
@@ -838,12 +838,41 @@ describe(remove, () => {
     };
 
     await expect(callRemove()).rejects.toThrow(/2 modified files and 2 untracked files/);
-    await expect(callRemove()).rejects.toThrow(/crew cleanup --force team-1/);
+    await expect(callRemove()).rejects.toThrow(/Run 'crew cleanup --force team-1'/);
     await expect(callRemove()).rejects.toThrow(
       new RegExp(
         `commit/stash in ${path.join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`,
       ),
     );
+  });
+
+  it("renders the dirty-worktree cleanup hint without shell-substituting backticks", async () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    mkdirSync(path.join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status --porcelain reports a dirty tree.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("Command failed: git worktree remove\nExit status: 128");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        return " M src/foo.ts\n";
+      }
+      return "";
+    });
+
+    const actual = await remove(config, {
+      repository: "repo-a",
+      task: "team-1",
+      branchName: "dev-team-1",
+      dir: path.join(projectDir, "repo-a-team-1"),
+      kind: "host",
+    }).then(() => "", String);
+
+    expect(actual).toContain("Run 'crew cleanup --force team-1'");
+    expect(actual).not.toContain("`");
   });
 
   it("uses singular wording when exactly one modified file is dirty", async () => {
@@ -944,13 +973,46 @@ describe(remove, () => {
     await expect(callRemove()).rejects.toThrow(
       /directory exists but is not a registered git worktree/,
     );
-    await expect(callRemove()).rejects.toThrow(/crew cleanup --force team-1/);
+    await expect(callRemove()).rejects.toThrow(/Run 'crew cleanup --force team-1'/);
     await expect(callRemove()).rejects.toThrow(
       new RegExp(
         `remove ${path.join(projectDir, "repo-a-team-1").replaceAll("/", String.raw`\/`)}`,
       ),
     );
     await expect(callRemove()).rejects.toThrow(/inspect it first/);
+  });
+
+  it("renders the orphan-worktree cleanup hint without shell-substituting backticks", async () => {
+    mkdirSync(path.join(projectDir, "repo-a"));
+    mkdirSync(path.join(projectDir, "repo-a-team-1"));
+    const config = makeConfig({ projectDir });
+
+    runCommandMock.mockImplementation((_command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- discriminator selects the worktree-remove call to fail; status fails because the dir has no .git.
+      if (hasArguments(arguments_, "worktree", "remove")) {
+        throw new Error("Command failed: git worktree remove\nExit status: 128");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "status", "--porcelain")) {
+        throw new Error("not a git repository");
+      }
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- as above
+      if (hasArguments(arguments_, "worktree", "list", "--porcelain")) {
+        return `worktree ${path.join(projectDir, "repo-a")}\nHEAD abc123\nbranch refs/heads/main\n`;
+      }
+      return "";
+    });
+
+    const actual = await remove(config, {
+      repository: "repo-a",
+      task: "team-1",
+      branchName: "dev-team-1",
+      dir: path.join(projectDir, "repo-a-team-1"),
+      kind: "host",
+    }).then(() => "", String);
+
+    expect(actual).toContain("Run 'crew cleanup --force team-1'");
+    expect(actual).not.toContain("`");
   });
 
   it("rethrows the original error when the registration probe itself fails", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -698,7 +698,7 @@ function describeDirtyWorktree(arguments_: {
   }
   const summary = parts.join(" and ");
   const pronoun = modified + untracked === 1 ? "it" : "them";
-  return `worktree has ${summary}. Run \`crew cleanup --force ${task}\` to discard ${pronoun}, or commit/stash in ${dir} first.`;
+  return `worktree has ${summary}. Run 'crew cleanup --force ${task}' to discard ${pronoun}, or commit/stash in ${dir} first.`;
 }
 
 type WorktreeRegistration = "registered" | "orphan" | "unknown";
@@ -732,7 +732,7 @@ async function probeWorktreeRegistration(arguments_: {
 
 function describeOrphanWorktree(arguments_: { task: string; dir: string }): string {
   const { task, dir } = arguments_;
-  return `directory exists but is not a registered git worktree. Run \`crew cleanup --force ${task}\` to remove ${dir}, or inspect it first if it may contain valuable files.`;
+  return `directory exists but is not a registered git worktree. Run 'crew cleanup --force ${task}' to remove ${dir}, or inspect it first if it may contain valuable files.`;
 }
 
 function expectedHostWorktreeDir(config: ResolvedConfig, entry: WorktreeEntry): string {


### PR DESCRIPTION
## Why

Groundcrew's operator-facing failure messages embed commands operators may run next. Some wrapped those commands in backticks. In a terminal, backticks perform command substitution, so piping or echoing a message through a double-quoted shell context can execute a command such as `crew cleanup --force` instead of displaying it.

These messages appear in terminals and logs, including a cleanup hint observed more than 18,000 times in one orchestrator log. Removing shell-active display markup reduces the risk of accidentally executing a destructive suggestion while preserving readable command boundaries.

## Summary

- Replaced backtick-wrapped runnable commands with single-quoted command spans across CLI, command, and library diagnostics.
- Kept the `crew cleanup` and `sbx create` examples single-quoted so surrounding prose and punctuation cannot be mistaken for part of the command.
- Updated existing tests to assert the single-quoted forms and reject backticks, including public worktree-removal behavior.
- Consolidated duplicate worktree test fixtures.
- Updated repository guidance and generated Linear task descriptions to use `cb-work`.

This changes message text only; runtime control flow is unchanged.

## Validation

- Focused red/green run: 4 files, 285 tests passed.
- `node --run verify`: all 10 checks passed.
- Pre-push verification: 85 test files and 2,091 tests passed with 100% statement, branch, function, and line coverage.
- Build, lint, format, architecture, duplication, dependency, Markdown, and package-consistency checks passed.

## Notes

- Backticks that represent configuration keys or identifiers, rather than runnable shell commands, remain out of scope.
- Single quotes prevent shell command substitution for the command span but do not fully shell-escape interpolated values; hardening interpolation is separate follow-up work.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.1</code></sub>
