### PR TITLE
fix: use effective source environment for health checks

### DIFF
--- a/v2/src/source/index.test.ts
+++ b/v2/src/source/index.test.ts
@@ -13,6 +13,64 @@ afterEach(async () => {
 });
 
 describe("SourceRegistry", () => {
+  it("uses the effective source environment for secret health checks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-v2-source-health-"));
+    fixtureRoots.push(root);
+    const bundleDirectory = join(root, "task-sources", "fixture");
+    await mkdir(bundleDirectory, { recursive: true });
+    await writeFile(
+      join(bundleDirectory, "source.json"),
+      JSON.stringify({
+        commands: { list: "./list" },
+        environment: { FIXTURE_MANIFEST_TOKEN: "manifest-token" },
+        prerequisites: [],
+        protocolVersion: 1,
+        secrets: ["FIXTURE_REQUIRED_TOKEN", "FIXTURE_MANIFEST_TOKEN"],
+      }),
+    );
+    await writeFile(
+      join(bundleDirectory, "list"),
+      [
+        "#!/bin/sh",
+        'if [ "$FIXTURE_REQUIRED_TOKEN" != "instance-token" ]; then',
+        '  printf \'%s\\n\' \'{"ok":false,"error":{"message":"token unavailable"}}\'',
+        "  exit 0",
+        "fi",
+        'if [ "$FIXTURE_MANIFEST_TOKEN" != "manifest-token" ]; then',
+        '  printf \'%s\\n\' \'{"ok":false,"error":{"message":"manifest token unavailable"}}\'',
+        "  exit 0",
+        "fi",
+        'printf \'%s\\n\' \'{"ok":true,"data":{"tasks":[]}}\'',
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const registry = await SourceRegistry.create({
+      configHome: join(root, "config"),
+      environment: process.env,
+      instances: [
+        {
+          environment: { FIXTURE_REQUIRED_TOKEN: "instance-token" },
+          kind: "fixture",
+        },
+      ],
+      packageRoot: root,
+    });
+
+    const result = await registry.health();
+
+    expect(result).toEqual([
+      {
+        errors: [],
+        kind: "fixture",
+        name: "fixture",
+        origin: "package",
+        probe: { data: { taskCount: 0 }, ok: true },
+        protocolVersion: 1,
+      },
+    ]);
+  });
+
   it("rejects update routing when configured source names collide", async () => {
     const root = await mkdtemp(join(tmpdir(), "groundcrew-v2-source-duplicate-"));
     fixtureRoots.push(root);

--- a/v2/src/source/index.ts
+++ b/v2/src/source/index.ts
@@ -96,6 +96,7 @@ interface DiscoveredBundle {
 
 interface RegisteredSource {
   readonly bundle: Bundle | undefined;
+  readonly environment: NodeJS.ProcessEnv;
   readonly instance: SourceInstance;
   readonly name: string;
   readonly origin: "package" | "user";
@@ -105,14 +106,9 @@ interface RegisteredSource {
 
 export class SourceRegistry {
   readonly #sources: readonly RegisteredSource[];
-  readonly #environment: NodeJS.ProcessEnv;
 
-  private constructor(input: {
-    readonly sources: readonly RegisteredSource[];
-    readonly environment: NodeJS.ProcessEnv;
-  }) {
+  private constructor(input: { readonly sources: readonly RegisteredSource[] }) {
     this.#sources = input.sources;
-    this.#environment = input.environment;
   }
 
   public static async create(input: {
@@ -133,6 +129,11 @@ export class SourceRegistry {
       return {
         bundle,
         discoveryErrors: [...discoveryErrors],
+        environment: {
+          ...input.environment,
+          ...bundle?.manifest.environment,
+          ...instance.environment,
+        },
         instance,
         lastTasks: [],
         name,
@@ -144,7 +145,7 @@ export class SourceRegistry {
         source.discoveryErrors.push(`duplicate configured source name '${source.name}'`);
       }
     }
-    return new SourceRegistry({ environment: input.environment, sources });
+    return new SourceRegistry({ sources });
   }
 
   public sourceDefaultProfile(input: { readonly sourceName: string }): string | undefined {
@@ -169,7 +170,7 @@ export class SourceRegistry {
           );
         }
         for (const secret of bundle.manifest.secrets) {
-          if (this.#environment[secret] === undefined) {
+          if (source.environment[secret] === undefined) {
             errors.push(`missing secret ${secret}`);
           }
         }
@@ -177,11 +178,7 @@ export class SourceRegistry {
           if (
             !(await commandExists({
               command: prerequisite,
-              environment: {
-                ...this.#environment,
-                ...bundle.manifest.environment,
-                ...source.instance.environment,
-              },
+              environment: source.environment,
             }))
           ) {
             errors.push(`missing prerequisite ${prerequisite}`);
@@ -336,11 +333,7 @@ export class SourceRegistry {
       await access(executable, constants.X_OK);
       const result = await execa(executable, [], {
         cwd: bundle.directory,
-        env: {
-          ...this.#environment,
-          ...bundle.manifest.environment,
-          ...source.instance.environment,
-        },
+        env: source.environment,
         input: JSON.stringify(payload),
         reject: false,
         ...(input.timeoutMilliseconds === undefined ? {} : { timeout: input.timeoutMilliseconds }),


### PR DESCRIPTION
## Why

`SourceRegistry.health` checked declared secrets only in the base process environment even though source commands receive the manifest and configured-instance overlays. A valid source could therefore run successfully while `crew doctor` incorrectly reported a missing secret and exited unsuccessfully, making diagnostics and automation unreliable.

## Summary

- Compose each registered source's effective environment once using the existing base → manifest → instance precedence.
- Reuse that environment for secret validation, prerequisite discovery, and source invocation.
- Cover secrets supplied by both configured-instance and manifest environments while requiring a successful live probe.

## Validation

- `node --run test -- src/source/index.test.ts` — 2 passed.
- `node --run verify` — 8 test files passed; 79 tests passed and 1 skipped.
- Regression test before implementation — failed with `missing secret FIXTURE_REQUIRED_TOKEN` and no live probe.

## Notes

Finding: `fnd_sig-feat-cli-command-012418b101-_4ba3185c1c`.

Agent session: `codex resume 019fecfc-5740-7e00-8c3d-c30dd8c6f0bc`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
