### PR TITLE
fix: clean up workspaces when run state persistence fails

### DIFF
--- a/src/commands/agentLaunchCleanup.ts
+++ b/src/commands/agentLaunchCleanup.ts
@@ -1,0 +1,12 @@
+import { errorMessage, log } from "../lib/util.ts";
+
+export function cleanupAgentLaunchBestEffort(arguments_: {
+  cleanup: (() => void) | undefined;
+  context: string;
+}): void {
+  try {
+    arguments_.cleanup?.();
+  } catch (error) {
+    log(`Agent launch cleanup failed during ${arguments_.context}: ${errorMessage(error)}`);
+  }
+}

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 
 import { ensureClearance } from "@clipboard-health/clearance";
+import * as agentLaunch from "../lib/agentLaunch.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { resolvePullRequest } from "../lib/pullRequests.ts";
@@ -644,6 +645,40 @@ describe(openWorkspace, () => {
     );
     expect(logMock).toHaveBeenCalledWith(
       "Workspace close was not confirmed during open rollback for pr-42. Close it manually in the configured workspace backend.",
+    );
+  });
+
+  it("still rolls back when agent launch cleanup fails", async () => {
+    const cleanup = vi.fn<() => void>(() => {
+      throw new Error("launch cleanup failed");
+    });
+    const composeAgentLaunchMock = vi
+      .spyOn(agentLaunch, "composeAgentLaunch")
+      .mockReturnValue({ command: "claude", cleanup });
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+
+    try {
+      await expect(
+        openWorkspace(config, {
+          input: { kind: "pr", pr: "42" },
+          repository: "acme/widgets",
+          promptText: "go",
+        }),
+      ).rejects.toThrow("state directory is read-only");
+    } finally {
+      composeAgentLaunchMock.mockRestore();
+    }
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(teardownMock).toHaveBeenCalledWith(
+      config,
+      [expect.objectContaining({ task: "pr-42" })],
+      { force: true },
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      "Agent launch cleanup failed during open rollback: launch cleanup failed",
     );
   });
 

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -608,6 +608,18 @@ describe(openWorkspace, () => {
     recordRunStateMock.mockImplementation(() => {
       throw new Error("state directory is read-only");
     });
+    teardownMock.mockResolvedValue({
+      closed: [],
+      removed: [openedWorktree()],
+      failures: [
+        {
+          entry: openedWorktree(),
+          step: "workspace_close",
+          error: new Error("workspace backend unavailable"),
+        },
+      ],
+      workspaceProbe: { kind: "unavailable" },
+    });
 
     await expect(
       openWorkspace(config, {

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -604,6 +604,25 @@ describe(openWorkspace, () => {
     expect(recordRunStateMock).not.toHaveBeenCalled();
   });
 
+  it("rolls back the live workspace and worktree when recording run state fails", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+
+    await expect(
+      openWorkspace(config, {
+        input: { kind: "pr", pr: "42" },
+        repository: "acme/widgets",
+        promptText: "go",
+      }),
+    ).rejects.toThrow("state directory is read-only");
+    expect(teardownMock).toHaveBeenCalledWith(
+      config,
+      [expect.objectContaining({ task: "pr-42" })],
+      { force: true },
+    );
+  });
+
   it("still surfaces the original failure when rollback teardown also fails", async () => {
     workspacesOpenMock.mockRejectedValue(new Error("cmux down"));
     teardownMock.mockRejectedValue(new Error("teardown blew up"));

--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -8,6 +8,7 @@ import { resolvePullRequest } from "../lib/pullRequests.ts";
 import { resolveRepositoryPreparationCommands } from "../lib/repositoryHooks.ts";
 import { readRunState, recordRunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
+import { log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { openWorkspace, openWorkspaceCli, parseOpenWorkspaceArgs } from "./openWorkspace.ts";
@@ -63,6 +64,10 @@ vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
     recordRunState: vi.fn<typeof recordRunState>(),
   };
 });
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, log: vi.fn<typeof actual.log>() };
+});
 vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -117,6 +122,7 @@ const resolvePullRequestMock = vi.mocked(resolvePullRequest);
 const resolveRepositoryPreparationCommandsMock = vi.mocked(resolveRepositoryPreparationCommands);
 const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
+const logMock = vi.mocked(log);
 const workspacesOpenMock = vi.mocked(workspaces.open);
 const seedLaunchWorkspaceTrustMock = vi.mocked(seedLaunchWorkspaceTrust);
 const workspacesProbeMock = vi.mocked(workspaces.probe);
@@ -632,6 +638,12 @@ describe(openWorkspace, () => {
       config,
       [expect.objectContaining({ task: "pr-42" })],
       { force: true },
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      "Worktree teardown workspace_close failed during rollback: workspace backend unavailable",
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      "Workspace close was not confirmed during open rollback for pr-42. Close it manually in the configured workspace backend.",
     );
   });
 

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -174,12 +174,30 @@ async function rollback(arguments_: {
   config: ResolvedConfig;
   entry: WorktreeEntry;
   promptDir: string;
+  workspaceOpened: boolean;
 }): Promise<void> {
   log(
     `Open failed; rolling back worktree ${arguments_.entry.repository}-${arguments_.entry.task}...`,
   );
   try {
-    await worktrees.teardown(arguments_.config, [arguments_.entry], { force: true });
+    const result = await worktrees.teardown(arguments_.config, [arguments_.entry], { force: true });
+    for (const failure of result.failures) {
+      log(
+        `Worktree teardown ${failure.step} failed during rollback: ${errorMessage(failure.error)}`,
+      );
+    }
+    const workspaceAbsent =
+      result.workspaceProbe.kind === "ok" &&
+      !result.workspaceProbe.names.has(arguments_.entry.task);
+    if (
+      arguments_.workspaceOpened &&
+      !workspaceAbsent &&
+      !result.closed.includes(arguments_.entry.task)
+    ) {
+      log(
+        `Workspace close was not confirmed during open rollback for ${arguments_.entry.task}. Close it manually in the configured workspace backend.`,
+      );
+    }
   } catch (error) {
     log(`Worktree teardown failed during rollback: ${errorMessage(error)}`);
   }
@@ -240,6 +258,7 @@ export async function openWorkspace(
     text: options.promptText ?? "",
   });
   let cleanupAgentLaunch: (() => void) | undefined;
+  let workspaceOpened = false;
   try {
     const { prepareWorktreeCommand, prepareWorktreeUnsandboxedCommand } =
       resolveRepositoryPreparationCommands({
@@ -282,6 +301,7 @@ export async function openWorkspace(
       agent,
       color: definition.color,
     });
+    workspaceOpened = true;
     recordRunState({
       config,
       state: {
@@ -299,7 +319,12 @@ export async function openWorkspace(
     });
   } catch (error) {
     cleanupAgentLaunch?.();
-    await rollback({ config, entry: created, promptDir: stagedPrompt.directory });
+    await rollback({
+      config,
+      entry: created,
+      promptDir: stagedPrompt.directory,
+      workspaceOpened,
+    });
     throw error;
   }
 

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -282,27 +282,26 @@ export async function openWorkspace(
       agent,
       color: definition.color,
     });
+    recordRunState({
+      config,
+      state: {
+        task: target.task,
+        repository,
+        agent,
+        worktreeDir: created.dir,
+        branchName: target.branch,
+        workspaceName: target.task,
+        state: "running",
+        title: target.title,
+        adoptedBranch: true,
+        ...(target.url === undefined ? {} : { url: target.url }),
+      },
+    });
   } catch (error) {
     cleanupAgentLaunch?.();
     await rollback({ config, entry: created, promptDir: stagedPrompt.directory });
     throw error;
   }
-
-  recordRunState({
-    config,
-    state: {
-      task: target.task,
-      repository,
-      agent,
-      worktreeDir: created.dir,
-      branchName: target.branch,
-      workspaceName: target.task,
-      state: "running",
-      title: target.title,
-      adoptedBranch: true,
-      ...(target.url === undefined ? {} : { url: target.url }),
-    },
-  });
 
   log(`${okMark()} "${target.task}" opened on branch ${target.branch} (${agent})`);
   debug(`  Worktree: ${launchDir}`);

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -18,6 +18,7 @@ import { normalizePlainTaskId } from "../lib/taskId.ts";
 import { debug, errorMessage, log, okMark } from "../lib/util.ts";
 import { failIfWorkspaceAlreadyLive } from "../lib/workspaceLiveness.ts";
 import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 
 interface PullRequestInput {
   kind: "pr";
@@ -318,7 +319,7 @@ export async function openWorkspace(
       },
     });
   } catch (error) {
-    cleanupAgentLaunch?.();
+    cleanupAgentLaunchBestEffort({ cleanup: cleanupAgentLaunch, context: "open rollback" });
     await rollback({
       config,
       entry: created,

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 
 import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-health/clearance";
+import * as agentLaunch from "../lib/agentLaunch.ts";
 import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
@@ -831,6 +832,38 @@ describe(resumeWorkspace, () => {
     );
     expect(logMock).toHaveBeenCalledWith(
       "Workspace close was not confirmed during resume rollback for team-1: workspace backend unavailable. Close it manually in the configured workspace backend.",
+    );
+  });
+
+  it("preserves the state failure when launch and prompt cleanup fail", async () => {
+    const cleanup = vi.fn<() => void>(() => {
+      throw new Error("launch cleanup failed");
+    });
+    const composeAgentLaunchMock = vi
+      .spyOn(agentLaunch, "composeAgentLaunch")
+      .mockReturnValue({ command: "claude", cleanup });
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+    rmSyncMock.mockImplementation(() => {
+      throw new Error("prompt cleanup failed");
+    });
+
+    try {
+      await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
+        "state directory is read-only",
+      );
+    } finally {
+      composeAgentLaunchMock.mockRestore();
+    }
+
+    expect(workspacesCloseMock).toHaveBeenCalledWith(config, "team-1");
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(logMock).toHaveBeenCalledWith(
+      "Agent launch cleanup failed during resume rollback for team-1: launch cleanup failed",
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      "Staged prompt cleanup failed during resume rollback for team-1: prompt cleanup failed",
     );
   });
 });

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -70,6 +70,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
     ...actual,
     workspaces: {
       ...actual.workspaces,
+      close: vi.fn<typeof actual.workspaces.close>(),
       open: vi.fn<typeof actual.workspaces.open>(),
       probe: vi.fn<typeof actual.workspaces.probe>(),
     },
