### PR TITLE
fix: trust portable CAs in Linear source

### DIFF
--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -1,12 +1,13 @@
 import { execFile } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const fixtureRoots: string[] = [];
 
 describe("the shipped Linear source", () => {
   let fixture: Awaited<ReturnType<typeof createLinearFixture>>;
@@ -17,6 +18,50 @@ describe("the shipped Linear source", () => {
 
   afterEach(async () => {
     await fixture.close();
+    await Promise.all(
+      fixtureRoots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })),
+    );
+  });
+
+  it("uses portable CA stores when the runtime build default cannot validate Linear", async () => {
+    const shimDirectory = await mkdtemp(join(tmpdir(), "groundcrew-v2-linear-node-shim-"));
+    fixtureRoots.push(shimDirectory);
+    await writeFile(
+      join(shimDirectory, "node"),
+      [
+        "#!/bin/sh",
+        'case " $* " in *" --use-bundled-ca "*) ;; *) printf \'%s\\n\' \'{"ok":false,"error":{"message":"bundled CA store not enabled"}}\'; exit 0 ;; esac',
+        'case " $* " in *" --use-system-ca "*) ;; *) printf \'%s\\n\' \'{"ok":false,"error":{"message":"system CA store not enabled"}}\'; exit 0 ;; esac',
+        'exec "$REAL_NODE_PATH" "$@"',
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const doctor = await runCrew({
+      arguments: ["doctor"],
+      environment: {
+        ...fixture.environment,
+        PATH: `${shimDirectory}:${fixture.environment["PATH"]}`,
+        REAL_NODE_PATH: process.execPath,
+      },
+    });
+
+    expect(doctor.stdout).toContain("live list probe: healthy (1 tasks)");
+  });
+
+  it("reports the underlying network cause when Linear cannot be reached", async () => {
+    const result = await runLinearList({
+      environment: {
+        ...fixture.environment,
+        LINEAR_API_URL: "http://127.0.0.1:65535/graphql",
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual({
+      error: { message: expect.stringContaining("ECONNREFUSED") },
+      ok: false,
+    });
   });
 
   it("probes, claims, comments, moves, and completes through the process protocol", async () => {

--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -26,10 +26,12 @@ describe("the shipped Linear source", () => {
   it("uses portable CA stores when the runtime build default cannot validate Linear", async () => {
     const shimDirectory = await mkdtemp(join(tmpdir(), "groundcrew-v2-linear-node-shim-"));
     fixtureRoots.push(shimDirectory);
+    const shimInvocationPath = join(shimDirectory, "invocation");
     await writeFile(
       join(shimDirectory, "node"),
       [
         "#!/bin/sh",
+        'printf \'%s\\n\' "$*" > "$NODE_SHIM_INVOCATION_PATH"',
         'case " $* " in *" --use-bundled-ca "*) ;; *) printf \'%s\\n\' \'{"ok":false,"error":{"message":"bundled CA store not enabled"}}\'; exit 0 ;; esac',
         'case " $* " in *" --use-system-ca "*) ;; *) printf \'%s\\n\' \'{"ok":false,"error":{"message":"system CA store not enabled"}}\'; exit 0 ;; esac',
         'exec "$REAL_NODE_PATH" "$@"',
@@ -44,17 +46,22 @@ describe("the shipped Linear source", () => {
         ...fixture.environment,
         PATH: `${shimDirectory}:${fixture.environment["PATH"]}`,
         REAL_NODE_PATH: process.execPath,
+        NODE_SHIM_INVOCATION_PATH: shimInvocationPath,
       },
     });
 
     expect(doctor.stdout).toContain("live list probe: healthy (1 tasks)");
+    const shimInvocation = await readFile(shimInvocationPath, "utf8");
+    expect(shimInvocation).toContain("--use-bundled-ca");
+    expect(shimInvocation).toContain("--use-system-ca");
   });
 
   it("reports the underlying network cause when Linear cannot be reached", async () => {
+    const refusalPort = await closedLoopbackPort();
     const result = await runLinearList({
       environment: {
         ...fixture.environment,
-        LINEAR_API_URL: "http://127.0.0.1:65535/graphql",
+        LINEAR_API_URL: `http://127.0.0.1:${refusalPort}/graphql`,
       },
     });
 
@@ -396,6 +403,7 @@ async function createLinearFixture(
     throw new Error("test server did not bind TCP");
   }
   const root = await mkdtemp(join(tmpdir(), "groundcrew-v2-linear-"));
+  fixtureRoots.push(root);
   const configPath = join(root, "crew.config.jsonc");
   const fakeBin = join(process.cwd(), "e2e", "fixtures", "fake-bin");
   await Promise.all([
@@ -438,6 +446,23 @@ async function createLinearFixture(
     },
     state,
   };
+}
+
+async function closedLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolvePromise) => {
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  await new Promise<void>((resolvePromise, reject) => {
+    server.close((error) => {
+      error ? reject(error) : resolvePromise();
+    });
+  });
+  if (address === null || typeof address === "string") {
+    throw new Error("refusal server did not bind TCP");
+  }
+  return address.port;
 }
 
 function linearIssue(input: {

--- a/v2/task-sources/linear/get
+++ b/v2/task-sources/linear/get
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --use-bundled-ca --use-system-ca
 
 import { run } from "./lib.js";
 

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -27,9 +27,21 @@ export async function run(input) {
     process.stdout.write(`${JSON.stringify({ data, ok: true })}\n`);
   } catch (error) {
     process.stdout.write(
-      `${JSON.stringify({ error: { message: error instanceof Error ? error.message : String(error) }, ok: false })}\n`,
+      `${JSON.stringify({ error: { message: errorMessage(error) }, ok: false })}\n`,
     );
   }
+}
+
+function errorMessage(error) {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const cause = error.cause;
+  if (!(cause instanceof Error)) {
+    return error.message;
+  }
+  const code = "code" in cause && typeof cause.code === "string" ? ` (${cause.code})` : "";
+  return `${error.message}: ${cause.message}${code}`;
 }
 
 async function listTasks() {

--- a/v2/task-sources/linear/list
+++ b/v2/task-sources/linear/list
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --use-bundled-ca --use-system-ca
 
 import { run } from "./lib.js";
 

--- a/v2/task-sources/linear/update
+++ b/v2/task-sources/linear/update
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --use-bundled-ca --use-system-ca
 
 import { run } from "./lib.js";
 


### PR DESCRIPTION
## Why

The packaged Linear task source inherited whichever Node executable appeared first in an agent workspace's `PATH`. Homebrew Node 26 selected a build-default certificate store that could not validate Linear, causing `crew continue` and `crew doctor` to fail with only `fetch failed`. This has no direct customer impact, but it blocks Groundcrew operators from continuing work and obscures the actionable TLS cause.

## Summary

- Launch every shipped Linear protocol command with both Node's bundled and system CA stores.
- Preserve the nested network error message and code in source protocol failures.
- Cover the operator-visible doctor path with a simulated unusable build-default CA store and cover refused-connection diagnostics.

## Validation

- `node --run verify` — 10 test files passed; 134 tests passed, 1 skipped.
- `node --run test -- e2e/linear.e2e.test.ts` — 13 tests passed.
- Patched source queried live Linear under Homebrew Node 26.7.0 — healthy, 873 tasks.
- `cb-review --effort low --report` — Ship gate: pass; zero findings.

## Notes

Agent session: `codex resume 019ffbd7-ab64-7251-81a8-4896b85c94b8`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
