### PR TITLE
fix: block paginated tasks in status queue

### DIFF
--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -420,6 +420,17 @@ describe("collectRemoteStatus", () => {
     expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
   });
 
+  it("blocks a todo whose blocker relation has more pages", async () => {
+    const actual = expectPayload(
+      await collectWithBoard([
+        makeIssue({ id: "linear:eng-225", status: "todo", hasMoreBlockers: true }),
+      ]),
+    );
+
+    expect(actual.queueReady).toEqual([]);
+    expect(actual.queueBlocked.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
+  });
+
   it("keeps only the open blockers on a blocked issue", async () => {
     const actual = expectPayload(
       await collectWithBoard([

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -498,7 +498,7 @@ function splitLogBuffer(buffer: Buffer): {
 }
 
 function hasOpenBlocker(issue: SourceIssue): boolean {
-  return issue.blockers.some((blocker) => blocker.status !== "done");
+  return issue.hasMoreBlockers || issue.blockers.some((blocker) => blocker.status !== "done");
 }
 
 function toBoardIssue(issue: SourceIssue): StatusBoardIssue {


### PR DESCRIPTION
## Why

`crew status` classified Todo tasks with paginated blocker relations as queue-ready when every blocker visible on the first page was done, even though dispatch conservatively skips those tasks because later pages may contain unresolved blockers. This gave operators and external monitors a queue snapshot that disagreed with actual dispatch behavior. There is no direct customer impact; the change improves operational accuracy.

## Summary

- Treat `hasMoreBlockers` as blocking in remote status collection, matching dispatch eligibility.
- Add a regression test proving the task is absent from `queueReady` and present in `queueBlocked`.
- Keep the existing status wire schema unchanged because it has no incomplete-blocker-list field.

## Validation

- `mise exec -- npm exec vitest -- run src/commands/statusCollect.test.ts` — 26 tests passed.
- `mise exec -- node --run verify` — all checks passed; 91 test files and 2,176 tests passed with 100% coverage.
- Pre-push verification reran successfully.

## Notes

- Independent cb-review: no findings; ship gate passed; eligibility boundary compatible.

Agent session: `codex resume 019fecba-d9d6-7230-ae16-233b1e2e7c2e`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
