### PR TITLE
fix(cleaner): stop re-logging identical cleanup failures every poll

### DIFF
--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -6,7 +6,7 @@ import type { BoardState } from "../lib/taskSource.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
-import { createCleaner } from "./cleaner.ts";
+import { type Cleaner, createCleaner } from "./cleaner.ts";
 
 vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -260,5 +260,84 @@ describe(createCleaner, () => {
     });
 
     expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry], { signal });
+  });
+
+  function linesContaining(needle: string): string[] {
+    return consoleLog.calls.map((call) => call.join(" ")).filter((line) => line.includes(needle));
+  }
+
+  function removeFailure(message: string): void {
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        failures: [
+          {
+            entry: hostEntryFor("repo-a", "team-1"),
+            step: "worktree_remove",
+            error: new Error(message),
+          },
+        ],
+      }),
+    );
+  }
+
+  async function pollTimes(count: number, cleaner: Cleaner): Promise<void> {
+    for (let poll = 0; poll < count; poll += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- each poll must observe the previous poll's outcome
+      await cleaner.runOnce({
+        state: boardOf([canonicalLinearIssue({ naturalId: "team-1", status: "done" })]),
+        worktreeEntries: [hostEntryFor("repo-a", "team-1")],
+        dryRun: false,
+      });
+    }
+  }
+
+  it("logs an unresolvable cleanup failure once across polls", async () => {
+    const cleaner = createCleaner({ config: makeConfig() });
+    removeFailure("worktree has 1 modified file and 2 untracked files");
+
+    await pollTimes(3, cleaner);
+
+    expect(linesContaining("Cleanup failed for team-1")).toHaveLength(1);
+    expect(teardownMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("logs the failure again when the dirty-file count changes", async () => {
+    const cleaner = createCleaner({ config: makeConfig() });
+    removeFailure("worktree has 1 modified file and 2 untracked files");
+    await pollTimes(1, cleaner);
+    removeFailure("worktree has 1 modified file and 3 untracked files");
+
+    await pollTimes(1, cleaner);
+
+    expect(linesContaining("Cleanup failed for team-1")).toEqual([
+      expect.stringContaining("2 untracked files"),
+      expect.stringContaining("3 untracked files"),
+    ]);
+  });
+
+  it("announces the failure again after it clears and recurs", async () => {
+    const cleaner = createCleaner({ config: makeConfig() });
+    removeFailure("worktree has 1 modified file");
+    await pollTimes(1, cleaner);
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({ removed: [hostEntryFor("repo-a", "team-1")] }),
+    );
+    await pollTimes(1, cleaner);
+    removeFailure("worktree has 1 modified file");
+
+    await pollTimes(1, cleaner);
+
+    expect(linesContaining("Cleanup failed for team-1")).toHaveLength(2);
+  });
+
+  it("summarizes a still-blocked worktree after thirty polls", async () => {
+    const cleaner = createCleaner({ config: makeConfig() });
+    removeFailure("worktree has 1 modified file");
+
+    await pollTimes(30, cleaner);
+
+    expect(
+      linesContaining("Cleanup still blocked for team-1 (host) after 30 attempts"),
+    ).toHaveLength(1);
   });
 });

--- a/src/commands/cleaner.test.ts
+++ b/src/commands/cleaner.test.ts
@@ -340,4 +340,18 @@ describe(createCleaner, () => {
       linesContaining("Cleanup still blocked for team-1 (host) after 30 attempts"),
     ).toHaveLength(1);
   });
+
+  it("keeps the batch announcement off the console", async () => {
+    setVerbose(false);
+    const cleaner = createCleaner({ config: makeConfig() });
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({ removed: [hostEntryFor("repo-a", "team-1")] }),
+    );
+
+    await pollTimes(1, cleaner);
+
+    const out = consoleLog.output();
+    expect(out).not.toContain("terminal worktree(s)");
+    expect(out).toContain("Cleanup complete for team-1");
+  });
 });

--- a/src/commands/cleaner.ts
+++ b/src/commands/cleaner.ts
@@ -9,7 +9,7 @@
 import type { ResolvedConfig } from "../lib/config.ts";
 import { createRepeatedFailureLog } from "../lib/repeatedFailures.ts";
 import { naturalIdFromCanonical, type BoardState } from "../lib/taskSource.ts";
