### PR TITLE
refactor: deepen v2 run lifecycle

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -380,6 +380,10 @@ describe("crew start", () => {
       tasks: [task({ blocked: true, repositories: [] })],
     });
     await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const initialVerdicts = JSON.parse(
+      await readFile(join(dirname(fixture.runsDirectory), "dispatch.json"), "utf8"),
+    );
+    expect(initialVerdicts).toHaveProperty("fixture:ENG-123");
     await writeFile(
       fixture.listedTasksPath,
       JSON.stringify([task({ blocked: false, repositories: [] })]),

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -930,6 +930,46 @@ describe("crew start", () => {
     ).toMatchObject({ state: "running" });
   });
 
+  it("stops per-run reconciliation before mutating later runs", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 2,
+      tasks: [
+        task({ id: "A-1", priority: 1, repositories: ["sample"] }),
+        task({ id: "B-1", priority: 2, repositories: ["sample"] }),
+      ],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const workspacesDirectory = dirname(fixture.workspaceDirectory);
+    const secondRunPath = join(fixture.runsDirectory, "fixture-b-1.json");
+    const secondRun = JSON.parse(await readFile(secondRunPath, "utf8"));
+    await Promise.all([
+      writeFile(
+        secondRunPath,
+        JSON.stringify({
+          ...secondRun,
+          events: [
+            ...secondRun.events,
+            { event: "complete:failed", timestamp: new Date().toISOString() },
+          ],
+          outcome: "failed",
+          state: "complete",
+          writebackPending: true,
+        }),
+      ),
+      writeFile(join(workspacesDirectory, "fixture-a-1", "sample", ".git"), "invalid\n"),
+      writeFile(fixture.updatesPath, ""),
+    ]);
+
+    await expect(
+      runCrew({ arguments: ["status", "--json"], environment: fixture.environment }),
+    ).rejects.toMatchObject({ code: 1 });
+
+    expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
+    expect(JSON.parse(await readFile(secondRunPath, "utf8"))).toMatchObject({
+      writebackPending: true,
+    });
+  });
+
   it("reconciles a missing workspace before delivered completion", async () => {
     const fixture = await createDispatchFixture({ repositories: [] });
     await runCrew({ arguments: ["start"], environment: fixture.environment });

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -374,6 +374,34 @@ describe("crew start", () => {
     expect(forced.stdout).toContain("Started fixture:ENG-123");
   });
 
+  it("clears a stale verdict when reconciliation wins the launch transition", async () => {
+    const fixture = await createDispatchFixture({
+      repositories: [],
+      tasks: [task({ blocked: true, repositories: [] })],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([task({ blocked: false, repositories: [] })]),
+    );
+    const releasePath = join(fixture.root, "release-presenter-open");
+    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = releasePath;
+
+    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
+    await waitForPath(`${releasePath}.ready`);
+    try {
+      await runCrew({ arguments: ["status", "--json"], environment: fixture.environment });
+    } finally {
+      await writeFile(releasePath, "release\n");
+    }
+    await start;
+
+    const verdicts = JSON.parse(
+      await readFile(join(dirname(fixture.runsDirectory), "dispatch.json"), "utf8"),
+    );
+    expect(verdicts).not.toHaveProperty("fixture:ENG-123");
+  });
+
   it("keeps the first slug holder and records a collision for the other task", async () => {
     const fixture = await createDispatchFixture({
       maximumInProgress: 2,

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { access, appendFile, readFile, writeFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 
 const [command, ...arguments_] = process.argv.slice(2);
 const statePath = process.env.FAKE_CMUX_STATE;
@@ -21,6 +22,20 @@ if (command === "new-workspace") {
   };
   state.workspaces.push(workspace);
   await writeFile(statePath, JSON.stringify(state));
+  if (process.env.FAKE_CMUX_OPEN_RELEASE !== undefined) {
+    await writeFile(`${process.env.FAKE_CMUX_OPEN_RELEASE}.ready`, "ready\n");
+    for (;;) {
+      try {
+        await access(process.env.FAKE_CMUX_OPEN_RELEASE);
+        break;
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+          throw error;
+        }
+      }
+      await delay(10);
+    }
+  }
   if (process.env.FAKE_CMUX_EXECUTE_COMMAND === "1") {
     const childEnvironment = { ...process.env };
     for (let index = 0; index < arguments_.length; index += 1) {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -452,10 +452,10 @@ async function start(input: {
           title: task.title,
         },
       });
+      await clearVerdict({ canonicalTaskId, runtime });
       if (!launched.transitioned) {
         continue;
       }
-      await clearVerdict({ canonicalTaskId, runtime });
       await log({
         canonicalTaskId,
         event: "run_started",
@@ -783,8 +783,12 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
       // eslint-disable-next-line no-await-in-loop
       const repaired = await runtime.runs.repairRepositories({
         canonicalTaskId: run.record.canonicalTaskId,
+        expectedRunId: run.record.runId,
         repositories: marker.repositories,
       });
+      if (repaired.run.record.runId !== run.record.runId) {
+        continue;
+      }
       run = repaired.run;
       if (repaired.transitioned) {
         // eslint-disable-next-line no-await-in-loop

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -9,14 +9,15 @@ import {
   type Task,
 } from "../source/index.js";
 import {
-  launchAgent,
-  presenterFor,
-  RunStore,
+  RunModule,
   taskSlug,
   withFileLock,
   type AgentProfile,
   type Artifact,
+  type CompletedRun,
+  type RunHandle,
   type RunRecord,
+  type RunningRun,
 } from "../run/index.js";
 import {
   DirtyWorkspaceError,
@@ -170,7 +171,7 @@ interface Runtime {
   readonly environment: NodeJS.ProcessEnv;
   readonly paths: ApplicationPaths;
   readonly registry: SourceRegistry;
-  readonly runs: RunStore;
+  readonly runs: RunModule;
   readonly workspaces: WorkspaceService;
 }
 
@@ -193,7 +194,11 @@ export async function createApplication(input: {
     instances: config.sources,
     packageRoot: paths.packageRoot,
   });
-  const runs = new RunStore({ stateRoot: paths.stateRoot });
+  const runs = new RunModule({
+    environment,
+    presenterName: config.presenter,
+    stateRoot: paths.stateRoot,
+  });
   const workspaces = new WorkspaceService({
     config: {
       baseDirectory: config.workspace.baseDirectory,
@@ -317,8 +322,8 @@ async function start(input: {
   const active = (await runtime.runs.list())
     .filter((run) => run.state === "provisioning" || run.state === "running")
     .map((run) => ({
-      agentProfile: run.agentProfile,
-      canonicalTaskId: run.canonicalTaskId,
+      agentProfile: run.record.agentProfile,
+      canonicalTaskId: run.record.canonicalTaskId,
     }));
   let activeCount = active.length;
   input.onProgress?.({
@@ -330,11 +335,11 @@ async function start(input: {
   for (const task of tasks) {
     const canonicalTaskId = canonicalId({ task });
     const slug = taskSlug({ canonicalTaskId });
-    const existing = await runtime.runs.getBySlug({ slug });
+    const existing = await runtime.runs.findBySlug({ slug });
     if (existing !== undefined) {
       const reason: VerdictReason =
-        existing.canonicalTaskId === canonicalTaskId ? "run-exists" : "slug-collision";
-      await skipTask({ canonicalTaskId, detail: existing.canonicalTaskId, reason });
+        existing.record.canonicalTaskId === canonicalTaskId ? "run-exists" : "slug-collision";
+      await skipTask({ canonicalTaskId, detail: existing.record.canonicalTaskId, reason });
       continue;
     }
     if (task.terminal) {
@@ -399,7 +404,7 @@ async function start(input: {
       continue;
     }
     const workspaceDirectory = runtime.workspaces.workspaceDirectory({ slug });
-    const record = await runtime.runs.create({
+    const provisioning = await runtime.runs.beginDispatch({
       agentProfile: profileName,
       canonicalTaskId,
       repositories: task.repositories,
@@ -407,10 +412,10 @@ async function start(input: {
     });
     const claim = await runtime.registry.update({
       canonicalTaskId,
-      event: { runId: record.runId, type: "claimed" },
+      event: { runId: provisioning.record.runId, type: "claimed" },
     });
     if (!claim.ok || claim.data.result === "rejected") {
-      await runtime.runs.remove({ canonicalTaskId });
+      await provisioning.discardUnclaimed();
       const detail = claim.ok
         ? (claim.data.reason ?? "source rejected claim")
         : claim.error.message;
@@ -418,7 +423,7 @@ async function start(input: {
         canonicalTaskId,
         detail,
         reason: "claim-rejected",
-        runId: record.runId,
+        runId: provisioning.record.runId,
       });
       continue;
     }
@@ -436,13 +441,10 @@ async function start(input: {
         repositories: task.repositories,
         slug,
       });
-      await launchAgent({
+      const launched = await provisioning.launch({
         acquiredRepositories: marker.repositories,
         branch: marker.branch,
-        environment: runtime.environment,
-        presenterName: runtime.config.presenter,
         profile,
-        record,
         task: {
           canonicalTaskId,
           description: task.description,
@@ -450,18 +452,7 @@ async function start(input: {
           title: task.title,
         },
       });
-      let transitioned = false;
-      await runtime.runs.mutate({
-        canonicalTaskId,
-        update: (current) => {
-          if (current.state !== "provisioning") {
-            return current;
-          }
-          transitioned = true;
-          return transition({ event: "running", record: current, state: "running" });
-        },
-      });
-      if (!transitioned) {
+      if (!launched.transitioned) {
         continue;
       }
       await clearVerdict({ canonicalTaskId, runtime });
@@ -470,7 +461,7 @@ async function start(input: {
         event: "run_started",
         level: "info",
         module: "core",
-        runId: record.runId,
+        runId: launched.run.record.runId,
         runtime,
       });
       started.push(canonicalTaskId);
@@ -478,30 +469,17 @@ async function start(input: {
     } catch (error) {
       const reason =
         error instanceof PrepareWorktreeError ? prepareFailureReason(error) : errorMessage(error);
-      let failedNow = false;
-      const failed = await runtime.runs.mutate({
-        canonicalTaskId,
-        update: (current) => {
-          if (current.state === "complete") {
-            return current;
-          }
-          failedNow = true;
-          return {
-            ...completeRecord({ outcome: "failed", reason, record: current }),
-            writebackPending: true,
-          };
-        },
-      });
-      if (failedNow) {
+      const failed = await provisioning.fail({ reason });
+      if (failed.transitioned) {
         await log({
           canonicalTaskId,
           event: "run_failed",
           level: "error",
           module: "core",
-          runId: failed.runId,
+          runId: failed.run.record.runId,
           runtime,
         });
-        await writeCompletion({ record: failed, runtime });
+        await writeCompletion({ run: failed.run, runtime });
       }
       if (input.task !== undefined) {
         throw error;
@@ -532,7 +510,7 @@ async function status(input: {
   const visibleTasks = listed.ok ? listed.data.tasks.map((task) => canonicalId({ task })) : [];
   const identities = new Set([
     ...visibleTasks,
-    ...runs.map((run) => run.canonicalTaskId),
+    ...runs.map((run) => run.record.canonicalTaskId),
     ...Object.keys(verdicts),
   ]);
   let selected = [...identities];
@@ -545,21 +523,15 @@ async function status(input: {
       selected = [input.task];
     }
   }
-  const presenter = presenterFor({
-    environment: runtime.environment,
-    name: runtime.config.presenter,
-  });
   const entries = await Promise.all(
     selected.toSorted().map(async (canonicalTaskId): Promise<StatusEntry> => {
-      const run = runs.find((candidate) => candidate.canonicalTaskId === canonicalTaskId);
+      const run = runs.find((candidate) => candidate.record.canonicalTaskId === canonicalTaskId);
+      const record = run?.record;
       const observed =
-        run === undefined
+        record === undefined
           ? undefined
           : await runtime.workspaces.observe({ slug: taskSlug({ canonicalTaskId }) });
-      const accessHint =
-        run?.state === "running"
-          ? await presenter.accessHint({ name: run.presentedWorkspaceName })
-          : undefined;
+      const accessHint = run?.state === "running" ? await run.accessHint() : undefined;
       return {
         accessHint,
         canonicalTaskId,
@@ -568,8 +540,12 @@ async function status(input: {
           wouldRemove: observed?.repositories.map((repository) => repository.path) ?? [],
         },
         observed,
-        reported: { artifacts: run?.artifacts ?? [], outcome: run?.outcome, reason: run?.reason },
-        run,
+        reported: {
+          artifacts: record?.artifacts ?? [],
+          outcome: record?.outcome,
+          reason: record?.reason,
+        },
+        run: record,
         verdict: verdicts[canonicalTaskId],
       };
     }),
@@ -582,30 +558,18 @@ async function artifactAdd(input: {
   readonly task: string;
   readonly artifact: Artifact;
 }): Promise<RunRecord> {
-  const canonicalTaskId = await resolveRunIdentity({ query: input.task, runtime: input.runtime });
-  const record = await input.runtime.runs.mutate({
-    canonicalTaskId,
-    update: (record) => {
-      requireRunningRun(record);
-      return {
-        ...record,
-        artifacts: [...record.artifacts, input.artifact],
-        events: [
-          ...record.events,
-          { event: "artifact-added", timestamp: new Date().toISOString() },
-        ],
-      };
-    },
-  });
+  const run = await input.runtime.runs.resolve({ query: input.task });
+  requireRunningRun(run);
+  const updated = await run.reportArtifact({ artifact: input.artifact });
   await log({
-    canonicalTaskId,
+    canonicalTaskId: updated.record.canonicalTaskId,
     event: "artifact_added",
     level: "info",
     module: "core",
-    runId: record.runId,
+    runId: updated.record.runId,
     runtime: input.runtime,
   });
-  return record;
+  return updated.record;
 }
 
 async function done(input: {
@@ -616,43 +580,36 @@ async function done(input: {
   readonly allowDirty: boolean;
 }): Promise<RunRecord> {
   const { runtime } = input;
-  const canonicalTaskId = await resolveRunIdentity({ query: input.task, runtime });
+  const run = await runtime.runs.resolve({ query: input.task });
+  requireRunningRun(run);
+  const canonicalTaskId = run.record.canonicalTaskId;
   const observed = await runtime.workspaces.observe({ slug: taskSlug({ canonicalTaskId }) });
   if (input.outcome === "delivered" && !input.allowDirty && observed.dirtyPaths.length > 0) {
     throw new DirtyWorkspaceError(observed.dirtyPaths);
   }
-  let record = await runtime.runs.mutate({
-    canonicalTaskId,
-    update: async (current) => {
-      requireRunningRun(current);
+  let completed = await run.finish({
+    assertWorkspaceIdle: async (record) => {
       await runtime.workspaces.assertNoActiveRepositoryOperation({
-        workspaceDirectory: current.workspaceDirectory,
+        workspaceDirectory: record.workspaceDirectory,
       });
-      return {
-        ...completeRecord({ outcome: input.outcome, record: current }),
-        message: input.message,
-        writebackPending: true,
-      };
     },
+    message: input.message,
+    outcome: input.outcome,
   });
   await log({
     canonicalTaskId,
     event: "run_completed",
     level: "info",
     module: "core",
-    runId: record.runId,
+    runId: completed.record.runId,
     runtime,
   });
-  const presenter = presenterFor({
-    environment: runtime.environment,
-    name: runtime.config.presenter,
-  });
-  await presenter.setStatus?.({ name: record.presentedWorkspaceName, text: input.outcome });
-  record = await writeCompletion({ record, runtime });
-  if (record.writebackPending === true) {
+  await completed.setPresentedStatus();
+  completed = await writeCompletion({ run: completed, runtime });
+  if (completed.record.writebackPending === true) {
     throw new Error("completion saved locally; source writeback is pending and will be retried");
   }
-  return record;
+  return completed.record;
 }
 
 async function repoAdd(input: {
@@ -660,24 +617,24 @@ async function repoAdd(input: {
   readonly task: string;
   readonly repository: string;
 }): Promise<RunRecord> {
-  const canonicalTaskId = await resolveRunIdentity({ query: input.task, runtime: input.runtime });
+  const resolved = await input.runtime.runs.resolve({ query: input.task });
+  requireRunningRun(resolved);
+  const canonicalTaskId = resolved.record.canonicalTaskId;
   const slug = taskSlug({ canonicalTaskId });
   const processId = process.pid;
-  let record = await input.runtime.runs.mutate({
-    canonicalTaskId,
-    update: async (current) => {
-      requireRunningRun(current);
+  let run = await resolved.reserveRepositoryOperation({
+    repository: input.repository,
+    reserveWhileLocked: async (record) => {
       await input.runtime.workspaces.reserveRepositoryOperation({
         processId,
         repository: input.repository,
-        workspaceDirectory: current.workspaceDirectory,
+        workspaceDirectory: record.workspaceDirectory,
       });
-      return current;
     },
   });
   try {
     const marker = await input.runtime.workspaces.readMarker({
-      workspaceDirectory: record.workspaceDirectory,
+      workspaceDirectory: run.record.workspaceDirectory,
     });
     if (marker === undefined) {
       throw new Error(`task marker missing for ${canonicalTaskId}`);
@@ -687,25 +644,15 @@ async function repoAdd(input: {
       repository: input.repository,
       slug,
     });
-    record = await input.runtime.runs.mutate({
-      canonicalTaskId,
-      update: (current) => {
-        requireRunningRun(current);
-        return {
-          ...current,
-          events: [
-            ...current.events,
-            { event: `repository-added:${input.repository}`, timestamp: new Date().toISOString() },
-          ],
-          repositories: updatedMarker.repositories,
-        };
-      },
+    run = await run.recordRepositories({
+      repositories: updatedMarker.repositories,
+      repository: input.repository,
     });
   } catch (error) {
     if (error instanceof PrepareWorktreeError) {
-      record = await failPrepare({
-        canonicalTaskId,
+      await failPrepare({
         error,
+        run,
         runtime: input.runtime,
       });
     }
@@ -713,7 +660,7 @@ async function repoAdd(input: {
   } finally {
     await input.runtime.workspaces.finishRepositoryOperation({
       processId,
-      workspaceDirectory: record.workspaceDirectory,
+      workspaceDirectory: run.record.workspaceDirectory,
     });
   }
   await log({
@@ -722,10 +669,10 @@ async function repoAdd(input: {
     level: "info",
     module: "core",
     repository: input.repository,
-    runId: record.runId,
+    runId: run.record.runId,
     runtime: input.runtime,
   });
-  return record;
+  return run.record;
 }
 
 async function cleanup(input: {
@@ -738,24 +685,24 @@ async function cleanup(input: {
   readonly preservedBranches: readonly string[];
 }> {
   const { runtime } = input;
-  let records = await runtime.runs.list();
+  let runs = await runtime.runs.list();
   if (!input.all) {
     if (input.task === undefined) {
       throw new Error("cleanup requires a task or --all");
     }
-    const canonicalTaskId = await resolveRunIdentity({ query: input.task, runtime });
-    records = records.filter((record) => record.canonicalTaskId === canonicalTaskId);
+    runs = [await runtime.runs.resolve({ query: input.task })];
   }
   const cleaned: string[] = [];
   const preservedBranches: string[] = [];
-  for (let record of records) {
-    const slug = taskSlug({ canonicalTaskId: record.canonicalTaskId });
+  for (const run of runs) {
+    const canonicalTaskId = run.record.canonicalTaskId;
+    const slug = taskSlug({ canonicalTaskId });
     // Check dirty state before stopping a running task.
     // eslint-disable-next-line no-await-in-loop
     const observed = await runtime.workspaces.observe({ slug });
     if (!input.allowDirty && observed.dirtyPaths.length > 0) {
       throw cleanupRefusedError({
-        canonicalTaskId: record.canonicalTaskId,
+        canonicalTaskId,
         paths: observed.dirtyPaths,
         query: input.task,
       });
@@ -763,34 +710,21 @@ async function cleanup(input: {
     // The operation check must run under the same run lock as repository reservation, including
     // for a run that reconciliation completed while acquisition was still active.
     // eslint-disable-next-line no-await-in-loop
-    let stoppedNow = false;
-    record = await runtime.runs.mutate({
-      canonicalTaskId: record.canonicalTaskId,
-      update: async (current) => {
+    const stopped = await run.stopForCleanup({
+      assertWorkspaceIdle: async (record) => {
         await runtime.workspaces.assertNoActiveRepositoryOperation({
-          workspaceDirectory: current.workspaceDirectory,
+          workspaceDirectory: record.workspaceDirectory,
         });
-        if (current.state === "complete") {
-          return current;
-        }
-        stoppedNow = true;
-        return {
-          ...completeRecord({ outcome: "stopped", record: current }),
-          writebackPending: true,
-        };
       },
     });
-    if (stoppedNow || record.writebackPending === true) {
+    let completed = stopped.run;
+    if (stopped.transitioned || completed.record.writebackPending === true) {
       // eslint-disable-next-line no-await-in-loop
-      record = await writeCompletion({ record, runtime });
+      completed = await writeCompletion({ run: completed, runtime });
     }
-    const presenter = presenterFor({
-      environment: runtime.environment,
-      name: runtime.config.presenter,
-    });
     // Presenter closes before its underlying directories disappear.
     // eslint-disable-next-line no-await-in-loop
-    await presenter.close({ name: record.presentedWorkspaceName });
+    await completed.closePresentedWorkspace();
     try {
       // eslint-disable-next-line no-await-in-loop
       const result = await runtime.workspaces.cleanup({ allowDirty: input.allowDirty, slug });
@@ -798,148 +732,98 @@ async function cleanup(input: {
     } catch (error) {
       if (error instanceof DirtyWorkspaceError) {
         throw cleanupRefusedError({
-          canonicalTaskId: record.canonicalTaskId,
+          canonicalTaskId,
           paths: error.paths,
           query: input.task,
         });
       }
       throw error;
     }
-    if (record.writebackPending !== true) {
+    if (completed.record.writebackPending !== true) {
       // eslint-disable-next-line no-await-in-loop
-      await runtime.runs.remove({ canonicalTaskId: record.canonicalTaskId });
+      await completed.remove();
     }
     // eslint-disable-next-line no-await-in-loop
     await log({
-      canonicalTaskId: record.canonicalTaskId,
+      canonicalTaskId,
       event: "cleanup_completed",
       level: "info",
       module: "core",
-      runId: record.runId,
+      runId: completed.record.runId,
       runtime,
     });
-    cleaned.push(record.canonicalTaskId);
+    cleaned.push(canonicalTaskId);
   }
   return { cleaned, preservedBranches };
 }
 
 async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
   const { runtime } = input;
-  const records = await runtime.runs.list();
-  if (records.length === 0) {
+  const runs = await runtime.runs.list();
+  if (runs.length === 0) {
     return;
   }
-  const presenter = presenterFor({
-    environment: runtime.environment,
-    name: runtime.config.presenter,
-  });
-  const probe = await presenter.probe();
-  for (let record of records) {
-    const slug = taskSlug({ canonicalTaskId: record.canonicalTaskId });
+  const canonicalTaskIds = runs.map((run) => run.record.canonicalTaskId);
+  for (let run of runs) {
     // Dead in-session acquisition processes leave a recoverable marker that reconciliation clears.
     // eslint-disable-next-line no-await-in-loop
-    record = await runtime.runs.mutate({
-      canonicalTaskId: record.canonicalTaskId,
-      update: async (current) => {
+    run = await run.reconcileWorkspaceOperation({
+      clearDeadWhileLocked: async (record) => {
         await runtime.workspaces.clearDeadRepositoryOperation({
-          workspaceDirectory: current.workspaceDirectory,
+          workspaceDirectory: record.workspaceDirectory,
         });
-        return current;
       },
     });
     // Marker repositories are authoritative after runtime acquisition.
     // eslint-disable-next-line no-await-in-loop
     const marker = await runtime.workspaces.readMarker({
-      workspaceDirectory: record.workspaceDirectory,
+      workspaceDirectory: run.record.workspaceDirectory,
     });
-    if (marker !== undefined && !sameStrings(marker.repositories, record.repositories)) {
+    if (marker !== undefined) {
       // eslint-disable-next-line no-await-in-loop
-      record = await runtime.runs.mutate({
-        canonicalTaskId: record.canonicalTaskId,
-        update: (current) => ({ ...current, repositories: marker.repositories }),
+      const repaired = await runtime.runs.repairRepositories({
+        canonicalTaskId: run.record.canonicalTaskId,
+        repositories: marker.repositories,
       });
-      // eslint-disable-next-line no-await-in-loop
-      await log({
-        canonicalTaskId: record.canonicalTaskId,
-        event: "run_repaired",
-        level: "info",
-        module: "core",
-        runId: record.runId,
-        runtime,
-      });
-    }
-    if (record.writebackPending === true) {
-      // eslint-disable-next-line no-await-in-loop
-      record = await writeCompletion({ record, runtime });
-    }
-    if (!probe.available || record.state === "complete") {
-      continue;
-    }
-    const exists = probe.workspaces.some(
-      (workspace) =>
-        workspace.name === record.presentedWorkspaceName ||
-        workspace.description === record.presentedWorkspaceName ||
-        workspace.description === `groundcrew:${record.canonicalTaskId}`,
-    );
-    if (record.state === "provisioning" && exists) {
-      let reconciledNow = false;
-      // eslint-disable-next-line no-await-in-loop
-      const running = await runtime.runs.mutate({
-        canonicalTaskId: record.canonicalTaskId,
-        update: (current) => {
-          if (current.state !== "provisioning") {
-            return current;
-          }
-          reconciledNow = true;
-          return transition({ event: "running", record: current, state: "running" });
-        },
-      });
-      if (reconciledNow) {
+      run = repaired.run;
+      if (repaired.transitioned) {
         // eslint-disable-next-line no-await-in-loop
         await log({
-          canonicalTaskId: running.canonicalTaskId,
-          event: "run_reconciled",
+          canonicalTaskId: run.record.canonicalTaskId,
+          event: "run_repaired",
           level: "info",
           module: "core",
-          runId: running.runId,
+          runId: run.record.runId,
           runtime,
         });
-      }
-    } else if (!exists) {
-      const reason =
-        record.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing";
-      // eslint-disable-next-line no-await-in-loop
-      let failedNow = false;
-      const failed = await runtime.runs.mutate({
-        canonicalTaskId: record.canonicalTaskId,
-        update: (current) => {
-          if (current.state === "complete") {
-            return current;
-          }
-          failedNow = true;
-          return {
-            ...completeRecord({ outcome: "failed", reason, record: current }),
-            writebackPending: true,
-          };
-        },
-      });
-      if (failedNow) {
-        // eslint-disable-next-line no-await-in-loop
-        await log({
-          canonicalTaskId: failed.canonicalTaskId,
-          event: "run_failed",
-          level: "error",
-          module: "core",
-          runId: failed.runId,
-          runtime,
-        });
-        // eslint-disable-next-line no-await-in-loop
-        await writeCompletion({ record: failed, runtime });
       }
     }
+    if (run.state === "complete" && run.record.writebackPending === true) {
+      // eslint-disable-next-line no-await-in-loop
+      await writeCompletion({ run, runtime });
+    }
+  }
+  for (const change of await runtime.runs.reconcilePresentedWorkspaces({
+    expectedRunIds: runs.map((run) => run.record.runId),
+  })) {
+    // eslint-disable-next-line no-await-in-loop
+    await log({
+      canonicalTaskId: change.run.record.canonicalTaskId,
+      event: change.type === "running" ? "run_reconciled" : "run_failed",
+      level: change.type === "running" ? "info" : "error",
+      module: "core",
+      runId: change.run.record.runId,
+      runtime,
+    });
+    if (change.type === "failed") {
+      // eslint-disable-next-line no-await-in-loop
+      await writeCompletion({ run: change.run, runtime });
+    }
+  }
+  for (const canonicalTaskId of canonicalTaskIds) {
     // Observe on every reconciliation so corrupt/missing worktrees fail loudly without mutation.
     // eslint-disable-next-line no-await-in-loop
-    await runtime.workspaces.observe({ slug });
+    await runtime.workspaces.observe({ slug: taskSlug({ canonicalTaskId }) });
   }
 }
 
@@ -950,11 +834,11 @@ async function reapTerminalTasks(input: {
   const terminal = new Set(
     input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
   );
-  for (const record of await input.runtime.runs.list()) {
-    if (!terminal.has(record.canonicalTaskId)) {
+  for (const run of await input.runtime.runs.list()) {
+    if (!terminal.has(run.record.canonicalTaskId)) {
       continue;
     }
-    const slug = taskSlug({ canonicalTaskId: record.canonicalTaskId });
+    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
     // eslint-disable-next-line no-await-in-loop
     const observed = await input.runtime.workspaces.observe({ slug });
     if (observed.dirtyPaths.length > 0) {
@@ -965,18 +849,19 @@ async function reapTerminalTasks(input: {
       allowDirty: false,
       all: false,
       runtime: input.runtime,
-      task: record.canonicalTaskId,
+      task: run.record.canonicalTaskId,
     });
   }
 }
 
 async function writeCompletion(input: {
   readonly runtime: Runtime;
-  readonly record: RunRecord;
-}): Promise<RunRecord> {
-  const { record, runtime } = input;
+  readonly run: CompletedRun;
+}): Promise<CompletedRun> {
+  const { run, runtime } = input;
+  const { record } = run;
   if (record.outcome === undefined) {
-    return record;
+    return run;
   }
   const result = await runtime.registry.update({
     canonicalTaskId: record.canonicalTaskId,
@@ -996,11 +881,15 @@ async function writeCompletion(input: {
       runId: record.runId,
       runtime,
     });
-    return record;
+    return run;
   }
-  const updated = await runtime.runs.mutate({
-    canonicalTaskId: record.canonicalTaskId,
-    update: (current) => ({ ...current, writebackPending: false }),
+  const completion = record.events.findLast(({ event }) => event.startsWith("complete:"));
+  if (completion === undefined) {
+    throw new Error(`completion event missing for ${record.canonicalTaskId}`);
+  }
+  const updated = await run.acknowledgeSourceWriteback({
+    expectedCompletionTimestamp: completion.timestamp,
+    expectedRunId: record.runId,
   });
   await log({
     canonicalTaskId: record.canonicalTaskId,
@@ -1013,35 +902,10 @@ async function writeCompletion(input: {
   return updated;
 }
 
-async function resolveRunIdentity(input: {
-  readonly query: string;
-  readonly runtime: Runtime;
-}): Promise<string> {
-  const records = await input.runtime.runs.list();
-  const normalizedQuery = input.query.toLowerCase();
-  const matches = records.filter((record) => {
-    const canonicalTaskId = record.canonicalTaskId.toLowerCase();
-    return (
-      canonicalTaskId === normalizedQuery ||
-      canonicalTaskId.slice(canonicalTaskId.indexOf(":") + 1) === normalizedQuery
-    );
-  });
-  const match = matches.at(0);
-  if (match === undefined) {
-    throw new Error(`No local run matches ${input.query}. Run crew status to list local runs.`);
-  }
-  if (matches.length > 1) {
+function requireRunningRun(run: RunHandle): asserts run is RunningRun {
+  if (run.state !== "running") {
     throw new Error(
-      `Multiple local runs match ${input.query}: ${matches.map((record) => record.canonicalTaskId).join(", ")}. Retry with a canonical task ID.`,
-    );
-  }
-  return match.canonicalTaskId;
-}
-
-function requireRunningRun(record: RunRecord): void {
-  if (record.state !== "running") {
-    throw new Error(
-      `run ${record.runId} is ${record.state}; in-session commands require a running run`,
+      `run ${run.record.runId} is ${run.state}; in-session commands require a running run`,
     );
   }
 }
@@ -1093,75 +957,26 @@ function cleanupRefusedError(input: {
   );
 }
 
-function transition(input: {
-  readonly record: RunRecord;
-  readonly state: "running";
-  readonly event: string;
-}): RunRecord {
-  if (input.record.state !== "provisioning") {
-    throw new Error(`cannot transition ${input.record.state} run ${input.record.runId} to running`);
-  }
-  return {
-    ...input.record,
-    events: [...input.record.events, { event: input.event, timestamp: new Date().toISOString() }],
-    state: input.state,
-  };
-}
-
-function completeRecord(input: {
-  readonly record: RunRecord;
-  readonly outcome: "delivered" | "failed" | "stopped";
-  readonly reason?: string | undefined;
-}): RunRecord {
-  if (input.record.state === "complete") {
-    throw new Error(`run ${input.record.runId} is already complete`);
-  }
-  return {
-    ...input.record,
-    events: [
-      ...input.record.events,
-      { event: `complete:${input.outcome}`, timestamp: new Date().toISOString() },
-    ],
-    outcome: input.outcome,
-    reason: input.reason,
-    state: "complete",
-  };
-}
-
 async function failPrepare(input: {
-  readonly canonicalTaskId: string;
   readonly error: PrepareWorktreeError;
+  readonly run: RunningRun;
   readonly runtime: Runtime;
-}): Promise<RunRecord> {
+}): Promise<CompletedRun> {
   const reason = prepareFailureReason(input.error);
-  let failedNow = false;
-  let record = await input.runtime.runs.mutate({
-    canonicalTaskId: input.canonicalTaskId,
-    update: (current) => {
-      if (current.state === "complete") {
-        return current;
-      }
-      failedNow = true;
-      return {
-        ...completeRecord({ outcome: "failed", reason, record: current }),
-        writebackPending: true,
-      };
-    },
-  });
-  if (!failedNow) {
-    return record;
+  const failed = await input.run.fail({ reason });
+  if (!failed.transitioned) {
+    return failed.run;
   }
   await log({
-    canonicalTaskId: input.canonicalTaskId,
+    canonicalTaskId: failed.run.record.canonicalTaskId,
     event: "run_failed",
     level: "error",
     module: "core",
     repository: input.error.repository,
-    runId: record.runId,
+    runId: failed.run.record.runId,
     runtime: input.runtime,
   });
-  record = await writeCompletion({ record, runtime: input.runtime });
-  return record;
+  return await writeCompletion({ run: failed.run, runtime: input.runtime });
 }
 
 function prepareFailureReason(error: PrepareWorktreeError): string {
@@ -1298,10 +1113,6 @@ async function commandExists(input: {
     reject: false,
   });
   return result.exitCode === 0;
-}
-
-function sameStrings(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function errorMessage(error: unknown): string {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -763,7 +763,7 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
   if (runs.length === 0) {
     return;
   }
-  const canonicalTaskIds = runs.map((run) => run.record.canonicalTaskId);
+  const presentation = await runtime.runs.capturePresentedWorkspaces();
   for (let run of runs) {
     // Dead in-session acquisition processes leave a recoverable marker that reconciliation clears.
     // eslint-disable-next-line no-await-in-loop
@@ -800,30 +800,30 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
     }
     if (run.state === "complete" && run.record.writebackPending === true) {
       // eslint-disable-next-line no-await-in-loop
-      await writeCompletion({ run, runtime });
+      run = await writeCompletion({ run, runtime });
     }
-  }
-  for (const change of await runtime.runs.reconcilePresentedWorkspaces({
-    expectedRunIds: runs.map((run) => run.record.runId),
-  })) {
     // eslint-disable-next-line no-await-in-loop
-    await log({
-      canonicalTaskId: change.run.record.canonicalTaskId,
-      event: change.type === "running" ? "run_reconciled" : "run_failed",
-      level: change.type === "running" ? "info" : "error",
-      module: "core",
-      runId: change.run.record.runId,
-      runtime,
-    });
-    if (change.type === "failed") {
+    const change = await runtime.runs.reconcilePresentedWorkspace({ run, snapshot: presentation });
+    if (change !== undefined) {
       // eslint-disable-next-line no-await-in-loop
-      await writeCompletion({ run: change.run, runtime });
+      await log({
+        canonicalTaskId: change.run.record.canonicalTaskId,
+        event: change.type === "running" ? "run_reconciled" : "run_failed",
+        level: change.type === "running" ? "info" : "error",
+        module: "core",
+        runId: change.run.record.runId,
+        runtime,
+      });
+      if (change.type === "failed") {
+        // eslint-disable-next-line no-await-in-loop
+        await writeCompletion({ run: change.run, runtime });
+      }
     }
-  }
-  for (const canonicalTaskId of canonicalTaskIds) {
     // Observe on every reconciliation so corrupt/missing worktrees fail loudly without mutation.
     // eslint-disable-next-line no-await-in-loop
-    await runtime.workspaces.observe({ slug: taskSlug({ canonicalTaskId }) });
+    await runtime.workspaces.observe({
+      slug: taskSlug({ canonicalTaskId: run.record.canonicalTaskId }),
+    });
   }
 }
 

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -219,6 +219,25 @@ describe("RunModule lifecycle", () => {
     await expect(runs.findBySlug({ slug: "fixture-eng-123" })).resolves.toBeUndefined();
   });
 
+  it("discards an unclaimed Run after recovery already completed it", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-rejected-race-"));
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+    await provisioning.fail({ reason: "provisioning-interrupted" });
+
+    await expect(provisioning.discardUnclaimed()).resolves.toBeUndefined();
+    await expect(runs.findBySlug({ slug: "fixture-eng-123" })).resolves.toBeUndefined();
+  });
+
   it("reconciles Run state from one presented Workspace probe", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-reconcile-"));
     const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
@@ -409,6 +428,41 @@ describe("RunModule concurrency", () => {
       undefined,
       undefined,
     ]);
+  });
+
+  it("does not repair repositories on a replacement Run", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-repair-race-"));
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const first = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: ["old"],
+      workspaceDirectory: join(stateRoot, "old-workspace"),
+    });
+    await first.discardUnclaimed();
+    const replacement = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: ["replacement"],
+      workspaceDirectory: join(stateRoot, "replacement-workspace"),
+    });
+
+    const repaired = await runs.repairRepositories({
+      canonicalTaskId: first.record.canonicalTaskId,
+      expectedRunId: first.record.runId,
+      repositories: ["stale"],
+    });
+
+    expect(repaired).toMatchObject({
+      run: {
+        record: { repositories: ["replacement"], runId: replacement.record.runId },
+      },
+      transitioned: false,
+    });
   });
 });
 

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -256,27 +256,97 @@ describe("RunModule lifecycle", () => {
       workspaceDirectory: join(stateRoot, "workspace"),
     });
 
-    const started = await runs.reconcilePresentedWorkspaces({
-      expectedRunIds: [provisioning.record.runId],
+    const started = await runs.reconcilePresentedWorkspace({
+      run: provisioning,
+      snapshot: await runs.capturePresentedWorkspaces(),
     });
     await writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}');
-    const failed = await runs.reconcilePresentedWorkspaces({
-      expectedRunIds: [provisioning.record.runId],
+    if (started?.type !== "running") {
+      throw new Error("provisioning run was not reconciled");
+    }
+    const failed = await runs.reconcilePresentedWorkspace({
+      run: started.run,
+      snapshot: await runs.capturePresentedWorkspaces(),
     });
 
-    expect(started).toMatchObject([
-      { run: { record: { state: "running" }, state: "running" }, type: "running" },
-    ]);
-    expect(failed).toMatchObject([
-      {
-        reason: "workspace-missing",
-        run: {
-          record: { outcome: "failed", state: "complete", writebackPending: true },
-          state: "complete",
-        },
-        type: "failed",
+    expect(started).toMatchObject({
+      run: { record: { state: "running" }, state: "running" },
+      type: "running",
+    });
+    expect(failed).toMatchObject({
+      reason: "workspace-missing",
+      run: {
+        record: { outcome: "failed", state: "complete", writebackPending: true },
+        state: "complete",
       },
+      type: "failed",
+    });
+  });
+
+  it("treats a reconciliation-won launch transition as unchanged", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-launch-race-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(
+        presentedWorkspaceStatePath,
+        JSON.stringify({
+          workspaces: [
+            {
+              description: "groundcrew:fixture:ENG-123",
+              id: "workspace-1",
+              title: "eng-123",
+            },
+          ],
+        }),
+      ),
+      writeFile(presenterCallsPath, ""),
     ]);
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const runs = new RunModule({
+      environment: {
+        ...process.env,
+        FAKE_CMUX_CALLS: presenterCallsPath,
+        FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+        HOME: stateRoot,
+        PATH: `${fakeBin}:${process.env["PATH"]}`,
+      },
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+    await runs.reconcilePresentedWorkspace({
+      run: provisioning,
+      snapshot: await runs.capturePresentedWorkspaces(),
+    });
+
+    const launched = await provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+
+    expect(launched).toMatchObject({
+      run: { record: { state: "running" }, state: "running" },
+      transitioned: false,
+    });
+    expect(launched.run.record.events.map(({ event }) => event)).toEqual([
+      "provisioning",
+      "running",
+    ]);
+    expect(await readFile(presenterCallsPath, "utf8")).not.toContain("new-workspace");
   });
 });
 
@@ -310,6 +380,35 @@ describe("RunModule concurrency", () => {
     });
     const stored = await runs.findBySlug({ slug: "fixture-eng-123" });
     expect(stored?.record.runId).toBe(fulfilled[0]?.value.record.runId);
+  });
+
+  it("allows concurrent cleanup removals to converge", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-remove-race-"));
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+    const stopped = await provisioning.stopForCleanup({ assertWorkspaceIdle: async () => {} });
+    const completion = stopped.run.record.events.at(-1);
+    if (completion === undefined) {
+      throw new Error("completion event missing");
+    }
+    const acknowledged = await stopped.run.acknowledgeSourceWriteback({
+      expectedCompletionTimestamp: completion.timestamp,
+      expectedRunId: stopped.run.record.runId,
+    });
+
+    await expect(Promise.all([acknowledged.remove(), acknowledged.remove()])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 });
 

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -1,19 +1,299 @@
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { RunStore, seedWorkspaceTrust, withFileLock } from "./index.js";
+import { RunModule, seedWorkspaceTrust, withFileLock } from "./index.js";
 
-describe("RunStore", () => {
+describe("RunModule lifecycle", () => {
+  it("owns failure transitions and preserves the first terminal outcome", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-lifecycle-"));
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: ["sample"],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+
+    const failed = await provisioning.fail({ reason: "prepare-failed:sample" });
+    const repeated = await provisioning.fail({ reason: "workspace-missing" });
+
+    expect(failed).toMatchObject({
+      run: {
+        record: {
+          canonicalTaskId: "fixture:ENG-123",
+          outcome: "failed",
+          reason: "prepare-failed:sample",
+          state: "complete",
+          version: 1,
+          writebackPending: true,
+        },
+        state: "complete",
+      },
+      transitioned: true,
+    });
+    expect(failed.run.record.events.map(({ event }) => event)).toEqual([
+      "provisioning",
+      "complete:failed",
+    ]);
+    expect(repeated).toMatchObject({
+      run: { record: { reason: "prepare-failed:sample" }, state: "complete" },
+      transitioned: false,
+    });
+  });
+
+  it("launches the presented workspace before returning a running Run", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-launch-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const runs = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+
+    const launched = await provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+
+    expect(launched).toMatchObject({
+      run: { record: { state: "running" }, state: "running" },
+      transitioned: true,
+    });
+    expect(launched.run.record.events.map(({ event }) => event)).toEqual([
+      "provisioning",
+      "running",
+    ]);
+    expect(await readFile(presenterCallsPath, "utf8")).toContain("new-workspace");
+  });
+
+  it("owns reported Artifacts, completion, and writeback acknowledgement", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-completion-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const runs = new RunModule({
+      environment: {
+        ...process.env,
+        FAKE_CMUX_CALLS: presenterCallsPath,
+        FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+        HOME: stateRoot,
+        PATH: `${fakeBin}:${process.env["PATH"]}`,
+      },
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+    const launched = await provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+
+    const withArtifact = await launched.run.reportArtifact({
+      artifact: { kind: "pull-request", locator: "https://example.test/pull/123" },
+    });
+    let assertedWorkspaceIdle = false;
+    const completed = await withArtifact.finish({
+      assertWorkspaceIdle: async (record) => {
+        assertedWorkspaceIdle = record.workspaceDirectory === workspaceDirectory;
+      },
+      message: "Shipped",
+      outcome: "delivered",
+    });
+    const completion = completed.record.events.at(-1);
+    if (completion === undefined) {
+      throw new Error("completion event missing");
+    }
+
+    await expect(
+      completed.acknowledgeSourceWriteback({
+        expectedCompletionTimestamp: "stale",
+        expectedRunId: completed.record.runId,
+      }),
+    ).rejects.toThrow("stale source writeback acknowledgement");
+    const acknowledged = await completed.acknowledgeSourceWriteback({
+      expectedCompletionTimestamp: completion.timestamp,
+      expectedRunId: completed.record.runId,
+    });
+
+    expect(assertedWorkspaceIdle).toBe(true);
+    expect(completed.record).toMatchObject({
+      artifacts: [{ kind: "pull-request", locator: "https://example.test/pull/123" }],
+      message: "Shipped",
+      outcome: "delivered",
+      state: "complete",
+      writebackPending: true,
+    });
+    expect(completed.record.events.map(({ event }) => event)).toEqual([
+      "provisioning",
+      "running",
+      "artifact-added",
+      "complete:delivered",
+    ]);
+    expect(acknowledged.record.writebackPending).toBe(false);
+  });
+
+  it("stops for cleanup and removes only an acknowledged completed Run", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-cleanup-"));
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+
+    const stopped = await provisioning.stopForCleanup({
+      assertWorkspaceIdle: async () => {},
+    });
+    const repeated = await provisioning.stopForCleanup({
+      assertWorkspaceIdle: async () => {},
+    });
+    await expect(stopped.run.remove()).rejects.toThrow("source writeback is pending");
+    const completion = stopped.run.record.events.at(-1);
+    if (completion === undefined) {
+      throw new Error("completion event missing");
+    }
+    const acknowledged = await stopped.run.acknowledgeSourceWriteback({
+      expectedCompletionTimestamp: completion.timestamp,
+      expectedRunId: stopped.run.record.runId,
+    });
+    await acknowledged.remove();
+
+    expect(stopped).toMatchObject({
+      run: { record: { outcome: "stopped", writebackPending: true }, state: "complete" },
+      transitioned: true,
+    });
+    expect(repeated).toMatchObject({
+      run: { record: { outcome: "stopped" }, state: "complete" },
+      transitioned: false,
+    });
+    await expect(runs.findBySlug({ slug: "fixture-eng-123" })).resolves.toBeUndefined();
+  });
+
+  it("reconciles Run state from one presented Workspace probe", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-reconcile-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(
+        presentedWorkspaceStatePath,
+        JSON.stringify({
+          workspaces: [
+            {
+              description: "groundcrew:fixture:ENG-123",
+              id: "workspace-1",
+              title: "eng-123",
+            },
+          ],
+        }),
+      ),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const runs = new RunModule({
+      environment: {
+        ...process.env,
+        FAKE_CMUX_CALLS: presenterCallsPath,
+        FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+        PATH: `${fakeBin}:${process.env["PATH"]}`,
+      },
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+
+    const started = await runs.reconcilePresentedWorkspaces({
+      expectedRunIds: [provisioning.record.runId],
+    });
+    await writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}');
+    const failed = await runs.reconcilePresentedWorkspaces({
+      expectedRunIds: [provisioning.record.runId],
+    });
+
+    expect(started).toMatchObject([
+      { run: { record: { state: "running" }, state: "running" }, type: "running" },
+    ]);
+    expect(failed).toMatchObject([
+      {
+        reason: "workspace-missing",
+        run: {
+          record: { outcome: "failed", state: "complete", writebackPending: true },
+          state: "complete",
+        },
+        type: "failed",
+      },
+    ]);
+  });
+});
+
+describe("RunModule concurrency", () => {
   it("creates one durable run when initial writers race", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-race-"));
-    const store = new RunStore({ stateRoot });
+    const runs = new RunModule({
+      environment: process.env,
+      presenterName: "cmux",
+      stateRoot,
+    });
 
     const results = await Promise.allSettled(
       Array.from(
         { length: 20 },
         async () =>
-          await store.create({
+          await runs.beginDispatch({
             agentProfile: "codex",
             canonicalTaskId: "fixture:ENG-123",
             repositories: [],
@@ -28,8 +308,8 @@ describe("RunStore", () => {
       fulfilled: 1,
       rejected: 19,
     });
-    const stored = await store.get({ canonicalTaskId: "fixture:ENG-123" });
-    expect(stored?.runId).toBe(fulfilled[0]?.value.runId);
+    const stored = await runs.findBySlug({ slug: "fixture-eng-123" });
+    expect(stored?.record.runId).toBe(fulfilled[0]?.value.record.runId);
   });
 });
 

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -2,7 +2,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { createPresenter, type Presenter } from "../presenter/index.js";
+import { createPresenter, type Presenter, type PresentedWorkspace } from "../presenter/index.js";
 
 export interface Artifact {
   readonly kind: string;
@@ -120,6 +120,15 @@ export type PresentationChange =
       readonly reason: "provisioning-interrupted" | "workspace-missing";
     };
 
+const presentedWorkspaceSnapshot = Symbol("presentedWorkspaceSnapshot");
+
+export interface PresentedWorkspaceSnapshot {
+  readonly [presentedWorkspaceSnapshot]: {
+    readonly available: boolean;
+    readonly workspaces: readonly PresentedWorkspace[];
+  };
+}
+
 export class RunModule {
   readonly #store: RunStore;
   readonly #environment: NodeJS.ProcessEnv;
@@ -180,78 +189,69 @@ export class RunModule {
     return (await this.#store.list()).map((record) => createRunHandle({ module: this, record }));
   }
 
-  public async reconcilePresentedWorkspaces(input: {
-    readonly expectedRunIds: readonly string[];
-  }): Promise<readonly PresentationChange[]> {
-    const expectedRunIds = new Set(input.expectedRunIds);
+  public async capturePresentedWorkspaces(): Promise<PresentedWorkspaceSnapshot> {
     const probe = await this.#presenter.probe();
-    if (!probe.available) {
-      return [];
+    return { [presentedWorkspaceSnapshot]: probe };
+  }
+
+  public async reconcilePresentedWorkspace(input: {
+    readonly run: RunHandle;
+    readonly snapshot: PresentedWorkspaceSnapshot;
+  }): Promise<PresentationChange | undefined> {
+    const probe = input.snapshot[presentedWorkspaceSnapshot];
+    if (!probe.available || input.run.state === "complete") {
+      return undefined;
     }
-    const changes: PresentationChange[] = [];
-    for (const existing of await this.#store.list()) {
-      if (existing.state === "complete" || !expectedRunIds.has(existing.runId)) {
-        continue;
-      }
-      const presented = probe.workspaces.some(
-        (workspace) =>
-          workspace.name === existing.presentedWorkspaceName ||
-          workspace.description === existing.presentedWorkspaceName ||
-          workspace.description === `groundcrew:${existing.canonicalTaskId}`,
-      );
-      if (existing.state === "provisioning" && presented) {
-        let transitioned = false;
-        // Reconciliation is ordered by canonical Task identity for deterministic changes.
-        // eslint-disable-next-line no-await-in-loop
-        const record = await this.#store.mutate({
-          canonicalTaskId: existing.canonicalTaskId,
-          update: (current) => {
-            if (current.runId !== existing.runId || current.state !== "provisioning") {
-              return current;
-            }
-            transitioned = true;
-            return {
-              ...current,
-              events: [
-                ...current.events,
-                { event: "running", timestamp: new Date().toISOString() },
-              ],
-              state: "running",
-            };
-          },
-        });
-        if (transitioned) {
-          changes.push({ run: new RunningRunHandle({ module: this, record }), type: "running" });
-        }
-        continue;
-      }
-      if (presented) {
-        continue;
-      }
-      const reason =
-        existing.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing";
+    const expected = input.run.record;
+    const presented = probe.workspaces.some(
+      (workspace) =>
+        workspace.name === expected.presentedWorkspaceName ||
+        workspace.description === expected.presentedWorkspaceName ||
+        workspace.description === `groundcrew:${expected.canonicalTaskId}`,
+    );
+    if (expected.state === "provisioning" && presented) {
       let transitioned = false;
-      // Reconciliation is ordered by canonical Task identity for deterministic changes.
-      // eslint-disable-next-line no-await-in-loop
       const record = await this.#store.mutate({
-        canonicalTaskId: existing.canonicalTaskId,
+        canonicalTaskId: expected.canonicalTaskId,
         update: (current) => {
-          if (current.runId !== existing.runId || current.state === "complete") {
+          if (current.runId !== expected.runId || current.state !== "provisioning") {
             return current;
           }
           transitioned = true;
-          return completeRunRecord({ outcome: "failed", reason, record: current });
+          return {
+            ...current,
+            events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+            state: "running",
+          };
         },
       });
-      if (transitioned) {
-        changes.push({
+      return transitioned
+        ? { run: new RunningRunHandle({ module: this, record }), type: "running" }
+        : undefined;
+    }
+    if (presented) {
+      return undefined;
+    }
+    const reason =
+      expected.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing";
+    let transitioned = false;
+    const record = await this.#store.mutate({
+      canonicalTaskId: expected.canonicalTaskId,
+      update: (current) => {
+        if (current.runId !== expected.runId || current.state === "complete") {
+          return current;
+        }
+        transitioned = true;
+        return completeRunRecord({ outcome: "failed", reason, record: current });
+      },
+    });
+    return transitioned
+      ? {
           reason,
           run: new CompletedRunHandle({ module: this, record }),
           type: "failed",
-        });
-      }
-    }
-    return changes;
+        }
+      : undefined;
   }
 
   public async fail(input: {
@@ -285,6 +285,21 @@ export class RunModule {
     readonly branch: string;
     readonly acquiredRepositories: readonly string[];
   }): Promise<RunChange<RunningRun>> {
+    const current = await this.#store.getBySlug({
+      slug: taskSlug({ canonicalTaskId: input.record.canonicalTaskId }),
+    });
+    if (current === undefined || current.runId !== input.record.runId) {
+      throw new Error(`run ${input.record.runId} is stale`);
+    }
+    if (current.state === "running") {
+      return {
+        run: new RunningRunHandle({ module: this, record: current }),
+        transitioned: false,
+      };
+    }
+    if (current.state !== "provisioning") {
+      throw new Error(`run ${input.record.runId} is no longer provisioning`);
+    }
     await launchAgent({
       acquiredRepositories: input.acquiredRepositories,
       branch: input.branch,
@@ -294,12 +309,20 @@ export class RunModule {
       record: input.record,
       task: input.task,
     });
+    let transitioned = false;
     const record = await this.#store.mutate({
       canonicalTaskId: input.record.canonicalTaskId,
       update: (current) => {
-        if (current.runId !== input.record.runId || current.state !== "provisioning") {
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
+        if (current.state === "running") {
+          return current;
+        }
+        if (current.state !== "provisioning") {
           throw new Error(`run ${input.record.runId} is no longer provisioning`);
         }
+        transitioned = true;
         return {
           ...current,
           events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
@@ -307,7 +330,7 @@ export class RunModule {
         };
       },
     });
-    return { run: new RunningRunHandle({ module: this, record }), transitioned: true };
+    return { run: new RunningRunHandle({ module: this, record }), transitioned };
   }
 
   public async discardUnclaimed(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
@@ -484,6 +507,7 @@ export class RunModule {
 
   public async remove(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
     await this.#store.removeWhen({
+      allowMissing: true,
       canonicalTaskId: input.record.canonicalTaskId,
       validate: (current) => {
         if (current.runId !== input.record.runId) {
@@ -621,6 +645,7 @@ class RunStore {
   }
 
   public async removeWhen(input: {
+    readonly allowMissing?: boolean | undefined;
     readonly canonicalTaskId: string;
     readonly validate: (record: RunRecord) => void;
   }): Promise<void> {
@@ -629,6 +654,9 @@ class RunStore {
       operation: async () => {
         const current = await this.getBySlug({ slug });
         if (current === undefined) {
+          if (input.allowMissing === true) {
+            return;
+          }
           throw new Error(`no run exists for ${input.canonicalTaskId}`);
         }
         input.validate(current);

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -337,7 +337,9 @@ export class RunModule {
     await this.#store.removeWhen({
       canonicalTaskId: input.record.canonicalTaskId,
       validate: (current) => {
-        requireCurrentRun({ current, expected: input.record, state: "provisioning" });
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
       },
     });
   }
@@ -424,13 +426,17 @@ export class RunModule {
 
   public async repairRepositories(input: {
     readonly canonicalTaskId: string;
+    readonly expectedRunId: string;
     readonly repositories: readonly string[];
   }): Promise<RunChange<RunHandle>> {
     let transitioned = false;
     const record = await this.#store.mutate({
       canonicalTaskId: input.canonicalTaskId,
       update: (current) => {
-        if (sameStrings(current.repositories, input.repositories)) {
+        if (
+          current.runId !== input.expectedRunId ||
+          sameStrings(current.repositories, input.repositories)
+        ) {
           return current;
         }
         transitioned = true;

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -47,7 +47,483 @@ export interface LaunchTask {
   readonly repositories: readonly string[];
 }
 
-export class RunStore {
+export interface RunChange<T extends RunHandle> {
+  readonly run: T;
+  readonly transitioned: boolean;
+}
+
+export interface BaseRun {
+  readonly record: Readonly<RunRecord>;
+  readonly state: RunRecord["state"];
+
+  stopForCleanup(input: {
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunChange<CompletedRun>>;
+  reconcileWorkspaceOperation(input: {
+    readonly clearDeadWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunHandle>;
+}
+
+export interface ProvisioningRun extends BaseRun {
+  readonly state: "provisioning";
+
+  fail(input: { readonly reason: string }): Promise<RunChange<CompletedRun>>;
+  discardUnclaimed(): Promise<void>;
+  launch(input: {
+    readonly task: LaunchTask;
+    readonly profile: AgentProfile;
+    readonly branch: string;
+    readonly acquiredRepositories: readonly string[];
+  }): Promise<RunChange<RunningRun>>;
+}
+
+export interface RunningRun extends BaseRun {
+  readonly state: "running";
+
+  reportArtifact(input: { readonly artifact: Artifact }): Promise<RunningRun>;
+  finish(input: {
+    readonly outcome: "delivered" | "failed" | "stopped";
+    readonly message?: string | undefined;
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<CompletedRun>;
+  fail(input: { readonly reason: string }): Promise<RunChange<CompletedRun>>;
+  reserveRepositoryOperation(input: {
+    readonly repository: string;
+    readonly reserveWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunningRun>;
+  recordRepositories(input: {
+    readonly repository: string;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun>;
+  accessHint(): Promise<string | undefined>;
+}
+
+export interface CompletedRun extends BaseRun {
+  readonly state: "complete";
+
+  acknowledgeSourceWriteback(input: {
+    readonly expectedRunId: string;
+    readonly expectedCompletionTimestamp: string;
+  }): Promise<CompletedRun>;
+  setPresentedStatus(): Promise<void>;
+  closePresentedWorkspace(): Promise<void>;
+  remove(): Promise<void>;
+}
+
+export type RunHandle = ProvisioningRun | RunningRun | CompletedRun;
+
+export type PresentationChange =
+  | { readonly type: "running"; readonly run: RunningRun }
+  | {
+      readonly type: "failed";
+      readonly run: CompletedRun;
+      readonly reason: "provisioning-interrupted" | "workspace-missing";
+    };
+
+export class RunModule {
+  readonly #store: RunStore;
+  readonly #environment: NodeJS.ProcessEnv;
+  readonly #presenterName: "cmux";
+  readonly #presenter: Presenter;
+
+  public constructor(input: {
+    readonly stateRoot: string;
+    readonly environment: NodeJS.ProcessEnv;
+    readonly presenterName: "cmux";
+  }) {
+    this.#store = new RunStore({ stateRoot: input.stateRoot });
+    this.#environment = input.environment;
+    this.#presenterName = input.presenterName;
+    this.#presenter = createPresenter({
+      environment: input.environment,
+      name: input.presenterName,
+    });
+  }
+
+  public async beginDispatch(input: {
+    readonly canonicalTaskId: string;
+    readonly agentProfile: string;
+    readonly workspaceDirectory: string;
+    readonly repositories: readonly string[];
+  }): Promise<ProvisioningRun> {
+    const record = await this.#store.create(input);
+    return new ProvisioningRunHandle({ module: this, record });
+  }
+
+  public async findBySlug(input: { readonly slug: string }): Promise<RunHandle | undefined> {
+    const record = await this.#store.getBySlug(input);
+    return record === undefined ? undefined : createRunHandle({ module: this, record });
+  }
+
+  public async resolve(input: { readonly query: string }): Promise<RunHandle> {
+    const normalizedQuery = input.query.toLowerCase();
+    const matches = (await this.#store.list()).filter((record) => {
+      const canonicalTaskId = record.canonicalTaskId.toLowerCase();
+      return (
+        canonicalTaskId === normalizedQuery ||
+        canonicalTaskId.slice(canonicalTaskId.indexOf(":") + 1) === normalizedQuery
+      );
+    });
+    const match = matches.at(0);
+    if (match === undefined) {
+      throw new Error(`No local run matches ${input.query}. Run crew status to list local runs.`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Multiple local runs match ${input.query}: ${matches.map((record) => record.canonicalTaskId).join(", ")}. Retry with a canonical task ID.`,
+      );
+    }
+    return createRunHandle({ module: this, record: match });
+  }
+
+  public async list(): Promise<readonly RunHandle[]> {
+    return (await this.#store.list()).map((record) => createRunHandle({ module: this, record }));
+  }
+
+  public async reconcilePresentedWorkspaces(input: {
+    readonly expectedRunIds: readonly string[];
+  }): Promise<readonly PresentationChange[]> {
+    const expectedRunIds = new Set(input.expectedRunIds);
+    const probe = await this.#presenter.probe();
+    if (!probe.available) {
+      return [];
+    }
+    const changes: PresentationChange[] = [];
+    for (const existing of await this.#store.list()) {
+      if (existing.state === "complete" || !expectedRunIds.has(existing.runId)) {
+        continue;
+      }
+      const presented = probe.workspaces.some(
+        (workspace) =>
+          workspace.name === existing.presentedWorkspaceName ||
+          workspace.description === existing.presentedWorkspaceName ||
+          workspace.description === `groundcrew:${existing.canonicalTaskId}`,
+      );
+      if (existing.state === "provisioning" && presented) {
+        let transitioned = false;
+        // Reconciliation is ordered by canonical Task identity for deterministic changes.
+        // eslint-disable-next-line no-await-in-loop
+        const record = await this.#store.mutate({
+          canonicalTaskId: existing.canonicalTaskId,
+          update: (current) => {
+            if (current.runId !== existing.runId || current.state !== "provisioning") {
+              return current;
+            }
+            transitioned = true;
+            return {
+              ...current,
+              events: [
+                ...current.events,
+                { event: "running", timestamp: new Date().toISOString() },
+              ],
+              state: "running",
+            };
+          },
+        });
+        if (transitioned) {
+          changes.push({ run: new RunningRunHandle({ module: this, record }), type: "running" });
+        }
+        continue;
+      }
+      if (presented) {
+        continue;
+      }
+      const reason =
+        existing.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing";
+      let transitioned = false;
+      // Reconciliation is ordered by canonical Task identity for deterministic changes.
+      // eslint-disable-next-line no-await-in-loop
+      const record = await this.#store.mutate({
+        canonicalTaskId: existing.canonicalTaskId,
+        update: (current) => {
+          if (current.runId !== existing.runId || current.state === "complete") {
+            return current;
+          }
+          transitioned = true;
+          return completeRunRecord({ outcome: "failed", reason, record: current });
+        },
+      });
+      if (transitioned) {
+        changes.push({
+          reason,
+          run: new CompletedRunHandle({ module: this, record }),
+          type: "failed",
+        });
+      }
+    }
+    return changes;
+  }
+
+  public async fail(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly reason: string;
+  }): Promise<RunChange<CompletedRun>> {
+    let transitioned = false;
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
+        if (current.state === "complete") {
+          return current;
+        }
+        transitioned = true;
+        return completeRunRecord({ outcome: "failed", reason: input.reason, record: current });
+      },
+    });
+    return {
+      run: new CompletedRunHandle({ module: this, record }),
+      transitioned,
+    };
+  }
+
+  public async launch(input: {
+    readonly record: RunRecord;
+    readonly task: LaunchTask;
+    readonly profile: AgentProfile;
+    readonly branch: string;
+    readonly acquiredRepositories: readonly string[];
+  }): Promise<RunChange<RunningRun>> {
+    await launchAgent({
+      acquiredRepositories: input.acquiredRepositories,
+      branch: input.branch,
+      environment: this.#environment,
+      presenterName: this.#presenterName,
+      profile: input.profile,
+      record: input.record,
+      task: input.task,
+    });
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        if (current.runId !== input.record.runId || current.state !== "provisioning") {
+          throw new Error(`run ${input.record.runId} is no longer provisioning`);
+        }
+        return {
+          ...current,
+          events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+          state: "running",
+        };
+      },
+    });
+    return { run: new RunningRunHandle({ module: this, record }), transitioned: true };
+  }
+
+  public async discardUnclaimed(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
+    await this.#store.removeWhen({
+      canonicalTaskId: input.record.canonicalTaskId,
+      validate: (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "provisioning" });
+      },
+    });
+  }
+
+  public async reportArtifact(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly artifact: Artifact;
+  }): Promise<RunningRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "running" });
+        return {
+          ...current,
+          artifacts: [...current.artifacts, input.artifact],
+          events: [
+            ...current.events,
+            { event: "artifact-added", timestamp: new Date().toISOString() },
+          ],
+        };
+      },
+    });
+    return new RunningRunHandle({ module: this, record });
+  }
+
+  public async finish(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly outcome: "delivered" | "failed" | "stopped";
+    readonly message?: string | undefined;
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<CompletedRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: async (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "running" });
+        await input.assertWorkspaceIdle(current);
+        return completeRunRecord({
+          message: input.message,
+          outcome: input.outcome,
+          record: current,
+        });
+      },
+    });
+    return new CompletedRunHandle({ module: this, record });
+  }
+
+  public async reserveRepositoryOperation(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly repository: string;
+    readonly reserveWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunningRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: async (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "running" });
+        await input.reserveWhileLocked(current);
+        return current;
+      },
+    });
+    return new RunningRunHandle({ module: this, record });
+  }
+
+  public async recordRepositories(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly repository: string;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "running" });
+        return {
+          ...current,
+          events: [
+            ...current.events,
+            { event: `repository-added:${input.repository}`, timestamp: new Date().toISOString() },
+          ],
+          repositories: input.repositories,
+        };
+      },
+    });
+    return new RunningRunHandle({ module: this, record });
+  }
+
+  public async repairRepositories(input: {
+    readonly canonicalTaskId: string;
+    readonly repositories: readonly string[];
+  }): Promise<RunChange<RunHandle>> {
+    let transitioned = false;
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.canonicalTaskId,
+      update: (current) => {
+        if (sameStrings(current.repositories, input.repositories)) {
+          return current;
+        }
+        transitioned = true;
+        return { ...current, repositories: input.repositories };
+      },
+    });
+    return { run: createRunHandle({ module: this, record }), transitioned };
+  }
+
+  public async acknowledgeSourceWriteback(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly expectedRunId: string;
+    readonly expectedCompletionTimestamp: string;
+  }): Promise<CompletedRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        const currentCompletionTimestamp = completionTimestamp({ record: current });
+        if (
+          current.runId !== input.expectedRunId ||
+          currentCompletionTimestamp !== input.expectedCompletionTimestamp
+        ) {
+          throw new Error(`stale source writeback acknowledgement for ${current.canonicalTaskId}`);
+        }
+        if (current.state !== "complete" || current.outcome === undefined) {
+          throw new Error(`run ${current.runId} is not complete`);
+        }
+        return current.writebackPending === false
+          ? current
+          : { ...current, writebackPending: false };
+      },
+    });
+    return new CompletedRunHandle({ module: this, record });
+  }
+
+  public async stopForCleanup(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunChange<CompletedRun>> {
+    let transitioned = false;
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: async (current) => {
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
+        await input.assertWorkspaceIdle(current);
+        if (current.state === "complete") {
+          return current;
+        }
+        transitioned = true;
+        return completeRunRecord({ outcome: "stopped", record: current });
+      },
+    });
+    return { run: new CompletedRunHandle({ module: this, record }), transitioned };
+  }
+
+  public async reconcileWorkspaceOperation(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly clearDeadWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunHandle> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: async (current) => {
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
+        await input.clearDeadWhileLocked(current);
+        return current;
+      },
+    });
+    return createRunHandle({ module: this, record });
+  }
+
+  public async remove(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
+    await this.#store.removeWhen({
+      canonicalTaskId: input.record.canonicalTaskId,
+      validate: (current) => {
+        if (current.runId !== input.record.runId) {
+          throw new Error(`run ${input.record.runId} is stale`);
+        }
+        if (current.state !== "complete") {
+          throw new Error(`run ${current.runId} is not complete`);
+        }
+        if (current.writebackPending === true) {
+          throw new Error(`run ${current.runId} source writeback is pending`);
+        }
+      },
+    });
+  }
+
+  public async accessHint(input: {
+    readonly record: Readonly<RunRecord>;
+  }): Promise<string | undefined> {
+    requireState({ record: input.record, state: "running" });
+    return await this.#presenter.accessHint({ name: input.record.presentedWorkspaceName });
+  }
+
+  public async setPresentedStatus(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
+    if (input.record.state !== "complete" || input.record.outcome === undefined) {
+      throw new Error(`run ${input.record.runId} is not complete`);
+    }
+    await this.#presenter.setStatus?.({
+      name: input.record.presentedWorkspaceName,
+      text: input.record.outcome,
+    });
+  }
+
+  public async closePresentedWorkspace(input: {
+    readonly record: Readonly<RunRecord>;
+  }): Promise<void> {
+    await this.#presenter.close({ name: input.record.presentedWorkspaceName });
+  }
+}
+
+class RunStore {
   readonly #runsDirectory: string;
 
   public constructor(input: { readonly stateRoot: string }) {
@@ -90,10 +566,6 @@ export class RunStore {
       },
       slug,
     });
-  }
-
-  public async get(input: { readonly canonicalTaskId: string }): Promise<RunRecord | undefined> {
-    return await this.getBySlug({ slug: taskSlug(input) });
   }
 
   public async getBySlug(input: { readonly slug: string }): Promise<RunRecord | undefined> {
@@ -148,10 +620,18 @@ export class RunStore {
     });
   }
 
-  public async remove(input: { readonly canonicalTaskId: string }): Promise<void> {
+  public async removeWhen(input: {
+    readonly canonicalTaskId: string;
+    readonly validate: (record: RunRecord) => void;
+  }): Promise<void> {
     const slug = taskSlug(input);
     await this.withLock({
       operation: async () => {
+        const current = await this.getBySlug({ slug });
+        if (current === undefined) {
+          throw new Error(`no run exists for ${input.canonicalTaskId}`);
+        }
+        input.validate(current);
         await rm(this.path({ slug }), { force: true });
       },
       slug,
@@ -176,6 +656,158 @@ export class RunStore {
     const lockPath = join(this.#runsDirectory, `${input.slug}.lock`);
     return await withFileLock({ operation: input.operation, path: lockPath });
   }
+}
+
+class ProvisioningRunHandle implements ProvisioningRun {
+  public readonly record: Readonly<RunRecord>;
+  public readonly state = "provisioning" as const;
+  readonly #module: RunModule;
+
+  public constructor(input: { readonly module: RunModule; readonly record: RunRecord }) {
+    this.#module = input.module;
+    this.record = input.record;
+  }
+
+  public async fail(input: { readonly reason: string }): Promise<RunChange<CompletedRun>> {
+    return await this.#module.fail({ reason: input.reason, record: this.record });
+  }
+
+  public async discardUnclaimed(): Promise<void> {
+    await this.#module.discardUnclaimed({ record: this.record });
+  }
+
+  public async launch(input: {
+    readonly task: LaunchTask;
+    readonly profile: AgentProfile;
+    readonly branch: string;
+    readonly acquiredRepositories: readonly string[];
+  }): Promise<RunChange<RunningRun>> {
+    return await this.#module.launch({ ...input, record: this.record });
+  }
+
+  public async stopForCleanup(input: {
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunChange<CompletedRun>> {
+    return await this.#module.stopForCleanup({ ...input, record: this.record });
+  }
+
+  public async reconcileWorkspaceOperation(input: {
+    readonly clearDeadWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunHandle> {
+    return await this.#module.reconcileWorkspaceOperation({ ...input, record: this.record });
+  }
+}
+
+class RunningRunHandle implements RunningRun {
+  public readonly record: Readonly<RunRecord>;
+  public readonly state = "running" as const;
+  readonly #module: RunModule;
+
+  public constructor(input: { readonly module: RunModule; readonly record: RunRecord }) {
+    this.#module = input.module;
+    this.record = input.record;
+  }
+
+  public async reportArtifact(input: { readonly artifact: Artifact }): Promise<RunningRun> {
+    return await this.#module.reportArtifact({ artifact: input.artifact, record: this.record });
+  }
+
+  public async finish(input: {
+    readonly outcome: "delivered" | "failed" | "stopped";
+    readonly message?: string | undefined;
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<CompletedRun> {
+    return await this.#module.finish({ ...input, record: this.record });
+  }
+
+  public async fail(input: { readonly reason: string }): Promise<RunChange<CompletedRun>> {
+    return await this.#module.fail({ reason: input.reason, record: this.record });
+  }
+
+  public async reserveRepositoryOperation(input: {
+    readonly repository: string;
+    readonly reserveWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunningRun> {
+    return await this.#module.reserveRepositoryOperation({ ...input, record: this.record });
+  }
+
+  public async recordRepositories(input: {
+    readonly repository: string;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun> {
+    return await this.#module.recordRepositories({ ...input, record: this.record });
+  }
+
+  public async accessHint(): Promise<string | undefined> {
+    return await this.#module.accessHint({ record: this.record });
+  }
+
+  public async stopForCleanup(input: {
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunChange<CompletedRun>> {
+    return await this.#module.stopForCleanup({ ...input, record: this.record });
+  }
+
+  public async reconcileWorkspaceOperation(input: {
+    readonly clearDeadWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunHandle> {
+    return await this.#module.reconcileWorkspaceOperation({ ...input, record: this.record });
+  }
+}
+
+class CompletedRunHandle implements CompletedRun {
+  public readonly record: Readonly<RunRecord>;
+  public readonly state = "complete" as const;
+  readonly #module: RunModule;
+
+  public constructor(input: { readonly module: RunModule; readonly record: RunRecord }) {
+    this.#module = input.module;
+    this.record = input.record;
+  }
+
+  public async acknowledgeSourceWriteback(input: {
+    readonly expectedRunId: string;
+    readonly expectedCompletionTimestamp: string;
+  }): Promise<CompletedRun> {
+    return await this.#module.acknowledgeSourceWriteback({ ...input, record: this.record });
+  }
+
+  public async remove(): Promise<void> {
+    await this.#module.remove({ record: this.record });
+  }
+
+  public async setPresentedStatus(): Promise<void> {
+    await this.#module.setPresentedStatus({ record: this.record });
+  }
+
+  public async closePresentedWorkspace(): Promise<void> {
+    await this.#module.closePresentedWorkspace({ record: this.record });
+  }
+
+  public async stopForCleanup(input: {
+    readonly assertWorkspaceIdle: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunChange<CompletedRun>> {
+    return await this.#module.stopForCleanup({ ...input, record: this.record });
+  }
+
+  public async reconcileWorkspaceOperation(input: {
+    readonly clearDeadWhileLocked: (record: Readonly<RunRecord>) => Promise<void>;
+  }): Promise<RunHandle> {
+    return await this.#module.reconcileWorkspaceOperation({ ...input, record: this.record });
+  }
+}
+
+function createRunHandle(input: {
+  readonly module: RunModule;
+  readonly record: RunRecord;
+}): RunHandle {
+  if (input.record.state === "provisioning") {
+    return new ProvisioningRunHandle(input);
+  }
+  if (input.record.state === "running") {
+    return new RunningRunHandle(input);
+  }
+  return new CompletedRunHandle(input);
 }
 
 export async function withFileLock<T>(input: {
@@ -252,7 +884,7 @@ export function taskSlug(input: { readonly canonicalTaskId: string }): string {
     .replaceAll(/^-|-$/g, "");
 }
 
-export function composeAgentCommand(input: {
+function composeAgentCommand(input: {
   readonly profile: AgentProfile;
   readonly prompt: string;
 }): readonly string[] {
@@ -273,7 +905,7 @@ export function composeAgentCommand(input: {
   return command;
 }
 
-export function renderPrompt(input: {
+function renderPrompt(input: {
   readonly task: LaunchTask;
   readonly workspaceDirectory: string;
   readonly branch: string;
@@ -299,7 +931,7 @@ export function renderPrompt(input: {
   ].join("\n");
 }
 
-export async function launchAgent(input: {
+async function launchAgent(input: {
   readonly environment: NodeJS.ProcessEnv;
   readonly presenterName: "cmux";
   readonly record: RunRecord;
@@ -418,17 +1050,70 @@ export async function seedWorkspaceTrust(input: {
   });
 }
 
-export function presenterFor(input: {
-  readonly environment: NodeJS.ProcessEnv;
-  readonly name: "cmux";
-}): Presenter {
-  return createPresenter(input);
-}
-
 function presenterWorkspaceName(input: { readonly canonicalTaskId: string }): string {
   const separatorIndex = input.canonicalTaskId.indexOf(":");
   const sourceLocalTaskId = input.canonicalTaskId.slice(separatorIndex + 1);
   return taskSlug({ canonicalTaskId: sourceLocalTaskId });
+}
+
+function completeRunRecord(input: {
+  readonly record: RunRecord;
+  readonly outcome: "delivered" | "failed" | "stopped";
+  readonly reason?: string | undefined;
+  readonly message?: string | undefined;
+}): RunRecord {
+  if (input.record.state === "complete") {
+    throw new Error(`run ${input.record.runId} is already complete`);
+  }
+  return {
+    ...input.record,
+    events: [
+      ...input.record.events,
+      { event: `complete:${input.outcome}`, timestamp: new Date().toISOString() },
+    ],
+    message: input.message,
+    outcome: input.outcome,
+    reason: input.reason,
+    state: "complete",
+    writebackPending: true,
+  };
+}
+
+function requireCurrentRun(input: {
+  readonly current: RunRecord;
+  readonly expected: Readonly<RunRecord>;
+  readonly state: RunRecord["state"];
+}): void {
+  if (input.current.runId !== input.expected.runId) {
+    throw new Error(`run ${input.expected.runId} is stale`);
+  }
+  if (input.current.state !== input.state) {
+    if (input.state === "running") {
+      throw new Error(
+        `run ${input.current.runId} is ${input.current.state}; in-session commands require a running run`,
+      );
+    }
+    throw new Error(
+      `run ${input.current.runId} is ${input.current.state}; expected ${input.state}`,
+    );
+  }
+}
+
+function requireState(input: {
+  readonly record: Readonly<RunRecord>;
+  readonly state: RunRecord["state"];
+}): void {
+  if (input.record.state !== input.state) {
+    throw new Error(`run ${input.record.runId} is ${input.record.state}; expected ${input.state}`);
+  }
+}
+
+function completionTimestamp(input: { readonly record: RunRecord }): string | undefined {
+  return input.record.events.findLast(({ event }) => event.startsWith("complete:"))?.timestamp;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 async function atomicWrite(input: {


### PR DESCRIPTION
## Why

Run lifecycle invariants were split between the public Run store, core orchestration, and presenter helpers. That made state transitions, recovery ordering, and concurrent cleanup behavior harder to reason about and easier to change inconsistently. This has no intended direct customer-visible impact; it improves developer reliability and keeps operational recovery behavior localized behind one module boundary.

## Summary

- Introduce state-specific provisioning, running, and completed Run handles that own durable lifecycle transitions.
- Move presented workspace launch, status, access, close, and reconciliation behavior behind the Run module.
- Keep source writeback and Workspace coordination in core through narrow callbacks while preserving RunRecord v1, CLI output, source events, and recovery ordering.
- Add regression coverage for launch/reconciliation races, concurrent cleanup removal, stale writeback acknowledgement, and per-run reconciliation ordering.

## Validation

- `cd v2 && node --run verify` (8 test files passed; 75 tests passed; 1 skipped)
- Focused Run and dispatch suite (54 tests passed)
- Spec-aware `cb-review --effort low --report`: 0 findings, requirements met, `Ship gate: pass`

## Notes

- The first sandboxed verification attempt could not bind the local Linear fixture server (`listen EPERM 127.0.0.1`); the exact suite was rerun outside the sandbox and passed.
- Agent session: `codex resume 019fe7f1-aea6-75b2-9c2d-c0263468968e`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
