### PR TITLE
feat: preview tasks before dispatch

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -18,6 +18,33 @@ import { describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 
 describe("crew start", () => {
+  it("previews the prioritized tasks that would start without dispatching them", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 2,
+      tasks: [
+        task({ id: "LOW-1", priority: 4, repositories: [] }),
+        task({ id: "URGENT-1", priority: 1, repositories: [] }),
+      ],
+    });
+
+    const result = await runCrew({
+      arguments: ["start", "--dry-run"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toBe(
+      [
+        "Slots 0/2 used (2 open)",
+        "Would start fixture:URGENT-1(codex) in slot 1/2",
+        "Would start fixture:LOW-1(codex) in slot 2/2",
+        "",
+      ].join("\n"),
+    );
+    expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
+    expect(await readFile(fixture.cmuxCallsPath, "utf8")).toBe("");
+    await expect(stat(fixture.runsDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("reports open slots and the task being dispatched", async () => {
     const fixture = await createDispatchFixture();
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -45,6 +45,66 @@ describe("crew start", () => {
     await expect(stat(fixture.runsDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("previews capacity after read-only reconciliation without changing the stale run", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 1,
+      tasks: [
+        task({ id: "ACTIVE-1", priority: 1, repositories: [] }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const runPath = join(fixture.runsDirectory, "fixture-active-1.json");
+    const runBeforePreview = await readFile(runPath, "utf8");
+    await Promise.all([
+      writeFile(fixture.cmuxCallsPath, ""),
+      writeFile(fixture.cmuxStatePath, '{"workspaces":[]}'),
+      writeFile(fixture.updatesPath, ""),
+    ]);
+
+    const result = await runCrew({
+      arguments: ["start", "--dry-run"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toBe(
+      ["Slots 0/1 used (1 open)", "Would start fixture:READY-1(codex) in slot 1/1", ""].join("\n"),
+    );
+    expect(await readFile(runPath, "utf8")).toBe(runBeforePreview);
+    expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
+  });
+
+  it("previews the slot a clean terminal run would release without reaping it", async () => {
+    const activeTask = task({ id: "ACTIVE-1", priority: 1, repositories: [] });
+    const readyTask = task({ id: "READY-1", priority: 2, repositories: [] });
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 1,
+      tasks: [activeTask, readyTask],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const runPath = join(fixture.runsDirectory, "fixture-active-1.json");
+    const runBeforePreview = await readFile(runPath, "utf8");
+    await Promise.all([
+      writeFile(
+        fixture.listedTasksPath,
+        JSON.stringify([
+          task({ id: "ACTIVE-1", priority: 1, repositories: [], terminal: true }),
+          readyTask,
+        ]),
+      ),
+      writeFile(fixture.updatesPath, ""),
+    ]);
+
+    const result = await runCrew({
+      arguments: ["start", "--dry-run"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Would start fixture:READY-1(codex) in slot 1/1");
+    expect(await readFile(runPath, "utf8")).toBe(runBeforePreview);
+    expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
+  });
+
   it("reports open slots and the task being dispatched", async () => {
     const fixture = await createDispatchFixture();
 

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -338,7 +338,10 @@ async function start(input: {
     });
     skipped.push(skipInput.canonicalTaskId);
   }
-  const active = (await runtime.runs.list())
+  const activeRuns = input.dryRun
+    ? await listActiveAfterPreviewReconciliation({ runtime, tasks: listed.data.tasks })
+    : await runtime.runs.list();
+  const active = activeRuns
     .filter((run) => run.state === "provisioning" || run.state === "running")
     .map((run) => ({
       agentProfile: run.record.agentProfile,
@@ -908,6 +911,31 @@ async function reapTerminalTasks(input: {
       task: run.record.canonicalTaskId,
     });
   }
+}
+
+async function listActiveAfterPreviewReconciliation(input: {
+  readonly runtime: Runtime;
+  readonly tasks: readonly Task[];
+}): Promise<readonly RunHandle[]> {
+  const active = await input.runtime.runs.listActiveAfterPresentationReconciliation();
+  const terminal = new Set(
+    input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
+  );
+  const remaining: RunHandle[] = [];
+  for (const run of active) {
+    if (!terminal.has(run.record.canonicalTaskId)) {
+      remaining.push(run);
+      continue;
+    }
+    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
+    // Repository observations stay ordered with lifecycle reconciliation.
+    // eslint-disable-next-line no-await-in-loop
+    const observed = await input.runtime.workspaces.observe({ slug });
+    if (observed.dirtyPaths.length > 0) {
+      remaining.push(run);
+    }
+  }
+  return remaining;
 }
 
 async function writeCompletion(input: {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -97,6 +97,14 @@ export type DispatchProgress =
       readonly forced: boolean;
     }
   | {
+      readonly type: "previewing";
+      readonly canonicalTaskId: string;
+      readonly agentProfile: string;
+      readonly slot: number;
+      readonly maximum: number;
+      readonly forced: boolean;
+    }
+  | {
       readonly type: "skipped";
       readonly canonicalTaskId: string;
       readonly detail: string;
@@ -141,6 +149,7 @@ export interface Application {
   start(input: {
     readonly task?: string | undefined;
     readonly force: boolean;
+    readonly dryRun: boolean;
     readonly agent?: string | undefined;
     readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
   }): Promise<{ readonly started: readonly string[]; readonly skipped: readonly string[] }>;
@@ -186,6 +195,7 @@ export async function createApplication(input: {
   readonly config: CoreConfig;
   readonly paths: ApplicationPaths;
   readonly environment: NodeJS.ProcessEnv;
+  readonly reconcileOnCreate?: boolean | undefined;
 }): Promise<Application> {
   const { config, environment, paths } = input;
   const registry = await SourceRegistry.create({
@@ -212,7 +222,9 @@ export async function createApplication(input: {
     git: config.git,
   });
   const runtime: Runtime = { config, environment, paths, registry, runs, workspaces };
-  await reconcile({ runtime });
+  if (input.reconcileOnCreate !== false) {
+    await reconcile({ runtime });
+  }
   return {
     async doctor(doctorInput = {}): Promise<DoctorResult> {
       return await doctor({ ...doctorInput, runtime });
@@ -284,16 +296,21 @@ async function start(input: {
   readonly runtime: Runtime;
   readonly task?: string | undefined;
   readonly force: boolean;
+  readonly dryRun: boolean;
   readonly agent?: string | undefined;
   readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
 }): Promise<{ readonly started: readonly string[]; readonly skipped: readonly string[] }> {
   const { runtime } = input;
-  await reconcile({ runtime });
+  if (!input.dryRun) {
+    await reconcile({ runtime });
+  }
   const listed = await runtime.registry.list();
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
-  await reapTerminalTasks({ runtime, tasks: listed.data.tasks });
+  if (!input.dryRun) {
+    await reapTerminalTasks({ runtime, tasks: listed.data.tasks });
+  }
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
     tasks = tasks
@@ -310,7 +327,9 @@ async function start(input: {
   const started: string[] = [];
   const skipped: string[] = [];
   async function skipTask(skipInput: SkipTaskInput): Promise<void> {
-    await writeVerdict({ ...skipInput, runtime });
+    if (!input.dryRun) {
+      await writeVerdict({ ...skipInput, runtime });
+    }
     input.onProgress?.({
       canonicalTaskId: skipInput.canonicalTaskId,
       detail: skipInput.detail,
@@ -331,6 +350,7 @@ async function start(input: {
     maximum: runtime.config.orchestrator.maximumInProgress,
     type: "slots",
   });
+  let previewedCount = 0;
   for (const task of tasks) {
     const canonicalTaskId = canonicalId({ task });
     const slug = taskSlug({ canonicalTaskId });
@@ -392,6 +412,27 @@ async function start(input: {
       if (input.task !== undefined) {
         throw new RepositoryMissingError(repositoryCheck.missing);
       }
+      continue;
+    }
+    if (input.dryRun) {
+      const activeCount = active.length + previewedCount;
+      if (!input.force && activeCount >= runtime.config.orchestrator.maximumInProgress) {
+        await skipTask({
+          canonicalTaskId,
+          detail: "concurrency limit reached",
+          reason: "slots-full",
+        });
+        continue;
+      }
+      input.onProgress?.({
+        agentProfile: profileName,
+        canonicalTaskId,
+        forced: input.force && activeCount >= runtime.config.orchestrator.maximumInProgress,
+        maximum: runtime.config.orchestrator.maximumInProgress,
+        slot: activeCount + 1,
+        type: "previewing",
+      });
+      previewedCount += 1;
       continue;
     }
     const workspaceDirectory = runtime.workspaces.workspaceDirectory({ slug });

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -144,6 +144,14 @@ export type DispatchReservation =
       readonly type: "reserved";
     };
 
+type PresentationReconciliation =
+  | { readonly type: "unchanged" }
+  | { readonly type: "running" }
+  | {
+      readonly type: "failed";
+      readonly reason: "provisioning-interrupted" | "workspace-missing";
+    };
+
 export class RunModule {
   readonly #store: RunStore;
   readonly #environment: NodeJS.ProcessEnv;
@@ -227,22 +235,30 @@ export class RunModule {
     return { [presentedWorkspaceSnapshot]: probe };
   }
 
+  public async listActiveAfterPresentationReconciliation(): Promise<readonly RunHandle[]> {
+    const runs = await this.list();
+    if (runs.length === 0) {
+      return [];
+    }
+    const snapshot = await this.capturePresentedWorkspaces();
+    return runs.filter((run) => {
+      if (run.state === "complete") {
+        return false;
+      }
+      return classifyPresentationReconciliation({ run, snapshot }).type !== "failed";
+    });
+  }
+
   public async reconcilePresentedWorkspace(input: {
     readonly run: RunHandle;
     readonly snapshot: PresentedWorkspaceSnapshot;
   }): Promise<PresentationChange | undefined> {
-    const probe = input.snapshot[presentedWorkspaceSnapshot];
-    if (!probe.available || input.run.state === "complete") {
+    const reconciliation = classifyPresentationReconciliation(input);
+    if (reconciliation.type === "unchanged") {
       return undefined;
     }
     const expected = input.run.record;
-    const presented = probe.workspaces.some(
-      (workspace) =>
-        workspace.name === expected.presentedWorkspaceName ||
-        workspace.description === expected.presentedWorkspaceName ||
-        workspace.description === `groundcrew:${expected.canonicalTaskId}`,
-    );
-    if (expected.state === "provisioning" && presented) {
+    if (reconciliation.type === "running") {
       let transitioned = false;
       const record = await this.#store.mutate({
         canonicalTaskId: expected.canonicalTaskId,
@@ -263,11 +279,7 @@ export class RunModule {
         ? { run: new RunningRunHandle({ module: this, record }), type: "running" }
         : undefined;
     }
-    if (presented) {
-      return undefined;
-    }
-    const reason =
-      expected.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing";
+    const { reason } = reconciliation;
     let transitioned = false;
     const record = await this.#store.mutate({
       canonicalTaskId: expected.canonicalTaskId,
@@ -1256,6 +1268,33 @@ function matchesProvisioningGeneration(input: {
     currentOwner?.processId === expectedOwner?.processId &&
     currentOwner?.phase === expectedOwner?.phase
   );
+}
+
+function classifyPresentationReconciliation(input: {
+  readonly run: RunHandle;
+  readonly snapshot: PresentedWorkspaceSnapshot;
+}): PresentationReconciliation {
+  const probe = input.snapshot[presentedWorkspaceSnapshot];
+  if (!probe.available || input.run.state === "complete") {
+    return { type: "unchanged" };
+  }
+  const record = input.run.record;
+  const presented = probe.workspaces.some(
+    (workspace) =>
+      workspace.name === record.presentedWorkspaceName ||
+      workspace.description === record.presentedWorkspaceName ||
+      workspace.description === `groundcrew:${record.canonicalTaskId}`,
+  );
+  if (record.state === "provisioning" && presented) {
+    return { type: "running" };
+  }
+  if (presented || (record.state === "provisioning" && provisioningOwnerIsAlive({ record }))) {
+    return { type: "unchanged" };
+  }
+  return {
+    reason: record.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing",
+    type: "failed",
+  };
 }
 
 function provisioningOwnerIsAlive(input: { readonly record: RunRecord }): boolean {

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -159,15 +159,21 @@ export async function main(input: MainInput): Promise<void> {
     .description("dispatch eligible tasks")
     .argument("[task]", "canonical or source-local task ID")
     .option("--watch", "repeat at the configured polling interval")
+    .option("--dry-run", "show which tasks would start without dispatching")
     .option("--force", "bypass blocked status and the concurrency limit")
     .option("--agent <profile>", "override agent routing")
     .option("--verbose", "include debug diagnostics")
     .action(async (task, options) => {
       const loaded = await loadConfig({ environment });
-      const application = await createConfiguredApplication({ environment, loaded });
+      const application = await createConfiguredApplication({
+        environment,
+        loaded,
+        reconcileOnCreate: options.dryRun !== true,
+      });
       do {
         const result = await application.start({
           agent: options.agent,
+          dryRun: options.dryRun === true,
           force: options.force === true,
           onProgress: (progress) =>
             renderDispatchProgress({
@@ -419,11 +425,13 @@ async function configuredApplication(input: { readonly environment: NodeJS.Proce
 async function createConfiguredApplication(input: {
   readonly environment: NodeJS.ProcessEnv;
   readonly loaded: Awaited<ReturnType<typeof loadConfig>>;
+  readonly reconcileOnCreate?: boolean | undefined;
 }) {
   return await createApplication({
     config: input.loaded.config,
     environment: input.environment,
     paths: input.loaded.paths,
+    reconcileOnCreate: input.reconcileOnCreate,
   });
 }
 
@@ -492,6 +500,15 @@ function renderDispatchProgress(input: RenderDispatchProgressInput): void {
       progress.forced
         ? `Dispatching ${task} with concurrency override (${progress.slot - 1}/${progress.maximum} slots used)\n`
         : `Dispatching ${task} into slot ${progress.slot}/${progress.maximum}\n`,
+    );
+    return;
+  }
+  if (progress.type === "previewing") {
+    const task = `${progress.canonicalTaskId}(${progress.agentProfile})`;
+    process.stdout.write(
+      progress.forced
+        ? `Would start ${task} with concurrency override in slot ${progress.slot}/${progress.maximum}\n`
+        : `Would start ${task} in slot ${progress.slot}/${progress.maximum}\n`,
     );
     return;
   }


### PR DESCRIPTION
## Why

Operators currently cannot inspect which eligible tasks `crew start` will select without immediately dispatching them. This adds a mutation-free preview so priority, eligibility, and available-capacity decisions can be checked before work starts. There is no direct customer impact; the impact is safer Groundcrew operation.

## Summary

- Add `crew start [task] --dry-run` for batch and explicit-task previews.
- Render prioritized tasks and their projected slots without reserving, claiming, provisioning, launching, or persisting verdicts.
- Model post-reconciliation and terminal-reaping capacity through read-only observations so preview matches a real start.

## Validation

- `node --run verify` — 103 passed, 1 skipped.
- `npx vitest run e2e/dispatch.e2e.test.ts` — 51 passed.
- `cb-review --effort low --report` — Ship gate: pass; requirements met; no findings.

## Notes

Agent session: `codex resume 019fed3d-1848-7072-8cb5-de12971c6dbb`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
