### PR TITLE
fix: propagate pull request cancellation

### DIFF
--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -118,6 +118,23 @@ describe(findPullRequestsForBranch, () => {
     expect(prs).toStrictEqual([]);
   });
 
+  it("rethrows the original error when the lookup is aborted", async () => {
+    const controller = new AbortController();
+    const abortError = new Error("lookup aborted");
+    runCommandMock.mockImplementation(async () => {
+      controller.abort();
+      throw abortError;
+    });
+
+    const actual = findPullRequestsForBranch({
+      cwd: "/work/widgets-team-1",
+      branchName: "x",
+      signal: controller.signal,
+    });
+
+    await expect(actual).rejects.toBe(abortError);
+  });
+
   it("returns empty when gh emits non-JSON output", async () => {
     runCommandMock.mockResolvedValue("not json at all");
 
@@ -298,6 +315,23 @@ describe(resolvePullRequest, () => {
     await expect(resolvePullRequest({ repoDir: "/work/acme/widgets", pr: "42" })).rejects.toThrow(
       /Could not look up pull request 42 from \/work\/acme\/widgets/,
     );
+  });
+
+  it("rethrows the original error when the lookup is aborted", async () => {
+    const controller = new AbortController();
+    const abortError = new Error("lookup aborted");
+    runCommandMock.mockImplementation(async () => {
+      controller.abort();
+      throw abortError;
+    });
+
+    const actual = resolvePullRequest({
+      repoDir: "/work/acme/widgets",
+      pr: "42",
+      signal: controller.signal,
+    });
+
+    await expect(actual).rejects.toBe(abortError);
   });
 
   it("throws when gh emits non-JSON output", async () => {

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -154,6 +154,9 @@ export async function resolvePullRequest(
       options,
     );
   } catch (error) {
+    if (signal?.aborted === true) {
+      throw error;
+    }
     throw new Error(
       `Could not look up pull request ${pr} from ${repoDir}. Ensure 'gh' is installed and authenticated (gh auth status) and the PR exists.`,
       { cause: error },
@@ -203,7 +206,10 @@ export async function findPullRequestsForBranch(
       options,
     );
     return parsePullRequests(output);
-  } catch {
+  } catch (error) {
+    if (signal?.aborted === true) {
+      throw error;
+    }
     // gh not installed / not authenticated / non-GitHub remote / network
     // error / etc. All resolve to "no PR info available" for display.
     return [];


### PR DESCRIPTION
## Why

Pull-request helpers accepted cancellation signals but hid cancellation as either a GitHub CLI lookup error or an empty result. That prevented callers from recognizing cancellation and could let canceled status work continue with partial data. This has no direct customer-facing impact; it improves CLI cancellation reliability for operators and maintainers.

## Summary

- Rethrow the original command error when the supplied signal is aborted in both pull-request helpers.
- Preserve the existing contextual error and best-effort empty-result behavior for non-abort failures.
- Add focused regression coverage for both cancellation paths.

## Validation

- `mise exec node@24.14.1 -- npm exec -- vitest run src/lib/pullRequests.test.ts`
- `mise exec node@24.14.1 -- node --run verify`
- Pre-push `node --run verify` hook: 91 files and 2,177 tests passed with 100% coverage.

## Notes

- Finding: `fnd_sig-feat-cli-command-06d9b3d7d3-_4832453e32`
- Agent session: `codex resume 019fecbc-3c9d-72a1-b73b-0291afa26300`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