-import { log, logEvent } from "../lib/util.ts";
+import { debug, log, logEvent } from "../lib/util.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { reapWorktrees } from "./teardownReporter.ts";
 
@@ -68,7 +68,7 @@ export function createCleaner(deps: CleanerDeps): Cleaner {
       return;
     }
 
-    log(`Cleaning up ${stale.length} terminal worktree(s)`);
+    debug(`Cleaning up ${stale.length} terminal worktree(s)`);
     await reapWorktrees(config, stale, { signal, failureLog });
   }
 

--- a/src/commands/cleaner.ts
+++ b/src/commands/cleaner.ts
@@ -1,10 +1,13 @@
 /**
  * Per-iteration scanner that closes workspaces and removes worktrees for
  * tasks that have reached a terminal status. One per `orchestrate()`
- * invocation; stateless across iterations. Mirrors `Dispatcher`.
+ * invocation; the only state it carries across iterations is the recurrence
+ * log that keeps a persistent cleanup failure from re-logging every poll.
+ * Mirrors `Dispatcher`.
  */
 
 import type { ResolvedConfig } from "../lib/config.ts";
+import { createRepeatedFailureLog } from "../lib/repeatedFailures.ts";
 import { naturalIdFromCanonical, type BoardState } from "../lib/taskSource.ts";
 import { log, logEvent } from "../lib/util.ts";
 import type { WorktreeEntry } from "../lib/worktrees.ts";