@@ -119,6 +120,7 @@ const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
 const getLinearClientMock = vi.mocked(getLinearClient);
 const seedLaunchWorkspaceTrustMock = vi.mocked(seedLaunchWorkspaceTrust);
+const workspacesCloseMock = vi.mocked(workspaces.close);
 const workspacesOpenMock = vi.mocked(workspaces.open);
 const workspacesProbeMock = vi.mocked(workspaces.probe);
 const findByTaskMock = vi.mocked(worktrees.findByTask);
@@ -256,6 +258,7 @@ describe(resumeWorkspace, () => {
     readRunStateMock.mockReturnValue(makeRunState());
     findByTaskMock.mockReturnValue([makeWorktree()]);
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
+    workspacesCloseMock.mockResolvedValue({ kind: "closed" });
     workspacesOpenMock.mockResolvedValue();
     detectHostMock.mockResolvedValue(host());
     ensureClearanceMock.mockResolvedValue({
@@ -762,6 +765,33 @@ describe(resumeWorkspace, () => {
       force: true,
     });
     expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("closes the live workspace when recording resumed run state fails", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
+      "state directory is read-only",
+    );
+    expect(workspacesCloseMock).toHaveBeenCalledWith(config, "team-1");
+    expect(rmSyncMock).toHaveBeenCalledWith("/tmp/groundcrew-resume-team-1-x", {
+      recursive: true,
+      force: true,
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the state failure when closing the resumed workspace also fails", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+    workspacesCloseMock.mockRejectedValue(new Error("cmux close failed"));
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
+      "state directory is read-only",
+    );
   });
 });
 

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -793,6 +793,31 @@ describe(resumeWorkspace, () => {
       "state directory is read-only",
     );
   });
