### PR TITLE
docs: align Node prerequisite with engine constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Groundcrew watches assigned tasks, creates isolated worktrees, launches agent CL
 
 `crew doctor` checks all of these, so you can install as you go.
 
-- **Node >= 24:** [nvm](https://github.com/nvm-sh/nvm): `nvm install 24`.
+- **Node 24.14.1:** [nvm](https://github.com/nvm-sh/nvm): `nvm install 24.14.1`.
 - **git:** e.g., `brew install git`, `apt install git`.
 - **A terminal multiplexer:** [tmux](https://github.com/tmux/tmux/wiki/Installing) (cross-platform), [cmux](https://cmux.com/) (macOS), or [zellij](https://zellij.dev/).
 - **An agent CLI:** [Claude Code](https://code.claude.com/docs/en/quickstart), [Codex](https://developers.openai.com/codex/quickstart?setup=cli), the [Cursor CLI](https://docs.cursor.com/en/cli/overview) (`cursor-agent`, for the `cursor` and `cursor-grok` presets), and/or [Pi](https://pi.dev/).

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@ node --run crew -- doctor
 node --run crew:op -- run --watch
 ```
 
-Both forms discover config through cosmiconfig. Source edits in `src/**` are picked up on the next invocation. Requires Node >= 24.
+Both forms discover config through cosmiconfig. Source edits in `src/**` are picked up on the next invocation. Requires Node 24.14.1.
 
 Regenerate the README demo with VHS:
 


### PR DESCRIPTION
## Why

The published package intentionally requires Node 24.14.1, and the repository enforces that engine during installation. The README and development guide instead claimed support for any Node version at or above 24, directing users and contributors to versions that fail with `EBADENGINE` under `engine-strict`.

## Summary

- Document Node 24.14.1 as the installation prerequisite in the README.
- Align the source development guide with the same exact requirement.
- Keep the tight `package.json` and lockfile engine constraints unchanged.

## Validation

- `mise exec node@24.14.1 -- node --run verify`
- `mise exec node@24.14.1 -- node --run markdown:lint`
- `mise exec node@24.14.1 -- npm pack --dry-run --json` (confirmed the packed artifact includes README.md and package.json)
- Checked README.md and docs/development.md against `package.json#engines.node` and `.nvmrc`

## Notes

Agent session: `codex resume 019fecba-ce57-75d2-88aa-be9167e73756`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
