### PR TITLE
chore: update Clipboard AI tooling packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,6 @@ Read the rule files relevant to the code you're changing or reviewing.
 | Testing                 | .rules/common/testing.md              | Writing unit tests: conventions, naming, structure                                                                    |
 | TypeScript              | .rules/common/typeScript.md           | Writing ANY TypeScript code                                                                                           |
 
-## Agent Skills
-
-Agent skills are linked from `node_modules/@clipboard-health/ai-rules` into `.agents/`.
-If a referenced skill is missing or unreadable, run `npm ci` from the repository root and retry.
-
 <!-- Source: ./OVERLAY.md -->
 
 ## Project-specific rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clipboard-health/groundcrew",
-  "version": "4.50.4",
+  "version": "4.50.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clipboard-health/groundcrew",
-      "version": "4.50.4",
+      "version": "4.50.6",
       "license": "MIT",
       "dependencies": {
         "@clipboard-health/clearance": "1.6.6",
@@ -21,7 +21,7 @@
         "crew-clearance-ensure": "bin/crewClearanceEnsure.js"
       },
       "devDependencies": {
-        "@clipboard-health/ai-rules": "2.46.0",
+        "@clipboard-health/ai-rules": "2.46.2",
         "@clipboard-health/oxlint-config": "1.14.3",
         "@nx/js": "23.1.0",
         "@tsconfig/node24": "24.0.4",
@@ -1802,9 +1802,9 @@
       }
     },
     "node_modules/@clipboard-health/ai-rules": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.46.0.tgz",
-      "integrity": "sha512-1z5xYPBrLvNgN8PKGPBkZi7YVM/Ekui3dFyZ+o7yMo7swntiPR8ouCSpmSVvt+UgPfvGxHea8ka/WFlFn62HkQ==",
+      "version": "2.46.2",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/ai-rules/-/ai-rules-2.46.2.tgz",
+      "integrity": "sha512-Xl6Xuh5xcta+Hydz/dMMATSkfNy9sfB5CiZFKYD3NCkCmnaDGWS3pY+MqKBFr0c2bJNIWct6m2p9ftNMiYYcRQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@clipboard-health/ai-rules": "2.46.0",
+    "@clipboard-health/ai-rules": "2.46.2",
     "@clipboard-health/oxlint-config": "1.14.3",
     "@nx/js": "23.1.0",
     "@tsconfig/node24": "24.0.4",


### PR DESCRIPTION
Summary
===
Update the Clipboard AI tooling packages declared by this repository to their latest versions:

- @clipboard-health/ai-rules to v2.46.2
- @clipboard-health/playwright-flake-linter to v1.0.3
- @clipboard-health/playwright-reporter-llm to v2.8.6
- @clipboard-health/playwright-toolkit to v1.1.8

Run "npm install" and sync AI agent memory files (e.g., AGENTS.md, CLAUDE.md) where the sync script is available.

Remove `.claude/setup.sh`, remove the `SessionStart` hook from `.claude/settings.json`, and remove `.agents/skills` when it is a symlink to the AI rules package.

[_Created by Sourcegraph batch change `rockywarren/update-ai-tooling-2.46.2-1.0.3-2.8.6-1.1.8`._](https://clipboardhealth.sourcegraphcloud.com/users/rockywarren/batch-changes/update-ai-tooling-2.46.2-1.0.3-2.8.6-1.1.8)