+
+  it("surfaces the state failure when resumed workspace closure is unavailable", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+    workspacesCloseMock.mockResolvedValue({
+      kind: "unavailable",
+      error: new Error("cmux unavailable"),
+    });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
+      "state directory is read-only",
+    );
+  });
+
+  it("surfaces the state failure when resumed workspace closure has no diagnostic", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+    workspacesCloseMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
+      "state directory is read-only",
+    );
+  });
 });
 
 describe(resumeWorkspaceCli, () => {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -9,6 +9,7 @@ import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
 import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
+import { log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
@@ -64,6 +65,10 @@ vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
     recordRunState: vi.fn<typeof recordRunState>(),
   };
 });
+vi.mock(import("../lib/util.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, log: vi.fn<typeof actual.log>() };
+});
 vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -118,6 +123,7 @@ const loadConfigMock = vi.mocked(loadConfig);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
+const logMock = vi.mocked(log);
 const getLinearClientMock = vi.mocked(getLinearClient);
 const seedLaunchWorkspaceTrustMock = vi.mocked(seedLaunchWorkspaceTrust);
 const workspacesCloseMock = vi.mocked(workspaces.close);
@@ -792,6 +798,9 @@ describe(resumeWorkspace, () => {
     await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
       "state directory is read-only",
     );
+    expect(logMock).toHaveBeenCalledWith(
+      "Workspace close failed during resume rollback for team-1: cmux close failed. Close it manually in the configured workspace backend.",
+    );
   });
 
   it("surfaces the state failure when resumed workspace closure is unavailable", async () => {
@@ -806,6 +815,9 @@ describe(resumeWorkspace, () => {
     await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
       "state directory is read-only",
     );
+    expect(logMock).toHaveBeenCalledWith(
+      "Workspace close was not confirmed during resume rollback for team-1: cmux unavailable. Close it manually in the configured workspace backend.",
+    );
   });
 
   it("surfaces the state failure when resumed workspace closure has no diagnostic", async () => {
@@ -816,6 +828,9 @@ describe(resumeWorkspace, () => {
 
     await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
       "state directory is read-only",
+    );
+    expect(logMock).toHaveBeenCalledWith(
+      "Workspace close was not confirmed during resume rollback for team-1: workspace backend unavailable. Close it manually in the configured workspace backend.",
     );
   });
 });

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -23,6 +23,7 @@ import { errorMessage, log } from "../lib/util.ts";
 import { failIfWorkspaceAlreadyLive } from "../lib/workspaceLiveness.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 
 export interface ResumeWorkspaceOptions {
   task: string;
@@ -345,8 +346,17 @@ export async function resumeWorkspace(
         );
       }
     }
