### PR TITLE
style: apply oxfmt formatting to two test files

### DIFF
--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -18,13 +18,10 @@ interface NodeFsMock {
   statSync: ReturnType<typeof vi.fn<typeof statSync>>;
 }
 
-vi.mock(
-  "node:fs",
-  (): NodeFsMock => ({
-    existsSync: vi.fn<typeof existsSync>(),
-    statSync: vi.fn<typeof statSync>(),
-  }),
-);
+vi.mock("node:fs", (): NodeFsMock => ({
+  existsSync: vi.fn<typeof existsSync>(),
+  statSync: vi.fn<typeof statSync>(),
+}));
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {

--- a/src/lib/commandRunner.test.ts
+++ b/src/lib/commandRunner.test.ts
@@ -12,13 +12,10 @@ interface ChildProcessMockModule {
   spawn: typeof spawnMock;
 }
 
-vi.mock(
-  "node:child_process",
-  (): ChildProcessMockModule => ({
-    execFileSync: vi.fn<typeof execFileSync>(),
-    spawn: spawnMock,
-  }),
-);
+vi.mock("node:child_process", (): ChildProcessMockModule => ({
+  execFileSync: vi.fn<typeof execFileSync>(),
+  spawn: spawnMock,
+}));
 
 const execFileMock = vi.mocked(execFileSync);
 


### PR DESCRIPTION
## Why

`node --run format:check` fails on clean `main` for `src/commands/doctor.test.ts` and `src/lib/commandRunner.test.ts` (formatter-idiom drift, likely from an oxfmt version bump landing without a reformat). Since `verify` runs in the pre-push hook, this blocks every push from a clean checkout.

## Validation

`node --run verify` passes locally with this change (it failed before on `format:check` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA27vNJ5AjUFpEo1ZcAHBc