### PR TITLE
fix: keep batch dispatch output terse

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -35,6 +35,29 @@ describe("crew start", () => {
     expect(second.stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
   });
 
+  it("omits routine eligibility skips from batch output", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 2,
+      tasks: [
+        task({ id: "TERMINAL-1", priority: 1, repositories: [], terminal: true }),
+        task({ blocked: true, id: "BLOCKED-1", priority: 2, repositories: [] }),
+        task({ agentProfile: "any", id: "UNAVAILABLE-1", priority: 3, repositories: [] }),
+        task({ id: "READY-1", priority: 4, repositories: [] }),
+      ],
+    });
+
+    const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    expect(result.stdout).toBe(
+      [
+        "Slots 0/2 used (2 open)",
+        "Dispatching fixture:READY-1(codex) into slot 1/2",
+        "Started fixture:READY-1",
+        "",
+      ].join("\n"),
+    );
+  });
+
   it("does not repeat routine skip lines while watching an explicit task", async () => {
     const fixture = await createDispatchFixture({ pollIntervalMilliseconds: 10 });
     let stdout = "";
@@ -284,7 +307,10 @@ describe("crew start", () => {
       tasks: [task({ blocked: true, repositories: [] })],
     });
 
-    const skipped = await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const skipped = await runCrew({
+      arguments: ["start", "ENG-123"],
+      environment: fixture.environment,
+    });
     expect(skipped.stdout).toContain(
       "Skipping fixture:ENG-123: blocked — task reports an open blocker",
     );

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -7,7 +7,7 @@ import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parse } from "jsonc-parser";
 import { z } from "zod";
-import { createApplication, type DispatchProgress } from "../core/index.js";
+import { createApplication, type DispatchProgress, type VerdictReason } from "../core/index.js";
 
 const AgentProfileSchema = z.object({
   kind: z.enum(["claude", "codex"]),
@@ -20,6 +20,12 @@ const DEFAULT_AGENT_PROFILES = {
   "claude-opus": { effort: "high", kind: "claude", model: "opus" },
   codex: { effort: "high", kind: "codex" },
 } as const;
+
+const BATCH_REPORTED_SKIP_REASONS = new Set<VerdictReason>([
+  "claim-rejected",
+  "repo-not-on-disk",
+  "slug-collision",
+]);
 
 const ConfigSchema = z.object({
   $schema: z.string().optional(),
@@ -471,11 +477,7 @@ function renderDispatchProgress(input: RenderDispatchProgressInput): void {
   if (progress.type === "skipped") {
     if (
       progress.reason === "slots-full" ||
-      (!showRoutineSkips &&
-        (progress.reason === "agent-unavailable" ||
-          progress.reason === "blocked" ||
-          progress.reason === "run-exists" ||
-          progress.reason === "terminal"))
+      (!showRoutineSkips && !BATCH_REPORTED_SKIP_REASONS.has(progress.reason))
     ) {
       return;
     }

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -471,7 +471,11 @@ function renderDispatchProgress(input: RenderDispatchProgressInput): void {
   if (progress.type === "skipped") {
     if (
       progress.reason === "slots-full" ||
-      (progress.reason === "run-exists" && !showRoutineSkips)
+      (!showRoutineSkips &&
+        (progress.reason === "agent-unavailable" ||
+          progress.reason === "blocked" ||
+          progress.reason === "run-exists" ||
+          progress.reason === "terminal"))
     ) {
       return;
     }


### PR DESCRIPTION
## Why

Batch dispatch printed one line for every terminal, blocked, or unavailable task returned by a source. Large Linear histories therefore buried the useful slot and dispatch information under hundreds of routine skip messages. This has no direct customer impact, but it makes Groundcrew's operator output noisy and harder to scan.

## Summary

- Suppress routine eligibility skip lines during batch dispatch and watch polling.
- Preserve skip explanations for explicit one-shot task starts.
- Use a typed allowlist to keep actionable failures such as rejected claims visible.
- Cover the mixed terminal, blocked, unavailable, and ready-task case through the built CLI.

## Validation

- `node --run verify` (8 test files passed; 64 tests passed, 1 skipped)
- Focused built-CLI regression test for terse batch output
- `cb-review --effort low --report`: `Ship gate: pass`; requirements met, including the allowlist follow-up; no findings

## Notes

Agent session: `codex resume 019fe29f-7562-7bb1-989c-66a46f288e54`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
