### PR TITLE
fix: validate workspace metadata before cleanup

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -219,6 +219,32 @@ describe("crew start", () => {
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("explains how to recover cleanup after worktreeDirectory changes", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const configPath = join(fixture.root, "crew.config.jsonc");
+    const previousConfig = await readFile(configPath, "utf8");
+    const changedConfig = previousConfig.replace(
+      join(fixture.root, "worktrees"),
+      join(fixture.root, "moved-worktrees"),
+    );
+    if (changedConfig === previousConfig) {
+      throw new Error("fixture worktreeDirectory was not changed");
+    }
+    await writeFile(configPath, changedConfig);
+
+    const cleanup = runCrew({
+      arguments: ["cleanup", "ENG-123", "--force"],
+      environment: fixture.environment,
+    });
+
+    await expect(cleanup).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("restore the previous workspace.worktreeDirectory"),
+    });
+    await expect(stat(fixture.workspaceDirectory)).resolves.toBeDefined();
+  });
+
   it("does not adopt tampered marker repositories before destructive cleanup", async () => {
     const fixture = await createDispatchFixture({ additionalRepositories: ["target"] });
     await runCrew({ arguments: ["start"], environment: fixture.environment });
@@ -238,7 +264,10 @@ describe("crew start", () => {
       environment: fixture.environment,
     });
 
-    await expect(cleanup).rejects.toMatchObject({ code: 1 });
+    await expect(cleanup).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("workspace repositories do not match its durable run"),
+    });
     await expect(
       gitOutput({ arguments: ["rev-parse", branch], cwd: targetRepository }),
     ).resolves.toBe(targetBranchTip);

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -219,6 +219,31 @@ describe("crew start", () => {
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not adopt tampered marker repositories before destructive cleanup", async () => {
+    const fixture = await createDispatchFixture({ additionalRepositories: ["target"] });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const targetRepository = join(fixture.baseDirectory, "target");
+    const branch = "crew/fixture-eng-123";
+    await runGit({ arguments: ["branch", branch], cwd: targetRepository });
+    const targetBranchTip = await gitOutput({
+      arguments: ["rev-parse", branch],
+      cwd: targetRepository,
+    });
+    const markerPath = join(fixture.workspaceDirectory, ".groundcrew", "task.json");
+    const marker = JSON.parse(await readFile(markerPath, "utf8"));
+    await writeFile(markerPath, JSON.stringify({ ...marker, repositories: ["target"] }));
+
+    const cleanup = runCrew({
+      arguments: ["cleanup", "ENG-123", "--force"],
+      environment: fixture.environment,
+    });
+
+    await expect(cleanup).rejects.toMatchObject({ code: 1 });
+    await expect(
+      gitOutput({ arguments: ["rev-parse", branch], cwd: targetRepository }),
+    ).resolves.toBe(targetBranchTip);
+  });
+
   it("explains how to find a task when cleanup has no matching run", async () => {
     const fixture = await createDispatchFixture();
 

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -727,7 +727,16 @@ async function cleanup(input: {
     await completed.closePresentedWorkspace();
     try {
       // eslint-disable-next-line no-await-in-loop
-      const result = await runtime.workspaces.cleanup({ allowDirty: input.allowDirty, slug });
+      const result = await runtime.workspaces.cleanup({
+        allowDirty: input.allowDirty,
+        record: {
+          canonicalTaskId: completed.record.canonicalTaskId,
+          pendingRepository: completed.record.pendingRepository,
+          repositories: completed.record.repositories,
+          workspaceDirectory: completed.record.workspaceDirectory,
+        },
+        slug,
+      });
       preservedBranches.push(...result.preservedBranches);
     } catch (error) {
       if (error instanceof DirtyWorkspaceError) {
@@ -774,7 +783,7 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
         });
       },
     });
-    // Marker repositories are authoritative after runtime acquisition.
+    // A marker can recover only a repository that was durably reserved before acquisition.
     // eslint-disable-next-line no-await-in-loop
     const marker = await runtime.workspaces.readMarker({
       workspaceDirectory: run.record.workspaceDirectory,

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -464,6 +464,66 @@ describe("RunModule concurrency", () => {
       transitioned: false,
     });
   });
+
+  it("normalizes repository names while repairing a reserved repository", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-repair-normalization-"));
+    const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+    const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await Promise.all([
+      writeFile(
+        presentedWorkspaceStatePath,
+        JSON.stringify({
+          workspaces: [
+            {
+              description: "groundcrew:fixture:ENG-123",
+              id: "workspace-1",
+              title: "eng-123",
+            },
+          ],
+        }),
+      ),
+      writeFile(presenterCallsPath, ""),
+    ]);
+    const runs = new RunModule({
+      environment: {
+        ...process.env,
+        FAKE_CMUX_CALLS: presenterCallsPath,
+        FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+        PATH: `${fakeBin}:${process.env["PATH"]}`,
+      },
+      presenterName: "cmux",
+      stateRoot,
+    });
+    const provisioning = await runs.beginDispatch({
+      agentProfile: "codex",
+      canonicalTaskId: "fixture:ENG-123",
+      repositories: ["owner/sample"],
+      workspaceDirectory: join(stateRoot, "workspace"),
+    });
+    const reconciled = await runs.reconcilePresentedWorkspace({
+      run: provisioning,
+      snapshot: await runs.capturePresentedWorkspaces(),
+    });
+    if (reconciled?.type !== "running") {
+      throw new Error("provisioning run was not reconciled");
+    }
+    const reserved = await reconciled.run.reserveRepositoryOperation({
+      repository: "owner/extra",
+      reserveWhileLocked: async () => {},
+    });
+
+    const repaired = await runs.repairRepositories({
+      canonicalTaskId: reserved.record.canonicalTaskId,
+      expectedRunId: reserved.record.runId,
+      repositories: ["owner/sample", "owner/extra"],
+    });
+
+    expect(repaired).toMatchObject({
+      run: { record: { repositories: ["sample", "extra"] } },
+      transitioned: true,
+    });
+  });
 });
 
 describe("withFileLock", () => {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -432,6 +432,7 @@ export class RunModule {
     readonly repositories: readonly string[];
   }): Promise<RunChange<RunHandle>> {
     let transitioned = false;
+    const repositories = input.repositories.map(repositoryName);
     const record = await this.#store.mutate({
       canonicalTaskId: input.canonicalTaskId,
       update: (current) => {
@@ -439,7 +440,7 @@ export class RunModule {
           current.runId !== input.expectedRunId ||
           current.pendingRepository === undefined ||
           !sameStringSets({
-            left: input.repositories,
+            left: repositories,
             right: [...current.repositories, current.pendingRepository].map(repositoryName),
           })
         ) {
@@ -449,7 +450,7 @@ export class RunModule {
         return {
           ...current,
           pendingRepository: undefined,
-          repositories: input.repositories,
+          repositories,
         };
       },
     });

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -1,7 +1,7 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { createPresenter, type Presenter, type PresentedWorkspace } from "../presenter/index.js";
 
 export interface Artifact {
@@ -30,6 +30,7 @@ export interface RunRecord {
   readonly presentedWorkspaceName: string;
   readonly workspaceDirectory: string;
   readonly repositories: readonly string[];
+  readonly pendingRepository?: string | undefined;
   readonly artifacts: readonly Artifact[];
   readonly events: readonly RunEvent[];
 }
@@ -396,7 +397,7 @@ export class RunModule {
       update: async (current) => {
         requireCurrentRun({ current, expected: input.record, state: "running" });
         await input.reserveWhileLocked(current);
-        return current;
+        return { ...current, pendingRepository: input.repository };
       },
     });
     return new RunningRunHandle({ module: this, record });
@@ -417,6 +418,7 @@ export class RunModule {
             ...current.events,
             { event: `repository-added:${input.repository}`, timestamp: new Date().toISOString() },
           ],
+          pendingRepository: undefined,
           repositories: input.repositories,
         };
       },
