### PR TITLE
fix: use canonical cmux workspace close

### DIFF
--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -452,6 +452,15 @@ describe("crew start", () => {
       JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-active-1.json"), "utf8")),
     ).toMatchObject({ state: "running" });
     expect(JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")).workspaces).toHaveLength(1);
+    const cmuxCalls = (await readFile(fixture.cmuxCallsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(cmuxCalls.map((call) => call.arguments)).toContainEqual([
+      "workspace",
+      "close",
+      "workspace-1",
+    ]);
   });
 
   it("requires exactly one cleanup selector", async () => {

--- a/v2/e2e/fixtures/fake-bin/cmux
+++ b/v2/e2e/fixtures/fake-bin/cmux
@@ -82,8 +82,8 @@ if (command === "new-workspace") {
       .map(([key, value]) => `${key}=${value}`)
       .join("\n"),
   );
-} else if (command === "close-workspace") {
-  const id = valueAfter("--workspace");
+} else if (command === "workspace" && arguments_[0] === "close") {
+  const id = arguments_[1];
   if (process.env.FAKE_CMUX_FAIL_CLOSE === "1") {
     process.stderr.write("fake cmux close failure\n");
     process.exit(1);

--- a/v2/src/presenter/index.test.ts
+++ b/v2/src/presenter/index.test.ts
@@ -26,7 +26,7 @@ describe("cmux presenter conformance", () => {
     const calls = await readFile(callsPath, "utf8");
     expect(calls).toContain("new-workspace");
     expect(calls).toContain("set-progress");
-    expect(calls).toContain("close-workspace");
+    expect(calls).toContain('"workspace","close"');
   });
 
   it("reports malformed cmux output as unavailable", async () => {

--- a/v2/src/presenter/index.ts
+++ b/v2/src/presenter/index.ts
@@ -130,14 +130,10 @@ export class CmuxPresenter implements Presenter {
     if (workspace === undefined) {
       return;
     }
-    const result = await execa(
-      "cmux",
-      ["close-workspace", "--workspace", workspace.presenterHandle],
-      {
-        env: this.#environment,
-        reject: false,
-      },
-    );
+    const result = await execa("cmux", ["workspace", "close", workspace.presenterHandle], {
+      env: this.#environment,
+      reject: false,
+    });
     if (result.exitCode !== 0) {
       throw new Error(result.stderr.trim() || "cmux close failed");
     }


### PR DESCRIPTION
## Why

`crew cleanup --completed` invokes cmux's legacy `close-workspace` alias, which emits a deprecation notice into operator output. Using cmux's canonical workspace command removes that noise and avoids retaining a deprecated integration surface.

## Summary

- Invoke `cmux workspace close <workspace>` when closing a presented workspace.
- Update the fake cmux boundary and presenter conformance coverage.
- Assert the exact canonical close command through the built `crew cleanup --completed` flow.

## Validation

- `cd v2 && node --run test -- e2e/dispatch.e2e.test.ts -t "cleans only completed runs with --completed"`
- `cd v2 && node --run test -- src/presenter/index.test.ts`
- `cd v2 && node --run verify` — 132 passed, 1 skipped
- Repository pre-push checks — 2,187 tests passed with 100% coverage; build, lint, format, architecture, duplication, and dependency checks passed

## Notes

Agent session: `codex resume 019ffb3f-8b01-72f3-ae4e-049c59ab3735`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
