### PR TITLE
feat: improve dispatch progress output

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -8,6 +8,33 @@ import { describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 
 describe("crew start", () => {
+  it("reports open slots and the task being dispatched", async () => {
+    const fixture = await createDispatchFixture();
+
+    const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    expect(result.stdout).toContain("Slots 0/1 used (1 open)");
+    expect(result.stdout).toContain("Dispatching fixture:ENG-123(codex) into slot 1/1");
+  });
+
+  it("summarizes full capacity without generic skipped-task lines", async () => {
+    const fixture = await createDispatchFixture({
+      tasks: [
+        task({ id: "LOW-1", priority: 4, repositories: [] }),
+        task({ id: "URGENT-1", priority: 1, repositories: [] }),
+      ],
+    });
+
+    const first = await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const second = await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    expect(first.stdout).not.toContain("Skipped");
+    expect(second.stdout).toContain(
+      "At capacity (1/1) [fixture:URGENT-1(codex)], no new work to start",
+    );
+    expect(second.stdout).not.toContain("Skipped");
+  });
+
   it("claims, provisions, and launches a ready task exactly once", async () => {
     const fixture = await createDispatchFixture();
 
@@ -488,7 +515,7 @@ describe("crew start", () => {
       tasks: [task({ repositories: [], terminal: true })],
     });
 
-    const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
     const status = JSON.parse(
       (
         await runCrew({
@@ -498,7 +525,6 @@ describe("crew start", () => {
       ).stdout,
     );
 
-    expect(result.stdout).toContain("Skipped fixture:ENG-123");
     expect(status.tasks[0].verdict).toMatchObject({ reason: "terminal" });
   });
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -28,11 +28,38 @@ describe("crew start", () => {
     const first = await runCrew({ arguments: ["start"], environment: fixture.environment });
     const second = await runCrew({ arguments: ["start"], environment: fixture.environment });
 
-    expect(first.stdout).not.toContain("Skipped");
+    expect(first.stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
     expect(second.stdout).toContain(
       "At capacity (1/1) [fixture:URGENT-1(codex)], no new work to start",
     );
-    expect(second.stdout).not.toContain("Skipped");
+    expect(second.stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
+  });
+
+  it("does not repeat routine skip lines while watching an explicit task", async () => {
+    const fixture = await createDispatchFixture({ pollIntervalMilliseconds: 10 });
+    let stdout = "";
+
+    try {
+      await execFileAsync(process.execPath, ["bin/run.js", "start", "ENG-123", "--watch"], {
+        cwd: process.cwd(),
+        env: fixture.environment,
+        timeout: 2_000,
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("killed" in error) ||
+        error.killed !== true ||
+        !("stdout" in error) ||
+        typeof error.stdout !== "string"
+      ) {
+        throw error;
+      }
+      stdout = error.stdout;
+    }
+
+    expect(stdout).toContain("Started fixture:ENG-123");
+    expect(stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
   });
 
   it("claims, provisions, and launches a ready task exactly once", async () => {
@@ -257,7 +284,10 @@ describe("crew start", () => {
       tasks: [task({ blocked: true, repositories: [] })],
     });
 
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const skipped = await runCrew({ arguments: ["start"], environment: fixture.environment });
+    expect(skipped.stdout).toContain(
+      "Skipping fixture:ENG-123: blocked — task reports an open blocker",
+    );
     expect(
       JSON.parse(await readFile(join(dirname(fixture.runsDirectory), "dispatch.json"), "utf8"))[
         "fixture:ENG-123"
@@ -295,11 +325,15 @@ describe("crew start", () => {
   it("removes the provisional run and records a rejected claim", async () => {
     const fixture = await createDispatchFixture({ rejectClaim: "ENG-123" });
 
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
 
     const dispatch = JSON.parse(
       await readFile(join(dirname(fixture.runsDirectory), "dispatch.json"), "utf8"),
     );
+    expect(result.stdout).toContain(
+      "Skipping fixture:ENG-123: claim-rejected — fixture rejected claim",
+    );
+    expect(result.stdout).not.toContain("Dispatching fixture:ENG-123");
     expect(dispatch["fixture:ENG-123"].reason).toBe("claim-rejected");
     await expect(stat(join(fixture.runsDirectory, "fixture-eng-123.json"))).rejects.toMatchObject({
       code: "ENOENT",
@@ -966,6 +1000,7 @@ async function createDispatchFixture(
     readonly prepareWorktree?: string | undefined;
     readonly failPresenterOpen?: boolean | undefined;
     readonly maximumInProgress?: number | undefined;
+    readonly pollIntervalMilliseconds?: number | undefined;
     readonly profiles?: Readonly<Record<string, Record<string, unknown>>> | undefined;
     readonly additionalRepositories?: readonly string[] | undefined;
     readonly scriptedAgent?: boolean | undefined;
@@ -1025,7 +1060,10 @@ async function createDispatchFixture(
         default: Object.keys(options.profiles ?? { codex: {} })[0],
         profiles: options.profiles ?? { codex: { effort: "high", kind: "codex" } },
       },
-      orchestrator: { maximumInProgress: options.maximumInProgress ?? 1 },
+      orchestrator: {
+        maximumInProgress: options.maximumInProgress ?? 1,
+        pollIntervalMilliseconds: options.pollIntervalMilliseconds ?? 120_000,
+      },
       sources: [{ kind: "fixture" }],
       workspace: {
         baseDirectory,

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -75,6 +75,27 @@ export interface DoctorInput {
   readonly onPrerequisiteChecks?: ((checks: readonly HealthCheck[]) => void) | undefined;
 }
 
+export interface DispatchSlotOccupant {
+  readonly canonicalTaskId: string;
+  readonly agentProfile: string;
+}
+
+export type DispatchProgress =
+  | {
+      readonly type: "slots";
+      readonly active: readonly DispatchSlotOccupant[];
+      readonly maximum: number;
+      readonly force: boolean;
+    }
+  | {
+      readonly type: "dispatching";
+      readonly canonicalTaskId: string;
+      readonly agentProfile: string;
+      readonly slot: number;
+      readonly maximum: number;
+      readonly forced: boolean;
+    };
+
 export type VerdictReason =
   | "blocked"
   | "slots-full"
@@ -114,6 +135,7 @@ export interface Application {
     readonly task?: string | undefined;
     readonly force: boolean;
     readonly agent?: string | undefined;
+    readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
   }): Promise<{ readonly started: readonly string[]; readonly skipped: readonly string[] }>;
   status(input: {
     readonly task?: string | undefined;
@@ -245,6 +267,7 @@ async function start(input: {
   readonly task?: string | undefined;
   readonly force: boolean;
   readonly agent?: string | undefined;
+  readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
 }): Promise<{ readonly started: readonly string[]; readonly skipped: readonly string[] }> {
   const { runtime } = input;
   await reconcile({ runtime });
@@ -268,9 +291,19 @@ async function start(input: {
   }
   const started: string[] = [];
   const skipped: string[] = [];
-  let activeCount = (await runtime.runs.list()).filter(
-    (run) => run.state === "provisioning" || run.state === "running",
-  ).length;
+  const active = (await runtime.runs.list())
+    .filter((run) => run.state === "provisioning" || run.state === "running")
+    .map((run) => ({
+      agentProfile: run.agentProfile,
+      canonicalTaskId: run.canonicalTaskId,
+    }));
+  let activeCount = active.length;
+  input.onProgress?.({
+    active,
+    force: input.force,
+    maximum: runtime.config.orchestrator.maximumInProgress,
+    type: "slots",
+  });
   for (const task of tasks) {
     const canonicalTaskId = canonicalId({ task });
     const slug = taskSlug({ canonicalTaskId });
@@ -355,6 +388,14 @@ async function start(input: {
       skipped.push(canonicalTaskId);
       continue;
     }
+    input.onProgress?.({
+      agentProfile: profileName,
+      canonicalTaskId,
+      forced: input.force && activeCount >= runtime.config.orchestrator.maximumInProgress,
+      maximum: runtime.config.orchestrator.maximumInProgress,
+      slot: activeCount + 1,
+      type: "dispatching",
+    });
     const workspaceDirectory = runtime.workspaces.workspaceDirectory({ slug });
     const record = await runtime.runs.create({
       agentProfile: profileName,

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -94,6 +94,12 @@ export type DispatchProgress =
       readonly slot: number;
       readonly maximum: number;
       readonly forced: boolean;
+    }
+  | {
+      readonly type: "skipped";
+      readonly canonicalTaskId: string;
+      readonly detail: string;
+      readonly reason: VerdictReason;
     };
 
 export type VerdictReason =
@@ -166,6 +172,13 @@ interface Runtime {
   readonly registry: SourceRegistry;
   readonly runs: RunStore;
   readonly workspaces: WorkspaceService;
+}
+
+interface SkipTaskInput {
+  readonly canonicalTaskId: string;
+  readonly detail: string;
+  readonly reason: VerdictReason;
+  readonly runId?: string | undefined;
 }
 
 export async function createApplication(input: {
@@ -291,6 +304,16 @@ async function start(input: {
   }
   const started: string[] = [];
   const skipped: string[] = [];
+  async function skipTask(skipInput: SkipTaskInput): Promise<void> {
+    await writeVerdict({ ...skipInput, runtime });
+    input.onProgress?.({
+      canonicalTaskId: skipInput.canonicalTaskId,
+      detail: skipInput.detail,
+      reason: skipInput.reason,
+      type: "skipped",
+    });
+    skipped.push(skipInput.canonicalTaskId);
+  }
   const active = (await runtime.runs.list())
     .filter((run) => run.state === "provisioning" || run.state === "running")
     .map((run) => ({
@@ -311,28 +334,23 @@ async function start(input: {
     if (existing !== undefined) {
       const reason: VerdictReason =
         existing.canonicalTaskId === canonicalTaskId ? "run-exists" : "slug-collision";
-      await writeVerdict({ canonicalTaskId, detail: existing.canonicalTaskId, reason, runtime });
-      skipped.push(canonicalTaskId);
+      await skipTask({ canonicalTaskId, detail: existing.canonicalTaskId, reason });
       continue;
     }
     if (task.terminal) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: "source reports the task as terminal",
         reason: "terminal",
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
     if (task.blocked && !input.force) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: "task reports an open blocker",
         reason: "blocked",
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
     const profileName =
@@ -342,23 +360,19 @@ async function start(input: {
       runtime.config.agents.default;
     const profile = runtime.config.agents.profiles[profileName];
     if (profile === undefined) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: profileName,
         reason: "agent-unavailable",
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
     if (!(await commandExists({ command: profile.kind, environment: runtime.environment }))) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: `missing harness executable ${profile.kind}`,
         reason: "agent-unavailable",
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
     const repositoryCheck = await runtime.workspaces.validateRepositories({
@@ -366,36 +380,24 @@ async function start(input: {
       slug,
     });
     if (!repositoryCheck.ok) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: repositoryCheck.missing.join(", "),
         reason: "repo-not-on-disk",
-        runtime,
       });
       if (input.task !== undefined) {
         throw new RepositoryMissingError(repositoryCheck.missing);
       }
-      skipped.push(canonicalTaskId);
       continue;
     }
     if (!input.force && activeCount >= runtime.config.orchestrator.maximumInProgress) {
-      await writeVerdict({
+      await skipTask({
         canonicalTaskId,
         detail: "concurrency limit reached",
         reason: "slots-full",
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
-    input.onProgress?.({
-      agentProfile: profileName,
-      canonicalTaskId,
-      forced: input.force && activeCount >= runtime.config.orchestrator.maximumInProgress,
-      maximum: runtime.config.orchestrator.maximumInProgress,
-      slot: activeCount + 1,
-      type: "dispatching",
-    });
     const workspaceDirectory = runtime.workspaces.workspaceDirectory({ slug });
     const record = await runtime.runs.create({
       agentProfile: profileName,
@@ -409,16 +411,25 @@ async function start(input: {
     });
     if (!claim.ok || claim.data.result === "rejected") {
       await runtime.runs.remove({ canonicalTaskId });
-      await writeVerdict({
+      const detail = claim.ok
+        ? (claim.data.reason ?? "source rejected claim")
+        : claim.error.message;
+      await skipTask({
         canonicalTaskId,
-        detail: claim.ok ? (claim.data.reason ?? "source rejected claim") : claim.error.message,
+        detail,
         reason: "claim-rejected",
         runId: record.runId,
-        runtime,
       });
-      skipped.push(canonicalTaskId);
       continue;
     }
+    input.onProgress?.({
+      agentProfile: profileName,
+      canonicalTaskId,
+      forced: input.force && activeCount >= runtime.config.orchestrator.maximumInProgress,
+      maximum: runtime.config.orchestrator.maximumInProgress,
+      slot: activeCount + 1,
+      type: "dispatching",
+    });
     try {
       const marker = await runtime.workspaces.provision({
         canonicalTaskId,

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -79,6 +79,11 @@ interface MainInput {
   readonly environment: NodeJS.ProcessEnv;
 }
 
+interface RenderDispatchProgressInput {
+  readonly progress: DispatchProgress;
+  readonly showRoutineSkips: boolean;
+}
+
 interface PathContext {
   readonly configHome: string;
   readonly stateRoot: string;
@@ -158,7 +163,11 @@ export async function main(input: MainInput): Promise<void> {
         const result = await application.start({
           agent: options.agent,
           force: options.force === true,
-          onProgress: (progress) => renderDispatchProgress({ progress }),
+          onProgress: (progress) =>
+            renderDispatchProgress({
+              progress,
+              showRoutineSkips: task !== undefined && options.watch !== true,
+            }),
           task,
         });
         for (const canonicalTaskId of result.started) {
@@ -457,8 +466,20 @@ async function readTaskMarker(input: {
   }
 }
 
-function renderDispatchProgress(input: { readonly progress: DispatchProgress }): void {
-  const { progress } = input;
+function renderDispatchProgress(input: RenderDispatchProgressInput): void {
+  const { progress, showRoutineSkips } = input;
+  if (progress.type === "skipped") {
+    if (
+      progress.reason === "slots-full" ||
+      (progress.reason === "run-exists" && !showRoutineSkips)
+    ) {
+      return;
+    }
+    process.stdout.write(
+      `Skipping ${progress.canonicalTaskId}: ${progress.reason} — ${progress.detail}\n`,
+    );
+    return;
+  }
   if (progress.type === "dispatching") {
     const task = `${progress.canonicalTaskId}(${progress.agentProfile})`;
     process.stdout.write(

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -7,7 +7,7 @@ import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parse } from "jsonc-parser";
 import { z } from "zod";
-import { createApplication } from "../core/index.js";
+import { createApplication, type DispatchProgress } from "../core/index.js";
 
 const AgentProfileSchema = z.object({
   kind: z.enum(["claude", "codex"]),
@@ -158,13 +158,11 @@ export async function main(input: MainInput): Promise<void> {
         const result = await application.start({
           agent: options.agent,
           force: options.force === true,
+          onProgress: (progress) => renderDispatchProgress({ progress }),
           task,
         });
         for (const canonicalTaskId of result.started) {
           process.stdout.write(`Started ${canonicalTaskId}\n`);
-        }
-        for (const canonicalTaskId of result.skipped) {
-          process.stdout.write(`Skipped ${canonicalTaskId}\n`);
         }
         if (options.watch !== true) {
           break;
@@ -457,6 +455,38 @@ async function readTaskMarker(input: {
     }
     throw error;
   }
+}
+
+function renderDispatchProgress(input: { readonly progress: DispatchProgress }): void {
+  const { progress } = input;
+  if (progress.type === "dispatching") {
+    const task = `${progress.canonicalTaskId}(${progress.agentProfile})`;
+    process.stdout.write(
+      progress.forced
+        ? `Dispatching ${task} with concurrency override (${progress.slot - 1}/${progress.maximum} slots used)\n`
+        : `Dispatching ${task} into slot ${progress.slot}/${progress.maximum}\n`,
+    );
+    return;
+  }
+
+  const activeTasks =
+    progress.active.length === 0
+      ? ""
+      : ` [${progress.active
+          .map(({ agentProfile, canonicalTaskId }) => `${canonicalTaskId}(${agentProfile})`)
+          .join(", ")}]`;
+  const activeCount = progress.active.length;
+  if (activeCount >= progress.maximum && !progress.force) {
+    process.stdout.write(
+      `At capacity (${activeCount}/${progress.maximum})${activeTasks}, no new work to start\n`,
+    );
+    return;
+  }
+
+  const openCount = Math.max(0, progress.maximum - activeCount);
+  process.stdout.write(
+    `Slots ${activeCount}/${progress.maximum} used${activeTasks} (${openCount} open)\n`,
+  );
 }
 
 function renderStatus(input: {


### PR DESCRIPTION
## Why

Groundcrew v2 gave operators no visibility into slot usage while dispatching and then printed a generic `Skipped <task>` line for every ineligible task. In watch mode, routine `run-exists` and `slots-full` outcomes could turn into repetitive noise without explaining what was actually happening. This has no direct customer impact, but it makes dispatch behavior harder for operators to understand and diagnose.

## Summary

- Report occupied and open concurrency slots before evaluating a dispatch tick, including active task and agent-profile names at capacity.
- Announce each task after its source claim is accepted and before workspace provisioning begins.
- Replace generic skipped-task output with reason-bearing feedback for actionable verdicts while suppressing routine `slots-full` and batch/watch `run-exists` noise.
- Add built-CLI e2e coverage for successful dispatch, full capacity, blocked tasks, rejected claims, and explicit watch mode.

## Validation

- `node --run verify`
- Pre-push repository checks: 91 files and 2,175 tests passed with 100% coverage; architecture, build, copy/paste detection, formatting, knip, lint, Markdown lint, and syncpack checks passed.
- `cb-review --effort low --report`: `Ship gate: pass`; requirements met; no actionable findings or nits on final HEAD.

## Notes

The output is inspired by v1's slot/capacity summaries without coupling v2 to v1's implementation.

Agent session: `codex resume 019fe19e-f302-7c81-98fd-29af319f6c75`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
