### PR TITLE
feat: make run cleanup explicit

### DIFF
--- a/v2/CONTEXT.md
+++ b/v2/CONTEXT.md
@@ -18,6 +18,11 @@ reports surface existence, not process liveness. **Observed facts** come from Gi
 **reported claims** come from the run record; **source facts** come from source processes.
 Status keeps those layers separate.
 
+Cleanup is always an explicit operator action. Source terminality affects dispatch eligibility
+but never closes a presented workspace or removes local task state. `crew cleanup <task>` tears
+down one Run, `crew cleanup --completed` tears down completed Runs without stopping active Runs,
+and `crew cleanup --all` tears down every local Run.
+
 A **source bundle** is a directory containing `source.json` and executable protocol commands.
 A configured **source instance** gives that bundle an instance name and environment. A
 **verdict** is the persisted reason a visible task did not dispatch.

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -151,7 +151,7 @@ describe("crew start", () => {
     expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
   });
 
-  it("previews the slot a clean terminal run would release without reaping it", async () => {
+  it("counts a clean terminal run against dry-run capacity", async () => {
     const activeTask = task({ id: "ACTIVE-1", priority: 1, repositories: [] });
     const readyTask = task({ id: "READY-1", priority: 2, repositories: [] });
     const fixture = await createDispatchFixture({
@@ -177,7 +177,10 @@ describe("crew start", () => {
       environment: fixture.environment,
     });
 
-    expect(result.stdout).toContain("Would start fixture:READY-1(codex) in slot 1/1");
+    expect(result.stdout).toContain(
+      "At capacity (1/1) [fixture:ACTIVE-1(codex)], no new work to start",
+    );
+    expect(result.stdout).not.toContain("Would start fixture:READY-1");
     expect(await readFile(runPath, "utf8")).toBe(runBeforePreview);
     expect(await readFile(fixture.updatesPath, "utf8")).toBe("");
   });
@@ -259,234 +262,22 @@ describe("crew start", () => {
     expect(stdout).not.toMatch(/\bSkipp(?:ed|ing)\b/);
   });
 
-  it("dispatches new work before cleaning terminal workspaces while watching", async () => {
-    const fixture = await createDispatchFixture({
-      maximumInProgress: 1,
-      pollIntervalMilliseconds: 10,
-      repositories: [],
-    });
+  it("preserves a clean terminal run until explicit cleanup", async () => {
+    const fixture = await createDispatchFixture({ repositories: [] });
     await runCrew({ arguments: ["start"], environment: fixture.environment });
     await writeFile(
       fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: [], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
-    );
-    const closeReleasePath = join(fixture.root, "close-release");
-    fixture.environment["FAKE_CMUX_CLOSE_RELEASE"] = closeReleasePath;
-    const child = spawn(process.execPath, ["bin/run.js", "start", "--watch"], {
-      cwd: process.cwd(),
-      env: fixture.environment,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    const childClosed = new Promise<void>((resolvePromise) => {
-      child.once("close", () => resolvePromise());
-    });
-
-    try {
-      await waitForPath(`${closeReleasePath}.ready`);
-      await waitFor(() => stdout.includes("Cleaning fixture:ENG-123"));
-
-      expect(stdout).toContain("Dispatching fixture:READY-1(codex) into slot 1/1");
-      expect(stdout).toContain("Cleaning fixture:ENG-123");
-      expect(
-        JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8")),
-      ).toMatchObject({ state: "complete" });
-      expect(stdout.indexOf("Dispatching fixture:READY-1")).toBeLessThan(
-        stdout.indexOf("Cleaning fixture:ENG-123"),
-      );
-    } finally {
-      await writeFile(closeReleasePath, "release\n");
-      child.kill();
-      await childClosed;
-    }
-  });
-
-  it("keeps a dirty terminal workspace in capacity until it can be cleaned", async () => {
-    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "keep me\n");
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
+      JSON.stringify([task({ repositories: [], terminal: true })]),
     );
 
     const result = await runCrew({ arguments: ["start"], environment: fixture.environment });
 
-    expect(result.stdout).toContain(
-      "At capacity (1/1) [fixture:ENG-123(codex)], no new work to start",
-    );
-    expect(result.stdout).not.toContain("Dispatching fixture:READY-1");
-  });
-
-  it("keeps terminal capacity released when the workspace becomes dirty during dispatch", async () => {
-    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
-    );
-    const openReleasePath = join(fixture.root, "open-release");
-    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
-    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
-    await waitForPath(`${openReleasePath}.ready`);
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "late change\n");
-    await writeFile(openReleasePath, "release\n");
-
-    const result = await start;
-
-    expect(result.stdout).toContain("Started fixture:READY-1");
+    expect(result.stdout).not.toContain("Cleaning fixture:ENG-123");
     expect(
       JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-eng-123.json"), "utf8")),
-    ).toMatchObject({ state: "complete" });
-    expect(
-      JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-ready-1.json"), "utf8")),
     ).toMatchObject({ state: "running" });
-    const calls = (await readFile(fixture.cmuxCallsPath, "utf8"))
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
-    const lastSetProgressCall = calls.filter((call) => call.arguments[0] === "set-progress").at(-1);
-    expect(lastSetProgressCall).toBeDefined();
-    expect(lastSetProgressCall?.arguments).toContain("stopped");
-    await expect(stat(fixture.workspaceDirectory)).resolves.toBeDefined();
-  });
-
-  it("does not release cleanup ownership acquired by another process", async () => {
-    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
-    );
-    const openReleasePath = join(fixture.root, "open-release");
-    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
-    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
-    await waitForPath(`${openReleasePath}.ready`);
-    const runPath = join(fixture.runsDirectory, "fixture-eng-123.json");
-    const run = JSON.parse(await readFile(runPath, "utf8"));
-    await writeFile(runPath, JSON.stringify({ ...run, cleanupOwnerProcessId: process.pid }));
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "late change\n");
-    await writeFile(openReleasePath, "release\n");
-
-    await start;
-
-    expect(JSON.parse(await readFile(runPath, "utf8"))).toMatchObject({
-      cleanupOwnerProcessId: process.pid,
-      cleanupPending: true,
-      state: "complete",
-    });
-  });
-
-  it("does not clean a resumed generation while replacement dispatch is blocked", async () => {
-    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
-    );
-    const openReleasePath = join(fixture.root, "open-release");
-    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
-    const start = runCrew({ arguments: ["start"], environment: fixture.environment });
-    await waitForPath(`${openReleasePath}.ready`);
-    const tasksPath = fixture.environment["FIXTURE_TASKS"];
-    if (tasksPath === undefined) {
-      throw new Error("fixture tasks path is missing");
-    }
-    await writeFile(tasksPath, JSON.stringify([task({ repositories: ["sample"] })]));
-
-    try {
-      await expect(
-        runCrew({
-          arguments: ["continue", "ENG-123", "--force"],
-          environment: fixture.environment,
-        }),
-      ).rejects.toMatchObject({
-        code: 1,
-        stderr: expect.stringContaining("cleanup is pending"),
-      });
-    } finally {
-      await writeFile(openReleasePath, "release\n");
-      await start;
-    }
-
-    await expect(stat(join(fixture.runsDirectory, "fixture-eng-123.json"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
-
-  it("releases cleanup ownership when automatic cleanup fails", async () => {
-    const fixture = await createDispatchFixture();
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([task({ repositories: ["sample"], terminal: true })]),
-    );
-    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = "1";
-
-    await expect(
-      runCrew({ arguments: ["start"], environment: fixture.environment }),
-    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("close failure") });
-    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = undefined;
-
-    const result = await runCrew({
-      arguments: ["continue", "ENG-123"],
-      environment: fixture.environment,
-    });
-
-    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
-  });
-
-  it("reclaims cleanup ownership after an interrupted watch process", async () => {
-    const fixture = await createDispatchFixture({ maximumInProgress: 1 });
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([
-        task({ id: "ENG-123", repositories: ["sample"], terminal: true }),
-        task({ id: "READY-1", priority: 2, repositories: [] }),
-      ]),
-    );
-    const openReleasePath = join(fixture.root, "open-release");
-    fixture.environment["FAKE_CMUX_OPEN_RELEASE"] = openReleasePath;
-    const child = spawn(process.execPath, ["bin/run.js", "start", "--watch"], {
-      cwd: process.cwd(),
-      env: fixture.environment,
-      stdio: "ignore",
-    });
-    const childClosed = new Promise<void>((resolvePromise) => {
-      child.once("close", () => resolvePromise());
-    });
-    await waitForPath(`${openReleasePath}.ready`);
-    child.kill();
-    await writeFile(openReleasePath, "release\n");
-    await childClosed;
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "preserve me\n");
-
-    const result = await runCrew({
-      arguments: ["continue", "ENG-123", "--force"],
-      environment: fixture.environment,
-    });
-
-    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
+    expect(await stat(fixture.workspaceDirectory)).toBeDefined();
+    expect(JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")).workspaces).toHaveLength(1);
   });
 
   it("claims, provisions, and launches a ready task exactly once", async () => {
@@ -623,6 +414,103 @@ describe("crew start", () => {
 
     expect(result.stdout).toContain("Cleaned fixture:ENG-123");
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("cleans only completed runs with --completed", async () => {
+    const fixture = await createDispatchFixture({
+      maximumInProgress: 2,
+      tasks: [
+        task({ id: "DONE-1", priority: 1, repositories: [] }),
+        task({ id: "ACTIVE-1", priority: 2, repositories: [] }),
+      ],
+    });
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    await runCrew({
+      arguments: ["done", "--task", "DONE-1"],
+      environment: fixture.environment,
+    });
+
+    const result = await runCrew({
+      arguments: ["cleanup", "--completed"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Cleaned fixture:DONE-1");
+    expect(result.stdout).not.toContain("fixture:ACTIVE-1");
+    await expect(stat(join(fixture.runsDirectory, "fixture-done-1.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(
+      JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-active-1.json"), "utf8")),
+    ).toMatchObject({ state: "running" });
+    expect(JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")).workspaces).toHaveLength(1);
+  });
+
+  it("requires exactly one cleanup selector", async () => {
+    const fixture = await createDispatchFixture();
+    const expectedError = "cleanup requires exactly one of a task, --all, or --completed";
+
+    await expect(
+      runCrew({ arguments: ["cleanup"], environment: fixture.environment }),
+    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });
+    await expect(
+      runCrew({
+        arguments: ["cleanup", "ENG-123", "--completed"],
+        environment: fixture.environment,
+      }),
+    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });
+    await expect(
+      runCrew({
+        arguments: ["cleanup", "--all", "--completed"],
+        environment: fixture.environment,
+      }),
+    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });
+  });
+
+  it("prevents continuation while explicit cleanup is in progress", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const closeReleasePath = join(fixture.root, "close-release");
+    fixture.environment["FAKE_CMUX_CLOSE_RELEASE"] = closeReleasePath;
+    const cleanup = spawn(process.execPath, ["bin/run.js", "cleanup", "ENG-123"], {
+      cwd: process.cwd(),
+      env: fixture.environment,
+      stdio: "ignore",
+    });
+    const cleanupClosed = new Promise<number | null>((resolvePromise) => {
+      cleanup.once("close", resolvePromise);
+    });
+    await waitForPath(`${closeReleasePath}.ready`);
+
+    try {
+      await expect(
+        runCrew({ arguments: ["continue", "ENG-123"], environment: fixture.environment }),
+      ).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining("cleanup is pending"),
+      });
+    } finally {
+      await writeFile(closeReleasePath, "release\n");
+    }
+
+    expect(await cleanupClosed).toBe(0);
+  });
+
+  it("recovers an explicit cleanup reservation after cleanup fails", async () => {
+    const fixture = await createDispatchFixture();
+    await runCrew({ arguments: ["start"], environment: fixture.environment });
+    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = "1";
+    await expect(
+      runCrew({ arguments: ["cleanup", "ENG-123"], environment: fixture.environment }),
+    ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("close failure") });
+    fixture.environment["FAKE_CMUX_FAIL_CLOSE"] = undefined;
+
+    const result = await runCrew({
+      arguments: ["continue", "ENG-123"],
+      environment: fixture.environment,
+    });
+
+    expect(result.stdout).toContain("Continuing fixture:ENG-123 as run ");
   });
 
   it("explains how to recover cleanup after worktreeDirectory changes", async () => {
@@ -1660,36 +1548,6 @@ describe("crew start", () => {
     ).toBe(uniqueTip);
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
-
-  it("reaps terminal tasks only while their worktrees are clean", async () => {
-    const fixture = await createDispatchFixture();
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "keep me\n");
-    await writeFile(
-      fixture.listedTasksPath,
-      JSON.stringify([task({ repositories: ["sample"], terminal: true })]),
-    );
-
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    expect(await stat(fixture.workspaceDirectory)).toBeDefined();
-    await writeFile(join(fixture.workspaceDirectory, "sample", "dirty.txt"), "");
-    await runGit({
-      arguments: ["clean", "-f"],
-      cwd: join(fixture.workspaceDirectory, "sample"),
-    });
-
-    await runCrew({ arguments: ["start"], environment: fixture.environment });
-    await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
-    const status = JSON.parse(
-      (
-        await runCrew({
-          arguments: ["status", "ENG-123", "--json"],
-          environment: fixture.environment,
-        })
-      ).stdout,
-    );
-    expect(status.tasks[0].verdict).toMatchObject({ reason: "terminal" });
-  });
 });
 
 describe("crew continue", () => {
@@ -2111,17 +1969,6 @@ async function waitForPath(path: string): Promise<void> {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
   }
   throw new Error(`timed out waiting for ${path}`);
-}
-
-async function waitFor(condition: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 200; attempt += 1) {
-    if (condition()) {
-      return;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
-  }
-  throw new Error("timed out waiting for expected condition");
 }
 
 async function waitForRunState(input: {

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -111,10 +111,6 @@ export type DispatchProgress =
       readonly canonicalTaskId: string;
       readonly detail: string;
       readonly reason: VerdictReason;
-    }
-  | {
-      readonly type: "cleaning";
-      readonly canonicalTaskId: string;
     };
 
 export type VerdictReason =
@@ -174,6 +170,7 @@ export interface Application {
   cleanup(input: {
     readonly task?: string | undefined;
     readonly all: boolean;
+    readonly completed: boolean;
     readonly allowDirty: boolean;
   }): Promise<{
     readonly cleaned: readonly string[];
@@ -196,17 +193,6 @@ interface SkipTaskInput {
   readonly detail: string;
   readonly reason: VerdictReason;
   readonly runId?: string | undefined;
-}
-
-interface PrepareTerminalRunsForCleanupInput {
-  readonly runtime: Runtime;
-  readonly tasks: readonly Task[];
-}
-
-interface ReapTerminalTasksInput {
-  readonly onProgress?: ((progress: DispatchProgress) => void) | undefined;
-  readonly runs: readonly CompletedRun[];
-  readonly runtime: Runtime;
 }
 
 export async function createApplication(input: {
@@ -329,9 +315,6 @@ async function start(input: {
   if (!listed.ok) {
     throw new Error(listed.error.message);
   }
-  const terminalRunsToClean = input.dryRun
-    ? []
-    : await prepareTerminalRunsForCleanup({ runtime, tasks: listed.data.tasks });
   let tasks = listed.data.tasks;
   if (input.task === undefined) {
     tasks = tasks
@@ -360,7 +343,7 @@ async function start(input: {
     skipped.push(skipInput.canonicalTaskId);
   }
   const activeRuns = input.dryRun
-    ? await listActiveAfterPreviewReconciliation({ runtime, tasks: listed.data.tasks })
+    ? await runtime.runs.listActiveAfterPresentationReconciliation()
     : await runtime.runs.list();
   const active = activeRuns
     .filter((run) => run.state === "provisioning" || run.state === "running")
@@ -552,13 +535,6 @@ async function start(input: {
         throw error;
       }
     }
-  }
-  if (!input.dryRun) {
-    await reapTerminalTasks({
-      onProgress: input.onProgress,
-      runs: terminalRunsToClean,
-      runtime,
-    });
   }
   return { skipped, started };
 }
@@ -838,18 +814,28 @@ async function cleanup(input: {
   readonly runtime: Runtime;
   readonly task?: string | undefined;
   readonly all: boolean;
+  readonly completed: boolean;
   readonly allowDirty: boolean;
 }): Promise<{
   readonly cleaned: readonly string[];
   readonly preservedBranches: readonly string[];
 }> {
   const { runtime } = input;
-  let runs = await runtime.runs.list();
-  if (!input.all) {
-    if (input.task === undefined) {
-      throw new Error("cleanup requires a task or --all");
-    }
+  const selectorCount =
+    Number(input.task !== undefined) + Number(input.all) + Number(input.completed);
+  if (selectorCount !== 1) {
+    throw new Error("cleanup requires exactly one of a task, --all, or --completed");
+  }
+  const localRuns = await runtime.runs.list();
+  let runs: readonly RunHandle[];
+  if (input.all) {
+    runs = localRuns;
+  } else if (input.completed) {
+    runs = localRuns.filter((run) => run.state === "complete");
+  } else if (input.task !== undefined) {
     runs = [await runtime.runs.resolve({ query: input.task })];
+  } else {
+    throw new Error("cleanup requires exactly one of a task, --all, or --completed");
   }
   const cleaned: string[] = [];
   const preservedBranches: string[] = [];
@@ -995,101 +981,6 @@ async function reconcile(input: { readonly runtime: Runtime }): Promise<void> {
       slug: taskSlug({ canonicalTaskId: run.record.canonicalTaskId }),
     });
   }
-}
-
-async function prepareTerminalRunsForCleanup(
-  input: PrepareTerminalRunsForCleanupInput,
-): Promise<readonly CompletedRun[]> {
-  const terminal = new Set(
-    input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
-  );
-  const prepared: CompletedRun[] = [];
-  for (const run of await input.runtime.runs.list()) {
-    if (!terminal.has(run.record.canonicalTaskId)) {
-      continue;
-    }
-    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
-    // eslint-disable-next-line no-await-in-loop
-    const observed = await input.runtime.workspaces.observe({ slug });
-    if (observed.dirtyPaths.length > 0) {
-      continue;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    const stopped = await run.stopForCleanup({
-      assertWorkspaceIdle: workspaceIdleAssertion({ runtime: input.runtime }),
-    });
-    prepared.push(stopped.run);
-  }
-  return prepared;
-}
-
-async function reapTerminalTasks(input: ReapTerminalTasksInput): Promise<void> {
-  for (const run of input.runs) {
-    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
-    // eslint-disable-next-line no-await-in-loop
-    const observed = await input.runtime.workspaces.observe({ slug });
-    if (observed.dirtyPaths.length > 0) {
-      // Keep the presented workspace legible before allowing a later continuation.
-      // eslint-disable-next-line no-await-in-loop
-      await run.setPresentedStatus();
-      // eslint-disable-next-line no-await-in-loop
-      await run.cancelCleanup();
-      continue;
-    }
-    input.onProgress?.({ canonicalTaskId: run.record.canonicalTaskId, type: "cleaning" });
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      await cleanup({
-        all: false,
-        allowDirty: false,
-        runtime: input.runtime,
-        task: run.record.canonicalTaskId,
-      });
-    } catch (cleanupError) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        await run.cancelCleanup();
-      } catch (cancelError) {
-        throw new AggregateError(
-          [cleanupError, cancelError],
-          `cleanup failed for ${run.record.canonicalTaskId} and its reservation could not be released`,
-        );
-      }
-      throw cleanupError;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await writeVerdict({
-      canonicalTaskId: run.record.canonicalTaskId,
-      detail: "source reports the task as terminal",
-      reason: "terminal",
-      runtime: input.runtime,
-    });
-  }
-}
-
-async function listActiveAfterPreviewReconciliation(input: {
-  readonly runtime: Runtime;
-  readonly tasks: readonly Task[];
-}): Promise<readonly RunHandle[]> {
-  const active = await input.runtime.runs.listActiveAfterPresentationReconciliation();
-  const terminal = new Set(
-    input.tasks.filter((task) => task.terminal).map((task) => canonicalId({ task })),
-  );
-  const remaining: RunHandle[] = [];
-  for (const run of active) {
-    if (!terminal.has(run.record.canonicalTaskId)) {
-      remaining.push(run);
-      continue;
-    }
-    const slug = taskSlug({ canonicalTaskId: run.record.canonicalTaskId });
-    // Repository observations stay ordered with lifecycle reconciliation.
-    // eslint-disable-next-line no-await-in-loop
-    const observed = await input.runtime.workspaces.observe({ slug });
-    if (observed.dirtyPaths.length > 0) {
-      remaining.push(run);
-    }
-  }
-  return remaining;
 }
 
 async function writeCompletion(input: {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -111,7 +111,6 @@ export interface RunningRun extends BaseRun {
 export interface CompletedRun extends BaseRun {
   readonly state: "complete";
 
-  cancelCleanup(): Promise<CompletedRun>;
   recoverAbandonedCleanup(): Promise<CompletedRun>;
   acknowledgeSourceWriteback(input: {
     readonly expectedRunId: string;
@@ -679,23 +678,6 @@ export class RunModule {
     return { run: new CompletedRunHandle({ module: this, record }), transitioned };
   }
 
-  public async cancelCleanup(input: {
-    readonly record: Readonly<RunRecord>;
-  }): Promise<CompletedRun> {
-    const record = await this.#store.mutate({
-      canonicalTaskId: input.record.canonicalTaskId,
-      update: (current) => {
-        requireCurrentRun({ current, expected: input.record, state: "complete" });
-        return current.cleanupPending === true &&
-          (current.cleanupOwnerProcessId === undefined ||
-            current.cleanupOwnerProcessId === process.pid)
-          ? { ...current, cleanupOwnerProcessId: undefined, cleanupPending: undefined }
-          : current;
-      },
-    });
-    return new CompletedRunHandle({ module: this, record });
-  }
-
   public async recoverAbandonedCleanup(input: {
     readonly record: Readonly<RunRecord>;
   }): Promise<CompletedRun> {
@@ -1116,10 +1098,6 @@ class CompletedRunHandle implements CompletedRun {
     readonly expectedCompletionTimestamp: string;
   }): Promise<CompletedRun> {
     return await this.#module.acknowledgeSourceWriteback({ ...input, record: this.record });
-  }
-
-  public async cancelCleanup(): Promise<CompletedRun> {
-    return await this.#module.cancelCleanup({ record: this.record });
   }
 
   public async recoverAbandonedCleanup(): Promise<CompletedRun> {

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -224,6 +224,7 @@ export async function main(input: MainInput): Promise<void> {
     .description("close presenters and safely remove task worktrees")
     .argument("[task]", "canonical or source-local task ID")
     .option("--all", "clean every local task")
+    .option("--completed", "clean every completed local run")
     .option("--force", "permanently delete dirty worktrees and unique task branches")
     .option("--verbose", "include debug diagnostics")
     .action(async (task, options) => {
@@ -231,6 +232,7 @@ export async function main(input: MainInput): Promise<void> {
       const result = await application.cleanup({
         all: options.all === true,
         allowDirty: options.force === true,
+        completed: options.completed === true,
         task,
       });
       for (const canonicalTaskId of result.cleaned) {
@@ -509,10 +511,6 @@ async function readTaskMarker(input: {
 
 function renderDispatchProgress(input: RenderDispatchProgressInput): void {
   const { progress, showAllSkips, showRoutineSkips } = input;
-  if (progress.type === "cleaning") {
-    process.stdout.write(`Cleaning ${progress.canonicalTaskId}\n`);
-    return;
-  }
   if (progress.type === "skipped") {
     if (
       !showAllSkips &&


### PR DESCRIPTION
## Why

Groundcrew automatically tore down clean Runs, worktrees, and cmux workspaces when polling observed that their source task had become terminal. A merged pull request can make its Linear issue terminal while an operator still wants the existing agent session to monitor post-merge behavior. There is no direct customer impact; this improves Groundcrew operator control and preserves useful session context until teardown is explicitly requested.

## Summary

- Remove source-terminal cleanup from `crew start` and `crew start --watch`; source terminality now affects dispatch eligibility without deleting local task state.
- Add `crew cleanup --completed` to tear down completed Runs without stopping active Runs.
- Require exactly one cleanup selector: a task, `--all`, or `--completed`.
- Preserve the cleanup ownership and recovery safeguards recently added on `origin/main`, with coverage through explicit cleanup races.
- Document explicit cleanup as part of the v2 domain contract.

## Validation

- `node --run verify` — 10 test files passed; 129 tests passed and 1 skipped.
- `cb-review --effort low --report` — no findings; requirements met; `Ship gate: pass`.

## Notes

- Active Runs, including source-terminal Runs, continue to consume dispatch capacity until completed or explicitly cleaned.
- `crew cleanup --completed` retains the existing dirty-worktree safety; use `--force` to permit destructive cleanup.
- The existing dependency-cruiser warning about TypeScript 7 support remains unchanged; it reported zero dependency violations.

Agent session: `codex resume 019ff1db-c5c4-7393-aa7c-5344fbefe49a`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