@@ -25,6 +28,7 @@ export interface Cleaner {
 
 export function createCleaner(deps: CleanerDeps): Cleaner {
   const { config } = deps;
+  const failureLog = createRepeatedFailureLog();
 
   async function runOnce(arguments_: {
     state: BoardState;
@@ -65,7 +69,7 @@ export function createCleaner(deps: CleanerDeps): Cleaner {
     }
 
     log(`Cleaning up ${stale.length} terminal worktree(s)`);
-    await reapWorktrees(config, stale, signal);
+    await reapWorktrees(config, stale, { signal, failureLog });
   }
 
   return { runOnce };

--- a/src/commands/reviewer.ts
+++ b/src/commands/reviewer.ts
@@ -242,7 +242,7 @@ export function createReviewer(deps: ReviewerDeps): Reviewer {
       });
       if (transition === "done" && reviewerConfig !== undefined) {
         try {
-          await reapWorktrees(reviewerConfig, [entry], signal);
+          await reapWorktrees(reviewerConfig, [entry], { signal });
         } catch (teardownError) {
           log(`Teardown failed for ${task}: ${errorMessage(teardownError)}`);
         }

--- a/src/commands/teardownReporter.test.ts
+++ b/src/commands/teardownReporter.test.ts
@@ -1,10 +1,16 @@
 import type { ResolvedConfig } from "../lib/config.ts";
+import { createRepeatedFailureLog } from "../lib/repeatedFailures.ts";
 import { removeRunState } from "../lib/runState.ts";
 import { setVerbose } from "../lib/util.ts";
 import { type TeardownResult, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
-import { logTeardown, reapWorktrees, recordTeardownEvents } from "./teardownReporter.ts";
+import {
+  logTeardown,
+  reapWorktrees,
+  recordTeardownEvents,
+  type TeardownReportOptions,
+} from "./teardownReporter.ts";
 
 vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -263,7 +269,7 @@ describe(reapWorktrees, () => {
     const { signal } = new AbortController();
     const entry = hostEntry("team-1");
 
-    await reapWorktrees(makeConfig(), [entry], signal);
+    await reapWorktrees(makeConfig(), [entry], { signal });
 
     expect(teardownMock).toHaveBeenCalledWith(expect.anything(), [entry], { signal });
   });
@@ -294,5 +300,121 @@ describe(reapWorktrees, () => {
     const actual = await reapWorktrees(makeConfig(), [entry]);
 
     expect(actual).toBe(expected);
+  });
+
+  function linesContaining(needle: string): string[] {
+    return consoleLog.calls.map((call) => call.join(" ")).filter((line) => line.includes(needle));
+  }
+
+  function removeFailure(message: string): TeardownResult {
+    return emptyTeardownResult({
+      failures: [
+        { entry: hostEntry("team-1"), step: "worktree_remove", error: new Error(message) },
+      ],
+    });
+  }
+
+  async function reapTimes(count: number, options: TeardownReportOptions): Promise<void> {
+    for (let attempt = 0; attempt < count; attempt += 1) {
+      // oxlint-disable-next-line no-await-in-loop -- each poll must observe the previous poll's outcome
+      await reapWorktrees(makeConfig(), [hostEntry("team-1")], options);
+    }
+  }
+
+  it("logs a repeated worktree_remove failure only once", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(removeFailure("worktree has 1 modified file"));
+
+    await reapTimes(2, { failureLog });
+
+    expect(linesContaining("Cleanup failed for team-1")).toHaveLength(1);
+    expect(teardownMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs a failure again when its message changes", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(removeFailure("worktree has 1 modified file"));
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")], { failureLog });
+    teardownMock.mockResolvedValue(removeFailure("worktree has 2 modified files"));
+
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")], { failureLog });
+
+    expect(linesContaining("Cleanup failed for team-1")).toEqual([
+      expect.stringContaining("worktree has 1 modified file"),
+      expect.stringContaining("worktree has 2 modified files"),
+    ]);
+  });
+
+  it("logs a still-blocked summary on the thirtieth unchanged attempt", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(removeFailure("worktree has 1 modified file"));
+
+    await reapTimes(30, { failureLog });
+
+    expect(linesContaining("Cleanup failed for team-1")).toHaveLength(1);
+    expect(linesContaining("Cleanup still blocked for team-1 (host) after 30 attempts")).toEqual([
+      expect.stringContaining("worktree has 1 modified file"),
+    ]);
+  });
+
+  it("logs a still-failing summary for a repeated workspace_close failure", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        failures: [
+          { entry: hostEntry("team-1"), step: "workspace_close", error: new Error("cmux down") },
+        ],
+      }),
+    );
+
+    await reapTimes(30, { failureLog });
+
+    expect(linesContaining("workspace close failed for team-1")).toHaveLength(1);
+    expect(linesContaining("workspace close still failing for team-1 after 30 attempts")).toEqual([
+      expect.stringContaining("cmux down"),
+    ]);
+  });
+
+  it("emits the repeat count on cleanup failure events", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(removeFailure("worktree has 1 modified file"));
+
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")], { failureLog });
+    expect(linesContaining("event=cleanup outcome=failed")).toEqual([
+      expect.stringContaining("repeats=1"),
+    ]);
+
+    const beforeSuppressedPoll = consoleLog.calls.length;
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")], { failureLog });
+    expect(consoleLog.calls.slice(beforeSuppressedPoll)).toEqual([]);
+
+    await reapTimes(28, { failureLog });
+    expect(linesContaining("event=cleanup outcome=failed")).toEqual([
+      expect.stringContaining("repeats=1"),
+      expect.stringContaining("repeats=30"),
+    ]);
+  });
+
+  it("reports every occurrence when no failure log is given", async () => {
+    teardownMock.mockResolvedValue(removeFailure("worktree has 1 modified file"));
+
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")]);
+    await reapWorktrees(makeConfig(), [hostEntry("team-1")]);
+
+    expect(linesContaining("Cleanup failed for team-1")).toHaveLength(2);
+  });
+
+  it("announces a repeated workspace list failure once", async () => {
+    const failureLog = createRepeatedFailureLog();
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        workspaceProbe: { kind: "unavailable", error: new Error("cmux exploded") },
+      }),
+    );
+
+    await reapTimes(2, { failureLog });
+
+    expect(linesContaining("workspace list failed:")).toHaveLength(1);
+    expect(linesContaining("reason=workspace_list_failed")).toHaveLength(1);
   });
 });

--- a/src/commands/teardownReporter.ts
+++ b/src/commands/teardownReporter.ts
@@ -1,26 +1,56 @@
 import type { ResolvedConfig } from "../lib/config.ts";
+import type {
+  FailureObservation,
+  FailureOccurrence,
+  RepeatedFailureLog,
+} from "../lib/repeatedFailures.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
 import { debug, errorMessage, log, logEvent, okMark } from "../lib/util.ts";
