### PR TITLE
feat: decouple presenter identity from titles

### DIFF
--- a/v2/CONTEXT.md
+++ b/v2/CONTEXT.md
@@ -14,7 +14,9 @@ Four nouns form the model:
   or ticket. Artifacts are reported claims, never inferred Git facts.
 
 The **presented workspace** is the cmux surface that hosts an interactive agent. A presenter
-reports surface existence, not process liveness. **Observed facts** come from Git;
+reports surface existence, not process liveness. A Run owns an immutable, presenter-neutral
+presentation ID and may store an opaque presenter handle; the human-editable title is never an
+identity. **Observed facts** come from Git;
 **reported claims** come from the run record; **source facts** come from source processes.
 Status keeps those layers separate.
 

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -306,7 +306,7 @@ describe("crew start", () => {
     expect(result.stdout).toContain("Started fixture:ENG-123");
     expect(run.state).toBe("running");
     expect(run.runId).toMatch(/^r_[0-9a-f]{8}$/);
-    expect(run.presentationId).toMatch(/^p_[0-9a-f]{8}$/);
+    expect(run.presentationId).toMatch(/^p_[0-9a-f]{32}$/);
     expect(run.presenterHandle).toBe("workspace-1");
     expect(run).not.toHaveProperty("presentedWorkspaceName");
     expect(marker).toEqual({

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -306,6 +306,9 @@ describe("crew start", () => {
     expect(result.stdout).toContain("Started fixture:ENG-123");
     expect(run.state).toBe("running");
     expect(run.runId).toMatch(/^r_[0-9a-f]{8}$/);
+    expect(run.presentationId).toMatch(/^p_[0-9a-f]{8}$/);
+    expect(run.presenterHandle).toBe("workspace-1");
+    expect(run).not.toHaveProperty("presentedWorkspaceName");
     expect(marker).toEqual({
       branch: "crew/fixture-eng-123",
       canonicalTaskId: "fixture:ENG-123",
@@ -317,12 +320,14 @@ describe("crew start", () => {
     expect(calls.at(-1).arguments).toContain("running");
     const launchArguments = calls.find((call) => call.arguments[0] === "new-workspace").arguments;
     expect(launchArguments[launchArguments.indexOf("--name") + 1]).toBe("eng-123");
+    expect(launchArguments).not.toContain("--description");
     const command = launchArguments[launchArguments.indexOf("--command") + 1];
     expect(command).toContain("codex");
     expect(command).toContain('model_reasoning_effort="high"');
     expect(command).toContain("Task: fixture:ENG-123");
     expect(command).toContain("crew continue");
     expect(launchArguments).toContain("GROUNDCREW_TASK_ID=fixture:ENG-123");
+    expect(launchArguments).toContain(`GROUNDCREW_PRESENTATION_ID=${run.presentationId}`);
     expect(launchArguments).toContain(
       `GROUNDCREW_CONFIG=${fixture.environment["GROUNDCREW_CONFIG"]}`,
     );
@@ -403,9 +408,12 @@ describe("crew start", () => {
     ).toBe(true);
   });
 
-  it("cleans a run using the lowercase task ID shown by cmux", async () => {
+  it("cleans a run after its cmux title is edited", async () => {
     const fixture = await createDispatchFixture();
     await runCrew({ arguments: ["start"], environment: fixture.environment });
+    const cmuxState = JSON.parse(await readFile(fixture.cmuxStatePath, "utf8"));
+    cmuxState.workspaces[0].title = "personal-label";
+    await writeFile(fixture.cmuxStatePath, JSON.stringify(cmuxState));
 
     const result = await runCrew({
       arguments: ["cleanup", "eng-123"],

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -64,6 +64,12 @@ if (command === "new-workspace") {
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "workspace" && arguments_[0] === "env") {
   const workspace = state.workspaces.find(({ id }) => id === arguments_[1]);
+  if (process.env.FAKE_CMUX_DELETE_BEFORE_ENV_READ === workspace?.id) {
+    state.workspaces = state.workspaces.filter(({ id }) => id !== workspace.id);
+    await writeFile(statePath, JSON.stringify(state));
+    process.stderr.write(`workspace not found: ${arguments_[1]}\n`);
+    process.exit(1);
+  }
   if (workspace === undefined) {
     process.stderr.write(`workspace not found: ${arguments_[1]}\n`);
     process.exit(1);

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -64,7 +64,10 @@ if (command === "new-workspace") {
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
 } else if (command === "workspace" && arguments_[0] === "env") {
   const workspace = state.workspaces.find(({ id }) => id === arguments_[1]);
-  if (process.env.FAKE_CMUX_DELETE_BEFORE_ENV_READ === workspace?.id) {
+  if (
+    workspace !== undefined &&
+    process.env.FAKE_CMUX_DELETE_BEFORE_ENV_READ === workspace.id
+  ) {
     state.workspaces = state.workspaces.filter(({ id }) => id !== workspace.id);
     await writeFile(statePath, JSON.stringify(state));
     process.stderr.write(`workspace not found: ${arguments_[1]}\n`);

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -16,7 +16,7 @@ if (command === "new-workspace") {
     process.exit(1);
   }
   const workspace = {
-    description: valueAfter("--description"),
+    environment: presentationEnvironment(),
     id: `workspace-${state.workspaces.length + 1}`,
     title: valueAfter("--name"),
   };
@@ -37,13 +37,7 @@ if (command === "new-workspace") {
     }
   }
   if (process.env.FAKE_CMUX_EXECUTE_COMMAND === "1") {
-    const childEnvironment = { ...process.env };
-    for (let index = 0; index < arguments_.length; index += 1) {
-      if (arguments_[index] !== "--env") continue;
-      const entry = arguments_[index + 1];
-      const separator = entry.indexOf("=");
-      childEnvironment[entry.slice(0, separator)] = entry.slice(separator + 1);
-    }
+    const childEnvironment = { ...process.env, ...workspaceEnvironment() };
     const child = spawn("/bin/sh", ["-c", valueAfter("--command")], {
       cwd: valueAfter("--cwd"),
       detached: true,
@@ -68,6 +62,17 @@ if (command === "new-workspace") {
     process.exit(0);
   }
   process.stdout.write(JSON.stringify({ workspaces: state.workspaces }));
+} else if (command === "workspace" && arguments_[0] === "env") {
+  const workspace = state.workspaces.find(({ id }) => id === arguments_[1]);
+  if (workspace === undefined) {
+    process.stderr.write(`workspace not found: ${arguments_[1]}\n`);
+    process.exit(1);
+  }
+  process.stdout.write(
+    Object.entries(workspace.environment ?? {})
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n"),
+  );
 } else if (command === "close-workspace") {
   const id = valueAfter("--workspace");
   if (process.env.FAKE_CMUX_FAIL_CLOSE === "1") {
@@ -108,4 +113,20 @@ async function readState() {
 
 function valueAfter(flag) {
   return arguments_[arguments_.indexOf(flag) + 1];
+}
+
+function workspaceEnvironment() {
+  const environment = {};
+  for (let index = 0; index < arguments_.length; index += 1) {
+    if (arguments_[index] !== "--env") continue;
+    const entry = arguments_[index + 1];
+    const separator = entry.indexOf("=");
+    environment[entry.slice(0, separator)] = entry.slice(separator + 1);
+  }
+  return environment;
+}
+
+function presentationEnvironment() {
+  const presentationId = workspaceEnvironment().GROUNDCREW_PRESENTATION_ID;
+  return presentationId === undefined ? {} : { GROUNDCREW_PRESENTATION_ID: presentationId };
 }

--- a/v2/src/presenter/index.test.ts
+++ b/v2/src/presenter/index.test.ts
@@ -53,25 +53,22 @@ describe("cmux presenter conformance", () => {
 });
 
 async function exercisePresenter(input: { readonly name: string; readonly presenter: Presenter }) {
-  await input.presenter.open({
+  const presentation = await input.presenter.open({
     command: ["/usr/bin/true"],
+    displayName: input.name,
     environment: { GROUNDCREW_TASK_ID: `conformance:${input.name}` },
-    name: input.name,
+    presentationId: input.name,
     workingDirectory: process.cwd(),
   });
   try {
     const opened = await input.presenter.probe();
     expect(opened.available).toBe(true);
-    expect(opened.workspaces).toEqual(
-      expect.arrayContaining([expect.objectContaining({ name: input.name })]),
-    );
-    expect(await input.presenter.accessHint({ name: input.name })).toContain("workspace");
-    await input.presenter.setStatus?.({ name: input.name, text: "running" });
+    expect(opened.workspaces).toEqual(expect.arrayContaining([presentation]));
+    expect(await input.presenter.accessHint(presentation)).toContain("workspace");
+    await input.presenter.setStatus?.({ ...presentation, text: "running" });
   } finally {
-    await input.presenter.close({ name: input.name });
+    await input.presenter.close(presentation);
   }
   const closed = await input.presenter.probe();
-  expect(closed.workspaces).not.toEqual(
-    expect.arrayContaining([expect.objectContaining({ name: input.name })]),
-  );
+  expect(closed.workspaces).not.toEqual(expect.arrayContaining([presentation]));
 }

--- a/v2/src/presenter/index.test.ts
+++ b/v2/src/presenter/index.test.ts
@@ -1,3 +1,4 @@
+import { execa } from "execa";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -71,6 +72,28 @@ describe("cmux presenter conformance", () => {
     });
 
     await expect(presenter.probe()).resolves.toEqual({ available: true, workspaces: [] });
+  });
+
+  it("reports an already-missing workspace through the fake cmux process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-presenter-missing-workspace-"));
+    const fakeCmux = join(process.cwd(), "e2e", "fixtures", "fake-bin", "cmux");
+    const statePath = join(root, "state.json");
+    await writeFile(
+      statePath,
+      JSON.stringify({ workspaces: [{ environment: {}, id: "workspace-2", title: "other" }] }),
+    );
+
+    const result = await execa(fakeCmux, ["workspace", "env", "workspace-1"], {
+      env: {
+        ...process.env,
+        FAKE_CMUX_CALLS: join(root, "calls.jsonl"),
+        FAKE_CMUX_STATE: statePath,
+      },
+      reject: false,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("workspace not found: workspace-1");
   });
 
   it.runIf(process.env["GROUNDCREW_LIVE_CMUX"] === "1")("conforms through live cmux", async () => {

--- a/v2/src/presenter/index.test.ts
+++ b/v2/src/presenter/index.test.ts
@@ -44,6 +44,35 @@ describe("cmux presenter conformance", () => {
     await expect(presenter.probe()).resolves.toEqual({ available: false, workspaces: [] });
   });
 
+  it("stays available when a listed workspace disappears before its environment is read", async () => {
+    const root = await mkdtemp(join(tmpdir(), "groundcrew-presenter-disappearing-workspace-"));
+    const statePath = join(root, "state.json");
+    const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        workspaces: [
+          {
+            environment: { GROUNDCREW_PRESENTATION_ID: "presentation-1" },
+            id: "workspace-1",
+            title: "workspace",
+          },
+        ],
+      }),
+    );
+    const presenter = new CmuxPresenter({
+      environment: {
+        ...process.env,
+        FAKE_CMUX_CALLS: join(root, "calls.jsonl"),
+        FAKE_CMUX_DELETE_BEFORE_ENV_READ: "workspace-1",
+        FAKE_CMUX_STATE: statePath,
+        PATH: `${fakeBin}:${process.env["PATH"]}`,
+      },
+    });
+
+    await expect(presenter.probe()).resolves.toEqual({ available: true, workspaces: [] });
+  });
+
   it.runIf(process.env["GROUNDCREW_LIVE_CMUX"] === "1")("conforms through live cmux", async () => {
     await exercisePresenter({
       name: `crew-conformance-live-${process.pid}`,

--- a/v2/src/presenter/index.ts
+++ b/v2/src/presenter/index.ts
@@ -104,8 +104,18 @@ export class CmuxPresenter implements Presenter {
         async (workspace) => await this.readPresentation({ presenterHandle: workspace.id }),
       ),
     );
-    if (presentations.some((presentation) => !presentation.available)) {
-      return { available: false, workspaces: [] };
+    const unreadWorkspaces = workspaces.filter(
+      (_, index) => presentations[index]?.available === false,
+    );
+    if (unreadWorkspaces.length > 0) {
+      const currentWorkspaces = await this.listWorkspaces();
+      if (currentWorkspaces === undefined) {
+        return { available: false, workspaces: [] };
+      }
+      const currentPresenterHandles = new Set(currentWorkspaces.map((workspace) => workspace.id));
+      if (unreadWorkspaces.some((workspace) => currentPresenterHandles.has(workspace.id))) {
+        return { available: false, workspaces: [] };
+      }
     }
     return {
       available: true,

--- a/v2/src/presenter/index.ts
+++ b/v2/src/presenter/index.ts
@@ -4,19 +4,18 @@ import { z } from "zod";
 
 const WORKSPACE_VISIBILITY_ATTEMPTS = 40;
 const WORKSPACE_VISIBILITY_INTERVAL_MILLISECONDS = 50;
+const PRESENTATION_ID_ENVIRONMENT_KEY = "GROUNDCREW_PRESENTATION_ID";
 
 const WorkspaceListSchema = z.object({
   workspaces: z.array(
     z.object({
       id: z.string(),
-      title: z.string(),
-      description: z.string().nullable().optional(),
     }),
   ),
 });
 
 export interface PresenterOpenInput {
-  readonly name: string;
+  readonly presentationId: string;
   readonly displayName?: string | undefined;
   readonly workingDirectory: string;
   readonly command: readonly string[];
@@ -25,20 +24,26 @@ export interface PresenterOpenInput {
 }
 
 export interface PresentedWorkspace {
-  readonly name: string;
-  readonly description?: string | undefined;
+  readonly presentationId: string;
+  readonly presenterHandle: string;
+}
+
+export interface PresentationTarget {
+  readonly presentationId: string;
+  readonly presenterHandle?: string | undefined;
 }
 
 export interface Presenter {
-  open(input: PresenterOpenInput): Promise<void>;
+  open(input: PresenterOpenInput): Promise<PresentedWorkspace>;
   probe(): Promise<{
     readonly available: boolean;
     readonly workspaces: readonly PresentedWorkspace[];
   }>;
-  close(input: { readonly name: string }): Promise<void>;
-  accessHint(input: { readonly name: string }): Promise<string | undefined>;
+  close(input: PresentationTarget): Promise<void>;
+  accessHint(input: PresentationTarget): Promise<string | undefined>;
   setStatus?(input: {
-    readonly name: string;
+    readonly presentationId: string;
+    readonly presenterHandle?: string | undefined;
     readonly text: string;
     readonly color?: string | undefined;
   }): Promise<void>;
@@ -58,29 +63,32 @@ export class CmuxPresenter implements Presenter {
     this.#environment = input.environment;
   }
 
-  public async open(input: PresenterOpenInput): Promise<void> {
+  public async open(input: PresenterOpenInput): Promise<PresentedWorkspace> {
     const arguments_ = [
       "new-workspace",
       "--name",
-      input.displayName ?? input.name,
-      "--description",
-      `groundcrew:${input.environment["GROUNDCREW_TASK_ID"] ?? input.name}`,
+      input.displayName ?? input.presentationId,
       "--cwd",
       input.workingDirectory,
       "--command",
       input.command.map(shellQuote).join(" "),
     ];
-    for (const [key, value] of Object.entries(input.environment)) {
+    const workspaceEnvironment = {
+      ...input.environment,
+      [PRESENTATION_ID_ENVIRONMENT_KEY]: input.presentationId,
+    };
+    for (const [key, value] of Object.entries(workspaceEnvironment)) {
       arguments_.push("--env", `${key}=${value}`);
     }
     const result = await execa("cmux", arguments_, { env: this.#environment, reject: false });
     if (result.exitCode !== 0) {
       throw new Error(result.stderr.trim() || "cmux failed to create workspace");
     }
-    const workspace = await this.waitUntilVisible({ name: input.name });
+    const workspace = await this.waitUntilVisible({ presentationId: input.presentationId });
     if (input.status !== undefined) {
-      await this.setWorkspaceStatus({ text: input.status, workspaceId: workspace.id });
+      await this.setWorkspaceStatus({ text: input.status, workspaceId: workspace.presenterHandle });
     }
+    return workspace;
   }
 
   public async probe(): Promise<{
@@ -91,47 +99,59 @@ export class CmuxPresenter implements Presenter {
     if (workspaces === undefined) {
       return { available: false, workspaces: [] };
     }
+    const presentations = await Promise.all(
+      workspaces.map(
+        async (workspace) => await this.readPresentation({ presenterHandle: workspace.id }),
+      ),
+    );
+    if (presentations.some((presentation) => !presentation.available)) {
+      return { available: false, workspaces: [] };
+    }
     return {
       available: true,
-      workspaces: workspaces.map((workspace) => ({
-        description: workspace.description ?? undefined,
-        name: workspace.title,
-      })),
+      workspaces: presentations.flatMap((presentation) =>
+        presentation.workspace === undefined ? [] : [presentation.workspace],
+      ),
     };
   }
 
-  public async close(input: { readonly name: string }): Promise<void> {
-    const workspace = await this.resolve({ name: input.name });
+  public async close(input: PresentationTarget): Promise<void> {
+    const workspace = await this.resolve(input);
     if (workspace === undefined) {
       return;
     }
-    const result = await execa("cmux", ["close-workspace", "--workspace", workspace.id], {
-      env: this.#environment,
-      reject: false,
-    });
+    const result = await execa(
+      "cmux",
+      ["close-workspace", "--workspace", workspace.presenterHandle],
+      {
+        env: this.#environment,
+        reject: false,
+      },
+    );
     if (result.exitCode !== 0) {
       throw new Error(result.stderr.trim() || "cmux close failed");
     }
   }
 
-  public async accessHint(input: { readonly name: string }): Promise<string | undefined> {
-    const workspace = await this.resolve({ name: input.name });
-    return workspace === undefined ? undefined : `cmux workspace ${workspace.id}`;
+  public async accessHint(input: PresentationTarget): Promise<string | undefined> {
+    const workspace = await this.resolve(input);
+    return workspace === undefined ? undefined : `cmux workspace ${workspace.presenterHandle}`;
   }
 
   public async setStatus(input: {
-    readonly name: string;
+    readonly presentationId: string;
+    readonly presenterHandle?: string | undefined;
     readonly text: string;
     readonly color?: string | undefined;
   }): Promise<void> {
-    const workspace = await this.resolve({ name: input.name });
+    const workspace = await this.resolve(input);
     if (workspace === undefined) {
       return;
     }
     await this.setWorkspaceStatus({
       color: input.color,
       text: input.text,
-      workspaceId: workspace.id,
+      workspaceId: workspace.presenterHandle,
     });
   }
 
@@ -154,37 +174,67 @@ export class CmuxPresenter implements Presenter {
   }
 
   private async waitUntilVisible(input: {
-    readonly name: string;
-  }): Promise<{ readonly id: string; readonly title: string }> {
-    let previousWorkspaceId: string | undefined;
+    readonly presentationId: string;
+  }): Promise<PresentedWorkspace> {
+    let previousPresenterHandle: string | undefined;
     for (let attempt = 0; attempt < WORKSPACE_VISIBILITY_ATTEMPTS; attempt += 1) {
       // cmux may acknowledge creation before the workspace reaches its list API.
       // eslint-disable-next-line no-await-in-loop
       const workspace = await this.resolve(input);
-      if (workspace !== undefined && workspace.id === previousWorkspaceId) {
+      if (workspace !== undefined && workspace.presenterHandle === previousPresenterHandle) {
         return workspace;
       }
-      previousWorkspaceId = workspace?.id;
+      previousPresenterHandle = workspace?.presenterHandle;
       // eslint-disable-next-line no-await-in-loop
       await delay(WORKSPACE_VISIBILITY_INTERVAL_MILLISECONDS);
     }
-    throw new Error(`cmux workspace ${input.name} did not become visible after creation`);
+    throw new Error(
+      `cmux presentation ${input.presentationId} did not become visible after creation`,
+    );
   }
 
-  private async resolve(input: {
-    readonly name: string;
-  }): Promise<{ readonly id: string; readonly title: string } | undefined> {
-    const workspaces = await this.listWorkspaces();
-    return workspaces?.find(
-      (workspace) => workspace.title === input.name || workspace.description === input.name,
-    );
+  private async resolve(input: PresentationTarget): Promise<PresentedWorkspace | undefined> {
+    if (input.presenterHandle !== undefined) {
+      const workspaces = await this.listWorkspaces();
+      if (workspaces?.some((workspace) => workspace.id === input.presenterHandle)) {
+        return {
+          presentationId: input.presentationId,
+          presenterHandle: input.presenterHandle,
+        };
+      }
+    }
+    const probe = await this.probe();
+    return probe.workspaces.find((workspace) => workspace.presentationId === input.presentationId);
+  }
+
+  private async readPresentation(input: { readonly presenterHandle: string }): Promise<{
+    readonly available: boolean;
+    readonly workspace?: PresentedWorkspace | undefined;
+  }> {
+    const result = await execa("cmux", ["workspace", "env", input.presenterHandle], {
+      env: { ...this.#environment, CMUX_QUIET: "1" },
+      reject: false,
+    });
+    if (result.exitCode !== 0) {
+      return { available: false };
+    }
+    const prefix = `${PRESENTATION_ID_ENVIRONMENT_KEY}=`;
+    const entry = result.stdout.split("\n").find((line) => line.startsWith(prefix));
+    return {
+      available: true,
+      workspace:
+        entry === undefined
+          ? undefined
+          : {
+              presentationId: entry.slice(prefix.length),
+              presenterHandle: input.presenterHandle,
+            },
+    };
   }
 
   private async listWorkspaces(): Promise<
     | readonly {
         readonly id: string;
-        readonly title: string;
-        readonly description?: string | null | undefined;
       }[]
     | undefined
   > {

--- a/v2/src/run/index.test.ts
+++ b/v2/src/run/index.test.ts
@@ -348,24 +348,13 @@ describe("RunModule lifecycle", () => {
     await expect(runs.findBySlug({ slug: "fixture-eng-123" })).resolves.toBeUndefined();
   });
 
-  it("reconciles Run state from one presented Workspace probe", async () => {
+  it("recovers a presenter handle after creation wins the durable launch race", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "groundcrew-v2-run-reconcile-"));
     const presentedWorkspaceStatePath = join(stateRoot, "presented-workspaces.json");
     const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
     const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
     await Promise.all([
-      writeFile(
-        presentedWorkspaceStatePath,
-        JSON.stringify({
-          workspaces: [
-            {
-              description: "groundcrew:fixture:ENG-123",
-              id: "workspace-1",
-              title: "eng-123",
-            },
-          ],
-        }),
-      ),
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
       writeFile(presenterCallsPath, ""),
     ]);
     const runs = new RunModule({
@@ -384,6 +373,18 @@ describe("RunModule lifecycle", () => {
       repositories: [],
       workspaceDirectory: join(stateRoot, "workspace"),
     });
+    await writeFile(
+      presentedWorkspaceStatePath,
+      JSON.stringify({
+        workspaces: [
+          {
+            environment: { GROUNDCREW_PRESENTATION_ID: provisioning.record.presentationId },
+            id: "workspace-1",
+            title: "a user-edited-title",
+          },
+        ],
+      }),
+    );
 
     const started = await runs.reconcilePresentedWorkspace({
       run: provisioning,
@@ -399,7 +400,7 @@ describe("RunModule lifecycle", () => {
     });
 
     expect(started).toMatchObject({
-      run: { record: { state: "running" }, state: "running" },
+      run: { record: { presenterHandle: "workspace-1", state: "running" }, state: "running" },
       type: "running",
     });
     expect(failed).toMatchObject({
@@ -555,7 +556,13 @@ describe("RunModule lifecycle", () => {
       state: "running",
     });
     expect(JSON.parse(await readFile(presentedWorkspaceStatePath, "utf8"))).toMatchObject({
-      workspaces: [{ description: "groundcrew:fixture:ENG-123" }],
+      workspaces: [
+        {
+          environment: {
+            GROUNDCREW_PRESENTATION_ID: provisioning.record.presentationId,
+          },
+        },
+      ],
     });
   });
 
@@ -625,7 +632,13 @@ describe("RunModule lifecycle", () => {
       transitioned: true,
     });
     expect(JSON.parse(await readFile(presentedWorkspaceStatePath, "utf8"))).toMatchObject({
-      workspaces: [{ description: "groundcrew:fixture:ENG-123" }],
+      workspaces: [
+        {
+          environment: {
+            GROUNDCREW_PRESENTATION_ID: provisioning.record.presentationId,
+          },
+        },
+      ],
     });
   });
 
@@ -756,18 +769,7 @@ describe("RunModule lifecycle", () => {
     const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
     const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
     await Promise.all([
-      writeFile(
-        presentedWorkspaceStatePath,
-        JSON.stringify({
-          workspaces: [
-            {
-              description: "groundcrew:fixture:ENG-123",
-              id: "workspace-1",
-              title: "eng-123",
-            },
-          ],
-        }),
-      ),
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
       writeFile(presenterCallsPath, ""),
     ]);
     const workspaceDirectory = join(stateRoot, "workspace");
@@ -789,6 +791,18 @@ describe("RunModule lifecycle", () => {
       repositories: [],
       workspaceDirectory,
     });
+    await writeFile(
+      presentedWorkspaceStatePath,
+      JSON.stringify({
+        workspaces: [
+          {
+            environment: { GROUNDCREW_PRESENTATION_ID: provisioning.record.presentationId },
+            id: "workspace-1",
+            title: "edited-title",
+          },
+        ],
+      }),
+    );
     await runs.reconcilePresentedWorkspace({
       run: provisioning,
       snapshot: await runs.capturePresentedWorkspaces(),
@@ -946,18 +960,7 @@ describe("RunModule concurrency", () => {
     const presenterCallsPath = join(stateRoot, "presenter-calls.jsonl");
     const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
     await Promise.all([
-      writeFile(
-        presentedWorkspaceStatePath,
-        JSON.stringify({
-          workspaces: [
-            {
-              description: "groundcrew:fixture:ENG-123",
-              id: "workspace-1",
-              title: "eng-123",
-            },
-          ],
-        }),
-      ),
+      writeFile(presentedWorkspaceStatePath, '{"workspaces":[]}'),
       writeFile(presenterCallsPath, ""),
     ]);
     const runs = new RunModule({
@@ -976,6 +979,18 @@ describe("RunModule concurrency", () => {
       repositories: ["owner/sample"],
       workspaceDirectory: join(stateRoot, "workspace"),
     });
+    await writeFile(
+      presentedWorkspaceStatePath,
+      JSON.stringify({
+        workspaces: [
+          {
+            environment: { GROUNDCREW_PRESENTATION_ID: provisioning.record.presentationId },
+            id: "workspace-1",
+            title: "edited-title",
+          },
+        ],
+      }),
+    );
     const reconciled = await runs.reconcilePresentedWorkspace({
       run: provisioning,
       snapshot: await runs.capturePresentedWorkspaces(),

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -1242,7 +1242,7 @@ export function mintRunId(): string {
 }
 
 function mintPresentationId(): string {
-  return `p_${randomBytes(4).toString("hex")}`;
+  return `p_${randomBytes(16).toString("hex")}`;
 }
 
 export function completedRunRefusal(input: {

--- a/v2/src/run/index.ts
+++ b/v2/src/run/index.ts
@@ -29,7 +29,8 @@ export interface RunRecord {
   readonly cleanupPending?: boolean | undefined;
   readonly cleanupOwnerProcessId?: number | undefined;
   readonly presenter: "cmux";
-  readonly presentedWorkspaceName: string;
+  readonly presentationId: string;
+  readonly presenterHandle?: string | undefined;
   readonly workspaceDirectory: string;
   readonly repositories: readonly string[];
   readonly pendingRepository?: string | undefined;
@@ -156,7 +157,7 @@ export type DispatchReservation =
 
 type PresentationReconciliation =
   | { readonly type: "unchanged" }
-  | { readonly type: "running" }
+  | { readonly type: "running"; readonly workspace: PresentedWorkspace }
   | {
       readonly type: "failed";
       readonly reason: "provisioning-interrupted" | "workspace-missing";
@@ -287,9 +288,14 @@ export class RunModule {
             return current;
           }
           transitioned = true;
+          const events =
+            current.state === "provisioning"
+              ? [...current.events, { event: "running", timestamp: new Date().toISOString() }]
+              : current.events;
           return {
             ...current,
-            events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+            events,
+            presenterHandle: reconciliation.workspace.presenterHandle,
             provisioningOwner: undefined,
             state: "running",
           };
@@ -388,7 +394,7 @@ export class RunModule {
       };
     }
     try {
-      await launchAgent({
+      const presentation = await launchAgent({
         acquiredRepositories: input.acquiredRepositories,
         branch: input.branch,
         environment: this.#environment,
@@ -417,6 +423,7 @@ export class RunModule {
           return {
             ...current,
             events: [...current.events, { event: "running", timestamp: new Date().toISOString() }],
+            presenterHandle: presentation.presenterHandle,
             provisioningOwner: undefined,
             state: "running",
           };
@@ -441,7 +448,10 @@ export class RunModule {
             };
           },
         });
-        await this.#presenter.close({ name: launchRecord.presentedWorkspaceName });
+        await this.#presenter.close({
+          presentationId: launchRecord.presentationId,
+          presenterHandle: launchRecord.presenterHandle,
+        });
       } catch (closeError) {
         throw new AggregateError(
           [launchError, closeError],
@@ -590,7 +600,8 @@ export class RunModule {
       });
     }
     await this.#presenter.setStatus?.({
-      name: reservation.record.presentedWorkspaceName,
+      presentationId: reservation.record.presentationId,
+      presenterHandle: reservation.record.presenterHandle,
       text: "running",
     });
     return new RunningRunHandle({ module: this, record: reservation.record });
@@ -611,7 +622,8 @@ export class RunModule {
     });
     if (input.priorRecord.outcome !== undefined) {
       await this.#presenter.setStatus?.({
-        name: input.priorRecord.presentedWorkspaceName,
+        presentationId: input.priorRecord.presentationId,
+        presenterHandle: input.priorRecord.presenterHandle,
         text: input.priorRecord.outcome,
       });
     }
@@ -737,7 +749,10 @@ export class RunModule {
     readonly record: Readonly<RunRecord>;
   }): Promise<string | undefined> {
     requireState({ record: input.record, state: "running" });
-    return await this.#presenter.accessHint({ name: input.record.presentedWorkspaceName });
+    return await this.#presenter.accessHint({
+      presentationId: input.record.presentationId,
+      presenterHandle: input.record.presenterHandle,
+    });
   }
 
   public async setPresentedStatus(input: { readonly record: Readonly<RunRecord> }): Promise<void> {
@@ -745,7 +760,8 @@ export class RunModule {
       throw new Error(`run ${input.record.runId} is not complete`);
     }
     await this.#presenter.setStatus?.({
-      name: input.record.presentedWorkspaceName,
+      presentationId: input.record.presentationId,
+      presenterHandle: input.record.presenterHandle,
       text: input.record.outcome,
     });
   }
@@ -753,7 +769,10 @@ export class RunModule {
   public async closePresentedWorkspace(input: {
     readonly record: Readonly<RunRecord>;
   }): Promise<void> {
-    await this.#presenter.close({ name: input.record.presentedWorkspaceName });
+    await this.#presenter.close({
+      presentationId: input.record.presentationId,
+      presenterHandle: input.record.presenterHandle,
+    });
   }
 }
 
@@ -787,7 +806,7 @@ class RunStore {
           artifacts: [],
           canonicalTaskId: input.canonicalTaskId,
           events: [{ event: "provisioning", timestamp: new Date().toISOString() }],
-          presentedWorkspaceName: `groundcrew:${input.canonicalTaskId}`,
+          presentationId: mintPresentationId(),
           presenter: "cmux",
           provisioningOwner: { phase: "preparing", processId: process.pid },
           repositories: input.repositories,
@@ -1222,6 +1241,10 @@ export function mintRunId(): string {
   return `r_${randomBytes(4).toString("hex")}`;
 }
 
+function mintPresentationId(): string {
+  return `p_${randomBytes(4).toString("hex")}`;
+}
+
 export function completedRunRefusal(input: {
   readonly runId: string;
   readonly canonicalTaskId: string;
@@ -1303,7 +1326,7 @@ async function launchAgent(input: {
   readonly task: LaunchTask;
   readonly branch: string;
   readonly acquiredRepositories: readonly string[];
-}): Promise<void> {
+}): Promise<PresentedWorkspace> {
   const { environment, record } = input;
   const presenter = createPresenter({ environment, name: input.presenterName });
   const prompt = renderPrompt({
@@ -1322,7 +1345,7 @@ async function launchAgent(input: {
       (entry): entry is [string, string] => entry[1] !== undefined,
     ),
   );
-  await presenter.open({
+  return await presenter.open({
     command: composeAgentCommand({ profile: input.profile, prompt }),
     displayName: presenterWorkspaceName({ canonicalTaskId: record.canonicalTaskId }),
     environment: {
@@ -1330,7 +1353,7 @@ async function launchAgent(input: {
       GROUNDCREW_TASK_ID: record.canonicalTaskId,
       GROUNDCREW_WORKSPACE: record.workspaceDirectory,
     },
-    name: record.presentedWorkspaceName,
+    presentationId: record.presentationId,
     status: "running",
     workingDirectory: record.workspaceDirectory,
   });
@@ -1476,9 +1499,12 @@ function classifyPresentationReconciliation(input: {
     return { type: "unchanged" };
   }
   const record = input.run.record;
-  const presented = isPresented({ record, workspaces: probe.workspaces });
+  const presented = findPresented({ record, workspaces: probe.workspaces });
   if (record.state === "provisioning" && presented) {
-    return { type: "running" };
+    return { type: "running", workspace: presented };
+  }
+  if (presented !== undefined && record.presenterHandle !== presented.presenterHandle) {
+    return { type: "running", workspace: presented };
   }
   if (presented || (record.state === "provisioning" && provisioningOwnerIsAlive({ record }))) {
     return { type: "unchanged" };
@@ -1493,12 +1519,15 @@ function isPresented(input: {
   readonly record: Readonly<RunRecord>;
   readonly workspaces: readonly PresentedWorkspace[];
 }): boolean {
-  const { record } = input;
-  return input.workspaces.some(
-    (workspace) =>
-      workspace.name === record.presentedWorkspaceName ||
-      workspace.description === record.presentedWorkspaceName ||
-      workspace.description === `groundcrew:${record.canonicalTaskId}`,
+  return findPresented(input) !== undefined;
+}
+
+function findPresented(input: {
+  readonly record: Readonly<RunRecord>;
+  readonly workspaces: readonly PresentedWorkspace[];
+}): PresentedWorkspace | undefined {
+  return input.workspaces.find(
+    (workspace) => workspace.presentationId === input.record.presentationId,
   );
 }
 


### PR DESCRIPTION
## Why

cmux workspace titles are user-editable, but Groundcrew previously relied on the title or a visible description to recover, update, and close a presented workspace. That duplicated internal identity in the sidebar and made human-facing text part of Groundcrew's correctness contract.

This change gives each Run a durable presenter-neutral identity while keeping presenter-specific handles and recovery behavior behind the presenter seam. Users can rename a cmux workspace without breaking completion or cleanup, and the sidebar no longer needs to show Groundcrew's internal lookup key.

## Summary

- replace `presentedWorkspaceName` with a generated `presentationId` and opaque `presenterHandle`
- store cmux's workspace UUID as the opaque handle without exposing cmux concepts to the Run module
- recover cmux workspaces through a hidden `GROUNDCREW_PRESENTATION_ID` environment marker
- stop setting a visible cmux workspace description
- cover edited titles, launch recovery races, handle persistence, and cleanup end to end

## Validation

- `node --run verify`
- repository pre-push checks: 91 test files, 2,187 tests, and 100% coverage passed
- cb-review: no findings; ship gate passed; requirements met

## Notes

This is an intentional breaking v2 state change. Existing Run records and presented workspaces are not migrated and must be cleaned up separately.

Agent session: `codex resume 019ff34e-3166-7061-a946-661eb91944be`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.2</code></sub>