@@ -435,12 +437,20 @@ export class RunModule {
       update: (current) => {
         if (
           current.runId !== input.expectedRunId ||
-          sameStrings(current.repositories, input.repositories)
+          current.pendingRepository === undefined ||
+          !sameStringSets({
+            left: input.repositories,
+            right: [...current.repositories, current.pendingRepository].map(repositoryName),
+          })
         ) {
           return current;
         }
         transitioned = true;
-        return { ...current, repositories: input.repositories };
+        return {
+          ...current,
+          pendingRepository: undefined,
+          repositories: input.repositories,
+        };
       },
     });
     return { run: createRunHandle({ module: this, record }), transitioned };
@@ -1146,8 +1156,17 @@ function completionTimestamp(input: { readonly record: RunRecord }): string | un
   return input.record.events.findLast(({ event }) => event.startsWith("complete:"))?.timestamp;
 }
 
-function sameStrings(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
+function repositoryName(repository: string): string {
+  return basename(repository);
+}
+
+function sameStringSets(input: {
+  readonly left: readonly string[];
+  readonly right: readonly string[];
+}): boolean {
+  const left = new Set(input.left);
+  const right = new Set(input.right);
+  return left.size === right.size && [...left].every((value) => right.has(value));
 }
 
 async function atomicWrite(input: {

--- a/v2/src/workspace/index.test.ts
+++ b/v2/src/workspace/index.test.ts
@@ -1,0 +1,280 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { WorkspaceMetadataError, WorkspaceService } from "./index.js";
+
+const execFileAsync = promisify(execFile);
+const fixtureRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("WorkspaceService cleanup", () => {
+  it("rejects traversal metadata before deleting a branch outside the checkout root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-cleanup-"));
+    fixtureRoots.push(root);
+    const baseDirectory = join(root, "repositories");
+    const outsideRepository = join(root, "target");
+    const worktreeDirectory = join(root, "worktrees");
+    const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+    await Promise.all([
+      mkdir(baseDirectory, { recursive: true }),
+      mkdir(join(workspaceDirectory, ".groundcrew"), { recursive: true }),
+      createRepository({ path: outsideRepository }),
+    ]);
+    await runGit({ arguments: ["branch", "attacker-selected"], cwd: outsideRepository });
+    await writeFile(
+      join(workspaceDirectory, ".groundcrew", "task.json"),
+      JSON.stringify({
+        branch: "attacker-selected",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["../target"],
+        version: 1,
+      }),
+    );
+    const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+    const rejected = await workspaces
+      .cleanup({
+        allowDirty: true,
+        record: {
+          canonicalTaskId: "fixture:ENG-123",
+          repositories: ["target"],
+          workspaceDirectory,
+        },
+        slug: "fixture-eng-123",
+      })
+      .then(
+        () => false,
+        () => true,
+      );
+    const outsideBranchExists = await gitBranchExists({
+      branch: "attacker-selected",
+      cwd: outsideRepository,
+    });
+
+    expect({ outsideBranchExists, rejected }).toEqual({
+      outsideBranchExists: true,
+      rejected: true,
+    });
+  });
+
+  it.each(["task.json", "provisioning.json"])(
+    "strictly validates %s workspace metadata",
+    async (fileName) => {
+      const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-metadata-"));
+      fixtureRoots.push(root);
+      const baseDirectory = join(root, "repositories");
+      const worktreeDirectory = join(root, "worktrees");
+      const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+      await Promise.all([
+        mkdir(baseDirectory, { recursive: true }),
+        mkdir(join(workspaceDirectory, ".groundcrew"), { recursive: true }),
+      ]);
+      await writeFile(
+        join(workspaceDirectory, ".groundcrew", fileName),
+        JSON.stringify({
+          branch: "crew/fixture-eng-123",
+          canonicalTaskId: "fixture:ENG-123",
+          repositories: [],
+          unexpected: true,
+          version: 1,
+        }),
+      );
+      const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+      const observed = workspaces.observe({ slug: "fixture-eng-123" });
+
+      await expect(observed).rejects.toBeInstanceOf(WorkspaceMetadataError);
+    },
+  );
+
+  it.each([
+    {
+      branchToPreserve: "crew/fixture-eng-123",
+      marker: {
+        branch: "crew/fixture-eng-123",
+        canonicalTaskId: "fixture:OTHER",
+        repositories: ["safe"],
+        version: 1 as const,
+      },
+      fileName: "task.json",
+      repositoryToPreserve: "safe",
+      subject: "canonical task",
+    },
+    {
+      branchToPreserve: "attacker-selected",
+      marker: {
+        branch: "attacker-selected",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["safe"],
+        version: 1 as const,
+      },
+      fileName: "task.json",
+      repositoryToPreserve: "safe",
+      subject: "branch",
+    },
+    {
+      branchToPreserve: "crew/fixture-eng-123",
+      marker: {
+        branch: "crew/fixture-eng-123",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["target"],
+        version: 1 as const,
+      },
+      fileName: "task.json",
+      repositoryToPreserve: "target",
+      subject: "repository set",
+    },
+    {
+      branchToPreserve: "crew/fixture-eng-123",
+      fileName: "provisioning.json",
+      marker: {
+        branch: "crew/fixture-eng-123",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["target"],
+        version: 1 as const,
+      },
+      repositoryToPreserve: "target",
+      subject: "recovery repository set",
+    },
+  ])("rejects a $subject mismatch against the durable run", async (testCase) => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-run-mismatch-"));
+    fixtureRoots.push(root);
+    const baseDirectory = join(root, "repositories");
+    const safeRepository = join(baseDirectory, "safe");
+    const targetRepository = join(baseDirectory, "target");
+    const worktreeDirectory = join(root, "worktrees");
+    const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+    await Promise.all([
+      createRepository({ path: safeRepository }),
+      createRepository({ path: targetRepository }),
+      mkdir(join(workspaceDirectory, ".groundcrew"), { recursive: true }),
+    ]);
+    await Promise.all([
+      runGit({ arguments: ["branch", "crew/fixture-eng-123"], cwd: safeRepository }),
+      runGit({ arguments: ["branch", "attacker-selected"], cwd: safeRepository }),
+      runGit({ arguments: ["branch", "crew/fixture-eng-123"], cwd: targetRepository }),
+    ]);
+    await writeFile(
+      join(workspaceDirectory, ".groundcrew", testCase.fileName),
+      JSON.stringify(testCase.marker),
+    );
+    const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+    const cleanup = workspaces.cleanup({
+      allowDirty: true,
+      record: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["safe"],
+        workspaceDirectory,
+      },
+      slug: "fixture-eng-123",
+    });
+
+    await expect(cleanup).rejects.toBeInstanceOf(WorkspaceMetadataError);
+    await expect(
+      gitBranchExists({
+        branch: testCase.branchToPreserve,
+        cwd: join(baseDirectory, testCase.repositoryToPreserve),
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects task and recovery markers with different workspace identities", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-identity-"));
+    fixtureRoots.push(root);
+    const baseDirectory = join(root, "repositories");
+    const worktreeDirectory = join(root, "worktrees");
+    const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+    const metadataDirectory = join(workspaceDirectory, ".groundcrew");
+    await Promise.all([
+      mkdir(baseDirectory, { recursive: true }),
+      mkdir(metadataDirectory, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(
+        join(metadataDirectory, "task.json"),
+        JSON.stringify({
+          branch: "crew/fixture-eng-123",
+          canonicalTaskId: "fixture:ENG-123",
+          repositories: [],
+          version: 1,
+        }),
+      ),
+      writeFile(
+        join(metadataDirectory, "provisioning.json"),
+        JSON.stringify({
+          branch: "crew/fixture-other",
+          canonicalTaskId: "fixture:OTHER",
+          repositories: [],
+          version: 1,
+        }),
+      ),
+    ]);
+    const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+    const observed = workspaces.observe({ slug: "fixture-eng-123" });
+
+    await expect(observed).rejects.toBeInstanceOf(WorkspaceMetadataError);
+  });
+});
+
+function createWorkspaceService(input: {
+  readonly baseDirectory: string;
+  readonly worktreeDirectory: string;
+}): WorkspaceService {
+  return new WorkspaceService({
+    config: {
+      baseDirectory: input.baseDirectory,
+      repositories: {},
+      worktreeDirectory: input.worktreeDirectory,
+    },
+    environment: process.env,
+    git: { branchPrefix: "crew", defaultBranch: "main", remote: "origin" },
+  });
+}
+
+async function createRepository(input: { readonly path: string }): Promise<void> {
+  await mkdir(input.path, { recursive: true });
+  await runGit({ arguments: ["init", "--initial-branch=main"], cwd: input.path });
+  await writeFile(join(input.path, "README.md"), "fixture\n");
+  await runGit({ arguments: ["add", "README.md"], cwd: input.path });
+  await runGit({
+    arguments: [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-m",
+      "initial",
+    ],
+    cwd: input.path,
+  });
+}
+
+async function gitBranchExists(input: {
+  readonly branch: string;
+  readonly cwd: string;
+}): Promise<boolean> {
+  const result = await execFileAsync(
+    "git",
+    ["show-ref", "--verify", `refs/heads/${input.branch}`],
+    { cwd: input.cwd },
+  ).catch(() => undefined);
+  return result !== undefined;
+}
+
+async function runGit(input: {
+  readonly arguments: readonly string[];
+  readonly cwd: string;
+}): Promise<void> {
+  await execFileAsync("git", [...input.arguments], { cwd: input.cwd });
+}

