### PR TITLE
fix: skip unavailable Linear review transition

### DIFF
--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -63,10 +63,12 @@ describe("the shipped Linear source", () => {
     fixture = await createLinearFixture({ includeInReviewState: false });
     await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
     expect(fixture.state.stateName).toBe("In Progress");
+    fixture.state.moveRequests.length = 0;
 
     await runCrew({ arguments: ["done", "--task", "LIN-1"], environment: fixture.environment });
 
     expect(fixture.state.stateName).toBe("In Progress");
+    expect(fixture.state.moveRequests).toEqual([]);
     expect(fixture.state.comments.at(-1)).toContain(":completed:delivered]");
   });
 
@@ -226,6 +228,7 @@ describe("the shipped Linear source", () => {
 interface LinearState {
   comments: string[];
   listRequests: Array<{ query: string; variables: Record<string, unknown> }>;
+  moveRequests: string[];
   stateName: string;
   stateType: string;
 }
@@ -247,6 +250,7 @@ async function createLinearFixture(
   const state: LinearState = {
     comments: [],
     listRequests: [],
+    moveRequests: [],
     stateName: "Todo",
     stateType: "unstarted",
   };
@@ -267,7 +271,11 @@ async function createLinearFixture(
       if (body.operationName === "GroundcrewList") {
         state.listRequests.push({ query: body.query, variables: body.variables });
         const listedIssues = input.filteringScenario
-          ? filteringScenarioIssues({ labelPrefix, state })
+          ? filteringScenarioIssues({
+              includeInReviewState: input.includeInReviewState,
+              labelPrefix,
+              state,
+            })
           : Array.from({ length: listedTaskCount }, (_, index) =>
               linearIssue({
                 description: input.issueDescription,
@@ -308,6 +316,7 @@ async function createLinearFixture(
         data = { commentCreate: { success: true } };
       } else if (body.operationName === "GroundcrewMove") {
         const stateId = body.variables.input.stateId;
+        state.moveRequests.push(stateId);
         state.stateName =
           stateId === "state-review"
             ? "In Review"
@@ -434,17 +443,20 @@ function linearIssue(input: {
 }
 
 function filteringScenarioIssues(input: {
+  readonly includeInReviewState?: boolean | undefined;
   readonly labelPrefix: string;
   readonly state: LinearState;
 }) {
   return [
     linearIssue({
       identifier: "LIN-ELIGIBLE",
+      includeInReviewState: input.includeInReviewState,
       labelNames: [`${input.labelPrefix}codex`],
       state: input.state,
     }),
     linearIssue({
       identifier: "LIN-COMPLETED",
+      includeInReviewState: input.includeInReviewState,
       labelNames: [`${input.labelPrefix}codex`],
       state: input.state,
       stateName: "Done",
@@ -452,6 +464,7 @@ function filteringScenarioIssues(input: {
     }),
     linearIssue({
       identifier: "LIN-BACKLOG",
+      includeInReviewState: input.includeInReviewState,
       labelNames: [`${input.labelPrefix}codex`],
       state: input.state,
       stateName: "Backlog",
@@ -459,13 +472,19 @@ function filteringScenarioIssues(input: {
     }),
     linearIssue({
       identifier: "LIN-TRIAGE",
+      includeInReviewState: input.includeInReviewState,
       labelNames: [`${input.labelPrefix}codex`],
       state: input.state,
       stateName: "Triage",
       stateType: "triage",
     }),
     ...Array.from({ length: 247 }, (_, index) =>
-      linearIssue({ identifier: `LIN-UNRELATED-${index + 1}`, labelNames: [], state: input.state }),
+      linearIssue({
+        identifier: `LIN-UNRELATED-${index + 1}`,
+        includeInReviewState: input.includeInReviewState,
+        labelNames: [],
+        state: input.state,
+      }),
     ),
   ];
 }

--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -58,6 +58,18 @@ describe("the shipped Linear source", () => {
     expect(fixture.state.comments.at(-1)).toContain(":completed:failed]");
   });
 
+  it("leaves a delivered run unchanged when In Review is unavailable", async () => {
+    await fixture.close();
+    fixture = await createLinearFixture({ includeInReviewState: false });
+    await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
+    expect(fixture.state.stateName).toBe("In Progress");
+
+    await runCrew({ arguments: ["done", "--task", "LIN-1"], environment: fixture.environment });
+
+    expect(fixture.state.stateName).toBe("In Progress");
+    expect(fixture.state.comments.at(-1)).toContain(":completed:delivered]");
+  });
+
   it("stamps a completion with its own run ID despite a newer claim comment", async () => {
     await runCrew({ arguments: ["start", "LIN-1"], environment: fixture.environment });
     const claimRunId = fixture.state.comments[0]?.match(
@@ -221,6 +233,7 @@ interface LinearState {
 async function createLinearFixture(
   input: {
     readonly filteringScenario?: boolean;
+    readonly includeInReviewState?: boolean;
     readonly issueDescription?: string;
     readonly labelPrefix?: string;
     readonly listedTaskCount?: number;
@@ -245,7 +258,11 @@ async function createLinearFixture(
         raw += chunk;
       }
       const body = JSON.parse(raw);
-      const issue = linearIssue({ description: input.issueDescription, state });
+      const issue = linearIssue({
+        description: input.issueDescription,
+        includeInReviewState: input.includeInReviewState,
+        state,
+      });
       let data;
       if (body.operationName === "GroundcrewList") {
         state.listRequests.push({ query: body.query, variables: body.variables });
@@ -255,6 +272,7 @@ async function createLinearFixture(
               linearIssue({
                 description: input.issueDescription,
                 identifier: `LIN-${index + 1}`,
+                includeInReviewState: input.includeInReviewState,
                 state,
               }),
             );
@@ -371,6 +389,7 @@ async function createLinearFixture(
 function linearIssue(input: {
   readonly description?: string | undefined;
   readonly identifier?: string;
+  readonly includeInReviewState?: boolean | undefined;
   readonly labelNames?: readonly string[];
   readonly state: LinearState;
   readonly stateName?: string;
@@ -404,7 +423,9 @@ function linearIssue(input: {
         nodes: [
           { id: "state-todo", name: "Todo", type: "unstarted" },
           { id: "state-progress", name: "In Progress", type: "started" },
-          { id: "state-review", name: "In Review", type: "started" },
+          ...(input.includeInReviewState === false
+            ? []
+            : [{ id: "state-review", name: "In Review", type: "started" }]),
         ],
       },
     },

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -120,7 +120,11 @@ async function updateTask(input) {
     .join("\n\n");
   await addCommentOnce({ issue, marker: completionMarker, text });
   if (input.event.outcome === "delivered") {
-    await moveIssue({ issue, stateName: environment("LINEAR_STATUS_IN_REVIEW", "In Review") });
+    await moveIssue({
+      allowMissing: true,
+      issue,
+      stateName: environment("LINEAR_STATUS_IN_REVIEW", "In Review"),
+    });
   } else if (input.event.outcome === "failed") {
     await moveIssue({ issue, stateName: environment("LINEAR_STATUS_TODO", "Todo") });
   }
@@ -219,6 +223,9 @@ async function moveIssue(input) {
     (candidate) => candidate.name === input.stateName,
   );
   if (!state) {
+    if (input.allowMissing === true) {
+      return;
+    }
     throw new Error(`Linear workflow state '${input.stateName}' was not found`);
   }
   await graphql({


### PR DESCRIPTION
## Why

Delivered Linear runs could not settle source writeback for teams without an `In Review` workflow state. Cleanup retained those completed runs and repeatedly reported them as cleaned.

## Summary

- Treat a missing delivered-state target as a supported no-op.
- Preserve strict missing-state failures for claim and failed-run transitions.
- Cover the shipped Linear source through its process protocol when `In Review` is unavailable.

## Validation

- `node --run test:e2e -- -t "leaves a delivered run unchanged when In Review is unavailable"`
- `node --run test -- e2e/linear.e2e.test.ts`
- `node --run verify` — 10 test files passed; 130 tests passed, 1 skipped

## Notes

Agent session: `codex resume 019ff252-90ed-7cc0-87d3-4ba61df4ca95`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
