### PR TITLE
feat: continue a completed run in its existing agent session

### DIFF
--- a/v2/CONTEXT.md
+++ b/v2/CONTEXT.md
@@ -7,7 +7,9 @@ Four nouns form the model:
 - **Workspace**: a per-task directory containing a task marker and zero or more Git
   worktrees. It is not a terminal workspace.
 - **Run**: one claim-and-execution attempt. Its durable record is Groundcrew's source of truth
-  and moves `provisioning -> running -> complete`.
+  and moves `provisioning -> running -> complete`. `crew continue` resumes a completed Run's
+  session as a new attempt on the same record: fresh run ID, prior IDs kept in
+  `previousRunIds`, once the prior completion's source writeback has settled.
 - **Artifact**: an output the agent reports, such as a pull request, branch, document, file,
   or ticket. Artifacts are reported claims, never inferred Git facts.
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -1603,12 +1603,24 @@ describe("crew continue", () => {
       code: 1,
       stderr: expect.stringContaining("concurrency limit reached (1/1)"),
     });
+    const updatesAfterRefusal = (await readFile(fixture.updatesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(updatesAfterRefusal.filter((update) => update.event.type === "continued")).toHaveLength(
+      0,
+    );
     const forced = await runCrew({
       arguments: ["continue", "ENG-1", "--force"],
       environment: fixture.environment,
     });
 
     expect(forced.stdout).toContain("Continuing fixture:ENG-1 as run ");
+    const updatesAfterForce = (await readFile(fixture.updatesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(updatesAfterForce.filter((update) => update.event.type === "continued")).toHaveLength(1);
   });
 });
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -300,6 +300,7 @@ describe("crew start", () => {
     expect(command).toContain("codex");
     expect(command).toContain('model_reasoning_effort="high"');
     expect(command).toContain("Task: fixture:ENG-123");
+    expect(command).toContain("crew continue");
     expect(launchArguments).toContain("GROUNDCREW_TASK_ID=fixture:ENG-123");
     expect(launchArguments).toContain(
       `GROUNDCREW_CONFIG=${fixture.environment["GROUNDCREW_CONFIG"]}`,
@@ -350,6 +351,7 @@ describe("crew start", () => {
       event: {
         artifacts: [{ kind: "pr", locator: "https://github.com/example/pull/1" }],
         outcome: "delivered",
+        runId: updates[0].event.runId,
         type: "completed",
       },
       id: "ENG-123",
@@ -780,7 +782,7 @@ describe("crew start", () => {
     expect(failed).toMatchObject({ outcome: "failed", state: "complete" });
     expect(running).toMatchObject({ state: "running" });
     expect(updates).toContainEqual({
-      event: { artifacts: [], outcome: "failed", type: "completed" },
+      event: { artifacts: [], outcome: "failed", runId: failed.runId, type: "completed" },
       id: "ENG-1",
     });
     expect(result.stdout).toContain("Started fixture:ENG-2");
@@ -863,13 +865,19 @@ describe("crew start", () => {
         arguments: ["artifact", "add", "late-output", "--task", "ENG-123"],
         environment: fixture.environment,
       }),
-    ).rejects.toMatchObject({ code: 1 });
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("crew continue fixture:ENG-123"),
+    });
     await expect(
       runCrew({
         arguments: ["repo", "add", "sample", "--task", "ENG-123"],
         environment: fixture.environment,
       }),
-    ).rejects.toMatchObject({ code: 1 });
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("crew continue fixture:ENG-123"),
+    });
 
     const run = JSON.parse(
       await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8"),
@@ -1442,6 +1450,165 @@ describe("crew start", () => {
 
     await runCrew({ arguments: ["start"], environment: fixture.environment });
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("crew continue", () => {
+  it("continues a completed run in its existing session with a fresh run ID", async () => {
+    const fixture = await createDispatchFixture({ additionalRepositories: ["second"] });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "ENG-123"], environment: fixture.environment });
+    const runPath = join(fixture.runsDirectory, "fixture-eng-123.json");
+    const completed = JSON.parse(await readFile(runPath, "utf8"));
+
+    const result = await runCrew({
+      arguments: ["continue", "ENG-123"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
+    const continued = JSON.parse(await readFile(runPath, "utf8"));
+    expect(continued).toMatchObject({
+      artifacts: [],
+      previousRunIds: [completed.runId],
+      state: "running",
+    });
+    expect(continued.runId).not.toBe(completed.runId);
+    expect(continued.outcome).toBeUndefined();
+    expect(continued.writebackPending).toBeUndefined();
+
+    await runCrew({
+      arguments: ["repo", "add", "second", "--task", "ENG-123"],
+      environment: fixture.environment,
+    });
+    await runCrew({
+      arguments: ["artifact", "add", "follow-up-output", "--task", "ENG-123"],
+      environment: fixture.environment,
+    });
+    await runCrew({ arguments: ["done", "--task", "ENG-123"], environment: fixture.environment });
+    const updates = (await readFile(fixture.updatesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(updates.map((update) => update.event.type)).toEqual([
+      "claimed",
+      "completed",
+      "continued",
+      "completed",
+    ]);
+    expect(updates[2].event).toMatchObject({
+      previousRunId: completed.runId,
+      runId: continued.runId,
+    });
+    expect(updates[3].event).toMatchObject({
+      artifacts: [{ kind: "file", locator: "follow-up-output" }],
+      outcome: "delivered",
+      runId: continued.runId,
+    });
+  });
+
+  it("settles a pending completion writeback before continuing", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const rejectingEnvironment = {
+      ...fixture.environment,
+      FIXTURE_REJECT_COMPLETIONS: "ENG-123",
+    };
+    await expect(
+      runCrew({ arguments: ["done", "--task", "ENG-123"], environment: rejectingEnvironment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("writeback is pending"),
+    });
+    await expect(
+      runCrew({ arguments: ["continue", "ENG-123"], environment: rejectingEnvironment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("writeback"),
+    });
+
+    const result = await runCrew({
+      arguments: ["continue", "ENG-123"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
+    const updates = (await readFile(fixture.updatesPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const types = updates.map((update) => update.event.type);
+    expect(types.at(-1)).toBe("continued");
+    expect(types.filter((type) => type === "completed").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("refuses to continue a run that is still running", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    await expect(
+      runCrew({ arguments: ["continue", "ENG-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("running"),
+    });
+  });
+
+  it("refuses to continue when the source task is terminal", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "ENG-123"], environment: fixture.environment });
+    await writeFile(
+      join(fixture.root, "tasks.json"),
+      JSON.stringify([task({ repositories: ["sample"], terminal: true })]),
+    );
+
+    await expect(
+      runCrew({ arguments: ["continue", "ENG-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("terminal"),
+    });
+  });
+
+  it("refuses to continue when the presented workspace is gone", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "ENG-123"], environment: fixture.environment });
+    await writeFile(fixture.cmuxStatePath, '{"workspaces":[]}');
+
+    await expect(
+      runCrew({ arguments: ["continue", "ENG-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("presented workspace"),
+    });
+  });
+
+  it("counts continued runs against the concurrency limit unless forced", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 1,
+      tasks: [
+        task({ id: "ENG-1", priority: 1, repositories: ["sample"] }),
+        task({ id: "ENG-2", priority: 2, repositories: ["sample"] }),
+      ],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "ENG-1"], environment: fixture.environment });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    await expect(
+      runCrew({ arguments: ["continue", "ENG-1"], environment: fixture.environment }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("concurrency limit reached (1/1)"),
+    });
+    const forced = await runCrew({
+      arguments: ["continue", "ENG-1", "--force"],
+      environment: fixture.environment,
+    });
+
+    expect(forced.stdout).toContain("Continuing fixture:ENG-1 as run ");
   });
 });
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -1542,6 +1542,26 @@ describe("crew continue", () => {
     expect(types.filter((type) => type === "completed").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("reverts the continuation when the source rejects the continued event", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "ENG-123"], environment: fixture.environment });
+    const runPath = join(fixture.runsDirectory, "fixture-eng-123.json");
+    const completed = await readFile(runPath, "utf8");
+
+    await expect(
+      runCrew({
+        arguments: ["continue", "ENG-123"],
+        environment: { ...fixture.environment, FIXTURE_REJECT_CONTINUATIONS: "ENG-123" },
+      }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("rejected"),
+    });
+
+    expect(await readFile(runPath, "utf8")).toBe(completed);
+  });
+
   it("refuses to continue a run that is still running", async () => {
     const fixture = await createDispatchFixture();
     await runCrew({ arguments: ["start"], environment: fixture.environment });

--- a/v2/e2e/fixtures/source/update
+++ b/v2/e2e/fixtures/source/update
@@ -5,7 +5,8 @@ import { appendFile } from "node:fs/promises";
 const input = await readStandardInput();
 await appendFile(process.env.FIXTURE_UPDATES, `${JSON.stringify(input)}\n`);
 const rejected =
-  input.event.type === "claimed" && process.env.FIXTURE_REJECT_CLAIMS === input.id;
+  (input.event.type === "claimed" && process.env.FIXTURE_REJECT_CLAIMS === input.id) ||
+  (input.event.type === "completed" && process.env.FIXTURE_REJECT_COMPLETIONS === input.id);
 process.stdout.write(
   `${JSON.stringify({
     ok: true,

--- a/v2/e2e/fixtures/source/update
+++ b/v2/e2e/fixtures/source/update
@@ -6,7 +6,8 @@ const input = await readStandardInput();
 await appendFile(process.env.FIXTURE_UPDATES, `${JSON.stringify(input)}\n`);
 const rejected =
   (input.event.type === "claimed" && process.env.FIXTURE_REJECT_CLAIMS === input.id) ||
-  (input.event.type === "completed" && process.env.FIXTURE_REJECT_COMPLETIONS === input.id);
+  (input.event.type === "completed" && process.env.FIXTURE_REJECT_COMPLETIONS === input.id) ||
+  (input.event.type === "continued" && process.env.FIXTURE_REJECT_CONTINUATIONS === input.id);
 process.stdout.write(
   `${JSON.stringify({
     ok: true,

--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -58,6 +58,81 @@ describe("the shipped Linear source", () => {
     expect(fixture.state.comments.at(-1)).toContain(":completed:failed]");
   });
 
+  it("stamps a completion with its own run ID despite a newer claim comment", async () => {
+    await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
+    const claimRunId = fixture.state.comments[0]?.match(
+      /\[groundcrew:(r_[0-9a-f]{8}):claimed\]/,
+    )?.[1];
+    fixture.state.comments.push("[groundcrew:r_deadbeef:claimed]\nClaimed by Groundcrew.");
+
+    await runCrew({ arguments: ["done", "--task", "LIN-1"], environment: fixture.environment });
+
+    expect(claimRunId).toBeDefined();
+    expect(fixture.state.comments.at(-1)).toContain(
+      `[groundcrew:${claimRunId}:completed:delivered]`,
+    );
+  });
+
+  it("continues a delivered run from In Review and completes under the new run ID", async () => {
+    await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
+    await runCrew({ arguments: ["done", "--task", "LIN-1"], environment: fixture.environment });
+    expect(fixture.state.stateName).toBe("In Review");
+
+    await runCrew({ arguments: ["continue", "LIN-1"], environment: fixture.environment });
+
+    expect(fixture.state.stateName).toBe("In Progress");
+    await runCrew({ arguments: ["done", "--task", "LIN-1"], environment: fixture.environment });
+    expect(fixture.state.stateName).toBe("In Review");
+    const claimRunIds = fixture.state.comments.flatMap(
+      (comment) => comment.match(/\[groundcrew:(r_[0-9a-f]{8}):claimed\]/)?.slice(1) ?? [],
+    );
+    const completionRunIds = fixture.state.comments.flatMap(
+      (comment) =>
+        comment.match(/\[groundcrew:(r_[0-9a-f]{8}):completed:delivered\]/)?.slice(1) ?? [],
+    );
+    expect(claimRunIds).toHaveLength(2);
+    expect(completionRunIds).toEqual(claimRunIds);
+  });
+
+  it("continues an In Review issue with a fresh claim marker", async () => {
+    fixture.state.stateName = "In Review";
+    fixture.state.stateType = "started";
+    fixture.state.comments.push("[groundcrew:r_00112233:claimed]\nClaimed by Groundcrew.");
+
+    const result = await runLinearUpdate({
+      environment: fixture.environment,
+      payload: {
+        event: { previousRunId: "r_00112233", runId: "r_44556677", type: "continued" },
+        id: "LIN-1",
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual({ data: { result: "ok" }, ok: true });
+    expect(fixture.state.comments.at(-1)).toContain("[groundcrew:r_44556677:claimed]");
+    expect(fixture.state.comments.at(-1)).toContain("r_00112233");
+    expect(fixture.state.stateName).toBe("In Progress");
+  });
+
+  it("rejects continuing a terminal issue", async () => {
+    fixture.state.stateName = "Done";
+    fixture.state.stateType = "completed";
+
+    const result = await runLinearUpdate({
+      environment: fixture.environment,
+      payload: {
+        event: { previousRunId: "r_00112233", runId: "r_44556677", type: "continued" },
+        id: "LIN-1",
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      data: { result: "rejected" },
+      ok: true,
+    });
+    expect(fixture.state.comments).toHaveLength(0);
+    expect(fixture.state.stateName).toBe("Done");
+  });
+
   it("paginates list queries beneath Linear's complexity limit", async () => {
     await fixture.close();
     fixture = await createLinearFixture({ listedTaskCount: 251 });
@@ -387,10 +462,29 @@ async function runCrew(input: {
 async function runLinearList(input: {
   readonly environment: NodeJS.ProcessEnv;
 }): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await runLinearCommand({ command: "list", environment: input.environment, payload: {} });
+}
+
+async function runLinearUpdate(input: {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly payload: Record<string, unknown>;
+}): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await runLinearCommand({
+    command: "update",
+    environment: input.environment,
+    payload: input.payload,
+  });
+}
+
+async function runLinearCommand(input: {
+  readonly command: "list" | "update";
+  readonly environment: NodeJS.ProcessEnv;
+  readonly payload: Record<string, unknown>;
+}): Promise<{ readonly stdout: string; readonly stderr: string }> {
   return await new Promise((resolvePromise, reject) => {
     const child = execFile(
       process.execPath,
-      ["task-sources/linear/list"],
+      [`task-sources/linear/${input.command}`],
       { cwd: process.cwd(), env: input.environment },
       (error, stdout, stderr) => {
         if (error) {
@@ -400,6 +494,6 @@ async function runLinearList(input: {
         resolvePromise({ stderr, stdout });
       },
     );
-    child.stdin?.end("{}");
+    child.stdin?.end(JSON.stringify(input.payload));
   });
 }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -768,30 +768,27 @@ async function continueRun(input: {
   if (marker === undefined) {
     throw new Error(`task marker missing for ${canonicalTaskId}`);
   }
-  // Refuse a full roster before notifying the source; the admission lock re-checks below.
-  await runtime.runs.assertContinuationAdmission({
-    force: input.force,
-    maximumInProgress: runtime.config.orchestrator.maximumInProgress,
-  });
+  // The local transition commits first, so the source is never told about a continuation
+  // that admission (or a concurrent mutation) then refuses; a source rejection reverts it.
   const continuationRunId = mintRunId();
-  const authorized = await runtime.registry.update({
-    canonicalTaskId,
-    event: { previousRunId: run.record.runId, runId: continuationRunId, type: "continued" },
-  });
-  if (!authorized.ok) {
-    throw new Error(
-      `source did not accept the continued event (its bundle may predate crew continue): ${authorized.error.message}`,
-    );
-  }
-  if (authorized.data.result === "rejected") {
-    throw new Error(authorized.data.reason ?? "source rejected the continuation");
-  }
   const running = await run.continueRun({
     continuationRunId,
     force: input.force,
     maximumInProgress: runtime.config.orchestrator.maximumInProgress,
     repositories: marker.repositories,
   });
+  const authorized = await runtime.registry.update({
+    canonicalTaskId,
+    event: { previousRunId: run.record.runId, runId: continuationRunId, type: "continued" },
+  });
+  if (!authorized.ok || authorized.data.result === "rejected") {
+    await runtime.runs.revertContinuation({ continuationRunId, priorRecord: run.record });
+    throw new Error(
+      authorized.ok
+        ? (authorized.data.reason ?? "source rejected the continuation")
+        : `source did not accept the continued event (its bundle may predate crew continue): ${authorized.error.message}`,
+    );
+  }
   await log({
     canonicalTaskId,
     event: "run_continued",

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -10,6 +10,7 @@ import {
 } from "../source/index.js";
 import {
   RunModule,
+  mintRunId,
   taskSlug,
   withFileLock,
   type AgentProfile,
@@ -164,6 +165,7 @@ export interface Application {
     readonly allowDirty: boolean;
   }): Promise<RunRecord>;
   repoAdd(input: { readonly task: string; readonly repository: string }): Promise<RunRecord>;
+  continueRun(input: { readonly task: string; readonly force: boolean }): Promise<RunRecord>;
   cleanup(input: {
     readonly task?: string | undefined;
     readonly all: boolean;
@@ -245,6 +247,9 @@ export async function createApplication(input: {
     },
     async repoAdd(repoInput): Promise<RunRecord> {
       return await repoAdd({ ...repoInput, runtime });
+    },
+    async continueRun(continueInput): Promise<RunRecord> {
+      return await continueRun({ ...continueInput, runtime });
     },
     async cleanup(cleanupInput): Promise<{
       readonly cleaned: readonly string[];
@@ -721,6 +726,75 @@ async function repoAdd(input: {
   return run.record;
 }
 
+async function continueRun(input: {
+  readonly runtime: Runtime;
+  readonly task: string;
+  readonly force: boolean;
+}): Promise<RunRecord> {
+  const { runtime } = input;
+  const resolved = await runtime.runs.resolve({ query: input.task });
+  if (resolved.state !== "complete") {
+    throw new Error(
+      `run ${resolved.record.runId} is ${resolved.state}; crew continue resumes a completed run`,
+    );
+  }
+  let run: CompletedRun = resolved;
+  const canonicalTaskId = run.record.canonicalTaskId;
+  // A pending completion must land under the prior run ID before a new attempt can claim.
+  if (run.record.writebackPending === true) {
+    run = await writeCompletion({ run, runtime });
+    if (run.record.writebackPending === true) {
+      throw new Error(
+        `run ${run.record.runId} completion writeback is still pending; retry when the source accepts it`,
+      );
+    }
+  }
+  if (!(await runtime.runs.presentedWorkspaceExists({ record: run.record }))) {
+    throw new Error(
+      `presented workspace for ${canonicalTaskId} is gone; run crew cleanup and dispatch again instead`,
+    );
+  }
+  const sourceTask = await runtime.registry.get({ canonicalTaskId });
+  if (!sourceTask.ok) {
+    throw new Error(sourceTask.error.message);
+  }
+  if (sourceTask.data.task.terminal) {
+    throw new Error(`${canonicalTaskId} is terminal at its source; dispatch a new task instead`);
+  }
+  const marker = await runtime.workspaces.readMarker({
+    workspaceDirectory: run.record.workspaceDirectory,
+  });
+  if (marker === undefined) {
+    throw new Error(`task marker missing for ${canonicalTaskId}`);
+  }
+  const continuationRunId = mintRunId();
+  const authorized = await runtime.registry.update({
+    canonicalTaskId,
+    event: { previousRunId: run.record.runId, runId: continuationRunId, type: "continued" },
+  });
+  if (!authorized.ok) {
+    throw new Error(authorized.error.message);
+  }
+  if (authorized.data.result === "rejected") {
+    throw new Error(authorized.data.reason ?? "source rejected the continuation");
+  }
+  const running = await run.continueRun({
+    continuationRunId,
+    force: input.force,
+    maximumInProgress: runtime.config.orchestrator.maximumInProgress,
+    repositories: marker.repositories,
+  });
+  await log({
+    canonicalTaskId,
+    event: "run_continued",
+    level: "info",
+    module: "core",
+    runId: running.record.runId,
+    runtime,
+  });
+  return running.record;
+}
+
 async function cleanup(input: {
   readonly runtime: Runtime;
   readonly task?: string | undefined;
@@ -955,6 +1029,7 @@ async function writeCompletion(input: {
       artifacts: record.artifacts,
       message: record.message,
       outcome: record.outcome,
+      runId: record.runId,
       type: "completed",
     },
   });
@@ -989,6 +1064,11 @@ async function writeCompletion(input: {
 }
 
 function requireRunningRun(run: RunHandle): asserts run is RunningRun {
+  if (run.state === "complete") {
+    throw new Error(
+      `run ${run.record.runId} is complete; continue this session in a new run with: crew continue ${run.record.canonicalTaskId}`,
+    );
+  }
   if (run.state !== "running") {
     throw new Error(
       `run ${run.record.runId} is ${run.state}; in-session commands require a running run`,

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -10,6 +10,7 @@ import {
 } from "../source/index.js";
 import {
   RunModule,
+  completedRunRefusal,
   mintRunId,
   taskSlug,
   withFileLock,
@@ -767,13 +768,20 @@ async function continueRun(input: {
   if (marker === undefined) {
     throw new Error(`task marker missing for ${canonicalTaskId}`);
   }
+  // Refuse a full roster before notifying the source; the admission lock re-checks below.
+  await runtime.runs.assertContinuationAdmission({
+    force: input.force,
+    maximumInProgress: runtime.config.orchestrator.maximumInProgress,
+  });
   const continuationRunId = mintRunId();
   const authorized = await runtime.registry.update({
     canonicalTaskId,
     event: { previousRunId: run.record.runId, runId: continuationRunId, type: "continued" },
   });
   if (!authorized.ok) {
-    throw new Error(authorized.error.message);
+    throw new Error(
+      `source did not accept the continued event (its bundle may predate crew continue): ${authorized.error.message}`,
+    );
   }
   if (authorized.data.result === "rejected") {
     throw new Error(authorized.data.reason ?? "source rejected the continuation");
@@ -1065,9 +1073,7 @@ async function writeCompletion(input: {
 
 function requireRunningRun(run: RunHandle): asserts run is RunningRun {
   if (run.state === "complete") {
-    throw new Error(
-      `run ${run.record.runId} is complete; continue this session in a new run with: crew continue ${run.record.canonicalTaskId}`,
-    );
+    throw completedRunRefusal(run.record);
   }
   if (run.state !== "running") {
     throw new Error(

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   RunModule,
   seedWorkspaceTrust,
+  taskSlug,
   withFileLock,
   type CompletedRun,
   type RunningRun,
@@ -1054,7 +1055,8 @@ async function launchRun(input: {
   readonly fixture: ContinuationFixture;
   readonly task: string;
 }): Promise<RunningRun> {
-  const workspaceDirectory = join(input.fixture.stateRoot, `workspace-${taskSlug(input)}`);
+  const slug = taskSlug({ canonicalTaskId: input.task });
+  const workspaceDirectory = join(input.fixture.stateRoot, `workspace-${slug}`);
   await mkdir(workspaceDirectory, { recursive: true });
   const provisioning = await input.fixture.runs.beginDispatch({
     agentProfile: "codex",
@@ -1064,7 +1066,7 @@ async function launchRun(input: {
   });
   const launched = await provisioning.launch({
     acquiredRepositories: [],
-    branch: `agent/${taskSlug(input)}`,
+    branch: `agent/${slug}`,
     profile: { effort: "high", kind: "codex" },
     task: { canonicalTaskId: input.task, repositories: ["sample"], title: "Continuation task" },
   });
@@ -1096,10 +1098,6 @@ async function completeAndAcknowledge(input: {
     expectedCompletionTimestamp: completion.timestamp,
     expectedRunId: completed.record.runId,
   });
-}
-
-function taskSlug(input: { readonly task: string }): string {
-  return input.task.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
 }
 
 function deadProcessId(): number {

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -267,6 +267,31 @@ describe("RunModule lifecycle", () => {
     ).rejects.toThrow("stale");
   });
 
+  it("reverts a continuation to its prior completed record", async () => {
+    const fixture = await continuationFixture({ prefix: "groundcrew-v2-run-continue-revert-" });
+    const acknowledged = await completeAndAcknowledge({ fixture, task: "fixture:ENG-123" });
+    const continued = await acknowledged.continueRun({
+      continuationRunId: "r_00c0ffee",
+      force: false,
+      maximumInProgress: 4,
+      repositories: ["sample"],
+    });
+
+    await fixture.runs.revertContinuation({
+      continuationRunId: continued.record.runId,
+      priorRecord: acknowledged.record,
+    });
+
+    const restored = await fixture.runs.findBySlug({ slug: "fixture-eng-123" });
+    expect(restored?.record).toEqual(acknowledged.record);
+    await expect(
+      fixture.runs.revertContinuation({
+        continuationRunId: continued.record.runId,
+        priorRecord: acknowledged.record,
+      }),
+    ).rejects.toThrow("stale");
+  });
+
   it("refuses to continue while source writeback is pending", async () => {
     const fixture = await continuationFixture({ prefix: "groundcrew-v2-run-continue-pending-" });
     const completed = await completeRun({ fixture, task: "fixture:ENG-123" });

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -2,7 +2,13 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { RunModule, seedWorkspaceTrust, withFileLock } from "./index.js";
+import {
+  RunModule,
+  seedWorkspaceTrust,
+  withFileLock,
+  type CompletedRun,
+  type RunningRun,
+} from "./index.js";
 
 describe("RunModule lifecycle", () => {
   it("owns failure transitions and preserves the first terminal outcome", async () => {
@@ -217,6 +223,84 @@ describe("RunModule lifecycle", () => {
       transitioned: false,
     });
     await expect(runs.findBySlug({ slug: "fixture-eng-123" })).resolves.toBeUndefined();
+  });
+
+  it("continues an acknowledged completed Run with a fresh run ID in the same session", async () => {
+    const fixture = await continuationFixture({ prefix: "groundcrew-v2-run-continue-" });
+    const acknowledged = await completeAndAcknowledge({ fixture, task: "fixture:ENG-123" });
+    await writeFile(fixture.presenterCallsPath, "");
+
+    const continued = await acknowledged.continueRun({
+      continuationRunId: "r_00c0ffee",
+      force: false,
+      maximumInProgress: 4,
+      repositories: ["sample", "second"],
+    });
+
+    expect(continued.state).toBe("running");
+    expect(continued.record).toMatchObject({
+      artifacts: [],
+      canonicalTaskId: "fixture:ENG-123",
+      previousRunIds: [acknowledged.record.runId],
+      repositories: ["sample", "second"],
+      runId: "r_00c0ffee",
+      state: "running",
+    });
+    expect(continued.record.outcome).toBeUndefined();
+    expect(continued.record.writebackPending).toBeUndefined();
+    expect(continued.record.events.map(({ event }) => event)).toEqual([
+      "provisioning",
+      "running",
+      "complete:delivered",
+      `continued-from:${acknowledged.record.runId}`,
+    ]);
+    const presenterCalls = await readFile(fixture.presenterCallsPath, "utf8");
+    expect(presenterCalls).toContain("set-progress");
+    await expect(
+      acknowledged.continueRun({
+        continuationRunId: "r_11223344",
+        force: false,
+        maximumInProgress: 4,
+        repositories: [],
+      }),
+    ).rejects.toThrow("stale");
+  });
+
+  it("refuses to continue while source writeback is pending", async () => {
+    const fixture = await continuationFixture({ prefix: "groundcrew-v2-run-continue-pending-" });
+    const completed = await completeRun({ fixture, task: "fixture:ENG-123" });
+
+    await expect(
+      completed.continueRun({
+        continuationRunId: "r_00c0ffee",
+        force: false,
+        maximumInProgress: 4,
+        repositories: [],
+      }),
+    ).rejects.toThrow("source writeback is pending");
+  });
+
+  it("counts continued Runs against the concurrency limit unless forced", async () => {
+    const fixture = await continuationFixture({ prefix: "groundcrew-v2-run-continue-slots-" });
+    const acknowledged = await completeAndAcknowledge({ fixture, task: "fixture:ENG-123" });
+    await launchRun({ fixture, task: "fixture:ENG-999" });
+
+    await expect(
+      acknowledged.continueRun({
+        continuationRunId: "r_00c0ffee",
+        force: false,
+        maximumInProgress: 1,
+        repositories: [],
+      }),
+    ).rejects.toThrow("concurrency limit reached (1/1)");
+    const forced = await acknowledged.continueRun({
+      continuationRunId: "r_00c0ffee",
+      force: true,
+      maximumInProgress: 1,
+      repositories: [],
+    });
+
+    expect(forced.record).toMatchObject({ runId: "r_00c0ffee", state: "running" });
   });
 
   it("discards an unclaimed Run after recovery already completed it", async () => {
@@ -934,6 +1018,89 @@ describe("seedWorkspaceTrust", () => {
     expect(Object.keys(configuration.projects).toSorted()).toEqual(workspaces.toSorted());
   });
 });
+
+interface ContinuationFixture {
+  readonly presenterCallsPath: string;
+  readonly runs: RunModule;
+  readonly stateRoot: string;
+}
+
+async function continuationFixture(input: {
+  readonly prefix: string;
+}): Promise<ContinuationFixture> {
+  const stateRoot = await mkdtemp(join(tmpdir(), input.prefix));
+  const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
+  const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
+  const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+  await Promise.all([
+    writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
+    writeFile(presenterCallsPath, ""),
+  ]);
+  const runs = new RunModule({
+    environment: {
+      ...process.env,
+      FAKE_CMUX_CALLS: presenterCallsPath,
+      FAKE_CMUX_STATE: presentedWorkspaceStatePath,
+      HOME: stateRoot,
+      PATH: `${fakeBin}:${process.env["PATH"]}`,
+    },
+    presenterName: "cmux",
+    stateRoot,
+  });
+  return { presenterCallsPath, runs, stateRoot };
+}
+
+async function launchRun(input: {
+  readonly fixture: ContinuationFixture;
+  readonly task: string;
+}): Promise<RunningRun> {
+  const workspaceDirectory = join(input.fixture.stateRoot, `workspace-${taskSlug(input)}`);
+  await mkdir(workspaceDirectory, { recursive: true });
+  const provisioning = await input.fixture.runs.beginDispatch({
+    agentProfile: "codex",
+    canonicalTaskId: input.task,
+    repositories: ["sample"],
+    workspaceDirectory,
+  });
+  const launched = await provisioning.launch({
+    acquiredRepositories: [],
+    branch: `agent/${taskSlug(input)}`,
+    profile: { effort: "high", kind: "codex" },
+    task: { canonicalTaskId: input.task, repositories: ["sample"], title: "Continuation task" },
+  });
+  return launched.run;
+}
+
+async function completeRun(input: {
+  readonly fixture: ContinuationFixture;
+  readonly task: string;
+}): Promise<CompletedRun> {
+  const running = await launchRun(input);
+  return await running.finish({
+    assertWorkspaceIdle: async () => {},
+    message: "Shipped",
+    outcome: "delivered",
+  });
+}
+
+async function completeAndAcknowledge(input: {
+  readonly fixture: ContinuationFixture;
+  readonly task: string;
+}): Promise<CompletedRun> {
+  const completed = await completeRun(input);
+  const completion = completed.record.events.at(-1);
+  if (completion === undefined) {
+    throw new Error("completion event missing");
+  }
+  return await completed.acknowledgeSourceWriteback({
+    expectedCompletionTimestamp: completion.timestamp,
+    expectedRunId: completed.record.runId,
+  });
+}
+
+function taskSlug(input: { readonly task: string }): string {
+  return input.task.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
+}
 
 function deadProcessId(): number {
   for (let candidate = 2_147_483_647; candidate > 2_147_483_547; candidate -= 1) {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -572,19 +572,6 @@ export class RunModule {
     return { run: createRunHandle({ module: this, record }), transitioned };
   }
 
-  public async assertContinuationAdmission(input: {
-    readonly force: boolean;
-    readonly maximumInProgress: number;
-  }): Promise<void> {
-    if (input.force) {
-      return;
-    }
-    const activeCount = await this.#store.activeCount();
-    if (activeCount >= input.maximumInProgress) {
-      throw admissionRefusedError({ activeCount, maximumInProgress: input.maximumInProgress });
-    }
-  }
-
   public async continueRun(input: {
     readonly record: Readonly<RunRecord>;
     readonly continuationRunId: string;
@@ -604,6 +591,27 @@ export class RunModule {
       text: "running",
     });
     return new RunningRunHandle({ module: this, record: reservation.record });
+  }
+
+  public async revertContinuation(input: {
+    readonly continuationRunId: string;
+    readonly priorRecord: Readonly<RunRecord>;
+  }): Promise<void> {
+    await this.#store.mutate({
+      canonicalTaskId: input.priorRecord.canonicalTaskId,
+      update: (current) => {
+        if (current.runId !== input.continuationRunId || current.state !== "running") {
+          throw new Error(`continuation ${input.continuationRunId} is stale; cannot revert`);
+        }
+        return input.priorRecord;
+      },
+    });
+    if (input.priorRecord.outcome !== undefined) {
+      await this.#presenter.setStatus?.({
+        name: input.priorRecord.presentedWorkspaceName,
+        text: input.priorRecord.outcome,
+      });
+    }
   }
 
   public async acknowledgeSourceWriteback(input: {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -572,6 +572,19 @@ export class RunModule {
     return { run: createRunHandle({ module: this, record }), transitioned };
   }
 
+  public async assertContinuationAdmission(input: {
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+  }): Promise<void> {
+    if (input.force) {
+      return;
+    }
+    const activeCount = await this.#store.activeCount();
+    if (activeCount >= input.maximumInProgress) {
+      throw admissionRefusedError({ activeCount, maximumInProgress: input.maximumInProgress });
+    }
+  }
+
   public async continueRun(input: {
     readonly record: Readonly<RunRecord>;
     readonly continuationRunId: string;
@@ -581,9 +594,10 @@ export class RunModule {
   }): Promise<RunningRun> {
     const reservation = await this.#store.continueRun(input);
     if (reservation.record === undefined) {
-      throw new Error(
-        `concurrency limit reached (${reservation.activeCount}/${input.maximumInProgress}); pass --force to continue anyway`,
-      );
+      throw admissionRefusedError({
+        activeCount: reservation.activeCount,
+        maximumInProgress: input.maximumInProgress,
+      });
     }
     await this.#presenter.setStatus?.({
       name: reservation.record.presentedWorkspaceName,
@@ -753,19 +767,17 @@ class RunStore {
     readonly force: boolean;
     readonly maximumInProgress: number;
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
-    return await withFileLock({
-      operation: async () => {
-        const activeCount = (await this.list()).filter(
-          (record) => record.state === "provisioning" || record.state === "running",
-        ).length;
-        if (!input.force && activeCount >= input.maximumInProgress) {
-          return { activeCount };
-        }
-        const record = await this.create(input);
-        return { activeCount, record };
-      },
-      path: join(this.#runsDirectory, ".locks", "dispatch-admission.lock"),
+    return await this.reserveAdmission({
+      force: input.force,
+      maximumInProgress: input.maximumInProgress,
+      whileAdmitted: async () => await this.create(input),
     });
+  }
+
+  public async activeCount(): Promise<number> {
+    return (await this.list()).filter(
+      (record) => record.state === "provisioning" || record.state === "running",
+    ).length;
   }
 
   public async continueRun(input: {
@@ -775,15 +787,11 @@ class RunStore {
     readonly maximumInProgress: number;
     readonly repositories: readonly string[];
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
-    return await withFileLock({
-      operation: async () => {
-        const activeCount = (await this.list()).filter(
-          (record) => record.state === "provisioning" || record.state === "running",
-        ).length;
-        if (!input.force && activeCount >= input.maximumInProgress) {
-          return { activeCount };
-        }
-        const record = await this.mutate({
+    return await this.reserveAdmission({
+      force: input.force,
+      maximumInProgress: input.maximumInProgress,
+      whileAdmitted: async () =>
+        await this.mutate({
           canonicalTaskId: input.record.canonicalTaskId,
           update: (current) => {
             if (current.runId !== input.record.runId) {
@@ -814,8 +822,22 @@ class RunStore {
               writebackPending: undefined,
             };
           },
-        });
-        return { activeCount, record };
+        }),
+    });
+  }
+
+  private async reserveAdmission(input: {
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+    readonly whileAdmitted: () => Promise<RunRecord>;
+  }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
+    return await withFileLock({
+      operation: async () => {
+        const activeCount = await this.activeCount();
+        if (!input.force && activeCount >= input.maximumInProgress) {
+          return { activeCount };
+        }
+        return { activeCount, record: await input.whileAdmitted() };
       },
       path: join(this.#runsDirectory, ".locks", "dispatch-admission.lock"),
     });
@@ -1147,6 +1169,24 @@ export function mintRunId(): string {
   return `r_${randomBytes(4).toString("hex")}`;
 }
 
+export function completedRunRefusal(input: {
+  readonly runId: string;
+  readonly canonicalTaskId: string;
+}): Error {
+  return new Error(
+    `run ${input.runId} is complete; continue this session in a new run with: crew continue ${input.canonicalTaskId}`,
+  );
+}
+
+function admissionRefusedError(input: {
+  readonly activeCount: number;
+  readonly maximumInProgress: number;
+}): Error {
+  return new Error(
+    `concurrency limit reached (${input.activeCount}/${input.maximumInProgress}); pass --force to continue anyway`,
+  );
+}
+
 export function taskSlug(input: { readonly canonicalTaskId: string }): string {
   return input.canonicalTaskId
     .toLowerCase()
@@ -1433,9 +1473,7 @@ function requireCurrentRun(input: {
   if (input.current.state !== input.state) {
     if (input.state === "running") {
       if (input.current.state === "complete") {
-        throw new Error(
-          `run ${input.current.runId} is complete; continue this session in a new run with: crew continue ${input.current.canonicalTaskId}`,
-        );
+        throw completedRunRefusal(input.current);
       }
       throw new Error(
         `run ${input.current.runId} is ${input.current.state}; in-session commands require a running run`,

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -33,6 +33,7 @@ export interface RunRecord {
   readonly pendingRepository?: string | undefined;
   readonly artifacts: readonly Artifact[];
   readonly events: readonly RunEvent[];
+  readonly previousRunIds?: readonly string[] | undefined;
   readonly provisioningOwner?:
     | {
         readonly processId: number;
@@ -112,6 +113,12 @@ export interface CompletedRun extends BaseRun {
     readonly expectedRunId: string;
     readonly expectedCompletionTimestamp: string;
   }): Promise<CompletedRun>;
+  continueRun(input: {
+    readonly continuationRunId: string;
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun>;
   setPresentedStatus(): Promise<void>;
   closePresentedWorkspace(): Promise<void>;
   remove(): Promise<void>;
@@ -233,6 +240,16 @@ export class RunModule {
   public async capturePresentedWorkspaces(): Promise<PresentedWorkspaceSnapshot> {
     const probe = await this.#presenter.probe();
     return { [presentedWorkspaceSnapshot]: probe };
+  }
+
+  public async presentedWorkspaceExists(input: {
+    readonly record: Readonly<RunRecord>;
+  }): Promise<boolean> {
+    const probe = await this.#presenter.probe();
+    if (!probe.available) {
+      throw new Error("presenter is unavailable; cannot verify the presented workspace");
+    }
+    return isPresented({ record: input.record, workspaces: probe.workspaces });
   }
 
   public async listActiveAfterPresentationReconciliation(): Promise<readonly RunHandle[]> {
@@ -555,6 +572,26 @@ export class RunModule {
     return { run: createRunHandle({ module: this, record }), transitioned };
   }
 
+  public async continueRun(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly continuationRunId: string;
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun> {
+    const reservation = await this.#store.continueRun(input);
+    if (reservation.record === undefined) {
+      throw new Error(
+        `concurrency limit reached (${reservation.activeCount}/${input.maximumInProgress}); pass --force to continue anyway`,
+      );
+    }
+    await this.#presenter.setStatus?.({
+      name: reservation.record.presentedWorkspaceName,
+      text: "running",
+    });
+    return new RunningRunHandle({ module: this, record: reservation.record });
+  }
+
   public async acknowledgeSourceWriteback(input: {
     readonly record: Readonly<RunRecord>;
     readonly expectedRunId: string;
@@ -696,7 +733,7 @@ class RunStore {
           presenter: "cmux",
           provisioningOwner: { phase: "preparing", processId: process.pid },
           repositories: input.repositories,
-          runId: `r_${randomBytes(4).toString("hex")}`,
+          runId: mintRunId(),
           state: "provisioning",
           version: 1,
           workspaceDirectory: input.workspaceDirectory,
@@ -725,6 +762,59 @@ class RunStore {
           return { activeCount };
         }
         const record = await this.create(input);
+        return { activeCount, record };
+      },
+      path: join(this.#runsDirectory, ".locks", "dispatch-admission.lock"),
+    });
+  }
+
+  public async continueRun(input: {
+    readonly record: Readonly<RunRecord>;
+    readonly continuationRunId: string;
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+    readonly repositories: readonly string[];
+  }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
+    return await withFileLock({
+      operation: async () => {
+        const activeCount = (await this.list()).filter(
+          (record) => record.state === "provisioning" || record.state === "running",
+        ).length;
+        if (!input.force && activeCount >= input.maximumInProgress) {
+          return { activeCount };
+        }
+        const record = await this.mutate({
+          canonicalTaskId: input.record.canonicalTaskId,
+          update: (current) => {
+            if (current.runId !== input.record.runId) {
+              throw new Error(`run ${input.record.runId} is stale`);
+            }
+            if (current.state !== "complete" || current.outcome === undefined) {
+              throw new Error(`run ${current.runId} is not complete`);
+            }
+            if (current.writebackPending === true) {
+              throw new Error(`run ${current.runId} source writeback is pending`);
+            }
+            return {
+              ...current,
+              artifacts: [],
+              events: [
+                ...current.events,
+                { event: `continued-from:${current.runId}`, timestamp: new Date().toISOString() },
+              ],
+              message: undefined,
+              outcome: undefined,
+              pendingRepository: undefined,
+              previousRunIds: [...(current.previousRunIds ?? []), current.runId],
+              provisioningOwner: undefined,
+              reason: undefined,
+              repositories: input.repositories,
+              runId: input.continuationRunId,
+              state: "running",
+              writebackPending: undefined,
+            };
+          },
+        });
         return { activeCount, record };
       },
       path: join(this.#runsDirectory, ".locks", "dispatch-admission.lock"),
@@ -939,6 +1029,15 @@ class CompletedRunHandle implements CompletedRun {
     return await this.#module.acknowledgeSourceWriteback({ ...input, record: this.record });
   }
 
+  public async continueRun(input: {
+    readonly continuationRunId: string;
+    readonly force: boolean;
+    readonly maximumInProgress: number;
+    readonly repositories: readonly string[];
+  }): Promise<RunningRun> {
+    return await this.#module.continueRun({ ...input, record: this.record });
+  }
+
   public async remove(): Promise<void> {
     await this.#module.remove({ record: this.record });
   }
@@ -1044,6 +1143,10 @@ export async function withFileLock<T>(input: {
   return result;
 }
 
+export function mintRunId(): string {
+  return `r_${randomBytes(4).toString("hex")}`;
+}
+
 export function taskSlug(input: { readonly canonicalTaskId: string }): string {
   return input.canonicalTaskId
     .toLowerCase()
@@ -1095,6 +1198,7 @@ function renderPrompt(input: {
     "Report every durable output with: crew artifact add <locator> --kind <kind>",
     "Complete the run with: crew done [--outcome delivered|failed|stopped]",
     "Report each durable output before completing.",
+    "If more task work is requested after completion, run crew continue before making or reporting further changes; questions alone need no new run.",
   ].join("\n");
 }
 
@@ -1279,12 +1383,7 @@ function classifyPresentationReconciliation(input: {
     return { type: "unchanged" };
   }
   const record = input.run.record;
-  const presented = probe.workspaces.some(
-    (workspace) =>
-      workspace.name === record.presentedWorkspaceName ||
-      workspace.description === record.presentedWorkspaceName ||
-      workspace.description === `groundcrew:${record.canonicalTaskId}`,
-  );
+  const presented = isPresented({ record, workspaces: probe.workspaces });
   if (record.state === "provisioning" && presented) {
     return { type: "running" };
   }
@@ -1295,6 +1394,19 @@ function classifyPresentationReconciliation(input: {
     reason: record.state === "provisioning" ? "provisioning-interrupted" : "workspace-missing",
     type: "failed",
   };
+}
+
+function isPresented(input: {
+  readonly record: Readonly<RunRecord>;
+  readonly workspaces: readonly PresentedWorkspace[];
+}): boolean {
+  const { record } = input;
+  return input.workspaces.some(
+    (workspace) =>
+      workspace.name === record.presentedWorkspaceName ||
+      workspace.description === record.presentedWorkspaceName ||
+      workspace.description === `groundcrew:${record.canonicalTaskId}`,
+  );
 }
 
 function provisioningOwnerIsAlive(input: { readonly record: RunRecord }): boolean {
@@ -1320,6 +1432,11 @@ function requireCurrentRun(input: {
   }
   if (input.current.state !== input.state) {
     if (input.state === "running") {
+      if (input.current.state === "complete") {
+        throw new Error(
+          `run ${input.current.runId} is complete; continue this session in a new run with: crew continue ${input.current.canonicalTaskId}`,
+        );
+      }
       throw new Error(
         `run ${input.current.runId} is ${input.current.state}; in-session commands require a running run`,
       );

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -279,6 +279,22 @@ export async function main(input: MainInput): Promise<void> {
     });
 
   program
+    .command("continue")
+    .description("continue a completed run in its existing agent session")
+    .argument("[task]", "canonical or source-local task ID")
+    .option("--force", "bypass the concurrency limit")
+    .option("--verbose", "include debug diagnostics")
+    .action(async (task, options) => {
+      const resolvedTask = await resolveTaskContext({ environment, explicitTask: task });
+      const application = await configuredApplication({ environment });
+      const record = await application.continueRun({
+        force: options.force === true,
+        task: resolvedTask,
+      });
+      process.stdout.write(`Continuing ${record.canonicalTaskId} as run ${record.runId}\n`);
+    });
+
+  program
     .command("done")
     .description("complete the active run and write back to its source")
     .option("--outcome <outcome>", "delivered, failed, or stopped", "delivered")

--- a/v2/src/source/index.ts
+++ b/v2/src/source/index.ts
@@ -54,8 +54,10 @@ export interface Task {
 
 export type SourceEvent =
   | { readonly type: "claimed"; readonly runId: string }
+  | { readonly type: "continued"; readonly runId: string; readonly previousRunId: string }
   | {
       readonly type: "completed";
+      readonly runId: string;
       readonly outcome: "delivered" | "failed" | "stopped";
       readonly artifacts: readonly Artifact[];
       readonly message?: string | undefined;

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -90,12 +90,26 @@ async function updateTask(input) {
     await moveIssue({ issue, stateName: environment("LINEAR_STATUS_IN_PROGRESS", "In Progress") });
     return { result: "ok" };
   }
+  if (input.event.type === "continued") {
+    const task = normalizeIssue(issue);
+    if (task === undefined || task.terminal) {
+      return { reason: "issue is no longer continuable", result: "rejected" };
+    }
+    const marker = `[groundcrew:${input.event.runId}:claimed]`;
+    await addCommentOnce({
+      issue,
+      marker,
+      text: `${marker}\nContinued by Groundcrew from ${input.event.previousRunId}.`,
+    });
+    await moveIssue({ issue, stateName: environment("LINEAR_STATUS_IN_PROGRESS", "In Progress") });
+    return { result: "ok" };
+  }
   const artifactLines = input.event.artifacts.map(
     (artifact) =>
       `- ${artifact.kind}: ${artifact.locator}${artifact.title ? ` — ${artifact.title}` : ""}`,
   );
-  const claimRunId = latestClaimRunId(issue);
-  const completionMarker = `[groundcrew:${claimRunId ?? "unclaimed"}:completed:${input.event.outcome}]`;
+  const completionRunId = input.event.runId ?? latestClaimRunId(issue);
+  const completionMarker = `[groundcrew:${completionRunId ?? "unclaimed"}:completed:${input.event.outcome}]`;
   const text = [
     completionMarker,
     `Groundcrew completed this run as ${input.event.outcome}.`,


### PR DESCRIPTION
## Why

After `crew done`, the agent's cmux workspace stays open with the full conversation, but every in-session command refuses with `run … is already complete`. The only recovery path — `crew cleanup` plus moving the ticket back to Todo for redispatch — destroys the conversation the follow-up needs (a delivered ticket lands In Review, which is blocked from dispatch, and the leftover run record blocks a new dispatch anyway). This hit DEVOP-6425: a follow-up request in a live session had no sanctioned path, so the agent stalled. No direct customer impact; this is developer/operator experience for Groundcrew-driven work.

Fixing this exposed a writeback attribution bug worth shipping on its own: completion events carried no run ID, so the Linear bundle stamped completions with the newest claim comment — a pending completion retried after a newer claim would be attributed to the wrong run.

## Summary

- Completion events now carry their exact `runId` end to end (core `writeCompletion` → source protocol → Linear completion marker), replacing latest-claim-comment inference.
- New `continued` source event `{runId, previousRunId}`. Linear policy: reject terminal issues; otherwise post a fresh claim marker and move the issue to In Progress (explicit path for continuing from In Review, where ordinary claims stay rejected).
- `crew continue [task]` resumes a completed run's session as a new attempt on the same record: settles or refuses pending writeback, verifies the presented workspace still exists, refuses terminal source tasks, then commits the continuation locally under the dispatch-admission lock (`--force` to bypass the slot limit) — fresh run ID with `previousRunIds` provenance, artifacts cleared, repositories re-derived from the workspace marker, presenter status reset — and only then notifies the source with the `continued` event; a source rejection reverts the local transition, so the source can never show a continuation that doesn't exist locally, and vice versa a refusal never touches the source.
- The in-session refusal now points at `crew continue <task>`, and the launch prompt tells agents to run it before making further post-completion changes (questions alone need no new run). CONTEXT.md domain language updated.

## Validation

- `cd v2 && node --run verify` green: format, typecheck, build, schema, architecture, 125 tests.
- New coverage: RunModule continuation unit tests (fresh run ID, stale-handle refusal, pending-writeback refusal, concurrency admission with `--force`); dispatch e2e (`crew continue` happy path incl. second writeback under the new run ID, settle-before-continue, refusals for running/terminal/missing-workspace, refused continuation emits no source event); Linear e2e (In Review → continue → In Progress → second completion under the new run ID, completion marker immune to a newer foreign claim comment, `continued` accept/reject protocol tests).
- `cb-review --effort low`: 1 MAJOR (source notified before admission — fixed by pre-checking the slot), 1 MINOR + 3 NITs also applied. Ship gate: pass.

## Notes

- Protocol surface: `continued` is a new event type within protocol version 1 and `completed` gains a `runId` field. Both shipped bundles handle it; a user-authored bundle that predates it will reject/crash on `continued` — the CLI wraps that failure with an actionable message and reverts the local continuation, so the failure is a clean abort.
- Residual crash window accepted: a crash between the local transition and the source notification leaves a locally running continuation whose ticket wasn't moved yet — benign, since the run is real and its completion writes back under the correct run ID.

Agent session: `claude --resume session_01BsVmR1QGTA8hmMjMpPG2Qs`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsVmR1QGTA8hmMjMpPG2Qs
