### PR TITLE
fix: wait for presented workspace visibility

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -1222,22 +1222,55 @@ describe("crew start", () => {
     });
   });
 
-  it("fails a running run when its presented workspace disappears", async () => {
+  it("fails an established run when its presented workspace disappears", async () => {
     const fixture = await createDispatchFixture({ repositories: [] });
     await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(fixture.cmuxStatePath, '{"workspaces":[]}');
+    const runPath = join(fixture.runsDirectory, "fixture-eng-123.json");
+    await writeFile(
+      fixture.cmuxStatePath,
+      JSON.stringify({
+        ...JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")),
+        hiddenListResponsesRemaining: 1,
+      }),
+    );
+
+    await runCrew({ arguments: ["status", "ENG-123", "--json"], environment: fixture.environment });
+
+    const run = JSON.parse(await readFile(runPath, "utf8"));
+    expect(run).toMatchObject({
+      outcome: "failed",
+      reason: "workspace-missing",
+      state: "complete",
+    });
+    const presenterCalls = (await readFile(fixture.cmuxCallsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(presenterCalls.map((call) => call.arguments)).toContainEqual([
+      "set-progress",
+      "1",
+      "--workspace",
+      "workspace-1",
+      "--label",
+      "failed",
+    ]);
+    expect(await stat(fixture.workspaceDirectory)).toBeDefined();
+  });
+
+  it("keeps a newly launched run active while its presented workspace becomes visible", async () => {
+    const fixture = await createDispatchFixture({
+      hiddenPresenterListResponses: 2,
+      repositories: [],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
 
     await runCrew({ arguments: ["status", "ENG-123", "--json"], environment: fixture.environment });
 
     const run = JSON.parse(
       await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8"),
     );
-    expect(run).toMatchObject({
-      outcome: "failed",
-      reason: "workspace-missing",
-      state: "complete",
-    });
-    expect(await stat(fixture.workspaceDirectory)).toBeDefined();
+    expect(run).toMatchObject({ state: "running" });
+    expect(run.events).not.toContainEqual(expect.objectContaining({ event: "complete:failed" }));
   });
 
   it("does not treat an unavailable presenter probe as an empty workspace list", async () => {
@@ -1434,6 +1467,7 @@ async function createDispatchFixture(
     readonly rejectClaim?: string | undefined;
     readonly prepareWorktree?: string | undefined;
     readonly failPresenterOpen?: boolean | undefined;
+    readonly hiddenPresenterListResponses?: number | undefined;
     readonly maximumInProgress?: number | undefined;
     readonly pollIntervalMilliseconds?: number | undefined;
     readonly profiles?: Readonly<Record<string, Record<string, unknown>>> | undefined;
@@ -1464,6 +1498,15 @@ async function createDispatchFixture(
     writeFile(updatesPath, ""),
   ]);
   await cp("e2e/fixtures/source", sourceDirectory, { recursive: true });
+  if (options.hiddenPresenterListResponses !== undefined) {
+    await writeFile(
+      cmuxStatePath,
+      JSON.stringify({
+        hiddenListResponsesRemaining: options.hiddenPresenterListResponses,
+        workspaces: [],
+      }),
+    );
+  }
   await createRepository({ baseDirectory, root });
   for (const repository of options.additionalRepositories ?? []) {
     // Fixture repositories are created in stable order for deterministic Git diagnostics.

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -61,6 +61,12 @@ if (command === "new-workspace") {
     process.stdout.write("not json");
     process.exit(0);
   }
+  if (state.hiddenListResponsesRemaining > 0) {
+    state.hiddenListResponsesRemaining -= 1;
+    await writeFile(statePath, JSON.stringify(state));
+    process.stdout.write('{"workspaces":[]}');
+    process.exit(0);
+  }
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "close-workspace") {
   const id = valueAfter("--workspace");

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -875,6 +875,8 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
       });
       if (change.type === "failed") {
         // eslint-disable-next-line no-await-in-loop
+        await change.run.setPresentedStatus();
+        // eslint-disable-next-line no-await-in-loop
         await writeCompletion({ run: change.run, runtime });
       }
     }

--- a/v2/src/presenter/index.ts
+++ b/v2/src/presenter/index.ts
@@ -1,5 +1,9 @@
 import { execa } from "execa";
+import { setTimeout as delay } from "node:timers/promises";
 import { z } from "zod";
+
+const WORKSPACE_VISIBILITY_ATTEMPTS = 40;
+const WORKSPACE_VISIBILITY_INTERVAL_MILLISECONDS = 50;
 
 const WorkspaceListSchema = z.object({
   workspaces: z.array(
@@ -73,8 +77,9 @@ export class CmuxPresenter implements Presenter {
     if (result.exitCode !== 0) {
       throw new Error(result.stderr.trim() || "cmux failed to create workspace");
     }
+    const workspace = await this.waitUntilVisible({ name: input.name });
     if (input.status !== undefined) {
-      await this.setStatus({ name: input.name, text: input.status });
+      await this.setWorkspaceStatus({ text: input.status, workspaceId: workspace.id });
     }
   }
 
@@ -123,17 +128,47 @@ export class CmuxPresenter implements Presenter {
     if (workspace === undefined) {
       return;
     }
+    await this.setWorkspaceStatus({
+      color: input.color,
+      text: input.text,
+      workspaceId: workspace.id,
+    });
+  }
+
+  private async setWorkspaceStatus(input: {
+    readonly workspaceId: string;
+    readonly text: string;
+    readonly color?: string | undefined;
+  }): Promise<void> {
     const progress = ["complete", "delivered", "failed", "stopped"].includes(input.text)
       ? "1"
       : "0.5";
     const result = await execa(
       "cmux",
-      ["set-progress", progress, "--workspace", workspace.id, "--label", input.text],
+      ["set-progress", progress, "--workspace", input.workspaceId, "--label", input.text],
       { env: this.#environment, reject: false },
     );
     if (result.exitCode !== 0) {
       throw new Error(result.stderr.trim() || "cmux status failed");
     }
+  }
+
+  private async waitUntilVisible(input: {
+    readonly name: string;
+  }): Promise<{ readonly id: string; readonly title: string }> {
+    let previousWorkspaceId: string | undefined;
+    for (let attempt = 0; attempt < WORKSPACE_VISIBILITY_ATTEMPTS; attempt += 1) {
+      // cmux may acknowledge creation before the workspace reaches its list API.
+      // eslint-disable-next-line no-await-in-loop
+      const workspace = await this.resolve(input);
+      if (workspace !== undefined && workspace.id === previousWorkspaceId) {
+        return workspace;
+      }
+      previousWorkspaceId = workspace?.id;
+      // eslint-disable-next-line no-await-in-loop
+      await delay(WORKSPACE_VISIBILITY_INTERVAL_MILLISECONDS);
+    }
+    throw new Error(`cmux workspace ${input.name} did not become visible after creation`);
   }
 
   private async resolve(input: {


### PR DESCRIPTION
## Why

Groundcrew could mark a newly launched run `failed: workspace-missing` when cmux acknowledged workspace creation before exposing that workspace through its list API. The agent could then continue working in the late-appearing workspace, but artifact reporting and `crew done` were permanently rejected because the durable run was already terminal. This has no direct customer impact; it prevents incorrect operator state and stranded completed work.

## Summary

- Keep the run in protected provisioning until cmux reports the created workspace consistently.
- Set the presenter status when reconciliation completes a run as failed.
- Exercise delayed cmux visibility and reconciled presenter status through the built `crew` CLI.

## Validation

- `node --run verify` — 10 test files passed; 110 tests passed, 1 skipped.
- `npx vitest run e2e/dispatch.e2e.test.ts` — 55 tests passed.

## Notes

- Reproduced from the stale run observed while processing [STAFF-2216](https://linear.app/clipboardhealth/issue/STAFF-2216).
- Agent session: `codex resume 019fee9f-f554-7ab3-8eab-b57ad568dec8`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
