### PR TITLE
fix: preserve terminal Linear issue states

### DIFF
--- a/v2/e2e/linear.e2e.test.ts
+++ b/v2/e2e/linear.e2e.test.ts
@@ -110,6 +110,31 @@ describe("the shipped Linear source", () => {
     expect(fixture.state.comments.at(-1)).toContain(":completed:failed]");
   });
 
+  it("preserves a terminal issue when delivered completion writeback settles", async () => {
+    fixture.state.stateName = "Done";
+    fixture.state.stateType = "completed";
+
+    const result = await runLinearUpdate({
+      environment: fixture.environment,
+      payload: {
+        event: {
+          artifacts: [],
+          message: "Delivered after the issue reached Done.",
+          outcome: "delivered",
+          runId: "r_00112233",
+          type: "completed",
+        },
+        id: "LIN-1",
+      },
+    });
+
+    expect(JSON.parse(result.stdout)).toEqual({ data: { result: "ok" }, ok: true });
+    expect(fixture.state.moveRequests).toEqual([]);
+    expect(fixture.state.stateName).toBe("Done");
+    expect(fixture.state.stateType).toBe("completed");
+    expect(fixture.state.comments.at(-1)).toContain("[groundcrew:r_00112233:completed:delivered]");
+  });
+
   it("leaves a delivered run unchanged when In Review is unavailable", async () => {
     await fixture.close();
     fixture = await createLinearFixture({ includeInReviewState: false });

--- a/v2/task-sources/linear/lib.js
+++ b/v2/task-sources/linear/lib.js
@@ -131,6 +131,9 @@ async function updateTask(input) {
     .filter(Boolean)
     .join("\n\n");
   await addCommentOnce({ issue, marker: completionMarker, text });
+  if (["completed", "canceled", "duplicate"].includes(issue.state?.type)) {
+    return { result: "ok" };
+  }
   if (input.event.outcome === "delivered") {
     await moveIssue({
       allowMissing: true,


### PR DESCRIPTION
## Why

Groundcrew v2 always moved delivered Linear issues to In Review during completion writeback. If an agent or Linear GitHub automation had already moved the issue to Done, the later Groundcrew writeback regressed it back to In Review. This left completed work incorrectly open and prevented terminal-task cleanup from observing the source as done.

## Summary

- Preserve Linear issues already in a completed, canceled, or duplicate workflow state when completion writeback settles.
- Continue recording the idempotent Groundcrew completion comment.
- Cover the Done-before-writeback sequence through the shipped Linear source process and GraphQL fixture.

## Validation

- node --run test -- e2e/linear.e2e.test.ts
- node --run verify
- Pre-push checks: 91 test files and 2,187 tests passed with 100% coverage; all checks passed.

## Notes

Verified against the STAFF-2428 state history: the issue reached Done before Groundcrew completion writeback moved it backward to In Review.

Agent session: `codex resume 019ffe42-a144-7c02-a1ea-d3aae85d091b`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