--- a/v2/src/workspace/index.test.ts
+++ b/v2/src/workspace/index.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -95,6 +95,52 @@ describe("WorkspaceService cleanup", () => {
     },
   );
 
+  it("rejects a checkout symlink that resolves outside the configured root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-symlink-"));
+    fixtureRoots.push(root);
+    const baseDirectory = join(root, "repositories");
+    const outsideRepository = join(root, "target");
+    const worktreeDirectory = join(root, "worktrees");
+    const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+    await Promise.all([
+      mkdir(baseDirectory, { recursive: true }),
+      mkdir(join(workspaceDirectory, ".groundcrew"), { recursive: true }),
+      createRepository({ path: outsideRepository }),
+    ]);
+    await Promise.all([
+      runGit({
+        arguments: ["branch", "crew/fixture-eng-123"],
+        cwd: outsideRepository,
+      }),
+      symlink(outsideRepository, join(baseDirectory, "linked"), "dir"),
+    ]);
+    await writeFile(
+      join(workspaceDirectory, ".groundcrew", "task.json"),
+      JSON.stringify({
+        branch: "crew/fixture-eng-123",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["linked"],
+        version: 1,
+      }),
+    );
+    const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+    const cleanup = workspaces.cleanup({
+      allowDirty: true,
+      record: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["linked"],
+        workspaceDirectory,
+      },
+      slug: "fixture-eng-123",
+    });
+
+    await expect(cleanup).rejects.toBeInstanceOf(WorkspaceMetadataError);
+    await expect(
+      gitBranchExists({ branch: "crew/fixture-eng-123", cwd: outsideRepository }),
+    ).resolves.toBe(true);
+  });
+
   it.each([
     {
       branchToPreserve: "crew/fixture-eng-123",
@@ -102,7 +148,7 @@ describe("WorkspaceService cleanup", () => {
         branch: "crew/fixture-eng-123",
         canonicalTaskId: "fixture:OTHER",
         repositories: ["safe"],
-        version: 1 as const,
+        version: 1,
       },
       fileName: "task.json",
       repositoryToPreserve: "safe",
@@ -114,7 +160,7 @@ describe("WorkspaceService cleanup", () => {
         branch: "attacker-selected",
         canonicalTaskId: "fixture:ENG-123",
         repositories: ["safe"],
-        version: 1 as const,
+        version: 1,
       },
       fileName: "task.json",
       repositoryToPreserve: "safe",
@@ -126,7 +172,7 @@ describe("WorkspaceService cleanup", () => {
         branch: "crew/fixture-eng-123",
         canonicalTaskId: "fixture:ENG-123",
         repositories: ["target"],
-        version: 1 as const,
+        version: 1,
       },
       fileName: "task.json",
       repositoryToPreserve: "target",
@@ -139,7 +185,7 @@ describe("WorkspaceService cleanup", () => {
         branch: "crew/fixture-eng-123",
         canonicalTaskId: "fixture:ENG-123",
         repositories: ["target"],
-        version: 1 as const,
+        version: 1,
       },
       repositoryToPreserve: "target",
       subject: "recovery repository set",

--- a/v2/src/workspace/index.test.ts
+++ b/v2/src/workspace/index.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -40,29 +40,55 @@ describe("WorkspaceService cleanup", () => {
     );
     const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
 
-    const rejected = await workspaces
-      .cleanup({
-        allowDirty: true,
-        record: {
-          canonicalTaskId: "fixture:ENG-123",
-          repositories: ["target"],
-          workspaceDirectory,
-        },
-        slug: "fixture-eng-123",
-      })
-      .then(
-        () => false,
-        () => true,
-      );
-    const outsideBranchExists = await gitBranchExists({
-      branch: "attacker-selected",
-      cwd: outsideRepository,
+    const cleanup = workspaces.cleanup({
+      allowDirty: true,
+      record: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["target"],
+        workspaceDirectory,
+      },
+      slug: "fixture-eng-123",
     });
 
-    expect({ outsideBranchExists, rejected }).toEqual({
-      outsideBranchExists: true,
-      rejected: true,
+    await expect(cleanup).rejects.toBeInstanceOf(WorkspaceMetadataError);
+    await expect(
+      gitBranchExists({ branch: "attacker-selected", cwd: outsideRepository }),
+    ).resolves.toBe(true);
+  });
+
+  it("removes the workspace when a durable repository checkout is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-workspace-missing-checkout-"));
+    fixtureRoots.push(root);
+    const baseDirectory = join(root, "repositories");
+    const worktreeDirectory = join(root, "worktrees");
+    const workspaceDirectory = join(worktreeDirectory, "fixture-eng-123");
+    await Promise.all([
+      mkdir(baseDirectory, { recursive: true }),
+      mkdir(join(workspaceDirectory, ".groundcrew"), { recursive: true }),
+    ]);
+    await writeFile(
+      join(workspaceDirectory, ".groundcrew", "task.json"),
+      JSON.stringify({
+        branch: "crew/fixture-eng-123",
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["missing"],
+        version: 1,
+      }),
+    );
+    const workspaces = createWorkspaceService({ baseDirectory, worktreeDirectory });
+
+    const result = await workspaces.cleanup({
+      allowDirty: true,
+      record: {
+        canonicalTaskId: "fixture:ENG-123",
+        repositories: ["missing"],
+        workspaceDirectory,
+      },
+      slug: "fixture-eng-123",
     });
+
+    expect(result).toEqual({ preservedBranches: [], removedRepositories: [] });
+    await expect(stat(workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it.each(["task.json", "provisioning.json"])(

--- a/v2/src/workspace/index.ts
+++ b/v2/src/workspace/index.ts
@@ -1,7 +1,19 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, join, resolve } from "node:path";
+import { mkdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { execa } from "execa";
+import { z } from "zod";
+
+const TaskMarkerSchema = z
+  .object({
+    version: z.literal(1),
+    canonicalTaskId: z.string().min(1),
+    branch: z.string().min(1),
+    repositories: z.array(
+      z.string().min(1).refine(isRepositoryName, "repository must be a basename"),
+    ),
+  })
+  .strict();
 
 export interface WorkspaceConfig {
   readonly baseDirectory: string;
@@ -23,6 +35,13 @@ export interface TaskMarker {
   readonly canonicalTaskId: string;
   readonly branch: string;
   readonly repositories: readonly string[];
+}
+
+export interface CleanupWorkspaceRecord {
+  readonly canonicalTaskId: string;
+  readonly pendingRepository?: string | undefined;
+  readonly repositories: readonly string[];
+  readonly workspaceDirectory: string;
 }
 
 export interface ObservedRepository {
@@ -50,6 +69,11 @@ interface RepositoryOperation {
   readonly repository: string;
 }
 
+interface WorkspaceMetadata {
+  readonly complete: boolean;
+  readonly marker: TaskMarker;
+}
+
 export class WorkspaceService {
   readonly #config: WorkspaceConfig;
   readonly #git: GitConfig;
@@ -66,7 +90,11 @@ export class WorkspaceService {
   }
 
   public workspaceDirectory(input: { readonly slug: string }): string {
-    return join(this.#config.worktreeDirectory, input.slug);
+    return resolveContainedChild({
+      child: input.slug,
+      label: "workspace slug",
+      parent: this.#config.worktreeDirectory,
+    });
   }
 
   public branch(input: { readonly slug: string }): string {
@@ -178,9 +206,13 @@ export class WorkspaceService {
     readonly workspaceDirectory: string;
   }): Promise<TaskMarker | undefined> {
     try {
-      return JSON.parse(
-        await readFile(join(input.workspaceDirectory, ".groundcrew", "task.json"), "utf8"),
-      ) as TaskMarker;
+      return parseTaskMarker({
+        contents: await readFile(
+          join(input.workspaceDirectory, ".groundcrew", "task.json"),
+          "utf8",
+        ),
+        label: "task marker",
+      });
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") {
         return undefined;
@@ -242,10 +274,11 @@ export class WorkspaceService {
 
   public async observe(input: { readonly slug: string }): Promise<ObservedWorkspace> {
     const workspaceDirectory = this.workspaceDirectory(input);
-    const marker = await this.readWorkspaceMetadata({ workspaceDirectory });
-    if (marker === undefined) {
+    const metadata = await this.readWorkspaceMetadata({ workspaceDirectory });
+    if (metadata === undefined) {
       return { dirtyPaths: [], exists: await pathExists(workspaceDirectory), repositories: [] };
     }
+    const { marker } = metadata;
     const repositories: ObservedRepository[] = [];
     for (const repositoryName of marker.repositories) {
       const worktree = join(workspaceDirectory, repositoryName);
@@ -288,16 +321,32 @@ export class WorkspaceService {
     };
   }
 
-  public async cleanup(input: { readonly slug: string; readonly allowDirty: boolean }): Promise<{
+  public async cleanup(input: {
+    readonly slug: string;
+    readonly allowDirty: boolean;
+    readonly record: CleanupWorkspaceRecord;
+  }): Promise<{
     readonly preservedBranches: readonly string[];
     readonly removedRepositories: readonly string[];
   }> {
     const workspaceDirectory = this.workspaceDirectory(input);
-    const marker = await this.readWorkspaceMetadata({ workspaceDirectory });
-    if (marker === undefined) {
+    assertSamePath({
+      actual: workspaceDirectory,
+      expected: input.record.workspaceDirectory,
+      label: "run workspace directory",
+    });
+    const metadata = await this.readWorkspaceMetadata({ workspaceDirectory });
+    if (metadata === undefined) {
+      await assertExistingPathContained({
+        child: workspaceDirectory,
+        label: "workspace directory",
+        parent: this.#config.worktreeDirectory,
+      });
       await rm(workspaceDirectory, { recursive: true, force: true });
       return { preservedBranches: [], removedRepositories: [] };
     }
+    const { marker } = metadata;
+    this.assertCleanupMetadata({ metadata, record: input.record, slug: input.slug });
     const observed = await this.observe(input);
     if (!input.allowDirty && observed.dirtyPaths.length > 0) {
       throw new DirtyWorkspaceError(observed.dirtyPaths);
@@ -305,11 +354,32 @@ export class WorkspaceService {
     const preservedBranches: string[] = [];
     const removedRepositories: string[] = [];
     for (const repositoryName of marker.repositories) {
-      const checkout = join(this.#config.baseDirectory, repositoryName);
-      const worktree = join(workspaceDirectory, repositoryName);
+      const checkout = resolveContainedChild({
+        child: repositoryName,
+        label: "repository checkout",
+        parent: this.#config.baseDirectory,
+      });
+      const worktree = resolveContainedChild({
+        child: repositoryName,
+        label: "repository worktree",
+        parent: workspaceDirectory,
+      });
+      // Git resolves symbolic links before operating, so lexical containment is not enough.
+      // eslint-disable-next-line no-await-in-loop
+      await assertExistingPathContained({
+        child: checkout,
+        label: "repository checkout",
+        parent: this.#config.baseDirectory,
+      });
       // Cleanup is sequential so a partial failure remains obvious and recoverable.
       // eslint-disable-next-line no-await-in-loop
       if (await pathExists(worktree)) {
+        // eslint-disable-next-line no-await-in-loop
+        await assertExistingPathContained({
+          child: worktree,
+          label: "repository worktree",
+          parent: workspaceDirectory,
+        });
         // eslint-disable-next-line no-await-in-loop
         await git({
           arguments: ["worktree", "remove", ...(input.allowDirty ? ["--force"] : []), worktree],
@@ -336,8 +406,40 @@ export class WorkspaceService {
         preservedBranches.push(`${repositoryName}:${marker.branch}`);
       }
     }
+    await assertExistingPathContained({
+      child: workspaceDirectory,
+      label: "workspace directory",
+      parent: this.#config.worktreeDirectory,
+    });
     await rm(workspaceDirectory, { recursive: true, force: true });
     return { preservedBranches, removedRepositories };
+  }
+
+  private assertCleanupMetadata(input: {
+    readonly metadata: WorkspaceMetadata;
+    readonly record: CleanupWorkspaceRecord;
+    readonly slug: string;
+  }): void {
+    const expectedBranch = this.branch({ slug: input.slug });
+    if (
+      input.metadata.marker.canonicalTaskId !== input.record.canonicalTaskId ||
+      input.metadata.marker.branch !== expectedBranch
+    ) {
+      throw new WorkspaceMetadataError("workspace metadata does not match its durable run");
+    }
+    const expectedRepositories = new Set(input.record.repositories.map(stripOwner));
+    const allowedRepositories = new Set(expectedRepositories);
+    if (input.record.pendingRepository !== undefined) {
+      allowedRepositories.add(stripOwner(input.record.pendingRepository));
+    }
+    const actualRepositories = new Set(input.metadata.marker.repositories);
+    const repositoriesMatch = input.metadata.complete
+      ? sameSet({ left: actualRepositories, right: expectedRepositories }) ||
+        sameSet({ left: actualRepositories, right: allowedRepositories })
+      : [...actualRepositories].every((repository) => allowedRepositories.has(repository));
+    if (!repositoriesMatch) {
+      throw new WorkspaceMetadataError("workspace repositories do not match its durable run");
+    }
   }
 
   private async resolveAll(input: {
@@ -477,9 +579,13 @@ export class WorkspaceService {
     readonly workspaceDirectory: string;
   }): Promise<TaskMarker | undefined> {
     try {
-      return JSON.parse(
-        await readFile(join(input.workspaceDirectory, ".groundcrew", "provisioning.json"), "utf8"),
-      ) as TaskMarker;
+      return parseTaskMarker({
+        contents: await readFile(
+          join(input.workspaceDirectory, ".groundcrew", "provisioning.json"),
+          "utf8",
+        ),
+        label: "workspace recovery marker",
+      });
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") {
         return undefined;
@@ -509,20 +615,26 @@ export class WorkspaceService {
 
   private async readWorkspaceMetadata(input: {
     readonly workspaceDirectory: string;
-  }): Promise<TaskMarker | undefined> {
+  }): Promise<WorkspaceMetadata | undefined> {
     const [marker, recovery] = await Promise.all([
       this.readMarker(input),
       this.readRecoveryMarker(input),
     ]);
     if (marker === undefined) {
-      return recovery;
+      return recovery === undefined ? undefined : { complete: false, marker: recovery };
     }
     if (recovery === undefined) {
-      return marker;
+      return { complete: true, marker };
+    }
+    if (marker.canonicalTaskId !== recovery.canonicalTaskId || marker.branch !== recovery.branch) {
+      throw new WorkspaceMetadataError("task and recovery markers do not describe one workspace");
     }
     return {
-      ...marker,
-      repositories: [...new Set([...marker.repositories, ...recovery.repositories])],
+      complete: true,
+      marker: {
+        ...marker,
+        repositories: [...new Set([...marker.repositories, ...recovery.repositories])],
+      },
     };
   }
 
@@ -582,6 +694,13 @@ export class RepositoryMissingError extends Error {
     super(`designated repositories not present: ${repositories.join(", ")}`);
     this.name = "RepositoryMissingError";
     this.repositories = repositories;
+  }
+}
+
+export class WorkspaceMetadataError extends Error {
+  public constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "WorkspaceMetadataError";
   }
 }
 
@@ -660,6 +779,92 @@ function stripOwner(repository: string): string {
     throw new RepositoryMissingError([repository]);
   }
   return name;
+}
+
+function isRepositoryName(repository: string): boolean {
+  return (
+    repository !== "." &&
+    repository !== ".." &&
+    !isAbsolute(repository) &&
+    basename(repository) === repository
+  );
+}
+
+function parseTaskMarker(input: { readonly contents: string; readonly label: string }): TaskMarker {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input.contents);
+  } catch (error) {
+    throw new WorkspaceMetadataError(`${input.label} is not valid JSON`, {
+      cause: error,
+    });
+  }
+  const result = TaskMarkerSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new WorkspaceMetadataError(`${input.label} is invalid: ${z.prettifyError(result.error)}`);
+  }
+  return result.data;
+}
+
+function resolveContainedChild(input: {
+  readonly child: string;
+  readonly label: string;
+  readonly parent: string;
+}): string {
+  const path = resolve(input.parent, input.child);
+  assertPathContained({ child: path, label: input.label, parent: input.parent });
+  return path;
+}
+
+async function assertExistingPathContained(input: {
+  readonly child: string;
+  readonly label: string;
+  readonly parent: string;
+}): Promise<void> {
+  assertPathContained(input);
+  if (!(await pathExists(input.child))) {
+    return;
+  }
+  const [canonicalChild, canonicalParent] = await Promise.all([
+    realpath(input.child),
+    realpath(input.parent),
+  ]);
+  assertPathContained({ child: canonicalChild, label: input.label, parent: canonicalParent });
+}
+
+function assertPathContained(input: {
+  readonly child: string;
+  readonly label: string;
+  readonly parent: string;
+}): void {
+  const relativePath = relative(resolve(input.parent), resolve(input.child));
+  if (
+    relativePath.length === 0 ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new WorkspaceMetadataError(`${input.label} escapes its configured root`);
+  }
+}
+
+function assertSamePath(input: {
+  readonly actual: string;
+  readonly expected: string;
+  readonly label: string;
+}): void {
+  if (resolve(input.actual) !== resolve(input.expected)) {
+    throw new WorkspaceMetadataError(`${input.label} does not match its durable run`);
+  }
+}
+
+function sameSet(input: {
+  readonly left: ReadonlySet<string>;
+  readonly right: ReadonlySet<string>;
+}): boolean {
+  return (
+    input.left.size === input.right.size && [...input.left].every((value) => input.right.has(value))
+  );
 }
 
 function processExists(processId: number): boolean {

--- a/v2/src/workspace/index.ts
+++ b/v2/src/workspace/index.ts
@@ -334,6 +334,7 @@ export class WorkspaceService {
       actual: workspaceDirectory,
       expected: input.record.workspaceDirectory,
       label: "run workspace directory",
+      recovery: "restore the previous workspace.worktreeDirectory before cleanup",
     });
     const metadata = await this.readWorkspaceMetadata({ workspaceDirectory });
     if (metadata === undefined) {
@@ -366,6 +367,10 @@ export class WorkspaceService {
         label: "repository worktree",
         parent: workspaceDirectory,
       });
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await pathExists(checkout))) {
+        continue;
+      }
       // Git resolves symbolic links before operating, so lexical containment is not enough.
       // eslint-disable-next-line no-await-in-loop
       await assertExistingPathContained({
@@ -863,9 +868,11 @@ function assertSamePath(input: {
   readonly actual: string;
   readonly expected: string;
   readonly label: string;
+  readonly recovery?: string | undefined;
 }): void {
   if (resolve(input.actual) !== resolve(input.expected)) {
-    throw new WorkspaceMetadataError(`${input.label} does not match its durable run`);
+    const recovery = input.recovery === undefined ? "" : `; ${input.recovery}`;
+    throw new WorkspaceMetadataError(`${input.label} does not match its durable run${recovery}`);
   }
 }
 

--- a/v2/src/workspace/index.ts
+++ b/v2/src/workspace/index.ts
@@ -337,11 +337,13 @@ export class WorkspaceService {
     });
     const metadata = await this.readWorkspaceMetadata({ workspaceDirectory });
     if (metadata === undefined) {
-      await assertExistingPathContained({
-        child: workspaceDirectory,
-        label: "workspace directory",
-        parent: this.#config.worktreeDirectory,
-      });
+      if (await pathExists(workspaceDirectory)) {
+        await assertExistingPathContained({
+          child: workspaceDirectory,
+          label: "workspace directory",
+          parent: this.#config.worktreeDirectory,
+        });
+      }
       await rm(workspaceDirectory, { recursive: true, force: true });
       return { preservedBranches: [], removedRepositories: [] };
     }
@@ -381,6 +383,12 @@ export class WorkspaceService {
           parent: workspaceDirectory,
         });
         // eslint-disable-next-line no-await-in-loop
+        await assertExistingPathContained({
+          child: checkout,
+          label: "repository checkout",
+          parent: this.#config.baseDirectory,
+        });
+        // eslint-disable-next-line no-await-in-loop
         await git({
           arguments: ["worktree", "remove", ...(input.allowDirty ? ["--force"] : []), worktree],
           cwd: checkout,
@@ -400,6 +408,12 @@ export class WorkspaceService {
       const safe =
         input.allowDirty || (await this.branchHasNoUniqueWork({ branch: marker.branch, checkout }));
       if (safe) {
+        // eslint-disable-next-line no-await-in-loop
+        await assertExistingPathContained({
+          child: checkout,
+          label: "repository checkout",
+          parent: this.#config.baseDirectory,
+        });
         // eslint-disable-next-line no-await-in-loop
         await git({ arguments: ["branch", "-D", marker.branch], cwd: checkout });
       } else {
@@ -822,9 +836,6 @@ async function assertExistingPathContained(input: {
   readonly parent: string;
 }): Promise<void> {
   assertPathContained(input);
-  if (!(await pathExists(input.child))) {
-    return;
-  }
   const [canonicalChild, canonicalParent] = await Promise.all([
     realpath(input.child),
     realpath(input.parent),


### PR DESCRIPTION
## Why

Workspace task and recovery metadata live inside the agent-accessible workspace, but cleanup previously trusted those files when selecting destructive Git operations. Corrupt or inconsistent metadata could therefore make cleanup act beyond the repositories recorded by the durable run. This is an operational and security hardening change; it does not add a customer-facing feature.

## Summary

- Strictly validate task and recovery marker JSON, including basename-only repository names.
- Require cleanup metadata to match the durable run and enforce canonical path containment before destructive operations.
- Persist repository acquisition reservations so crash recovery remains safe without treating workspace metadata as authoritative.
- Add public-service and CLI regressions for malformed, inconsistent, and redirected workspace metadata.

## Validation

- `npx vitest run src/workspace/index.test.ts src/run/index.test.ts`
- Focused cleanup and repository-acquisition e2e tests
- `node --run verify` — 9 test files passed; 88 tests passed, 1 skipped

## Notes

- Finding: `fnd_sig-feat-cli-command-012418b101-_1c0fc57393`
- Agent session: `codex resume 019fecf3-d014-7040-b1d2-2df136e18c69`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
