### PR TITLE
fix: protect presenter launch reconciliation

### DIFF
--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -302,6 +302,279 @@ describe("RunModule lifecycle", () => {
     });
   });
 
+  it("does not fail a presenter-less Run while its provisioning owner is alive", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-live-provisioning-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const owner = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const reconciler = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    await owner.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+    const provisioning = await reconciler.findBySlug({ slug: "fixture-eng-123" });
+    if (provisioning === undefined) {
+      throw new Error("provisioning run missing");
+    }
+
+    const change = await reconciler.reconcilePresentedWorkspace({
+      run: provisioning,
+      snapshot: await reconciler.capturePresentedWorkspaces(),
+    });
+
+    expect(change).toBeUndefined();
+    await expect(owner.findBySlug({ slug: "fixture-eng-123" })).resolves.toMatchObject({
+      record: { state: "provisioning" },
+      state: "provisioning",
+    });
+  });
+
+  it("fails a presenter-less Run after its provisioning owner exits", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-dead-provisioning-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const owner = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const provisioning = await owner.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+    await writeFile(
+      join(stateRoot, "runs", "fixture-eng-123.json"),
+      `${JSON.stringify(
+        {
+          ...provisioning.record,
+          provisioningOwner: {
+            phase: "preparing",
+            processId: deadProcessId(),
+          },
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+    const reconciler = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const interrupted = await reconciler.findBySlug({ slug: "fixture-eng-123" });
+    if (interrupted === undefined) {
+      throw new Error("provisioning run missing");
+    }
+
+    const change = await reconciler.reconcilePresentedWorkspace({
+      run: interrupted,
+      snapshot: await reconciler.capturePresentedWorkspaces(),
+    });
+
+    expect(change).toMatchObject({
+      reason: "provisioning-interrupted",
+      run: { record: { outcome: "failed", state: "complete" }, state: "complete" },
+      type: "failed",
+    });
+  });
+
+  it("rejects an empty snapshot captured before a Run launches", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-stale-snapshot-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const owner = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const reconciler = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const provisioning = await owner.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+    const emptySnapshot = await reconciler.capturePresentedWorkspaces();
+
+    await provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+    const change = await reconciler.reconcilePresentedWorkspace({
+      run: provisioning,
+      snapshot: emptySnapshot,
+    });
+
+    expect(change).toBeUndefined();
+    await expect(owner.findBySlug({ slug: "fixture-eng-123" })).resolves.toMatchObject({
+      record: { state: "running" },
+      state: "running",
+    });
+    expect(JSON.parse(await readFile(presentedWorkspaceStatePath, "utf8"))).toMatchObject({
+      workspaces: [{ description: "groundcrew:fixture:ENG-123" }],
+    });
+  });
+
+  it("rejects a stale empty snapshot while the presenter is opening", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-opening-snapshot-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const openReleasePath = join(stateRoot, "release-open");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_OPEN_RELEASE: openReleasePath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const owner = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const reconciler = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const provisioning = await owner.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+    const emptySnapshot = await reconciler.capturePresentedWorkspaces();
+
+    const launch = provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+    let change;
+    try {
+      await expect
+        .poll(async () => {
+          try {
+            return await readFile(`${openReleasePath}.ready`, "utf8");
+          } catch {
+            return undefined;
+          }
+        })
+        .toBe("ready\n");
+      change = await reconciler.reconcilePresentedWorkspace({
+        run: provisioning,
+        snapshot: emptySnapshot,
+      });
+    } finally {
+      await writeFile(openReleasePath, "release\n");
+    }
+    const launched = await launch;
+
+    expect(change).toBeUndefined();
+    expect(launched).toMatchObject({
+      run: { record: { state: "running" }, state: "running" },
+      transitioned: true,
+    });
+    expect(JSON.parse(await readFile(presentedWorkspaceStatePath, "utf8"))).toMatchObject({
+      workspaces: [{ description: "groundcrew:fixture:ENG-123" }],
+    });
+  });
+
+  it("closes the presented Workspace when launch loses its durable transition", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-lost-launch-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const openReleasePath = join(stateRoot, "release-open");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_OPEN_RELEASE: openReleasePath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const runs = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+
+    const launch = provisioning.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+    await expect
+      .poll(async () => {
+        try {
+          return await readFile(`${openReleasePath}.ready`, "utf8");
+        } catch {
+          return undefined;
+        }
+      })
+      .toBe("ready\n");
+    await provisioning.fail({ reason: "launch-cancelled" });
+    await writeFile(openReleasePath, "release\n");
+
+    await expect(launch).rejects.toThrow("no longer provisioning");
+    expect(JSON.parse(await readFile(presentedWorkspaceStatePath, "utf8"))).toEqual({
+      workspaces: [],
+    });
+  });
+
   it("treats a reconciliation-won launch transition as unchanged", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-launch-race-"));
     const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
@@ -509,3 +782,17 @@ describe("seedWorkspaceTrust", () => {
     expect(Object.keys(configuration.projects).toSorted()).toEqual(workspaces.toSorted());
   });
 });
+
+function deadProcessId(): number {
+  for (let candidate = 2_147_483_647; candidate > 2_147_483_547; candidate -= 1) {
+    try {
+      process.kill(candidate, 0);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+        return candidate;
+      }
+      throw error;
+    }
+  }
+  throw new Error("could not find an unused process ID");
+}

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -575,6 +575,71 @@ describe("RunModule lifecycle", () => {
     });
   });
 
+  it("releases the launch reservation when presenter launch fails", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-retry-launch-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const environment = {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    };
+    const workspaceDirectory = join(stateRoot, "workspace");
+    await mkdir(workspaceDirectory);
+    const failingRuns = new RunModule({
+      environment: { ...environment, FAKE_CMUX_FAIL_OPEN: "1" },
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await failingRuns.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: [],
+      workspaceDirectory,
+    });
+
+    await expect(
+      provisioning.launch({
+        acquiredRepositories: [],
+        branch: "agent/fixture-eng-123",
+        profile: { effort: "high", kind: "codex" },
+        task: {
+          canonicalTaskId: "fixture:ENG-123",
+          repositories: [],
+          title: "Deepen the Run module",
+        },
+      }),
+    ).rejects.toThrow("fake cmux open failure");
+    const retryingRuns = new RunModule({ environment, presenterName: "cmux", stateRoot });
+    const retrying = await retryingRuns.findBySlug({ slug: "fixture-eng-123" });
+    if (retrying?.state !== "provisioning") {
+      throw new Error("provisioning run missing");
+    }
+
+    const launched = await retrying.launch({
+      acquiredRepositories: [],
+      branch: "agent/fixture-eng-123",
+      profile: { effort: "high", kind: "codex" },
+      task: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: [],
+        title: "Deepen the Run module",
+      },
+    });
+
+    expect(launched).toMatchObject({
+      run: { record: { state: "running" }, state: "running" },
+      transitioned: true,
+    });
+  });
+
   it("treats a reconciliation-won launch transition as unchanged", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-launch-race-"));
     const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -366,6 +366,22 @@ export class RunModule {
       return { run: new RunningRunHandle({ module: this, record }), transitioned };
     } catch (launchError) {
       try {
+        await this.#store.mutate({
+          canonicalTaskId: input.record.canonicalTaskId,
+          update: (current) => {
+            if (
+              current.runId !== input.record.runId ||
+              current.state !== "provisioning" ||
+              !matchesProvisioningGeneration({ current, expected: launchRecord })
+            ) {
+              return current;
+            }
+            return {
+              ...current,
+              provisioningOwner: { phase: "preparing", processId: process.pid },
+            };
+          },
+        });
         await this.#presenter.close({ name: launchRecord.presentedWorkspaceName });
       } catch (closeError) {
         throw new AggregateError(

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -32,6 +32,12 @@ export interface RunRecord {
   readonly repositories: readonly string[];
   readonly artifacts: readonly Artifact[];
   readonly events: readonly RunEvent[];
+  readonly provisioningOwner?:
+    | {
+        readonly processId: number;
+        readonly phase: "preparing" | "launching";
+      }
+    | undefined;
 }
 
 export interface AgentProfile {
@@ -214,13 +220,14 @@ export class RunModule {
       const record = await this.#store.mutate({
         canonicalTaskId: expected.canonicalTaskId,
         update: (current) => {
-          if (current.runId !== expected.runId || current.state !== "provisioning") {
+          if (!matchesRunSnapshot({ current, expected })) {
             return current;
           }
           transitioned = true;
           return {
             ...current,
             events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+            provisioningOwner: undefined,
             state: "running",
           };
         },
@@ -238,7 +245,10 @@ export class RunModule {
     const record = await this.#store.mutate({
       canonicalTaskId: expected.canonicalTaskId,
       update: (current) => {
-        if (current.runId !== expected.runId || current.state === "complete") {
+        if (!matchesRunSnapshot({ current, expected })) {
+          return current;
+        }
+        if (current.state === "provisioning" && provisioningOwnerIsAlive({ record: current })) {
           return current;
         }
         transitioned = true;
@@ -285,32 +295,8 @@ export class RunModule {
     readonly branch: string;
     readonly acquiredRepositories: readonly string[];
   }): Promise<RunChange<RunningRun>> {
-    const current = await this.#store.getBySlug({
-      slug: taskSlug({ canonicalTaskId: input.record.canonicalTaskId }),
-    });
-    if (current === undefined || current.runId !== input.record.runId) {
-      throw new Error(`run ${input.record.runId} is stale`);
-    }
-    if (current.state === "running") {
-      return {
-        run: new RunningRunHandle({ module: this, record: current }),
-        transitioned: false,
-      };
-    }
-    if (current.state !== "provisioning") {
-      throw new Error(`run ${input.record.runId} is no longer provisioning`);
-    }
-    await launchAgent({
-      acquiredRepositories: input.acquiredRepositories,
-      branch: input.branch,
-      environment: this.#environment,
-      presenterName: this.#presenterName,
-      profile: input.profile,
-      record: input.record,
-      task: input.task,
-    });
-    let transitioned = false;
-    const record = await this.#store.mutate({
+    let reserved = false;
+    const launchRecord = await this.#store.mutate({
       canonicalTaskId: input.record.canonicalTaskId,
       update: (current) => {
         if (current.runId !== input.record.runId) {
@@ -322,15 +308,73 @@ export class RunModule {
         if (current.state !== "provisioning") {
           throw new Error(`run ${input.record.runId} is no longer provisioning`);
         }
-        transitioned = true;
+        const owner = current.provisioningOwner;
+        if (owner !== undefined && owner.processId !== process.pid) {
+          throw new Error(`run ${input.record.runId} is owned by another provisioning process`);
+        }
+        if (owner?.phase === "launching") {
+          throw new Error(`run ${input.record.runId} is already launching`);
+        }
+        reserved = true;
         return {
           ...current,
-          events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
-          state: "running",
+          provisioningOwner: { phase: "launching", processId: process.pid },
         };
       },
     });
-    return { run: new RunningRunHandle({ module: this, record }), transitioned };
+    if (!reserved) {
+      return {
+        run: new RunningRunHandle({ module: this, record: launchRecord }),
+        transitioned: false,
+      };
+    }
+    try {
+      await launchAgent({
+        acquiredRepositories: input.acquiredRepositories,
+        branch: input.branch,
+        environment: this.#environment,
+        presenterName: this.#presenterName,
+        profile: input.profile,
+        record: launchRecord,
+        task: input.task,
+      });
+      let transitioned = false;
+      const record = await this.#store.mutate({
+        canonicalTaskId: input.record.canonicalTaskId,
+        update: (current) => {
+          if (current.runId !== input.record.runId) {
+            throw new Error(`run ${input.record.runId} is stale`);
+          }
+          if (current.state === "running") {
+            return current;
+          }
+          if (
+            current.state !== "provisioning" ||
+            !matchesProvisioningGeneration({ current, expected: launchRecord })
+          ) {
+            throw new Error(`run ${input.record.runId} is no longer provisioning`);
+          }
+          transitioned = true;
+          return {
+            ...current,
+            events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+            provisioningOwner: undefined,
+            state: "running",
+          };
+        },
+      });
+      return { run: new RunningRunHandle({ module: this, record }), transitioned };
+    } catch (launchError) {
+      try {
+        await this.#presenter.close({ name: launchRecord.presentedWorkspaceName });
+      } catch (closeError) {
+        throw new AggregateError(
+          [launchError, closeError],
+          `run ${input.record.runId} failed to launch and its presented Workspace could not be closed`,
+        );
+      }
+      throw launchError;
+    }
   }
 
   public async discardUnclaimed(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
@@ -585,6 +629,7 @@ class RunStore {
           events: [{ event: "provisioning", timestamp: new Date().toISOString() }],
           presentedWorkspaceName: `groundcrew:${input.canonicalTaskId}`,
           presenter: "cmux",
+          provisioningOwner: { phase: "preparing", processId: process.pid },
           repositories: input.repositories,
           runId: `r_${randomBytes(4).toString("hex")}`,
           state: "provisioning",
@@ -1107,10 +1152,47 @@ function completeRunRecord(input: {
     ],
     message: input.message,
     outcome: input.outcome,
+    provisioningOwner: undefined,
     reason: input.reason,
     state: "complete",
     writebackPending: true,
   };
+}
+
+function matchesRunSnapshot(input: {
+  readonly current: RunRecord;
+  readonly expected: Readonly<RunRecord>;
+}): boolean {
+  return (
+    input.current.runId === input.expected.runId &&
+    input.current.state === input.expected.state &&
+    (input.current.state !== "provisioning" || matchesProvisioningGeneration(input))
+  );
+}
+
+function matchesProvisioningGeneration(input: {
+  readonly current: RunRecord;
+  readonly expected: Readonly<RunRecord>;
+}): boolean {
+  const currentOwner = input.current.provisioningOwner;
+  const expectedOwner = input.expected.provisioningOwner;
+  return (
+    currentOwner?.processId === expectedOwner?.processId &&
+    currentOwner?.phase === expectedOwner?.phase
+  );
+}
+
+function provisioningOwnerIsAlive(input: { readonly record: RunRecord }): boolean {
+  const processId = input.record.provisioningOwner?.processId;
+  if (processId === undefined) {
+    return false;
+  }
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return !(error instanceof Error && "code" in error && error.code === "ESRCH");
+  }
 }
 
 function requireCurrentRun(input: {


### PR DESCRIPTION
## Why

Concurrent Groundcrew CLI processes can reconcile a healthy provisioning run against an empty or stale cmux snapshot while the owning process is preparing or launching it. That can durably fail a healthy run or leave a live agent workspace untracked. This has no direct customer impact; it improves dispatch reliability and prevents operator cleanup work.

## Summary

- Persist the provisioning owner process and a preparing-to-launching generation in each active run.
- Reconcile only snapshots that still match the durable run state and generation, and keep presenter-less runs alive while their owner process is alive.
- Close a presented workspace when launch creates it but loses the durable running transition.
- Add deterministic cross-instance and barrier-controlled concurrency regressions for both race orderings and owner recovery.

## Validation

- node --run verify (8 test files passed; 83 tests passed, 1 skipped)
- npx vitest run src/run/index.test.ts (17 tests passed)

## Notes

Findings: fnd_sig-feat-cli-command-012418b101-_c2c978fbb3 and fnd_sig-feat-cli-command-49a9766219-_65990038f3.

Agent session: `codex resume 019fecf3-bf31-73b2-92d8-01afb9524089`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
