### PR TITLE
fix: make cleanup workflow actionable

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -315,6 +315,23 @@ describe("crew start", () => {
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("explains how to force cleanup when the workspace becomes dirty while stopping", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    fixture.environment["FAKE_CMUX_DIRTY_ON_CLOSE"] = join(
+      fixture.workspaceDirectory,
+      "sample",
+      "late-dirty.txt",
+    );
+
+    await expect(
+      runCrew({ arguments: ["cleanup", "eng-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(/late-dirty\.txt[\s\S]*crew cleanup eng-123 --force/),
+    });
+  });
+
   it("dispatches urgent tasks first and records the concurrency verdict", async () => {
     const fixture = await createDispatchFixture({
       tasks: [

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -121,6 +121,7 @@ describe("crew start", () => {
     expect(calls.filter((call) => call.arguments[0] === "new-workspace")).toHaveLength(1);
     expect(calls.at(-1).arguments).toContain("running");
     const launchArguments = calls.find((call) => call.arguments[0] === "new-workspace").arguments;
+    expect(launchArguments[launchArguments.indexOf("--name") + 1]).toBe("eng-123");
     const command = launchArguments[launchArguments.indexOf("--command") + 1];
     expect(command).toContain("codex");
     expect(command).toContain('model_reasoning_effort="high"');
@@ -205,6 +206,30 @@ describe("crew start", () => {
     ).toBe(true);
   });
 
+  it("cleans a run using the lowercase task ID shown by cmux", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    const result = await runCrew({
+      arguments: ["cleanup", "eng-123"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Cleaned fixture:ENG-123");
+    await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("explains how to find a task when cleanup has no matching run", async () => {
+    const fixture = await createDispatchFixture();
+
+    await expect(
+      runCrew({ arguments: ["cleanup", "missing-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("Run crew status to list local runs"),
+    });
+  });
+
   it("persists a missing-repository verdict without creating a partial workspace", async () => {
     const fixture = await createDispatchFixture({ repository: "missing" });
 
@@ -276,10 +301,15 @@ describe("crew start", () => {
     ).rejects.toMatchObject({ code: 1 });
     await expect(
       runCrew({ arguments: ["cleanup", "ENG-123"], environment: fixture.environment }),
-    ).rejects.toMatchObject({ code: 1 });
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(
+        /Cleanup refused[\s\S]*sample\/dirty\.txt[\s\S]*permanently discard[\s\S]*crew cleanup ENG-123 --force/,
+      ),
+    });
 
     await runCrew({
-      arguments: ["cleanup", "ENG-123", "--allow-dirty"],
+      arguments: ["cleanup", "ENG-123", "--force"],
       environment: fixture.environment,
     });
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
@@ -443,7 +473,7 @@ describe("crew start", () => {
       runCrew({ arguments: ["cleanup", "ENG-123"], environment: fixture.environment }),
     ).rejects.toMatchObject({ code: 1 });
     await runCrew({
-      arguments: ["cleanup", "ENG-123", "--allow-dirty"],
+      arguments: ["cleanup", "ENG-123", "--force"],
       environment: fixture.environment,
     });
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -49,6 +49,9 @@ if (command === "new-workspace") {
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "close-workspace") {
   const id = valueAfter("--workspace");
+  if (process.env.FAKE_CMUX_DIRTY_ON_CLOSE !== undefined) {
+    await writeFile(process.env.FAKE_CMUX_DIRTY_ON_CLOSE, "uncommitted\n");
+  }
   state.workspaces = state.workspaces.filter((workspace) => workspace.id !== id);
   await writeFile(statePath, JSON.stringify(state));
 } else if (command !== "set-progress") {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -754,7 +754,11 @@ async function cleanup(input: {
     // eslint-disable-next-line no-await-in-loop
     const observed = await runtime.workspaces.observe({ slug });
     if (!input.allowDirty && observed.dirtyPaths.length > 0) {
-      throw new DirtyWorkspaceError(observed.dirtyPaths);
+      throw cleanupRefusedError({
+        canonicalTaskId: record.canonicalTaskId,
+        paths: observed.dirtyPaths,
+        query: input.task,
+      });
     }
     // The operation check must run under the same run lock as repository reservation, including
     // for a run that reconciliation completed while acquisition was still active.
@@ -1003,14 +1007,25 @@ async function resolveRunIdentity(input: {
   readonly runtime: Runtime;
 }): Promise<string> {
   const records = await input.runtime.runs.list();
-  const matches = records.filter(
-    (record) =>
-      record.canonicalTaskId === input.query ||
-      record.canonicalTaskId.slice(record.canonicalTaskId.indexOf(":") + 1) === input.query,
-  );
+  const normalizedQuery = input.query.toLowerCase();
+  const matches = records.filter((record) => {
+    const canonicalTaskId = record.canonicalTaskId.toLowerCase();
+    return (
+      canonicalTaskId === normalizedQuery ||
+      canonicalTaskId.slice(canonicalTaskId.indexOf(":") + 1) === normalizedQuery
+    );
+  });
+  if (matches.length === 0) {
+    throw new Error(`No local run matches ${input.query}. Run crew status to list local runs.`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple local runs match ${input.query}: ${matches.map((record) => record.canonicalTaskId).join(", ")}. Retry with a canonical task ID.`,
+    );
+  }
   const match = matches.at(0);
-  if (matches.length !== 1 || match === undefined) {
-    throw new Error(`could not resolve exactly one run for ${input.query}`);
+  if (match === undefined) {
+    throw new Error(`Local run ${input.query} disappeared during lookup.`);
   }
   return match.canonicalTaskId;
 }
@@ -1052,6 +1067,22 @@ async function resolveExplicitTask(input: {
 
 function canonicalId(input: { readonly task: Task }): string {
   return `${input.task.sourceName}:${input.task.id}`;
+}
+
+function cleanupRefusedError(input: {
+  readonly canonicalTaskId: string;
+  readonly paths: readonly string[];
+  readonly query?: string | undefined;
+}): Error {
+  const task = input.query ?? input.canonicalTaskId;
+  return new Error(
+    [
+      `Cleanup refused because ${input.canonicalTaskId} has uncommitted changes:`,
+      ...input.paths.map((path) => `  ${path}`),
+      "Review, commit, or stash them. To permanently discard these changes and any unique task-branch commits, rerun:",
+      `  crew cleanup ${task} --force`,
+    ].join("\n"),
+  );
 }
 
 function transition(input: {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -1026,17 +1026,14 @@ async function resolveRunIdentity(input: {
       canonicalTaskId.slice(canonicalTaskId.indexOf(":") + 1) === normalizedQuery
     );
   });
-  if (matches.length === 0) {
+  const match = matches.at(0);
+  if (match === undefined) {
     throw new Error(`No local run matches ${input.query}. Run crew status to list local runs.`);
   }
   if (matches.length > 1) {
     throw new Error(
       `Multiple local runs match ${input.query}: ${matches.map((record) => record.canonicalTaskId).join(", ")}. Retry with a canonical task ID.`,
     );
-  }
-  const match = matches.at(0);
-  if (match === undefined) {
-    throw new Error(`Local run ${input.query} disappeared during lookup.`);
   }
   return match.canonicalTaskId;
 }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -791,9 +791,20 @@ async function cleanup(input: {
     // Presenter closes before its underlying directories disappear.
     // eslint-disable-next-line no-await-in-loop
     await presenter.close({ name: record.presentedWorkspaceName });
-    // eslint-disable-next-line no-await-in-loop
-    const result = await runtime.workspaces.cleanup({ allowDirty: input.allowDirty, slug });
-    preservedBranches.push(...result.preservedBranches);
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await runtime.workspaces.cleanup({ allowDirty: input.allowDirty, slug });
+      preservedBranches.push(...result.preservedBranches);
+    } catch (error) {
+      if (error instanceof DirtyWorkspaceError) {
+        throw cleanupRefusedError({
+          canonicalTaskId: record.canonicalTaskId,
+          paths: error.paths,
+          query: input.task,
+        });
+      }
+      throw error;
+    }
     if (record.writebackPending !== true) {
       // eslint-disable-next-line no-await-in-loop
       await runtime.runs.remove({ canonicalTaskId: record.canonicalTaskId });

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -77,7 +77,7 @@ export class RunStore {
           artifacts: [],
           canonicalTaskId: input.canonicalTaskId,
           events: [{ event: "provisioning", timestamp: new Date().toISOString() }],
-          presentedWorkspaceName: `crew-${slug}`,
+          presentedWorkspaceName: `groundcrew:${input.canonicalTaskId}`,
           presenter: "cmux",
           repositories: input.repositories,
           runId: `r_${randomBytes(4).toString("hex")}`,
@@ -328,6 +328,7 @@ export async function launchAgent(input: {
   );
   await presenter.open({
     command: composeAgentCommand({ profile: input.profile, prompt }),
+    displayName: presenterWorkspaceName({ canonicalTaskId: record.canonicalTaskId }),
     environment: {
       ...inheritedEnvironment,
       GROUNDCREW_TASK_ID: record.canonicalTaskId,
@@ -422,6 +423,12 @@ export function presenterFor(input: {
   readonly name: "cmux";
 }): Presenter {
   return createPresenter(input);
+}
+
+function presenterWorkspaceName(input: { readonly canonicalTaskId: string }): string {
+  const separatorIndex = input.canonicalTaskId.indexOf(":");
+  const sourceLocalTaskId = input.canonicalTaskId.slice(separatorIndex + 1);
+  return taskSlug({ canonicalTaskId: sourceLocalTaskId });
 }
 
 async function atomicWrite(input: {

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -207,13 +207,13 @@ export async function main(input: MainInput): Promise<void> {
     .description("close presenters and safely remove task worktrees")
     .argument("[task]", "canonical or source-local task ID")
     .option("--all", "clean every local task")
-    .option("--allow-dirty", "permit deletion of dirty worktrees and unique branches")
+    .option("--force", "permanently delete dirty worktrees and unique task branches")
     .option("--verbose", "include debug diagnostics")
     .action(async (task, options) => {
       const application = await configuredApplication({ environment });
       const result = await application.cleanup({
         all: options.all === true,
-        allowDirty: options.allowDirty === true,
+        allowDirty: options.force === true,
         task,
       });
       for (const canonicalTaskId of result.cleaned) {


### PR DESCRIPTION
## Why

Groundcrew showed operators a lowercase cmux title such as `crew-l-staff-2218`, while cleanup lookup required the differently cased canonical task ID. When cleanup found dirty paths, it stopped at a diagnostic with no recovery command. This created avoidable operator confusion in a destructive workflow. There is no direct customer impact; the change improves Groundcrew operator usability and makes the data-loss override explicit.

## Summary

- Show the lowercase source-local task ID as the cmux workspace title.
- Resolve local run IDs case-insensitively and replace ambiguous lookup jargon with actionable guidance.
- Rename cleanup's destructive override from `--allow-dirty` to `--force`.
- List dirty paths, explain the risk, and print the exact `crew cleanup <task> --force` command on either cleanup safety check.

## Validation

- `node --run verify` — 8 test files passed; 67 tests passed and 1 skipped.
- Red-green e2e coverage through the built `crew` executable for lowercase lookup, cmux naming, dirty cleanup guidance, `--force`, and the late-dirty race.

## Notes

- Existing runs retain their current cmux title; newly started runs use the shorter title.

Agent session: `codex resume 019fe2cd-fee4-70f1-b75c-3897a857aaff`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
