### PR TITLE
fix: dispatch before watch cleanup

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -353,7 +353,54 @@ describe("crew start", () => {
     expect(
       JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-ready-1.json"), "utf8")),
     ).toMatchObject({ state: "running" });
+    const calls = (await readFile(fixture.cmuxCallsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(calls.filter((call) => call.arguments[0] === "set-progress").at(-1).arguments).toContain(
+      "stopped",
+    );
     await expect(stat(fixture.workspaceDirectory)).resolves.toBeDefined();
+  });
+
+  it("does not clean a resumed generation while replacement dispatch is blocked", async () => {
+    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+    const openReleasePath = join(fixture.root, "open-release");
+    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
+    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
+    await waitForPath(`${openReleasePath}.ready`);
+    const tasksPath = fixture.environment["FIXTURE_TASKS"];
+    if (tasksPath === undefined) {
+      throw new Error("fixture tasks path is missing");
+    }
+    await writeFile(tasksPath, JSON.stringify([task({ repositories: ["sample"] })]));
+
+    try {
+      await expect(
+        runCrew({
+          arguments: ["continue", "ENG-123", "--force"],
+          environment: fixture.environment,
+        }),
+      ).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining("cleanup is pending"),
+      });
+    } finally {
+      await writeFile(openReleasePath, "release\n");
+      await start;
+    }
+
+    await expect(stat(join(fixture.runsDirectory, "fixture-eng-123.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("claims, provisions, and launches a ready task exactly once", async () => {

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -425,6 +425,40 @@ describe("crew start", () => {
     expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
   });
 
+  it("reclaims cleanup ownership after an interrupted watch process", async () => {
+    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+    const openReleasePath = join(fixture.root, "open-release");
+    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
+    const child = spawn(process.execPath, ["bin/run.js", "start", "--watch"], {
+      cwd: process.cwd(),
+      env: fixture.environment,
+      stdio: "ignore",
+    });
+    const childClosed = new Promise<void>((resolvePromise) => {
+      child.once("close", () => resolvePromise());
+    });
+    await waitForPath(`${openReleasePath}.ready`);
+    child.kill();
+    await writeFile(openReleasePath, "release\n");
+    await childClosed;
+    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "preserve me\n");
+
+    const result = await runCrew({
+      arguments: ["continue", "ENG-123", "--force"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
+  });
+
   it("claims, provisions, and launches a ready task exactly once", async () => {
     const fixture = await createDispatchFixture();
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -261,7 +261,7 @@ describe("crew start", () => {
 
   it("dispatches new work before cleaning terminal workspaces while watching", async () => {
     const fixture = await createDispatchFixture({
-      maximumInProgress: 2,
+      maximumInProgress: 1,
       pollIntervalMilliseconds: 10,
       repositories: [],
     });
@@ -289,7 +289,11 @@ describe("crew start", () => {
     try {
       await waitForPath(`${closeReleasePath}.ready`);
 
-      expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 2/2");
+      expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 1/1");
+      expect(stdout).toContain("Cleaning fixture:ENG-123");
+      expect(stdout.indexOf("Dispatching fixture:READY-1")).toBeLessThan(
+        stdout.indexOf("Cleaning fixture:ENG-123"),
+      );
     } finally {
       await writeFile(closeReleasePath, "release\n");
       child.kill();

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -403,6 +403,28 @@ describe("crew start", () => {
     });
   });
 
+  it("releases cleanup ownership when automatic cleanup fails", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([task({ repositories: ["sample"], terminal: true })]),
+    );
+    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = "1";
+
+    await expect(
+      runCrew({ arguments: ["start"], environment: fixture.environment }),
+    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("close failure") });
+    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = undefined;
+
+    const result = await runCrew({
+      arguments: ["continue", "ENG-123"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
+  });
+
   it("claims, provisions, and launches a ready task exactly once", async () => {
     const fixture = await createDispatchFixture();
 
@@ -1594,6 +1616,15 @@ describe("crew start", () => {
 
     await runCrew({ arguments: ["start"], environment: fixture.environment });
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+    const status = JSON.parse(
+      (
+        await runCrew({
+          arguments: ["status", "ENG-123", "--json"],
+          environment: fixture.environment,
+        })
+      ).stdout,
+    );
+    expect(status.tasks[0].verdict).toMatchObject({ reason: "terminal" });
   });
 });
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -303,6 +303,26 @@ describe("crew start", () => {
     }
   });
 
+  it("keeps a dirty terminal workspace in capacity until it can be cleaned", async () => {
+    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "keep me\n");
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+
+    const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
+
+    expect(result.stdout).toContain(
+      "At capacity (1/1) [fixture:ENG-123(codex)], no new work to start",
+    );
+    expect(result.stdout).not.toContain("Dispatching fixture:READY-1");
+  });
+
   it("claims, provisions, and launches a ready task exactly once", async () => {
     const fixture = await createDispatchFixture();
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import {
   chmod,
   cp,
@@ -257,6 +257,46 @@ describe("crew start", () => {
 
     expect(stdout).toContain("Started fixture:ENG-123");
     expect(stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
+  });
+
+  it("dispatches new work before cleaning terminal workspaces while watching", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 2,
+      pollIntervalMilliseconds: 10,
+      repositories: [],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: [], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+    const closeReleasePath = join(fixture.root, "close-release");
+    fixture.environment["FAKE_CMUX_CLOSE_RELEASE"] = closeReleasePath;
+    const child = spawn(process.execPath, ["bin/run.js", "start", "--watch"], {
+      cwd: process.cwd(),
+      env: fixture.environment,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    try {
+      await waitForPath(`${closeReleasePath}.ready`);
+
+      expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 2/2");
+    } finally {
+      await writeFile(closeReleasePath, "release\n");
+      child.kill();
+      await new Promise<void>((resolvePromise) => {
+        child.once("close", () => resolvePromise());
+      });
+    }
   });
 
   it("claims, provisions, and launches a ready task exactly once", async () => {

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -291,6 +291,7 @@ describe("crew start", () => {
 
     try {
       await waitForPath(`${closeReleasePath}.ready`);
+      await waitFor(() => stdout.includes("Cleaning fixture:ENG-123"));
 
       expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 1/1");
       expect(stdout).toContain("Cleaning fixture:ENG-123");
@@ -357,10 +358,39 @@ describe("crew start", () => {
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line));
-    expect(calls.filter((call) => call.arguments[0] === "set-progress").at(-1).arguments).toContain(
-      "stopped",
-    );
+    const lastSetProgressCall = calls.filter((call) => call.arguments[0] === "set-progress").at(-1);
+    expect(lastSetProgressCall).toBeDefined();
+    expect(lastSetProgressCall?.arguments).toContain("stopped");
     await expect(stat(fixture.workspaceDirectory)).resolves.toBeDefined();
+  });
+
+  it("does not release cleanup ownership acquired by another process", async () => {
+    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+    const openReleasePath = join(fixture.root, "open-release");
+    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
+    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
+    await waitForPath(`${openReleasePath}.ready`);
+    const runPath = join(fixture.runsDirectory, "fixture-eng-123.json");
+    const run = JSON.parse(await readFile(runPath, "utf8"));
+    await writeFile(runPath, JSON.stringify({ ...run, cleanupOwnerProcessId: process.pid }));
+    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "late change\n");
+    await writeFile(openReleasePath, "release\n");
+
+    await start;
+
+    expect(JSON.parse(await readFile(runPath, "utf8"))).toMatchObject({
+      cleanupOwnerProcessId: process.pid,
+      cleanupPending: true,
+      state: "complete",
+    });
   });
 
   it("does not clean a resumed generation while replacement dispatch is blocked", async () => {
@@ -2081,6 +2111,17 @@ async function waitForPath(path: string): Promise<void> {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
   }
   throw new Error(`timed out waiting for ${path}`);
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (condition()) {
+      return;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+  }
+  throw new Error("timed out waiting for expected condition");
 }
 
 async function waitForRunState(input: {

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -285,21 +285,25 @@ describe("crew start", () => {
     child.stdout.on("data", (chunk: string) => {
       stdout += chunk;
     });
+    const childClosed = new Promise<void>((resolvePromise) => {
+      child.once("close", () => resolvePromise());
+    });
 
     try {
       await waitForPath(`${closeReleasePath}.ready`);
 
       expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 1/1");
       expect(stdout).toContain("Cleaning fixture:ENG-123");
+      expect(
+        JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8")),
+      ).toMatchObject({ state: "complete" });
       expect(stdout.indexOf("Dispatching fixture:READY-1")).toBeLessThan(
         stdout.indexOf("Cleaning fixture:ENG-123"),
       );
     } finally {
       await writeFile(closeReleasePath, "release\n");
       child.kill();
-      await new Promise<void>((resolvePromise) => {
-        child.once("close", () => resolvePromise());
-      });
+      await childClosed;
     }
   });
 
@@ -321,6 +325,35 @@ describe("crew start", () => {
       "At capacity (1/1) [fixture:ENG-123(codex)], no new work to start",
     );
     expect(result.stdout).not.toContain("Dispatching fixture:READY-1");
+  });
+
+  it("keeps terminal capacity released when the workspace becomes dirty during dispatch", async () => {
+    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await writeFile(
+      fixture.listedTasksPath,
+      JSON.stringify([
+        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
+        task({ id: "READY-1", priority: 2, repositories: [] }),
+      ]),
+    );
+    const openReleasePath = join(fixture.root, "open-release");
+    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
+    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
+    await waitForPath(`${openReleasePath}.ready`);
+    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "late change\n");
+    await writeFile(openReleasePath, "release\n");
+
+    const result = await start;
+
+    expect(result.stdout).toContain("Started fixture:READY-1");
+    expect(
+      JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8")),
+    ).toMatchObject({ state: "complete" });
+    expect(
+      JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-ready-1.json"), "utf8")),
+    ).toMatchObject({ state: "running" });
+    await expect(stat(fixture.workspaceDirectory)).resolves.toBeDefined();
   });
 
   it("claims, provisions, and launches a ready task exactly once", async () => {

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -70,6 +70,10 @@ if (command === "new-workspace") {
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "close-workspace") {
   const id = valueAfter("--workspace");
+  if (process.env.FAKE_CMUX_FAIL_CLOSE === "1") {
+    process.stderr.write("fake cmux close failure\n");
+    process.exit(1);
+  }
   if (process.env.FAKE_CMUX_CLOSE_RELEASE !== undefined) {
     await writeFile(`${process.env.FAKE_CMUX_CLOSE_RELEASE}.ready`, "ready\n");
     for (;;) {

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -70,6 +70,20 @@ if (command === "new-workspace") {
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "close-workspace") {
   const id = valueAfter("--workspace");
+  if (process.env.FAKE_CMUX_CLOSE_RELEASE !== undefined) {
+    await writeFile(`${process.env.FAKE_CMUX_CLOSE_RELEASE}.ready`, "ready\n");
+    for (;;) {
+      try {
+        await access(process.env.FAKE_CMUX_CLOSE_RELEASE);
+        break;
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+          throw error;
+        }
+      }
+      await delay(10);
+    }
+  }
   if (process.env.FAKE_CMUX_DIRTY_ON_CLOSE !== undefined) {
     await writeFile(process.env.FAKE_CMUX_DIRTY_ON_CLOSE, "uncommitted\n");
   }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -763,6 +763,9 @@ async function continueRun(input: {
   }
   let run: CompletedRun = resolved;
   const canonicalTaskId = run.record.canonicalTaskId;
+  if (run.record.cleanupPending === true) {
+    throw new Error(`run ${run.record.runId} cleanup is pending`);
+  }
   // A pending completion must land under the prior run ID before a new attempt can claim.
   if (run.record.writebackPending === true) {
     run = await writeCompletion({ run, runtime });
@@ -1025,6 +1028,11 @@ async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
     // eslint-disable-next-line no-await-in-loop
     const observed = await input.runtime.workspaces.observe({ slug });
     if (observed.dirtyPaths.length > 0) {
+      // Keep the presented workspace legible before allowing a later continuation.
+      // eslint-disable-next-line no-await-in-loop
+      await run.setPresentedStatus();
+      // eslint-disable-next-line no-await-in-loop
+      await run.cancelCleanup();
       continue;
     }
     input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -111,6 +111,10 @@ export type DispatchProgress =
       readonly canonicalTaskId: string;
       readonly detail: string;
       readonly reason: VerdictReason;
+    }
+  | {
+      readonly type: "cleaning";
+      readonly canonicalTaskId: string;
     };
 
 export type VerdictReason =
@@ -314,6 +318,9 @@ async function start(input: {
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
+  const terminalTaskIds = new Set(
+    listed.data.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
+  );
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
     tasks = tasks
@@ -345,7 +352,11 @@ async function start(input: {
     ? await listActiveAfterPreviewReconciliation({ runtime, tasks: listed.data.tasks })
     : await runtime.runs.list();
   const active = activeRuns
-    .filter((run) => run.state === "provisioning" || run.state === "running")
+    .filter(
+      (run) =>
+        (run.state === "provisioning" || run.state === "running") &&
+        !terminalTaskIds.has(run.record.canonicalTaskId),
+    )
     .map((run) => ({
       agentProfile: run.record.agentProfile,
       canonicalTaskId: run.record.canonicalTaskId,
@@ -445,6 +456,7 @@ async function start(input: {
     const reservation = await runtime.runs.reserveDispatch({
       agentProfile: profileName,
       canonicalTaskId,
+      excludedCanonicalTaskIds: terminalTaskIds,
       force: input.force,
       maximumInProgress: runtime.config.orchestrator.maximumInProgress,
       repositories: task.repositories,
@@ -536,7 +548,11 @@ async function start(input: {
     }
   }
   if (!input.dryRun) {
-    await reapTerminalTasks({ runtime, tasks: listed.data.tasks });
+    await reapTerminalTasks({
+      onProgress: input.onProgress,
+      runtime,
+      tasks: listed.data.tasks,
+    });
   }
   return { skipped, started };
 }
@@ -968,6 +984,7 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
 }
 
 async function reapTerminalTasks(input: {
+  readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
   readonly runtime: Runtime;
   readonly tasks: readonly Task[];
 }): Promise<void> {
@@ -984,6 +1001,7 @@ async function reapTerminalTasks(input: {
     if (observed.dirtyPaths.length > 0) {
       continue;
     }
+    input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });
     // eslint-disable-next-line no-await-in-loop
     await cleanup({
       allowDirty: false,

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -764,7 +764,10 @@ async function continueRun(input: {
   let run: CompletedRun = resolved;
   const canonicalTaskId = run.record.canonicalTaskId;
   if (run.record.cleanupPending === true) {
-    throw new Error(`run ${run.record.runId} cleanup is pending`);
+    run = await run.recoverAbandonedCleanup();
+    if (run.record.cleanupPending === true) {
+      throw new Error(`run ${run.record.runId} cleanup is pending`);
+    }
   }
   // A pending completion must land under the prior run ID before a new attempt can claim.
   if (run.record.writebackPending === true) {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -314,9 +314,6 @@ async function start(input: {
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
-  if (!input.dryRun) {
-    await reapTerminalTasks({ runtime, tasks: listed.data.tasks });
-  }
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
     tasks = tasks
@@ -537,6 +534,9 @@ async function start(input: {
         throw error;
       }
     }
+  }
+  if (!input.dryRun) {
+    await reapTerminalTasks({ runtime, tasks: listed.data.tasks });
   }
   return { skipped, started };
 }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -198,14 +198,14 @@ interface SkipTaskInput {
   readonly runId?: string | undefined;
 }
 
-interface ListReapableTerminalRunsInput {
+interface PrepareTerminalRunsForCleanupInput {
   readonly runtime: Runtime;
   readonly tasks: readonly Task[];
 }
 
 interface ReapTerminalTasksInput {
   readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
-  readonly runs: readonly RunHandle[];
+  readonly runs: readonly CompletedRun[];
   readonly runtime: Runtime;
 }
 
@@ -329,12 +329,9 @@ async function start(input: {
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
-  const terminalRunsToReap = input.dryRun
+  const terminalRunsToClean = input.dryRun
     ? []
-    : await listReapableTerminalRuns({ runtime, tasks: listed.data.tasks });
-  const reapableTerminalTaskIds = new Set(
-    terminalRunsToReap.map((run) => run.record.canonicalTaskId),
-  );
+    : await prepareTerminalRunsForCleanup({ runtime, tasks: listed.data.tasks });
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
     tasks = tasks
@@ -366,11 +363,7 @@ async function start(input: {
     ? await listActiveAfterPreviewReconciliation({ runtime, tasks: listed.data.tasks })
     : await runtime.runs.list();
   const active = activeRuns
-    .filter(
-      (run) =>
-        (run.state === "provisioning" || run.state === "running") &&
-        !reapableTerminalTaskIds.has(run.record.canonicalTaskId),
-    )
+    .filter((run) => run.state === "provisioning" || run.state === "running")
     .map((run) => ({
       agentProfile: run.record.agentProfile,
       canonicalTaskId: run.record.canonicalTaskId,
@@ -470,7 +463,6 @@ async function start(input: {
     const reservation = await runtime.runs.reserveDispatch({
       agentProfile: profileName,
       canonicalTaskId,
-      excludedCanonicalTaskIds: reapableTerminalTaskIds,
       force: input.force,
       maximumInProgress: runtime.config.orchestrator.maximumInProgress,
       repositories: task.repositories,
@@ -564,7 +556,7 @@ async function start(input: {
   if (!input.dryRun) {
     await reapTerminalTasks({
       onProgress: input.onProgress,
-      runs: terminalRunsToReap,
+      runs: terminalRunsToClean,
       runtime,
     });
   }
@@ -997,13 +989,13 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
   }
 }
 
-async function listReapableTerminalRuns(
-  input: ListReapableTerminalRunsInput,
-): Promise<readonly RunHandle[]> {
+async function prepareTerminalRunsForCleanup(
+  input: PrepareTerminalRunsForCleanupInput,
+): Promise<readonly CompletedRun[]> {
   const terminal = new Set(
     input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
   );
-  const reapable: RunHandle[] = [];
+  const prepared: CompletedRun[] = [];
   for (const run of await input.runtime.runs.list()) {
     if (!terminal.has(run.record.canonicalTaskId)) {
       continue;
@@ -1014,13 +1006,27 @@ async function listReapableTerminalRuns(
     if (observed.dirtyPaths.length > 0) {
       continue;
     }
-    reapable.push(run);
+    // eslint-disable-next-line no-await-in-loop
+    const stopped = await run.stopForCleanup({
+      assertWorkspaceIdle: async (record) => {
+        await input.runtime.workspaces.assertNoActiveRepositoryOperation({
+          workspaceDirectory: record.workspaceDirectory,
+        });
+      },
+    });
+    prepared.push(stopped.run);
   }
-  return reapable;
+  return prepared;
 }
 
 async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
   for (const run of input.runs) {
+    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
+    // eslint-disable-next-line no-await-in-loop
+    const observed = await input.runtime.workspaces.observe({ slug });
+    if (observed.dirtyPaths.length > 0) {
+      continue;
+    }
     input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });
     // eslint-disable-next-line no-await-in-loop
     await cleanup({

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -1036,12 +1036,32 @@ async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
       continue;
     }
     input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await cleanup({
+        allowDirty: false,
+        all: false,
+        runtime: input.runtime,
+        task: run.record.canonicalTaskId,
+      });
+    } catch (cleanupError) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await run.cancelCleanup();
+      } catch (cancelError) {
+        throw new AggregateError(
+          [cleanupError, cancelError],
+          `cleanup failed for ${run.record.canonicalTaskId} and its reservation could not be released`,
+        );
+      }
+      throw cleanupError;
+    }
     // eslint-disable-next-line no-await-in-loop
-    await cleanup({
-      allowDirty: false,
-      all: false,
+    await writeVerdict({
+      canonicalTaskId: run.record.canonicalTaskId,
+      detail: "source reports the task as terminal",
+      reason: "terminal",
       runtime: input.runtime,
-      task: run.record.canonicalTaskId,
     });
   }
 }

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -662,11 +662,7 @@ async function done(input: {
     throw new DirtyWorkspaceError(observed.dirtyPaths);
   }
   let completed = await run.finish({
-    assertWorkspaceIdle: async (record) => {
-      await runtime.workspaces.assertNoActiveRepositoryOperation({
-        workspaceDirectory: record.workspaceDirectory,
-      });
-    },
+    assertWorkspaceIdle: workspaceIdleAssertion({ runtime }),
     message: input.message,
     outcome: input.outcome,
   });
@@ -828,6 +824,16 @@ async function continueRun(input: {
   return running.record;
 }
 
+function workspaceIdleAssertion(input: {
+  readonly runtime: Runtime;
+}): (record: Readonly<RunRecord>) => Promise<void> {
+  return async (record) => {
+    await input.runtime.workspaces.assertNoActiveRepositoryOperation({
+      workspaceDirectory: record.workspaceDirectory,
+    });
+  };
+}
+
 async function cleanup(input: {
   readonly runtime: Runtime;
   readonly task?: string | undefined;
@@ -864,11 +870,7 @@ async function cleanup(input: {
     // for a run that reconciliation completed while acquisition was still active.
     // eslint-disable-next-line no-await-in-loop
     const stopped = await run.stopForCleanup({
-      assertWorkspaceIdle: async (record) => {
-        await runtime.workspaces.assertNoActiveRepositoryOperation({
-          workspaceDirectory: record.workspaceDirectory,
-        });
-      },
+      assertWorkspaceIdle: workspaceIdleAssertion({ runtime }),
     });
     let completed = stopped.run;
     if (stopped.transitioned || completed.record.writebackPending === true) {
@@ -1014,11 +1016,7 @@ async function prepareTerminalRunsForCleanup(
     }
     // eslint-disable-next-line no-await-in-loop
     const stopped = await run.stopForCleanup({
-      assertWorkspaceIdle: async (record) => {
-        await input.runtime.workspaces.assertNoActiveRepositoryOperation({
-          workspaceDirectory: record.workspaceDirectory,
-        });
-      },
+      assertWorkspaceIdle: workspaceIdleAssertion({ runtime: input.runtime }),
     });
     prepared.push(stopped.run);
   }
@@ -1042,8 +1040,8 @@ async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
     try {
       // eslint-disable-next-line no-await-in-loop
       await cleanup({
-        allowDirty: false,
         all: false,
+        allowDirty: false,
         runtime: input.runtime,
         task: run.record.canonicalTaskId,
       });

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -198,6 +198,17 @@ interface SkipTaskInput {
   readonly runId?: string | undefined;
 }
 
+interface ListReapableTerminalRunsInput {
+  readonly runtime: Runtime;
+  readonly tasks: readonly Task[];
+}
+
+interface ReapTerminalTasksInput {
+  readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
+  readonly runs: readonly RunHandle[];
+  readonly runtime: Runtime;
+}
+
 export async function createApplication(input: {
   readonly config: CoreConfig;
   readonly paths: ApplicationPaths;
@@ -318,8 +329,11 @@ async function start(input: {
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
-  const terminalTaskIds = new Set(
-    listed.data.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
+  const terminalRunsToReap = input.dryRun
+    ? []
+    : await listReapableTerminalRuns({ runtime, tasks: listed.data.tasks });
+  const reapableTerminalTaskIds = new Set(
+    terminalRunsToReap.map((run) => run.record.canonicalTaskId),
   );
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
@@ -355,7 +369,7 @@ async function start(input: {
     .filter(
       (run) =>
         (run.state === "provisioning" || run.state === "running") &&
-        !terminalTaskIds.has(run.record.canonicalTaskId),
+        !reapableTerminalTaskIds.has(run.record.canonicalTaskId),
     )
     .map((run) => ({
       agentProfile: run.record.agentProfile,
@@ -456,7 +470,7 @@ async function start(input: {
     const reservation = await runtime.runs.reserveDispatch({
       agentProfile: profileName,
       canonicalTaskId,
-      excludedCanonicalTaskIds: terminalTaskIds,
+      excludedCanonicalTaskIds: reapableTerminalTaskIds,
       force: input.force,
       maximumInProgress: runtime.config.orchestrator.maximumInProgress,
       repositories: task.repositories,
@@ -550,8 +564,8 @@ async function start(input: {
   if (!input.dryRun) {
     await reapTerminalTasks({
       onProgress: input.onProgress,
+      runs: terminalRunsToReap,
       runtime,
-      tasks: listed.data.tasks,
     });
   }
   return { skipped, started };
@@ -983,14 +997,13 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
   }
 }
 
-async function reapTerminalTasks(input: {
-  readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
-  readonly runtime: Runtime;
-  readonly tasks: readonly Task[];
-}): Promise<void> {
+async function listReapableTerminalRuns(
+  input: ListReapableTerminalRunsInput,
+): Promise<readonly RunHandle[]> {
   const terminal = new Set(
     input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
   );
+  const reapable: RunHandle[] = [];
   for (const run of await input.runtime.runs.list()) {
     if (!terminal.has(run.record.canonicalTaskId)) {
       continue;
@@ -1001,6 +1014,13 @@ async function reapTerminalTasks(input: {
     if (observed.dirtyPaths.length > 0) {
       continue;
     }
+    reapable.push(run);
+  }
+  return reapable;
+}
+
+async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
+  for (const run of input.runs) {
     input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });
     // eslint-disable-next-line no-await-in-loop
     await cleanup({

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -26,6 +26,7 @@ export interface RunRecord {
   readonly reason?: string | undefined;
   readonly message?: string | undefined;
   readonly writebackPending?: boolean | undefined;
+  readonly cleanupPending?: boolean | undefined;
   readonly presenter: "cmux";
   readonly presentedWorkspaceName: string;
   readonly workspaceDirectory: string;
@@ -109,6 +110,7 @@ export interface RunningRun extends BaseRun {
 export interface CompletedRun extends BaseRun {
   readonly state: "complete";
 
+  cancelCleanup(): Promise<CompletedRun>;
   acknowledgeSourceWriteback(input: {
     readonly expectedRunId: string;
     readonly expectedCompletionTimestamp: string;
@@ -652,14 +654,32 @@ export class RunModule {
           throw new Error(`run ${input.record.runId} is stale`);
         }
         await input.assertWorkspaceIdle(current);
-        if (current.state === "complete") {
-          return current;
-        }
-        transitioned = true;
-        return completeRunRecord({ outcome: "stopped", record: current });
+        const completed =
+          current.state === "complete"
+            ? current
+            : completeRunRecord({ outcome: "stopped", record: current });
+        transitioned = current.state !== "complete";
+        return completed.cleanupPending === true
+          ? completed
+          : { ...completed, cleanupPending: true };
       },
     });
     return { run: new CompletedRunHandle({ module: this, record }), transitioned };
+  }
+
+  public async cancelCleanup(input: {
+    readonly record: Readonly<RunRecord>;
+  }): Promise<CompletedRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "complete" });
+        return current.cleanupPending === true
+          ? { ...current, cleanupPending: undefined }
+          : current;
+      },
+    });
+    return new CompletedRunHandle({ module: this, record });
   }
 
   public async reconcileWorkspaceOperation(input: {
@@ -811,9 +831,13 @@ class RunStore {
             if (current.writebackPending === true) {
               throw new Error(`run ${current.runId} source writeback is pending`);
             }
+            if (current.cleanupPending === true) {
+              throw new Error(`run ${current.runId} cleanup is pending`);
+            }
             return {
               ...current,
               artifacts: [],
+              cleanupPending: undefined,
               events: [
                 ...current.events,
                 { event: `continued-from:${current.runId}`, timestamp: new Date().toISOString() },
@@ -1057,6 +1081,10 @@ class CompletedRunHandle implements CompletedRun {
     readonly expectedCompletionTimestamp: string;
   }): Promise<CompletedRun> {
     return await this.#module.acknowledgeSourceWriteback({ ...input, record: this.record });
+  }
+
+  public async cancelCleanup(): Promise<CompletedRun> {
+    return await this.#module.cancelCleanup({ record: this.record });
   }
 
   public async continueRun(input: {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -194,6 +194,7 @@ export class RunModule {
     readonly agentProfile: string;
     readonly workspaceDirectory: string;
     readonly repositories: readonly string[];
+    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
   }): Promise<DispatchReservation> {
@@ -772,19 +773,25 @@ class RunStore {
     readonly agentProfile: string;
     readonly workspaceDirectory: string;
     readonly repositories: readonly string[];
+    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
     return await this.reserveAdmission({
+      excludedCanonicalTaskIds: input.excludedCanonicalTaskIds,
       force: input.force,
       maximumInProgress: input.maximumInProgress,
       whileAdmitted: async () => await this.create(input),
     });
   }
 
-  public async activeCount(): Promise<number> {
+  public async activeCount(input: {
+    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
+  }): Promise<number> {
     return (await this.list()).filter(
-      (record) => record.state === "provisioning" || record.state === "running",
+      (record) =>
+        (record.state === "provisioning" || record.state === "running") &&
+        input.excludedCanonicalTaskIds?.has(record.canonicalTaskId) !== true,
     ).length;
   }
 
@@ -835,13 +842,16 @@ class RunStore {
   }
 
   private async reserveAdmission(input: {
+    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
     readonly whileAdmitted: () => Promise<RunRecord>;
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
     return await withFileLock({
       operation: async () => {
-        const activeCount = await this.activeCount();
+        const activeCount = await this.activeCount({
+          excludedCanonicalTaskIds: input.excludedCanonicalTaskIds,
+        });
         if (!input.force && activeCount >= input.maximumInProgress) {
           return { activeCount };
         }

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -27,6 +27,7 @@ export interface RunRecord {
   readonly message?: string | undefined;
   readonly writebackPending?: boolean | undefined;
   readonly cleanupPending?: boolean | undefined;
+  readonly cleanupOwnerProcessId?: number | undefined;
   readonly presenter: "cmux";
   readonly presentedWorkspaceName: string;
   readonly workspaceDirectory: string;
@@ -111,6 +112,7 @@ export interface CompletedRun extends BaseRun {
   readonly state: "complete";
 
   cancelCleanup(): Promise<CompletedRun>;
+  recoverAbandonedCleanup(): Promise<CompletedRun>;
   acknowledgeSourceWriteback(input: {
     readonly expectedRunId: string;
     readonly expectedCompletionTimestamp: string;
@@ -659,9 +661,19 @@ export class RunModule {
             ? current
             : completeRunRecord({ outcome: "stopped", record: current });
         transitioned = current.state !== "complete";
-        return completed.cleanupPending === true
-          ? completed
-          : { ...completed, cleanupPending: true };
+        if (
+          completed.cleanupPending === true &&
+          completed.cleanupOwnerProcessId !== process.pid &&
+          completed.cleanupOwnerProcessId !== undefined &&
+          processIsAlive({ processId: completed.cleanupOwnerProcessId })
+        ) {
+          throw new Error(`run ${current.runId} cleanup is owned by another process`);
+        }
+        return {
+          ...completed,
+          cleanupOwnerProcessId: process.pid,
+          cleanupPending: true,
+        };
       },
     });
     return { run: new CompletedRunHandle({ module: this, record }), transitioned };
@@ -675,8 +687,28 @@ export class RunModule {
       update: (current) => {
         requireCurrentRun({ current, expected: input.record, state: "complete" });
         return current.cleanupPending === true
-          ? { ...current, cleanupPending: undefined }
+          ? { ...current, cleanupOwnerProcessId: undefined, cleanupPending: undefined }
           : current;
+      },
+    });
+    return new CompletedRunHandle({ module: this, record });
+  }
+
+  public async recoverAbandonedCleanup(input: {
+    readonly record: Readonly<RunRecord>;
+  }): Promise<CompletedRun> {
+    const record = await this.#store.mutate({
+      canonicalTaskId: input.record.canonicalTaskId,
+      update: (current) => {
+        requireCurrentRun({ current, expected: input.record, state: "complete" });
+        if (
+          current.cleanupPending !== true ||
+          (current.cleanupOwnerProcessId !== undefined &&
+            processIsAlive({ processId: current.cleanupOwnerProcessId }))
+        ) {
+          return current;
+        }
+        return { ...current, cleanupOwnerProcessId: undefined, cleanupPending: undefined };
       },
     });
     return new CompletedRunHandle({ module: this, record });
@@ -838,6 +870,7 @@ class RunStore {
               ...current,
               artifacts: [],
               cleanupPending: undefined,
+              cleanupOwnerProcessId: undefined,
               events: [
                 ...current.events,
                 { event: `continued-from:${current.runId}`, timestamp: new Date().toISOString() },
@@ -1085,6 +1118,10 @@ class CompletedRunHandle implements CompletedRun {
 
   public async cancelCleanup(): Promise<CompletedRun> {
     return await this.#module.cancelCleanup({ record: this.record });
+  }
+
+  public async recoverAbandonedCleanup(): Promise<CompletedRun> {
+    return await this.#module.recoverAbandonedCleanup({ record: this.record });
   }
 
   public async continueRun(input: {
@@ -1490,8 +1527,12 @@ function provisioningOwnerIsAlive(input: { readonly record: RunRecord }): boolea
   if (processId === undefined) {
     return false;
   }
+  return processIsAlive({ processId });
+}
+
+function processIsAlive(input: { readonly processId: number }): boolean {
   try {
-    process.kill(processId, 0);
+    process.kill(input.processId, 0);
     return true;
   } catch (error) {
     return !(error instanceof Error && "code" in error && error.code === "ESRCH");

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -159,10 +159,6 @@ type PresentationReconciliation =
       readonly reason: "provisioning-interrupted" | "workspace-missing";
     };
 
-interface ActiveCountInput {
-  readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
-}
-
 export class RunModule {
   readonly #store: RunStore;
   readonly #environment: NodeJS.ProcessEnv;
@@ -198,7 +194,6 @@ export class RunModule {
     readonly agentProfile: string;
     readonly workspaceDirectory: string;
     readonly repositories: readonly string[];
-    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
   }): Promise<DispatchReservation> {
@@ -777,24 +772,19 @@ class RunStore {
     readonly agentProfile: string;
     readonly workspaceDirectory: string;
     readonly repositories: readonly string[];
-    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
     return await this.reserveAdmission({
-      excludedCanonicalTaskIds: input.excludedCanonicalTaskIds,
       force: input.force,
       maximumInProgress: input.maximumInProgress,
       whileAdmitted: async () => await this.create(input),
     });
   }
 
-  public async activeCount(input: ActiveCountInput): Promise<number> {
-    const { excludedCanonicalTaskIds } = input;
+  public async activeCount(): Promise<number> {
     return (await this.list()).filter(
-      (record) =>
-        (record.state === "provisioning" || record.state === "running") &&
-        excludedCanonicalTaskIds?.has(record.canonicalTaskId) !== true,
+      (record) => record.state === "provisioning" || record.state === "running",
     ).length;
   }
 
@@ -845,16 +835,13 @@ class RunStore {
   }
 
   private async reserveAdmission(input: {
-    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
     readonly force: boolean;
     readonly maximumInProgress: number;
     readonly whileAdmitted: () => Promise<RunRecord>;
   }): Promise<{ readonly activeCount: number; readonly record?: RunRecord | undefined }> {
     return await withFileLock({
       operation: async () => {
-        const activeCount = await this.activeCount({
-          excludedCanonicalTaskIds: input.excludedCanonicalTaskIds,
-        });
+        const activeCount = await this.activeCount();
         if (!input.force && activeCount >= input.maximumInProgress) {
           return { activeCount };
         }

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -686,7 +686,9 @@ export class RunModule {
       canonicalTaskId: input.record.canonicalTaskId,
       update: (current) => {
         requireCurrentRun({ current, expected: input.record, state: "complete" });
-        return current.cleanupPending === true
+        return current.cleanupPending === true &&
+          (current.cleanupOwnerProcessId === undefined ||
+            current.cleanupOwnerProcessId === process.pid)
           ? { ...current, cleanupOwnerProcessId: undefined, cleanupPending: undefined }
           : current;
       },
@@ -869,8 +871,8 @@ class RunStore {
             return {
               ...current,
               artifacts: [],
-              cleanupPending: undefined,
               cleanupOwnerProcessId: undefined,
+              cleanupPending: undefined,
               events: [
                 ...current.events,
                 { event: `continued-from:${current.runId}`, timestamp: new Date().toISOString() },

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -159,6 +159,10 @@ type PresentationReconciliation =
       readonly reason: "provisioning-interrupted" | "workspace-missing";
     };
 
+interface ActiveCountInput {
+  readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
+}
+
 export class RunModule {
   readonly #store: RunStore;
   readonly #environment: NodeJS.ProcessEnv;
@@ -785,13 +789,12 @@ class RunStore {
     });
   }
 
-  public async activeCount(input: {
-    readonly excludedCanonicalTaskIds?: ReadonlySet<string> | undefined;
-  }): Promise<number> {
+  public async activeCount(input: ActiveCountInput): Promise<number> {
+    const { excludedCanonicalTaskIds } = input;
     return (await this.list()).filter(
       (record) =>
         (record.state === "provisioning" || record.state === "running") &&
-        input.excludedCanonicalTaskIds?.has(record.canonicalTaskId) !== true,
+        excludedCanonicalTaskIds?.has(record.canonicalTaskId) !== true,
     ).length;
   }
 

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -509,6 +509,10 @@ async function readTaskMarker(input: {
 
 function renderDispatchProgress(input: RenderDispatchProgressInput): void {
   const { progress, showAllSkips, showRoutineSkips } = input;
+  if (progress.type === "cleaning") {
+    process.stdout.write(`Cleaning ${progress.canonicalTaskId}\n`);
+    return;
+  }
   if (progress.type === "skipped") {
     if (
       !showAllSkips &&


### PR DESCRIPTION
## Why

`crew start --watch` could appear hung because terminal workspace cleanup ran before any dispatch progress was emitted. That delayed ready work and gave operators no indication that cleanup was blocking. This restores the v1 ordering while preserving v2 run and workspace safety.

## Summary

- Complete clean source-terminal runs to release capacity before dispatch, then perform destructive cleanup afterward.
- Emit `Cleaning <task>` before potentially slow presenter and worktree teardown.
- Preserve dirty terminal workspaces, protect deferred cleanup with generation and process ownership, recover failed or interrupted cleanup reservations, and record terminal verdicts after successful cleanup.
- Add end-to-end coverage for ordering, live output, capacity, dirty-workspace races, continuation races, cleanup failures, and interrupted owners.

## Validation

- `node --run verify` — 10 test files passed; 131 tests passed and 1 skipped.
- Push-time repository checks passed.
- Final `cb-review`: `Ship gate: pass`; requested behavior met.

## Notes

- One review edge was dismissed: PID reuse follows the repository's existing process-ownership invariant. Adding process birth identity would be a broader lifecycle redesign.
- The existing dependency-cruiser TypeScript 7 compatibility warning remains unchanged; there are no dependency violations.
- Agent session: `codex resume 019ff1da-caf4-7671-80ad-5369092262e1`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