-    cleanupAgentLaunch?.();
-    removeStagedPrompt(stagedPrompt.directory);
+    cleanupAgentLaunchBestEffort({
+      cleanup: cleanupAgentLaunch,
+      context: `resume rollback for ${task}`,
+    });
+    try {
+      removeStagedPrompt(stagedPrompt.directory);
+    } catch (cleanupError) {
+      log(
+        `Staged prompt cleanup failed during resume rollback for ${task}: ${errorMessage(cleanupError)}`,
+      );
+    }
     throw error;
   }
   log(`Resumed ${task} in ${context.worktree.dir} (${context.agent})`);

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -21,6 +21,7 @@ import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.t
 import { naturalIdFromCanonical, toCanonicalId } from "../lib/taskSource.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { failIfWorkspaceAlreadyLive } from "../lib/workspaceLiveness.ts";
+import { workspaces } from "../lib/workspaces.ts";
 import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 export interface ResumeWorkspaceOptions {
@@ -263,6 +264,7 @@ export async function resumeWorkspace(
   });
   const secretsFile = stageBuildSecrets(stagedPrompt.directory);
   let cleanupAgentLaunch: (() => void) | undefined;
+  let workspaceOpened = false;
   try {
     const taskSourceWritePaths =
       runner === "safehouse"
@@ -307,27 +309,35 @@ export async function resumeWorkspace(
       agent: context.agent,
       color: definition.color,
     });
