### PR TITLE
perf: improve Linear doctor responsiveness (DEVOP-6369)

### DIFF
--- a/v2/e2e/doctor.e2e.test.ts
+++ b/v2/e2e/doctor.e2e.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -26,6 +26,37 @@ describe("crew doctor", () => {
     expect(result.stdout).toContain("fixture (user, protocol 1)");
     expect(result.stdout).toContain("live list probe");
     expect(result.stdout).toContain("healthy");
+  });
+
+  it("shows prerequisite checks while live source probes are still running", async () => {
+    const fixture = await createFixture({ waitForListRelease: true });
+    const child = spawn("bin/run.js", ["doctor"], {
+      cwd: process.cwd(),
+      env: fixture.environment,
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    const completed = new Promise<number | null>((resolvePromise, reject) => {
+      child.once("error", reject);
+      child.once("close", resolvePromise);
+    });
+
+    try {
+      await waitForOutput({ expected: "waiting for live source probes", read: () => stdout });
+
+      expect(child.exitCode).toBeNull();
+      expect(stdout).toContain("✓ Node.js 24+");
+      expect(stdout).toContain("✓ git: available");
+      expect(stdout).not.toContain("live list probe: healthy");
+    } finally {
+      await writeFile(fixture.listReleasePath, "release\n");
+    }
+
+    const exitCode = await completed;
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("live list probe: healthy");
   });
 
   it("names missing secrets and unsupported protocol versions", async () => {
@@ -119,14 +150,16 @@ async function createFixture(
     readonly prerequisiteFromManifest?: boolean | undefined;
     readonly protocolVersion?: number | undefined;
     readonly secrets?: readonly string[] | undefined;
+    readonly waitForListRelease?: boolean | undefined;
   } = {},
-): Promise<{ readonly environment: NodeJS.ProcessEnv }> {
+): Promise<{ readonly environment: NodeJS.ProcessEnv; readonly listReleasePath: string }> {
   const root = await mkdtemp(join(tmpdir(), "groundcrew-v2-doctor-"));
   fixtureRoots.push(root);
   const configHome = join(root, "config");
   const kind = options.kind ?? "fixture";
   const sourceDirectory = join(configHome, "groundcrew", "task-sources", kind);
   const tasksPath = join(root, "tasks.json");
+  const listReleasePath = join(root, "list-release");
   const updatesPath = join(root, "updates.jsonl");
   const prerequisiteDirectory = join(root, "prerequisites");
   const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
@@ -181,10 +214,27 @@ async function createFixture(
       ...process.env,
       FIXTURE_TASKS: tasksPath,
       FIXTURE_UPDATES: updatesPath,
+      ...(options.waitForListRelease === true ? { FIXTURE_LIST_RELEASE: listReleasePath } : {}),
       GROUNDCREW_CONFIG: configPath,
       PATH: `${fakeBin}:${process.env["PATH"]}`,
       XDG_CONFIG_HOME: configHome,
       XDG_STATE_HOME: join(root, "state"),
     },
+    listReleasePath,
   };
+}
+
+async function waitForOutput(input: {
+  readonly expected: string;
+  readonly read: () => string;
+}): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!input.read().includes(input.expected)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for output: ${input.expected}`);
+    }
+    await new Promise((resolvePromise) => {
+      setTimeout(resolvePromise, 10);
+    });
+  }
 }

--- a/v2/e2e/fixtures/source/list
+++ b/v2/e2e/fixtures/source/list
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 
 await readStandardInput();
 if (process.env.FIXTURE_LIST_FAILURE === "1") {
   process.stderr.write("fixture list failed\n");
   process.exit(7);
+}
+if (process.env.FIXTURE_LIST_RELEASE !== undefined) {
+  for (;;) {
+    try {
+      await access(process.env.FIXTURE_LIST_RELEASE);
+      break;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+      await delay(10);
+    }
+  }
 }
 const tasks = JSON.parse(
   await readFile(process.env.FIXTURE_LIST_TASKS ?? process.env.FIXTURE_TASKS, "utf8"),

--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -47,11 +47,38 @@ describe("the shipped Linear source", () => {
 
   it("paginates list queries beneath Linear's complexity limit", async () => {
     await fixture.close();
-    fixture = await createLinearFixture({ listedTaskCount: 21 });
+    fixture = await createLinearFixture({ listedTaskCount: 251 });
 
     const doctor = await runCrew({ arguments: ["doctor"], environment: fixture.environment });
 
-    expect(doctor.stdout).toContain("live list probe: healthy (21 tasks)");
+    expect(doctor.stdout).toContain("live list probe: healthy (251 tasks)");
+  });
+
+  it("filters list queries before paginating while retaining actionable and terminal tasks", async () => {
+    await fixture.close();
+    fixture = await createLinearFixture({ filteringScenario: true, labelPrefix: "crew-" });
+
+    const result = await runLinearList({ environment: fixture.environment });
+    const response = JSON.parse(result.stdout);
+
+    expect(response.error).toBeUndefined();
+    expect(response.data.tasks).toEqual([
+      expect.objectContaining({ id: "LIN-ELIGIBLE", terminal: false }),
+      expect.objectContaining({ id: "LIN-COMPLETED", terminal: true }),
+    ]);
+    expect(fixture.state.listRequests).toHaveLength(1);
+    const request = fixture.state.listRequests[0];
+    expect(request?.query).toContain("assignee: { isMe: { eq: true } }");
+    expect(request?.query).toContain(
+      "labels: { some: { name: { startsWith: $agentLabelPrefix } } }",
+    );
+    expect(request?.query).toContain("state: { type: { in: $stateTypes } }");
+    expect(request?.query).toContain("first: 250");
+    expect(request?.query).toContain("includeArchived: false");
+    expect(request?.variables).toMatchObject({
+      agentLabelPrefix: "crew-",
+      stateTypes: ["unstarted", "started", "completed", "canceled", "duplicate"],
+    });
   });
 
   it("recognizes a singular Repository header", async () => {
@@ -98,19 +125,31 @@ describe("the shipped Linear source", () => {
 
 interface LinearState {
   comments: string[];
+  listRequests: Array<{ query: string; variables: Record<string, unknown> }>;
   stateName: string;
   stateType: string;
 }
 
 async function createLinearFixture(
-  input: { readonly issueDescription?: string; readonly listedTaskCount?: number } = {},
+  input: {
+    readonly filteringScenario?: boolean;
+    readonly issueDescription?: string;
+    readonly labelPrefix?: string;
+    readonly listedTaskCount?: number;
+  } = {},
 ): Promise<{
   readonly close: () => Promise<void>;
   readonly environment: NodeJS.ProcessEnv;
   readonly state: LinearState;
 }> {
   const listedTaskCount = input.listedTaskCount ?? 1;
-  const state: LinearState = { comments: [], stateName: "Todo", stateType: "unstarted" };
+  const state: LinearState = {
+    comments: [],
+    listRequests: [],
+    stateName: "Todo",
+    stateType: "unstarted",
+  };
+  const labelPrefix = input.labelPrefix ?? "agent-";
   const server = createServer(async (request, response) => {
     try {
       let raw = "";
@@ -121,32 +160,41 @@ async function createLinearFixture(
       const issue = linearIssue({ description: input.issueDescription, state });
       let data;
       if (body.operationName === "GroundcrewList") {
-        if (listedTaskCount > 20 && !body.query.includes("first: 20")) {
-          response.statusCode = 400;
-          response.setHeader("Content-Type", "application/json");
-          response.end(JSON.stringify({ errors: [{ message: "Unexpected page size" }] }));
-          return;
-        }
+        state.listRequests.push({ query: body.query, variables: body.variables });
+        const listedIssues = input.filteringScenario
+          ? filteringScenarioIssues({ labelPrefix, state })
+          : Array.from({ length: listedTaskCount }, (_, index) =>
+              linearIssue({
+                description: input.issueDescription,
+                identifier: `LIN-${index + 1}`,
+                state,
+              }),
+            );
+        const usesServerFilters = body.query.includes("issues(");
+        const stateTypes = Array.isArray(body.variables.stateTypes)
+          ? body.variables.stateTypes
+          : [];
+        const requestedLabelPrefix = body.variables.agentLabelPrefix;
+        const candidateIssues = usesServerFilters
+          ? listedIssues.filter(
+              (listedIssue) =>
+                stateTypes.includes(listedIssue.state.type) &&
+                listedIssue.labels.nodes.some((label) =>
+                  label.name.startsWith(requestedLabelPrefix),
+                ),
+            )
+          : listedIssues;
+        const pageSize = body.query.includes("first: 250") ? 250 : 20;
         const pageStart = body.variables.after === undefined ? 0 : Number(body.variables.after);
-        const pageEnd = Math.min(pageStart + 20, listedTaskCount);
-        const nodes = Array.from({ length: pageEnd - pageStart }, (_, offset) =>
-          linearIssue({
-            description: input.issueDescription,
-            identifier: `LIN-${pageStart + offset + 1}`,
-            state,
-          }),
-        );
-        data = {
-          viewer: {
-            assignedIssues: {
-              nodes,
-              pageInfo: {
-                endCursor: pageEnd < listedTaskCount ? String(pageEnd) : undefined,
-                hasNextPage: pageEnd < listedTaskCount,
-              },
-            },
+        const pageEnd = Math.min(pageStart + pageSize, candidateIssues.length);
+        const page = {
+          nodes: candidateIssues.slice(pageStart, pageEnd),
+          pageInfo: {
+            endCursor: pageEnd < candidateIssues.length ? String(pageEnd) : undefined,
+            hasNextPage: pageEnd < candidateIssues.length,
           },
         };
+        data = usesServerFilters ? { issues: page } : { viewer: { assignedIssues: page } };
       } else if (body.operationName === "GroundcrewIssue") {
         data = { issue };
       } else if (body.operationName === "GroundcrewComment") {
@@ -217,6 +265,8 @@ async function createLinearFixture(
       FAKE_CMUX_STATE: join(root, "cmux-state.json"),
       GROUNDCREW_CONFIG: configPath,
       LINEAR_API_KEY: "test-key",
+      LINEAR_API_URL: `http://127.0.0.1:${address.port}/graphql`,
+      LINEAR_GROUNDCREW_LABEL_PREFIX: labelPrefix,
       PATH: `${fakeBin}:${process.env["PATH"]}`,
       XDG_CONFIG_HOME: join(root, "config"),
       XDG_STATE_HOME: join(root, "state"),
@@ -228,7 +278,10 @@ async function createLinearFixture(
 function linearIssue(input: {
   readonly description?: string | undefined;
   readonly identifier?: string;
+  readonly labelNames?: readonly string[];
   readonly state: LinearState;
+  readonly stateName?: string;
+  readonly stateType?: string;
 }) {
   const identifier = input.identifier ?? "LIN-1";
   return {
@@ -245,10 +298,14 @@ function linearIssue(input: {
     id: `issue-${identifier}`,
     identifier,
     inverseRelations: { nodes: [] },
-    labels: { nodes: [{ name: "agent-codex" }] },
+    labels: { nodes: (input.labelNames ?? ["agent-codex"]).map((name) => ({ name })) },
     priority: 1,
     relations: { nodes: [] },
-    state: { id: "state-current", name: input.state.stateName, type: input.state.stateType },
+    state: {
+      id: "state-current",
+      name: input.stateName ?? input.state.stateName,
+      type: input.stateType ?? input.state.stateType,
+    },
     team: {
       states: {
         nodes: [
@@ -261,6 +318,43 @@ function linearIssue(input: {
   };
 }
 
+function filteringScenarioIssues(input: {
+  readonly labelPrefix: string;
+  readonly state: LinearState;
+}) {
+  return [
+    linearIssue({
+      identifier: "LIN-ELIGIBLE",
+      labelNames: [`${input.labelPrefix}codex`],
+      state: input.state,
+    }),
+    linearIssue({
+      identifier: "LIN-COMPLETED",
+      labelNames: [`${input.labelPrefix}codex`],
+      state: input.state,
+      stateName: "Done",
+      stateType: "completed",
+    }),
+    linearIssue({
+      identifier: "LIN-BACKLOG",
+      labelNames: [`${input.labelPrefix}codex`],
+      state: input.state,
+      stateName: "Backlog",
+      stateType: "backlog",
+    }),
+    linearIssue({
+      identifier: "LIN-TRIAGE",
+      labelNames: [`${input.labelPrefix}codex`],
+      state: input.state,
+      stateName: "Triage",
+      stateType: "triage",
+    }),
+    ...Array.from({ length: 247 }, (_, index) =>
+      linearIssue({ identifier: `LIN-UNRELATED-${index + 1}`, labelNames: [], state: input.state }),
+    ),
+  ];
+}
+
 async function runCrew(input: {
   readonly arguments: readonly string[];
   readonly environment: NodeJS.ProcessEnv;
@@ -268,5 +362,25 @@ async function runCrew(input: {
   return await execFileAsync(process.execPath, ["bin/run.js", ...input.arguments], {
     cwd: process.cwd(),
     env: input.environment,
+  });
+}
+
+async function runLinearList(input: {
+  readonly environment: NodeJS.ProcessEnv;
+}): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await new Promise((resolvePromise, reject) => {
+    const child = execFile(
+      process.execPath,
+      ["task-sources/linear/list"],
+      { cwd: process.cwd(), env: input.environment },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolvePromise({ stderr, stdout });
+      },
+    );
+    child.stdin?.end("{}");
   });
 }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -71,6 +71,10 @@ export interface DoctorResult {
   readonly sources: readonly SourceHealth[];
 }
 
+export interface DoctorInput {
+  readonly onPrerequisiteChecks?: ((checks: readonly HealthCheck[]) => void) | undefined;
+}
+
 export type VerdictReason =
   | "blocked"
   | "slots-full"
@@ -105,7 +109,7 @@ export interface StatusEntry {
 }
 
 export interface Application {
-  doctor(): Promise<DoctorResult>;
+  doctor(input?: DoctorInput): Promise<DoctorResult>;
   start(input: {
     readonly task?: string | undefined;
     readonly force: boolean;
@@ -170,8 +174,8 @@ export async function createApplication(input: {
   const runtime: Runtime = { config, environment, paths, registry, runs, workspaces };
   await reconcile({ runtime });
   return {
-    async doctor(): Promise<DoctorResult> {
-      return await doctor({ runtime });
+    async doctor(doctorInput = {}): Promise<DoctorResult> {
+      return await doctor({ ...doctorInput, runtime });
     },
     async start(
       startInput,
@@ -202,7 +206,7 @@ export async function createApplication(input: {
   };
 }
 
-async function doctor(input: { readonly runtime: Runtime }): Promise<DoctorResult> {
+async function doctor(input: DoctorInput & { readonly runtime: Runtime }): Promise<DoctorResult> {
   const { runtime } = input;
   const checks: HealthCheck[] = [
     {
@@ -225,6 +229,7 @@ async function doctor(input: { readonly runtime: Runtime }): Promise<DoctorResul
       ok: available,
     });
   }
+  input.onPrerequisiteChecks?.(checks);
   const sources = await runtime.registry.health();
   return {
     checks,

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -115,10 +115,14 @@ export async function main(input: MainInput): Promise<void> {
         environment,
         paths: loaded.paths,
       });
-      const result = await application.doctor();
-      for (const check of result.checks) {
-        process.stdout.write(`${check.ok ? "✓" : "✗"} ${check.name}: ${check.detail}\n`);
-      }
+      const result = await application.doctor({
+        onPrerequisiteChecks(checks) {
+          for (const check of checks) {
+            process.stdout.write(`${check.ok ? "✓" : "✗"} ${check.name}: ${check.detail}\n`);
+          }
+          process.stdout.write("… waiting for live source probes\n");
+        },
+      });
       for (const source of result.sources) {
         process.stdout.write(
           `${source.name} (${source.origin}, protocol ${source.protocolVersion ?? "unknown"})\n`,

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -13,6 +13,8 @@ const ISSUE_FIELDS = `
   comments { nodes { body createdAt } }
 `;
 
+const LIST_STATE_TYPES = ["unstarted", "started", "completed", "canceled", "duplicate"];
+
 export async function run(input) {
   try {
     const payload = await readStandardInput();
@@ -32,14 +34,29 @@ export async function run(input) {
 
 async function listTasks() {
   const issues = [];
+  const agentLabelPrefix = environment("LINEAR_GROUNDCREW_LABEL_PREFIX", "agent-");
   let after;
   for (;;) {
     const data = await graphql({
       operationName: "GroundcrewList",
-      query: `query GroundcrewList($after: String) { viewer { assignedIssues(first: 20, after: $after) { nodes { ${TASK_FIELDS} } pageInfo { endCursor hasNextPage } } } }`,
-      variables: { after },
+      query: `query GroundcrewList($after: String, $stateTypes: [String!]!, $agentLabelPrefix: String!) {
+        issues(
+          filter: {
+            assignee: { isMe: { eq: true } }
+            state: { type: { in: $stateTypes } }
+            labels: { some: { name: { startsWith: $agentLabelPrefix } } }
+          }
+          first: 250
+          after: $after
+          includeArchived: false
+        ) {
+          nodes { ${TASK_FIELDS} }
+          pageInfo { endCursor hasNextPage }
+        }
+      }`,
+      variables: { after, agentLabelPrefix, stateTypes: LIST_STATE_TYPES },
     });
-    const page = data.viewer?.assignedIssues;
+    const page = data.issues;
     issues.push(...(page?.nodes ?? []));
     if (page?.pageInfo?.hasNextPage !== true) {
       break;


### PR DESCRIPTION
## Why

Groundcrew v2's live Linear doctor probe queried every issue assigned to the authenticated viewer in pages of 20, then discarded non-agent and backlog/triage issues locally. Users with large assigned backlogs could therefore wait through many sequential GraphQL requests even when only a few tasks were relevant. This change reduces that operational delay without weakening the required live doctor probe.

The live probe can still take noticeable time, so doctor now streams completed prerequisite checks before starting it and prints a waiting indicator instead of leaving the CLI silent.

## Summary

- Query top-level Linear issues with server-side filters for the authenticated assignee, configured Groundcrew label prefix, and supported workflow state types.
- Exclude archived issues and increase the page size from 20 to 250 while retaining cursor pagination.
- Preserve local normalization and visibility for unstarted, started, completed, canceled, and duplicate tasks.
- Add source-protocol coverage proving 251 assigned issues collapse to one request when only two are eligible, including a terminal task and a non-default label prefix.
- Stream prerequisite results before live source probes finish and show a stable waiting indicator while they run.

## Validation

- `cd v2 && node --run verify` — 8 test files passed; 59 tests passed, 1 skipped.
- `cd v2 && node --run test -- e2e/linear.e2e.test.ts` — 5 tests passed.
- `cd v2 && node --run test -- e2e/doctor.e2e.test.ts` — 8 tests passed, including streamed output while the source list is blocked.
- Authenticated live Linear doctor checkpoint not run: 1Password CLI reported no active sign-in before any Linear request was made.

## Notes

- [DEVOP-6369](https://linear.app/clipboard/issue/DEVOP-6369)
- Agent session: `codex resume 019fdda1-7441-7873-8cff-c5ea903b5461`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
