### PR TITLE
fix: return failed Linear runs to Todo

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -317,8 +317,16 @@ describe("crew start", () => {
     const runsDirectory = fixture.runsDirectory;
     const failed = JSON.parse(await readFile(join(runsDirectory, "fixture-eng-1.json"), "utf8"));
     const running = JSON.parse(await readFile(join(runsDirectory, "fixture-eng-2.json"), "utf8"));
+    const updates = (await readFile(fixture.updatesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
     expect(failed).toMatchObject({ outcome: "failed", state: "complete" });
     expect(running).toMatchObject({ state: "running" });
+    expect(updates).toContainEqual({
+      event: { artifacts: [], outcome: "failed", type: "completed" },
+      id: "ENG-1",
+    });
     expect(result.stdout).toContain("Started fixture:ENG-2");
   });
 

--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -45,6 +45,19 @@ describe("the shipped Linear source", () => {
     expect(fixture.state.comments[1]).toContain("https://example.test/pr/1");
   });
 
+  it("returns a failed run to Todo", async () => {
+    await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
+
+    await runCrew({
+      arguments: ["done", "--outcome", "failed", "--task", "LIN-1"],
+      environment: fixture.environment,
+    });
+
+    expect(fixture.state.stateName).toBe("Todo");
+    expect(fixture.state.stateType).toBe("unstarted");
+    expect(fixture.state.comments.at(-1)).toContain(":completed:failed]");
+  });
+
   it("paginates list queries beneath Linear's complexity limit", async () => {
     await fixture.close();
     fixture = await createLinearFixture({ listedTaskCount: 251 });
@@ -202,8 +215,13 @@ async function createLinearFixture(
         data = { commentCreate: { success: true } };
       } else if (body.operationName === "GroundcrewMove") {
         const stateId = body.variables.input.stateId;
-        state.stateName = stateId === "state-review" ? "In Review" : "In Progress";
-        state.stateType = "started";
+        state.stateName =
+          stateId === "state-review"
+            ? "In Review"
+            : stateId === "state-todo"
+              ? "Todo"
+              : "In Progress";
+        state.stateType = stateId === "state-todo" ? "unstarted" : "started";
         data = { issueUpdate: { success: true } };
       } else {
         response.statusCode = 400;
@@ -309,6 +327,7 @@ function linearIssue(input: {
     team: {
       states: {
         nodes: [
+          { id: "state-todo", name: "Todo", type: "unstarted" },
           { id: "state-progress", name: "In Progress", type: "started" },
           { id: "state-review", name: "In Review", type: "started" },
         ],

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -107,6 +107,8 @@ async function updateTask(input) {
   await addCommentOnce({ issue, marker: completionMarker, text });
   if (input.event.outcome === "delivered") {
     await moveIssue({ issue, stateName: environment("LINEAR_STATUS_IN_REVIEW", "In Review") });
+  } else if (input.event.outcome === "failed") {
+    await moveIssue({ issue, stateName: environment("LINEAR_STATUS_TODO", "Todo") });
   }
   return { result: "ok" };
 }


### PR DESCRIPTION
## Why

Groundcrew claims Linear tickets before preparing their worktrees. When preparation fails, the run is correctly reported as failed, but the Linear source previously left the ticket in In Progress. That stranded failed work with no agent workspace or automatic retry path. This change returns failed runs to Todo so operators can retry them after resolving the underlying failure.

## Summary

- Move Linear issues to the configurable Todo state after failed Groundcrew completions.
- Preserve the existing In Review transition for delivered runs and current behavior for stopped runs.
- Cover provisioning failure emission and the Linear failed-run transition through the CLI e2e seams.

## Validation

- `node --run verify` — 60 passed, 1 skipped.
- Focused provisioning and Linear failure e2e tests — 2 passed.

## Notes

- The Todo workflow name defaults to `Todo` and can be overridden with `LINEAR_STATUS_TODO`.

Agent session: `codex resume 019fe174-52a0-7963-a7be-43f8091b5e4c`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