-import { type TeardownResult, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import {
+  type TeardownFailure,
+  type TeardownResult,
+  type WorktreeEntry,
+  worktrees,
+} from "../lib/worktrees.ts";
 
-export function logTeardown(result: TeardownResult): void {
-  if (result.workspaceProbe.kind === "unavailable" && result.workspaceProbe.error !== undefined) {
+export interface TeardownReportOptions {
+  signal?: AbortSignal | undefined;
+  /**
+   * Recurrence tracker shared across polls. Omit it — as one-shot callers do —
+   * to report every occurrence verbatim.
+   */
+  failureLog?: RepeatedFailureLog | undefined;
+}
+
+export function logTeardown(
+  result: TeardownResult,
+  observations?: ReadonlyMap<string, FailureObservation>,
+): void {
+  if (
+    result.workspaceProbe.kind === "unavailable" &&
+    result.workspaceProbe.error !== undefined &&
+    observationFor(observations, WORKSPACE_LIST_KEY).recurrence !== "suppressed"
+  ) {
     log(`workspace list failed: ${errorMessage(result.workspaceProbe.error)}`);
   }
+
   for (const task of result.closed) {
     debug(`Closed workspace ${task}`);
   }
+
   for (const entry of result.removed) {
     log(`${okMark()} Cleanup complete for ${entry.task} (${entry.kind})`);
     debug(`  Worktree: ${entry.dir} (removed)`);
   }
+
   for (const failure of result.failures) {
     const message = errorMessage(failure.error);
-    if (failure.step === "workspace_close") {
-      log(`workspace close failed for ${failure.entry.task}: ${message}`);
-    } else {
-      log(`Cleanup failed for ${failure.entry.task} (${failure.entry.kind}): ${message}`);
+    const { recurrence, repeats } = observationFor(observations, failureKey(failure));
+    if (recurrence === "suppressed") {
+      continue;
     }
+
+    log(failureLine({ failure, message, ongoing: recurrence === "ongoing", repeats }));
   }
 }
 
@@ -32,31 +62,42 @@ export function logTeardown(result: TeardownResult): void {
 export async function reapWorktrees(
   config: ResolvedConfig,
   entries: readonly WorktreeEntry[],
-  signal?: AbortSignal,
+  options: TeardownReportOptions = {},
 ): Promise<TeardownResult> {
+  const { signal, failureLog } = options;
   const result =
     signal === undefined
       ? await worktrees.teardown(config, entries)
       : await worktrees.teardown(config, entries, { signal });
   recordCleanedUpRuns(config, result.removed);
-  logTeardown(result);
-  recordTeardownEvents(result);
+  const observations = failureLog?.observeAll({ occurrences: failureOccurrences(result) });
+  logTeardown(result, observations);
+  recordTeardownEvents(result, observations);
   return result;
 }
 
-export function recordTeardownEvents(result: TeardownResult): void {
+export function recordTeardownEvents(
+  result: TeardownResult,
+  observations?: ReadonlyMap<string, FailureObservation>,
+): void {
   if (result.workspaceProbe.kind === "unavailable") {
-    logEvent("cleanup", {
-      outcome: "failed",
-      reason: "workspace_list_failed",
-      ...(result.workspaceProbe.error === undefined
-        ? {}
-        : { error: errorMessage(result.workspaceProbe.error) }),
-    });
+    const { recurrence, repeats } = observationFor(observations, WORKSPACE_LIST_KEY);
+    if (recurrence !== "suppressed") {
+      logEvent("cleanup", {
+        outcome: "failed",
+        reason: "workspace_list_failed",
+        ...(result.workspaceProbe.error === undefined
+          ? {}
+          : { error: errorMessage(result.workspaceProbe.error) }),
+        repeats,
+      });
+    }
   }
+
   for (const task of result.closed) {
     logEvent("cleanup", { outcome: "workspace_closed", task });
   }
+
   for (const entry of result.removed) {
     logEvent("cleanup", {
       outcome: "cleaned",
@@ -65,14 +106,21 @@ export function recordTeardownEvents(result: TeardownResult): void {
       kind: entry.kind,
     });
   }
+
   for (const failure of result.failures) {
     const message = errorMessage(failure.error);
+    const { recurrence, repeats } = observationFor(observations, failureKey(failure));
+    if (recurrence === "suppressed") {
+      continue;
+    }
+
     if (failure.step === "workspace_close") {
       logEvent("cleanup", {
         outcome: "failed",
         reason: "workspace_close_failed",
         task: failure.entry.task,
         error: message,
+        repeats,
       });
     } else {
       logEvent("cleanup", {
@@ -81,7 +129,60 @@ export function recordTeardownEvents(result: TeardownResult): void {
         repository: failure.entry.repository,
         kind: failure.entry.kind,
         error: message,
+        repeats,
       });
     }
   }
+}
+
+const WORKSPACE_LIST_KEY = "workspace_list";
+
+const untrackedFailure: FailureObservation = { recurrence: "first", repeats: 1 };
+
+function observationFor(
+  observations: ReadonlyMap<string, FailureObservation> | undefined,
+  key: string,
+): FailureObservation {
+  return observations?.get(key) ?? untrackedFailure;
+}
+
+function failureKey(failure: TeardownFailure): string {
+  const { entry, step } = failure;
+  return `${step}:${entry.repository}:${entry.task}:${entry.kind}`;
+}
+
+function failureOccurrences(result: TeardownResult): FailureOccurrence[] {
+  const occurrences: FailureOccurrence[] = [];
+  if (result.workspaceProbe.kind === "unavailable") {
+    occurrences.push({
+      key: WORKSPACE_LIST_KEY,
+      message:
+        result.workspaceProbe.error === undefined ? "" : errorMessage(result.workspaceProbe.error),
+    });
+  }
+
+  for (const failure of result.failures) {
+    occurrences.push({ key: failureKey(failure), message: errorMessage(failure.error) });
+  }
+
+  return occurrences;
+}
+
+function failureLine(arguments_: {
+  failure: TeardownFailure;
+  message: string;
+  ongoing: boolean;
+  repeats: number;
+}): string {
+  const { failure, message, ongoing, repeats } = arguments_;
+  const { entry, step } = failure;
+  if (step === "workspace_close") {
+    return ongoing
+      ? `workspace close still failing for ${entry.task} after ${repeats} attempts: ${message}`
+      : `workspace close failed for ${entry.task}: ${message}`;
+  }
+
+  return ongoing
+    ? `Cleanup still blocked for ${entry.task} (${entry.kind}) after ${repeats} attempts: ${message}`
+    : `Cleanup failed for ${entry.task} (${entry.kind}): ${message}`;
 }

--- a/src/lib/repeatedFailures.test.ts
+++ b/src/lib/repeatedFailures.test.ts
@@ -1,0 +1,73 @@
+import { createRepeatedFailureLog } from "./repeatedFailures.ts";
+
+describe(createRepeatedFailureLog, () => {
+  it("reports a newly seen failure as first", () => {
+    const failureLog = createRepeatedFailureLog();
+
+    const actual = failureLog.observeAll({
+      occurrences: [{ key: "team-1", message: "worktree is dirty" }],
+    });
+
+    expect(actual.get("team-1")).toEqual({ recurrence: "first", repeats: 1 });
+  });
+
+  it("suppresses an unchanged repeat", () => {
+    const failureLog = createRepeatedFailureLog();
+    const occurrences = [{ key: "team-1", message: "worktree is dirty" }];
+    failureLog.observeAll({ occurrences });
+
+    const actual = failureLog.observeAll({ occurrences });
+
+    expect(actual.get("team-1")).toEqual({ recurrence: "suppressed", repeats: 2 });
+  });
+
+  it("reports a changed message and restarts the count", () => {
+    const failureLog = createRepeatedFailureLog();
+    failureLog.observeAll({ occurrences: [{ key: "team-1", message: "1 untracked file" }] });
+
+    const actual = failureLog.observeAll({
+      occurrences: [{ key: "team-1", message: "2 untracked files" }],
+    });
+
+    expect(actual.get("team-1")).toEqual({ recurrence: "changed", repeats: 1 });
+  });
+
+  it("reports an ongoing summary every thirtieth unchanged repeat", () => {
+    const failureLog = createRepeatedFailureLog();
+    const occurrences = [{ key: "team-1", message: "worktree is dirty" }];
+
+    const actual = Array.from({ length: 60 }, () =>
+      failureLog.observeAll({ occurrences }).get("team-1"),
+    );
+
+    expect(actual[29]).toEqual({ recurrence: "ongoing", repeats: 30 });
+    expect(actual[30]).toEqual({ recurrence: "suppressed", repeats: 31 });
+    expect(actual[59]).toEqual({ recurrence: "ongoing", repeats: 60 });
+  });
+
+  it("tracks each key independently within one batch", () => {
+    const failureLog = createRepeatedFailureLog();
+    failureLog.observeAll({ occurrences: [{ key: "team-1", message: "worktree is dirty" }] });
+
+    const actual = failureLog.observeAll({
+      occurrences: [
+        { key: "team-1", message: "worktree is dirty" },
+        { key: "team-2", message: "workspace is locked" },
+      ],
+    });
+
+    expect(actual.get("team-1")).toEqual({ recurrence: "suppressed", repeats: 2 });
+    expect(actual.get("team-2")).toEqual({ recurrence: "first", repeats: 1 });
+  });
+
+  it("forgets a key that is absent from a later batch", () => {
+    const failureLog = createRepeatedFailureLog();
+    const occurrences = [{ key: "team-1", message: "worktree is dirty" }];
+    failureLog.observeAll({ occurrences });
+    failureLog.observeAll({ occurrences: [] });
+
+    const actual = failureLog.observeAll({ occurrences });
+
+    expect(actual.get("team-1")).toEqual({ recurrence: "first", repeats: 1 });
+  });
+});

--- a/src/lib/repeatedFailures.ts
+++ b/src/lib/repeatedFailures.ts
@@ -1,0 +1,77 @@
+/**
+ * In-memory recurrence tracker that lets a polling loop announce a failure when
+ * it starts, when its message changes, and periodically while it persists,
+ * without re-logging the identical line on every poll.
+ */
+
+type FailureRecurrence = "changed" | "first" | "ongoing" | "suppressed";
+
+export interface FailureOccurrence {
+  key: string;
+  message: string;
+}
+
+export interface FailureObservation {
+  recurrence: FailureRecurrence;
+  repeats: number;
+}
+
+export interface RepeatedFailureLog {
+  /**
+   * Records one poll's complete set of failures and returns how each should be
+   * reported. Keys absent from `occurrences` are forgotten, so a failure that
+   * clears and later recurs is announced again — callers must therefore pass
+   * every failure they track, not a subset.
+   */
+  observeAll: (arguments_: {
+    occurrences: readonly FailureOccurrence[];
+  }) => ReadonlyMap<string, FailureObservation>;
+}
+
+const ONGOING_SUMMARY_INTERVAL = 30;
+
+export function createRepeatedFailureLog(): RepeatedFailureLog {
+  let tracked = new Map<string, FailureOccurrence & { repeats: number }>();
+
+  function observeAll(arguments_: {
+    occurrences: readonly FailureOccurrence[];
+  }): ReadonlyMap<string, FailureObservation> {
+    const { occurrences } = arguments_;
+    const nextTracked = new Map<string, FailureOccurrence & { repeats: number }>();
+    const observations = new Map<string, FailureObservation>();
+
+    for (const occurrence of occurrences) {
+      const previous = tracked.get(occurrence.key);
+      const unchanged = previous !== undefined && previous.message === occurrence.message;
+      const repeats = unchanged ? previous.repeats + 1 : 1;
+
+      nextTracked.set(occurrence.key, { ...occurrence, repeats });
+      observations.set(occurrence.key, {
+        recurrence: recurrenceOf({ previous, unchanged, repeats }),
+        repeats,
+      });
+    }
+
+    tracked = nextTracked;
+    return observations;
+  }
+
+  return { observeAll };
+}
+
+function recurrenceOf(arguments_: {
+  previous: FailureOccurrence | undefined;
+  unchanged: boolean;
+  repeats: number;
+}): FailureRecurrence {
+  const { previous, unchanged, repeats } = arguments_;
+  if (previous === undefined) {
+    return "first";
+  }
+
+  if (!unchanged) {
+    return "changed";
+  }
+
+  return repeats % ONGOING_SUMMARY_INTERVAL === 0 ? "ongoing" : "suppressed";
+}


### PR DESCRIPTION
## Why

A single worktree the orchestrator can never tear down produces one identical log line per poll, forever. On my machine that is 18,138 lines / 19.4 MB of:

```
[15:48:57] Cleanup failed for tg-4259 (host): worktree has 1 modified file and 2 untracked files. Run crew cleanup --force tg-4259 to discard them, or commit/stash in /Users/jason/.../cbh-admin-frontend-tg-4259 first.
```

`createCleaner` runs `reapWorktrees` on every 120s poll. Teardown hits the dirty-worktree data-loss guard, reports the same failure, and `logTeardown` prints it verbatim — with no memory of having just printed it. The `event=cleanup outcome=failed` line doubles the volume. The operator's main pane, which `zellijAdapter` tails from the log file, becomes unreadable.

This PR fixes the reporting. It deliberately does **not** touch the dirty-worktree guard or the `npm ci` hook that dirties worktrees in the first place — those are separate PRs.

## What

A new `src/lib/repeatedFailures.ts` holds a per-orchestrator, in-memory recurrence log. `createRepeatedFailureLog().observeAll({ occurrences })` takes one poll's complete set of failures and classifies each:

| recurrence   | when                        | reported as                                                   |
| ------------ | --------------------------- | ------------------------------------------------------------- |
| `first`      | key not seen last poll      | the existing line, verbatim                                     |
| `changed`    | same key, different message | the existing line, verbatim                                     |
| `ongoing`    | every 30th unchanged repeat | `Cleanup still blocked for <task> (<kind>) after N attempts:`    |
| `suppressed` | any other unchanged repeat  | nothing                                                         |

`createCleaner` constructs one log and threads it into `reapWorktrees` through a new options object (`{ signal?, failureLog? }`). One-shot callers — `crew cleanup` via `logTeardown`, and the reviewer's single-entry fast path — pass no log and keep reporting every occurrence verbatim, so a user who just asked for a cleanup is never shown a blank where a reason should be.

For one stuck worktree that is roughly 1,440 lines/day down to roughly 48.

### Design notes

- **Teardown still runs every poll.** Only the reporting is coalesced. The attempt is one `git status --porcelain`; skipping it would delay real cleanup once the operator clears the dirt. This is not backoff.
- **The first occurrence is never swallowed.** The operator learns about a blocker on the poll it appears.
- **A changed message always re-announces.** A change is real news, and a silent slot would otherwise let a different failure (worktree locked, disk full) hide behind a suppressed one.
- **Not log-once-and-never-again.** An operator attaching an hour later would see a healthy-looking log. The hourly "still blocked after N attempts" heartbeat is the deliberate cost of not going fully silent.
- **`observeAll` forgets keys absent from the batch**, so a failure that clears and later recurs is announced again. Documented on the interface: callers must hand over every failure they track, not a subset.
- **In-memory and per-`orchestrate()`.** A restarted orchestrator re-announces every still-blocked worktree once — deliberate; the person who just restarted is exactly the person who wants to see current blockers.

### Telemetry change worth a reviewer's attention

`event=cleanup outcome=failed` becomes edge-triggered rather than one-per-poll, and carries a new cumulative `repeats=N`. `max(repeats)` recovers the true occurrence count exactly. There is no machine consumer of this stream today (`grep -rn 'getLogFile' src` finds only `zellijAdapter` tailing the file for a human), and leaving it per-poll would have left roughly half the spam in the file the operator actually watches.

The third commit demotes `Cleaning up N terminal worktree(s)` from `log()` to `debug()` — it repeats every poll for the same reason and is fully subsumed by the per-entry lines that follow. Kept as its own commit so it can be dropped independently.

## Validation

Red/green/refactor throughout: `src/lib/repeatedFailures.test.ts`, the new cases in `src/commands/teardownReporter.test.ts`, and the user-visible regression in `src/commands/cleaner.test.ts` were each written and watched fail before the implementation existed.

The regression test that encodes the bug:

```
logs an unresolvable cleanup failure once across polls
  -> one "Cleanup failed for team-1" line after 3 polls
  -> teardown still called 3 times
```

`node --run verify`:

- `test`: 13 failed | 2096 passed (2109), 86 files. All 13 are the pre-existing `openWorkspace.test.ts` / `cmuxIntegration.addDirs is not iterable` failures present on `main`. No new failures.
- Coverage of the three touched source files from their own suites: 100% statements / branches / functions / lines (93/93, 48/48, 15/15, 92/92).
- `architecture:check`, `cpd`, `format:check`, `knip`, `markdown:lint`, `syncpack:lint`: green.
- `build`: only the pre-existing `agentLaunch.ts(164,26) TS2339 addDirs` error.
- `lint`: fails locally with `Rule 'no-top-level-await' not found in plugin 'node'` — my sandbox's `node_modules` carries oxlint 1.73.0 while `main` pins 1.76.0. Re-run under `oxlint@1.76.0` the branch is clean apart from the same pre-existing `addDirs` errors. CI should be green here.