+    workspaceOpened = true;
+    recordRunState({
+      config,
+      state: {
+        task,
+        repository: context.repository,
+        agent: context.agent,
+        worktreeDir: context.worktree.dir,
+        branchName: context.worktree.branchName,
+        workspaceName: task,
+        state: "resumed",
+        resumeCount: context.resumeCount + 1,
+        completionTaskId: context.completionTaskId,
+        ...(context.url === undefined ? {} : { url: context.url }),
+        ...(context.reason === undefined ? {} : { reason: context.reason }),
+      },
+    });
   } catch (error) {
+    if (workspaceOpened) {
+      try {
+        await workspaces.close(config, task);
+      } catch (closeError) {
+        log(`Workspace close failed during resume rollback: ${errorMessage(closeError)}`);
+      }
+    }
     cleanupAgentLaunch?.();
     removeStagedPrompt(stagedPrompt.directory);
     throw error;
   }
-  recordRunState({
-    config,
-    state: {
-      task,
-      repository: context.repository,
-      agent: context.agent,
-      worktreeDir: context.worktree.dir,
-      branchName: context.worktree.branchName,
-      workspaceName: task,
-      state: "resumed",
-      resumeCount: context.resumeCount + 1,
-      completionTaskId: context.completionTaskId,
-      ...(context.url === undefined ? {} : { url: context.url }),
-      ...(context.reason === undefined ? {} : { reason: context.reason }),
-    },
-  });
   log(`Resumed ${task} in ${context.worktree.dir} (${context.agent})`);
 }
 

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -329,9 +329,20 @@ export async function resumeWorkspace(
   } catch (error) {
     if (workspaceOpened) {
       try {
-        await workspaces.close(config, task);
+        const result = await workspaces.close(config, task);
+        if (result.kind === "unavailable") {
+          const detail =
+            result.error === undefined
+              ? "workspace backend unavailable"
+              : errorMessage(result.error);
+          log(
+            `Workspace close was not confirmed during resume rollback for ${task}: ${detail}. Close it manually in the configured workspace backend.`,
+          );
+        }
       } catch (closeError) {
-        log(`Workspace close failed during resume rollback: ${errorMessage(closeError)}`);
+        log(
+          `Workspace close failed during resume rollback for ${task}: ${errorMessage(closeError)}. Close it manually in the configured workspace backend.`,
+        );
       }
     }
     cleanupAgentLaunch?.();

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -24,6 +24,7 @@ import {
   type WorktreeEntry,
   worktrees,
 } from "../lib/worktrees.ts";
+import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 
 export interface TaskDetails {
   title: string;
@@ -224,7 +225,7 @@ export async function setupWorkspace(
       logAccessHint(accessHint);
     }
   } catch (error) {
-    cleanupAgentLaunch?.();
+    cleanupAgentLaunchBestEffort({ cleanup: cleanupAgentLaunch, context: "setup rollback" });
     await rollbackWorktree({ config, entry: created, promptDir });
     recordFailedToLaunch({ config, options, paths: { worktreeDir, branchName }, error });
     throw error;


### PR DESCRIPTION
## Why

Run-state writes happen after open/resume launch. If persistence fails, the command rejects while a live workspace remains; open may also leave its worktree without lifecycle metadata. This is an operational reliability issue for operators, especially non-Linear work that cannot be resumed from missing state.

## Summary

- Treat workspace launch and run-state persistence as one guarded lifecycle for `crew open` and `crew resume`.
- Roll back open workspaces/worktrees and close resumed workspaces when state persistence fails.
- Preserve the original persistence error and log manual-close guidance when cleanup cannot be confirmed.
- Add regression coverage for persistence failures and cleanup error result shapes.

## Validation

- `mise exec node@24.14.1 -- node --run verify` (all checks passed; 2,180 tests; 100% coverage)
- Pre-push hook reran `node --run verify` successfully.
- `cb-review --effort low --report`: Ship gate: pass; no findings; requirements met.

## Notes

Agent session: `codex resume 019fecba-75ee-7532-a240-afb1c6556bc1`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
