### PR TITLE
fix: explain dry-run task decisions

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -18,6 +18,78 @@ import { describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 
 describe("crew start", () => {
+  it("explains every decision when a dry run would start no tasks", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 15,
+      tasks: [task({ blocked: true, id: "BLOCKED-1", repositories: [] })],
+    });
+
+    const result = await runCrew({
+      arguments: ["start", "--dry-run"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toBe(
+      [
+        "Slots 0/15 used (15 open)",
+        "Skipping fixture:BLOCKED-1: blocked — task reports an open blocker",
+        "No tasks would start",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("shows tasks excluded from a dry run by the concurrency limit", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 1,
+      tasks: [
+        task({ id: "FIRST-1", priority: 1, repositories: [] }),
+        task({ id: "SECOND-1", priority: 2, repositories: [] }),
+      ],
+    });
+
+    const result = await runCrew({
+      arguments: ["start", "--dry-run"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain(
+      "Skipping fixture:SECOND-1: slots-full — concurrency limit reached",
+    );
+  });
+
+  it("repeats dry-run decisions while watching", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 15,
+      pollIntervalMilliseconds: 10,
+      tasks: [task({ blocked: true, id: "BLOCKED-1", repositories: [] })],
+    });
+    let stdout = "";
+
+    try {
+      await execFileAsync(process.execPath, ["bin/run.js", "start", "--watch", "--dry-run"], {
+        cwd: process.cwd(),
+        env: fixture.environment,
+        timeout: 1_000,
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !("killed" in error) ||
+        error.killed !== true ||
+        !("stdout" in error) ||
+        typeof error.stdout !== "string"
+      ) {
+        throw error;
+      }
+      stdout = error.stdout;
+    }
+
+    expect(stdout.match(/Skipping fixture:BLOCKED-1: blocked/g)?.length).toBeGreaterThan(1);
+    expect(stdout.match(/No tasks would start/g)?.length).toBeGreaterThan(1);
+    expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
+  });
+
   it("previews the prioritized tasks that would start without dispatching them", async () => {
     const fixture = await createDispatchFixture({
       maximumInProgress: 2,
@@ -68,7 +140,12 @@ describe("crew start", () => {
     });
 
     expect(result.stdout).toBe(
-      ["Slots 0/1 used (1 open)", "Would start fixture:READY-1(codex) in slot 1/1", ""].join("\n"),
+      [
+        "Slots 0/1 used (1 open)",
+        "Skipping fixture:ACTIVE-1: run-exists — fixture:ACTIVE-1",
+        "Would start fixture:READY-1(codex) in slot 1/1",
+        "",
+      ].join("\n"),
     );
     expect(await readFile(runPath, "utf8")).toBe(runBeforePreview);
     expect(await readFile(fixture.updatesPath, "utf8")).toBe("");

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -87,6 +87,7 @@ interface MainInput {
 
 interface RenderDispatchProgressInput {
   readonly progress: DispatchProgress;
+  readonly showAllSkips: boolean;
   readonly showRoutineSkips: boolean;
 }
 
@@ -171,19 +172,29 @@ export async function main(input: MainInput): Promise<void> {
         reconcileOnCreate: options.dryRun !== true,
       });
       do {
+        let previewedCount = 0;
         const result = await application.start({
           agent: options.agent,
           dryRun: options.dryRun === true,
           force: options.force === true,
-          onProgress: (progress) =>
+          onProgress: (progress) => {
+            if (progress.type === "previewing") {
+              previewedCount += 1;
+            }
             renderDispatchProgress({
               progress,
-              showRoutineSkips: task !== undefined && options.watch !== true,
-            }),
+              showAllSkips: options.dryRun === true,
+              showRoutineSkips:
+                options.dryRun === true || (task !== undefined && options.watch !== true),
+            });
+          },
           task,
         });
         for (const canonicalTaskId of result.started) {
           process.stdout.write(`Started ${canonicalTaskId}\n`);
+        }
+        if (options.dryRun === true && previewedCount === 0) {
+          process.stdout.write("No tasks would start\n");
         }
         if (options.watch !== true) {
           break;
@@ -481,11 +492,12 @@ async function readTaskMarker(input: {
 }
 
 function renderDispatchProgress(input: RenderDispatchProgressInput): void {
-  const { progress, showRoutineSkips } = input;
+  const { progress, showAllSkips, showRoutineSkips } = input;
   if (progress.type === "skipped") {
     if (
-      progress.reason === "slots-full" ||
-      (!showRoutineSkips && !BATCH_REPORTED_SKIP_REASONS.has(progress.reason))
+      !showAllSkips &&
+      (progress.reason === "slots-full" ||
+        (!showRoutineSkips && !BATCH_REPORTED_SKIP_REASONS.has(progress.reason)))
     ) {
       return;
     }


### PR DESCRIPTION
## Why

`crew start --dry-run` could print only slot capacity when every visible task was skipped, so operators could not tell which tasks were considered or why none would start. This improves operator visibility and makes preview mode useful before dispatching work.

## Summary

- show every dry-run task decision, including routine and capacity skips
- print `No tasks would start` when none qualify
- repeat useful decision output under `--watch`

## Validation

- `node --run verify` — 109 passed, 1 skipped
- `npx vitest run e2e/dispatch.e2e.test.ts` — 54 passed
- `cb-review --effort low --report` — ship gate passed; requirements met; no findings

## Notes

Agent session: `codex resume 019fed3d-1848-7072-8cb5-de12971c6dbb`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
