### PR TITLE
feat(usage): record agent token usage against the task

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { doctor } from "./commands/doctor.ts";
 import { initConfigCli } from "./commands/init.ts";
 import { interruptWorkspaceCli } from "./commands/interruptWorkspace.ts";
 import { openWorkspaceCli } from "./commands/openWorkspace.ts";
+import { recordUsageCli } from "./commands/recordUsage.ts";
 import { orchestrate } from "./commands/orchestrator.ts";
 import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
@@ -187,6 +188,12 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
     summary: "List, get, create, and complete tasks across configured sources",
     usage: "<list|get|create|done|validate> [...]",
     invoke: taskCli,
+  },
+  "record-usage": {
+    summary: "Record an agent session's token usage against a task",
+    usage: "--task <task> [--transcript <path>]",
+    hidden: true,
+    invoke: recordUsageCli,
   },
   status: {
     summary: "Print read-only groundcrew state, or one task's local/Linear status",

--- a/src/commands/recordUsage.test.ts
+++ b/src/commands/recordUsage.test.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from "node:fs";
+
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import { readRunState, type RunState, updateRunState } from "../lib/runState.ts";
+import { recordUsageCli } from "./recordUsage.ts";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, readFileSync: vi.fn<typeof readFileSync>() };
+});
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    updateRunState: vi.fn<typeof updateRunState>(),
+  };
+});
+
+const readFileSyncMock = vi.mocked(readFileSync);
+const loadConfigMock = vi.mocked(loadConfig);
+const readRunStateMock = vi.mocked(readRunState);
+const updateRunStateMock = vi.mocked(updateRunState);
+
+const config = { logging: { file: "/tmp/groundcrew.log" } } as ResolvedConfig;
+
+function runState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    task: "ENG-1",
+    repository: "repo-a",
+    agent: "claude",
+    worktreeDir: "/work/repo-a-eng-1",
+    branchName: "dev-eng-1",
+    workspaceName: "eng-1",
+    state: "running",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    resumeCount: 0,
+    ...overrides,
+  };
+}
+
+function assistantLine(id: string, outputTokens: number): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: { id, role: "assistant", usage: { output_tokens: outputTokens } },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadConfigMock.mockResolvedValue(config);
+  readRunStateMock.mockReturnValue(runState());
+});
+
+describe(recordUsageCli, () => {
+  it.each([[[]], [["--task"]], [["--task", ""]]])(
+    "rejects a missing task rather than silently recording nothing (%j)",
+    async (argv) => {
+      await expect(recordUsageCli(argv)).rejects.toThrow("Usage: crew record-usage");
+    },
+  );
+
+  it("records the session against the task", async () => {
+    readFileSyncMock.mockReturnValue([assistantLine("m1", 10), assistantLine("m2", 5)].join("\n"));
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/session.jsonl"]);
+
+    expect(updateRunStateMock).toHaveBeenCalledWith({
+      config,
+      task: "ENG-1",
+      patch: {
+        state: "running",
+        usage: {
+          inputTokens: 0,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          outputTokens: 15,
+          messages: 2,
+        },
+      },
+    });
+  });
+
+  it("folds a resumed session into the counts already recorded", async () => {
+    readRunStateMock.mockReturnValue(
+      runState({
+        usage: {
+          inputTokens: 1,
+          cacheCreationInputTokens: 2,
+          cacheReadInputTokens: 3,
+          outputTokens: 4,
+          messages: 1,
+        },
+      }),
+    );
+    readFileSyncMock.mockReturnValue(assistantLine("m9", 6));
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/session.jsonl"]);
+
+    expect(updateRunStateMock.mock.calls[0]?.[0].patch.usage).toStrictEqual({
+      inputTokens: 1,
+      cacheCreationInputTokens: 2,
+      cacheReadInputTokens: 3,
+      outputTokens: 10,
+      messages: 2,
+    });
+  });
+
+  it("preserves the lifecycle state rather than moving the task", async () => {
+    readRunStateMock.mockReturnValue(runState({ state: "resumed" }));
+    readFileSyncMock.mockReturnValue(assistantLine("m1", 1));
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/session.jsonl"]);
+
+    expect(updateRunStateMock.mock.calls[0]?.[0].patch.state).toBe("resumed");
+  });
+
+  it("reads the transcript path from the hook payload on stdin", async () => {
+    readFileSyncMock
+      .mockReturnValueOnce(JSON.stringify({ transcript_path: "/tmp/from-stdin.jsonl" }))
+      .mockReturnValueOnce(assistantLine("m1", 3));
+
+    await recordUsageCli(["--task", "ENG-1"]);
+
+    expect(readFileSyncMock).toHaveBeenCalledWith("/tmp/from-stdin.jsonl", "utf8");
+    expect(updateRunStateMock).toHaveBeenCalled();
+  });
+
+  it("prefers an explicit transcript over the stdin payload", async () => {
+    readFileSyncMock.mockReturnValue(assistantLine("m1", 1));
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/explicit.jsonl"]);
+
+    // stdin is never read when the path is already known.
+    expect(readFileSyncMock).not.toHaveBeenCalledWith(0, "utf8");
+  });
+
+  it("does nothing when stdin carries no usable payload", async () => {
+    readFileSyncMock.mockReturnValue("not a hook payload");
+
+    await recordUsageCli(["--task", "ENG-1"]);
+
+    expect(updateRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when stdin cannot be read at all", async () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("EAGAIN");
+    });
+
+    await recordUsageCli(["--task", "ENG-1"]);
+
+    expect(updateRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the transcript is gone", async () => {
+    // A transcript can be rotated or cleaned up before the hook runs.
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/missing.jsonl"]);
+
+    expect(updateRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not write an empty total when the transcript has no usage", async () => {
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({ type: "user", message: { role: "user", content: "hi" } }),
+    );
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/session.jsonl"]);
+
+    expect(updateRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the session outlives its run state", async () => {
+    // Not worth failing a hook over: there is nothing left to attribute to.
+    readRunStateMock.mockReset();
+    readFileSyncMock.mockReturnValue(assistantLine("m1", 1));
+
+    await recordUsageCli(["--task", "ENG-1", "--transcript", "/tmp/session.jsonl"]);
+
+    expect(updateRunStateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/recordUsage.ts
+++ b/src/commands/recordUsage.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+
+import { loadConfig } from "../lib/config.ts";
+import { readRunState, updateRunState } from "../lib/runState.ts";
+import {
+  addTokenUsage,
+  emptyTokenUsage,
+  sumTranscriptUsage,
+  type TokenUsage,
+  transcriptPathFromHookPayload,
+} from "../lib/tokenUsage.ts";
+
+/**
+ * Fold one agent session's token usage into a task's run state.
+ *
+ * Invoked by the SessionEnd hook groundcrew installs into the agent, which
+ * pipes Claude's hook payload on stdin. Everything here is best-effort: the
+ * hook already swallows a non-zero exit, and a missing token count should
+ * degrade reporting rather than fail a run that otherwise succeeded.
+ */
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function argumentValue(argv: string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+export async function recordUsageCli(argv: string[]): Promise<void> {
+  const task = argumentValue(argv, "--task");
+  if (task === undefined || task.length === 0) {
+    throw new Error("Usage: crew record-usage --task <task> [--transcript <path>]");
+  }
+
+  // Explicit --transcript exists for testing and for agents whose hook payload
+  // shape differs; the stdin payload is the production path.
+  const transcriptPath =
+    argumentValue(argv, "--transcript") ?? transcriptPathFromHookPayload(readStdin());
+  if (transcriptPath === undefined) {
+    return;
+  }
+
+  let transcript: string;
+  try {
+    transcript = readFileSync(transcriptPath, "utf8");
+  } catch {
+    // The transcript can be rotated or cleaned up before the hook runs.
+    return;
+  }
+
+  const session = sumTranscriptUsage(transcript);
+  if (session.messages === 0) {
+    return;
+  }
+
+  const config = await loadConfig();
+  const existing = readRunState(config, task);
+  if (existing === undefined) {
+    // A session outliving its run state is not an error worth failing a hook
+    // over; there is simply nothing left to attribute the tokens to.
+    return;
+  }
+
+  const total: TokenUsage = addTokenUsage(existing.usage ?? emptyTokenUsage(), session);
+
+  updateRunState({ config, task, patch: { state: existing.state, usage: total } });
+}

--- a/src/lib/cmuxAgentHooks.test.ts
+++ b/src/lib/cmuxAgentHooks.test.ts
@@ -13,6 +13,15 @@ function commandFor(settings: CmuxAgentHookSettings, event: string): string {
   return command;
 }
 
+function commandsFor(settings: CmuxAgentHookSettings, event: string): string[] {
+  const hooks = settings.hooks[event]?.[0]?.hooks;
+  if (hooks === undefined) {
+    throw new Error(`No hook commands for event ${event}`);
+  }
+
+  return hooks.map((hook) => hook.command);
+}
+
 describe(buildCmuxAgentHookSettings, () => {
   it("emits one command hook for each lifecycle event", () => {
     const actual = buildCmuxAgentHookSettings({ agent: "claude" });
@@ -59,6 +68,30 @@ describe(buildCmuxAgentHookSettings, () => {
     const actual = commandFor(buildCmuxAgentHookSettings({ agent: "codex" }), "SessionStart");
 
     expect(actual).toContain("running · codex");
+  });
+
+  it("records token usage on SessionEnd, after the progress hook", () => {
+    const actual = commandsFor(buildCmuxAgentHookSettings({ agent: "claude" }), "SessionEnd");
+
+    expect(actual).toHaveLength(2);
+    expect(actual[0]).toContain("set-progress");
+    expect(actual[1]).toContain("groundcrew record-usage");
+  });
+
+  it("adds the usage hook only to SessionEnd, so a session is counted once", () => {
+    const settings = buildCmuxAgentHookSettings({ agent: "claude" });
+
+    for (const event of ["SessionStart", "UserPromptSubmit", "Notification", "Stop"]) {
+      expect(commandsFor(settings, event)).toHaveLength(1);
+    }
+  });
+
+  it("guards the usage hook on the task id and keeps it best-effort", () => {
+    const actual = commandsFor(buildCmuxAgentHookSettings({ agent: "claude" }), "SessionEnd")[1];
+
+    expect(actual).toContain('if [ -n "$GROUNDCREW_TASK_ID" ]');
+    expect(actual).toContain('--task "$GROUNDCREW_TASK_ID"');
+    expect(actual).toContain("|| true");
   });
 });
 

--- a/src/lib/cmuxAgentHooks.ts
+++ b/src/lib/cmuxAgentHooks.ts
@@ -37,7 +37,15 @@ export function buildCmuxAgentHookSettings(input: { agent: string }): CmuxAgentH
 
   const hooks: Record<string, readonly CmuxAgentHookGroup[]> = {};
   for (const phase of phases) {
-    hooks[phase.event] = [{ hooks: [{ type: "command", command: setProgressCommand(phase) }] }];
+    const commands: CmuxAgentHookCommand[] = [
+      { type: "command", command: setProgressCommand(phase) },
+    ];
+
+    if (phase.event === "SessionEnd") {
+      commands.push({ type: "command", command: recordUsageCommand() });
+    }
+
+    hooks[phase.event] = [{ hooks: commands }];
   }
 
   return { hooks };
@@ -57,4 +65,23 @@ function setProgressCommand(phase: CmuxAgentHookPhase): string {
   const setProgress = `"\${CMUX_BUNDLED_CLI_PATH:-cmux}" set-progress ${phase.value} --label ${shellSingleQuote(phase.label)} --workspace "$CMUX_WORKSPACE_ID" >/dev/null 2>&1 || true`;
 
   return `if [ -n "$CMUX_WORKSPACE_ID" ]; then ${setProgress}; fi`;
+}
+
+/**
+ * Record the session's token usage once the agent is finished with it.
+ *
+ * Claude hands a hook `{"transcript_path":..}` on stdin, and the transcript
+ * already carries a `usage` block per assistant message, so the counts cost
+ * nothing extra to collect. `groundcrew record-usage` reads that payload and
+ * folds the totals into the task's run state, which is what makes cost per task
+ * computable alongside the wall clock and pull request outcome already tracked.
+ *
+ * Guarded on `GROUNDCREW_TASK_ID` and swallowing every failure, matching the
+ * progress hook above: a hook must never be able to break the agent it watches,
+ * and a missing token count is a gap in reporting rather than a broken run.
+ */
+function recordUsageCommand(): string {
+  const record = `groundcrew record-usage --task "$GROUNDCREW_TASK_ID" >/dev/null 2>&1 || true`;
+
+  return `if [ -n "$GROUNDCREW_TASK_ID" ]; then ${record}; fi`;
 }

--- a/src/lib/runState.test.ts
+++ b/src/lib/runState.test.ts
@@ -468,4 +468,95 @@ describe("run state store", () => {
       state: "running",
     });
   });
+
+  describe("token usage", () => {
+    const usage = {
+      inputTokens: 11,
+      cacheCreationInputTokens: 22,
+      cacheReadInputTokens: 33,
+      outputTokens: 44,
+      messages: 5,
+    };
+
+    function seed(): void {
+      recordRunState({
+        config,
+        state: {
+          task: "TEAM-9",
+          repository: "repo-a",
+          agent: "claude",
+          worktreeDir: "/work/repo-a-team-9",
+          branchName: "dev-team-9",
+          workspaceName: "team-9",
+          state: "running",
+        },
+      });
+    }
+
+    it("round-trips through a write and a read", () => {
+      // The parser builds RunState field by field, so a field it forgets is
+      // written to disk and silently dropped on the way back.
+      seed();
+      updateRunState({ config, task: "TEAM-9", patch: { state: "running", usage } });
+
+      expect(readRunState(config, "TEAM-9")?.usage).toStrictEqual(usage);
+    });
+
+    it("survives a lifecycle transition that does not mention it", () => {
+      seed();
+      updateRunState({ config, task: "TEAM-9", patch: { state: "running", usage } });
+
+      updateRunState({ config, task: "TEAM-9", patch: { state: "interrupted" } });
+
+      expect(readRunState(config, "TEAM-9")?.usage).toStrictEqual(usage);
+    });
+
+    it("survives a resume that rebuilds the record", () => {
+      // recordRunState reconstructs the state rather than spreading it, so the
+      // counts have to be carried forward explicitly.
+      seed();
+      updateRunState({ config, task: "TEAM-9", patch: { state: "running", usage } });
+
+      recordRunState({
+        config,
+        state: {
+          task: "TEAM-9",
+          repository: "repo-a",
+          agent: "claude",
+          worktreeDir: "/work/repo-a-team-9",
+          branchName: "dev-team-9",
+          workspaceName: "team-9",
+          state: "resumed",
+          resumeCount: 1,
+        },
+      });
+
+      expect(readRunState(config, "TEAM-9")?.usage).toStrictEqual(usage);
+    });
+
+    it("is absent rather than zero when nothing was recorded", () => {
+      // Consumers must be able to tell "no transcript" from "cost nothing".
+      seed();
+
+      expect(readRunState(config, "TEAM-9")?.usage).toBeUndefined();
+    });
+
+    it("reads a malformed total on disk as zeroes rather than failing the record", () => {
+      seed();
+      const statePath = runStatePath(config, "TEAM-9");
+      const onDisk: unknown = JSON.parse(readFileSync(statePath, "utf8"));
+      writeFileSync(
+        statePath,
+        JSON.stringify({ ...(onDisk as object), usage: { outputTokens: "lots" } }),
+      );
+
+      expect(readRunState(config, "TEAM-9")?.usage).toStrictEqual({
+        inputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 0,
+        messages: 0,
+      });
+    });
+  });
 });

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -5,7 +5,7 @@ import { writeJsonAtomic } from "./atomicJson.ts";
 
 import type { ResolvedConfig } from "./config.ts";
 import { normalizePlainTaskId } from "./taskId.ts";
-import type { TokenUsage } from "./tokenUsage.ts";
+import { parseTokenUsage, type TokenUsage } from "./tokenUsage.ts";
 
 export type RunLifecycleState =
   | "provisioning"
@@ -129,6 +129,31 @@ function isValidResumeCount(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
+/**
+ * The fields that are absent rather than defaulted. Split out of parseRunState
+ * so that adding one does not push that function past the complexity ceiling,
+ * and so "absent" keeps meaning absent rather than a zero value.
+ */
+function optionalFields(value: Record<string, unknown>): Partial<RunState> {
+  const reason = stringField(value, "reason");
+  const detail = stringField(value, "detail");
+  const title = stringField(value, "title");
+  const url = stringField(value, "url");
+  const completionTaskId = stringField(value, "completionTaskId");
+  const adoptedBranch = value["adoptedBranch"] === true ? true : undefined;
+  const usage = parseTokenUsage(value["usage"]);
+
+  return {
+    ...(reason === undefined ? {} : { reason }),
+    ...(detail === undefined ? {} : { detail }),
+    ...(title === undefined ? {} : { title }),
+    ...(url === undefined ? {} : { url }),
+    ...(completionTaskId === undefined ? {} : { completionTaskId }),
+    ...(adoptedBranch === undefined ? {} : { adoptedBranch }),
+    ...(usage === undefined ? {} : { usage }),
+  };
+}
+
 function parseRunState(value: unknown): RunState | undefined {
   if (!isPlainObject(value)) {
     return undefined;
@@ -142,12 +167,6 @@ function parseRunState(value: unknown): RunState | undefined {
   const { state, resumeCount } = value;
   const createdAt = stringField(value, "createdAt");
   const updatedAt = stringField(value, "updatedAt");
-  const reason = stringField(value, "reason");
-  const detail = stringField(value, "detail");
-  const title = stringField(value, "title");
-  const url = stringField(value, "url");
-  const completionTaskId = stringField(value, "completionTaskId");
-  const adoptedBranch = value["adoptedBranch"] === true ? true : undefined;
   if (
     task === undefined ||
     repository === undefined ||
@@ -173,12 +192,7 @@ function parseRunState(value: unknown): RunState | undefined {
     createdAt,
     updatedAt,
     resumeCount,
-    ...(reason === undefined ? {} : { reason }),
-    ...(detail === undefined ? {} : { detail }),
-    ...(title === undefined ? {} : { title }),
-    ...(url === undefined ? {} : { url }),
-    ...(completionTaskId === undefined ? {} : { completionTaskId }),
-    ...(adoptedBranch === undefined ? {} : { adoptedBranch }),
+    ...optionalFields(value),
   };
 }
 
@@ -200,16 +214,40 @@ export function readRunState(config: ResolvedConfig, task: string): RunState | u
   }
 }
 
+/**
+ * Fields a caller may omit that must survive the transition anyway.
+ *
+ * Resume and interrupt callers do not know the title or url, so they fall back
+ * to what is already on disk. Token counts go further: they are only ever
+ * accumulated by `record-usage` and never supplied by a dispatch caller, so
+ * they come from disk alone. Rebuilding the record without them silently resets
+ * a task's spend to zero.
+ */
+function carriedFields(fields: {
+  input: RunStateDraft;
+  existing: RunState | undefined;
+}): Partial<RunState> {
+  const { input, existing } = fields;
+  const title = input.title ?? existing?.title;
+  const url = input.url ?? existing?.url;
+  const completionTaskId = input.completionTaskId ?? existing?.completionTaskId;
+  const adoptedBranch = input.adoptedBranch ?? existing?.adoptedBranch;
+  const usage = existing?.usage;
+
+  return {
+    ...(input.reason === undefined ? {} : { reason: input.reason }),
+    ...(input.detail === undefined ? {} : { detail: input.detail }),
+    ...(title === undefined ? {} : { title }),
+    ...(url === undefined ? {} : { url }),
+    ...(completionTaskId === undefined ? {} : { completionTaskId }),
+    ...(adoptedBranch === undefined ? {} : { adoptedBranch }),
+    ...(usage === undefined ? {} : { usage }),
+  };
+}
+
 export function recordRunState(input: RecordRunStateInput): RunState {
   const existing = readRunState(input.config, input.state.task);
   const timestamp = nowIso();
-  // Resume/interrupt callers don't know the title or url, so they omit
-  // them. Fall back to the on-disk value so cached display fields survive
-  // transitions.
-  const title = input.state.title ?? existing?.title;
-  const url = input.state.url ?? existing?.url;
-  const completionTaskId = input.state.completionTaskId ?? existing?.completionTaskId;
-  const adoptedBranch = input.state.adoptedBranch ?? existing?.adoptedBranch;
   const state: RunState = {
     task: taskKey(input.state.task),
     repository: input.state.repository,
@@ -221,12 +259,7 @@ export function recordRunState(input: RecordRunStateInput): RunState {
     createdAt: existing?.createdAt ?? timestamp,
     updatedAt: timestamp,
     resumeCount: input.state.resumeCount ?? existing?.resumeCount ?? 0,
-    ...(input.state.reason === undefined ? {} : { reason: input.state.reason }),
-    ...(input.state.detail === undefined ? {} : { detail: input.state.detail }),
-    ...(title === undefined ? {} : { title }),
-    ...(url === undefined ? {} : { url }),
-    ...(completionTaskId === undefined ? {} : { completionTaskId }),
-    ...(adoptedBranch === undefined ? {} : { adoptedBranch }),
+    ...carriedFields({ input: input.state, existing }),
   };
   writeState(input.config, state);
   return state;

--- a/src/lib/runState.ts
+++ b/src/lib/runState.ts
@@ -5,6 +5,7 @@ import { writeJsonAtomic } from "./atomicJson.ts";
 
 import type { ResolvedConfig } from "./config.ts";
 import { normalizePlainTaskId } from "./taskId.ts";
+import type { TokenUsage } from "./tokenUsage.ts";
 
 export type RunLifecycleState =
   | "provisioning"
@@ -49,6 +50,12 @@ export interface RunState {
    * rather than created by groundcrew. Teardown must preserve such branches.
    */
   adoptedBranch?: boolean;
+  /**
+   * Tokens the agent spent on this task, summed from its session transcripts
+   * and folded across resumes. Absent when the agent reports no transcript, so
+   * consumers must treat missing as unknown rather than as zero.
+   */
+  usage?: TokenUsage;
 }
 
 export interface RunStateDraft {

--- a/src/lib/tokenUsage.test.ts
+++ b/src/lib/tokenUsage.test.ts
@@ -1,0 +1,192 @@
+import {
+  addTokenUsage,
+  emptyTokenUsage,
+  sumTranscriptUsage,
+  type TokenUsage,
+  transcriptPathFromHookPayload,
+} from "./tokenUsage.ts";
+
+function assistantLine(input: {
+  id?: string;
+  inputTokens?: number;
+  cacheCreation?: number;
+  cacheRead?: number;
+  outputTokens?: number;
+}): string {
+  const usage = {
+    input_tokens: input.inputTokens ?? 0,
+    cache_creation_input_tokens: input.cacheCreation ?? 0,
+    cache_read_input_tokens: input.cacheRead ?? 0,
+    output_tokens: input.outputTokens ?? 0,
+  };
+
+  return JSON.stringify({
+    type: "assistant",
+    message: { ...(input.id === undefined ? {} : { id: input.id }), role: "assistant", usage },
+  });
+}
+
+describe(transcriptPathFromHookPayload, () => {
+  it("reads the path Claude puts on stdin", () => {
+    const payload = JSON.stringify({
+      session_id: "abc",
+      transcript_path: "/tmp/session.jsonl",
+      hook_event_name: "SessionEnd",
+    });
+
+    expect(transcriptPathFromHookPayload(payload)).toBe("/tmp/session.jsonl");
+  });
+
+  it.each([
+    ["not json at all", "not json at all"],
+    ["an empty string", ""],
+    ["a payload without the key", JSON.stringify({ session_id: "abc" })],
+    ["an empty path", JSON.stringify({ transcript_path: "" })],
+    ["a non-string path", JSON.stringify({ transcript_path: 42 })],
+    ["a JSON array", JSON.stringify([1, 2, 3])],
+  ])("returns undefined for %s rather than throwing", (_label, payload) => {
+    expect(transcriptPathFromHookPayload(payload)).toBeUndefined();
+  });
+});
+
+describe(sumTranscriptUsage, () => {
+  it("sums the four fields across messages", () => {
+    const transcript = [
+      assistantLine({
+        id: "m1",
+        inputTokens: 10,
+        cacheCreation: 20,
+        cacheRead: 30,
+        outputTokens: 5,
+      }),
+      assistantLine({ id: "m2", inputTokens: 1, cacheCreation: 2, cacheRead: 3, outputTokens: 4 }),
+    ].join("\n");
+
+    expect(sumTranscriptUsage(transcript)).toStrictEqual({
+      inputTokens: 11,
+      cacheCreationInputTokens: 22,
+      cacheReadInputTokens: 33,
+      outputTokens: 9,
+      messages: 2,
+    } satisfies TokenUsage);
+  });
+
+  it("counts a repeated message id once", () => {
+    // A transcript rewrites the same assistant message as it streams and again
+    // on resume. Summing every record inflated a real transcript 2.13x.
+    const line = assistantLine({ id: "m1", inputTokens: 100, outputTokens: 50 });
+    const transcript = [line, line, line].join("\n");
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.inputTokens).toBe(100);
+    expect(actual.outputTokens).toBe(50);
+    expect(actual.messages).toBe(1);
+  });
+
+  it("keeps counting after a malformed line", () => {
+    // Transcripts are appended to while the agent runs, so a half-written final
+    // line is expected rather than exceptional.
+    const transcript = [
+      assistantLine({ id: "m1", outputTokens: 7 }),
+      '{"type":"assistant","message":{"id":"m2","usage":{"output_to',
+      assistantLine({ id: "m3", outputTokens: 3 }),
+    ].join("\n");
+
+    expect(sumTranscriptUsage(transcript).outputTokens).toBe(10);
+  });
+
+  it("counts records that carry usage but no id", () => {
+    // Dropping them would undercount, and without an id there is nothing to
+    // double count against.
+    const transcript = [
+      assistantLine({ outputTokens: 4 }),
+      assistantLine({ outputTokens: 6 }),
+    ].join("\n");
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.outputTokens).toBe(10);
+    expect(actual.messages).toBe(2);
+  });
+
+  it("ignores lines that are valid JSON but not objects", () => {
+    const transcript = [
+      "42",
+      '"a string"',
+      "[1,2,3]",
+      "null",
+      assistantLine({ id: "m1", outputTokens: 8 }),
+    ].join("\n");
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.outputTokens).toBe(8);
+    expect(actual.messages).toBe(1);
+  });
+
+  it("ignores lines that carry no usage", () => {
+    const transcript = [
+      JSON.stringify({ type: "user", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "summary", summary: "a compaction entry" }),
+      assistantLine({ id: "m1", outputTokens: 2 }),
+    ].join("\n");
+
+    expect(sumTranscriptUsage(transcript).messages).toBe(1);
+  });
+
+  it("treats missing and null fields as zero without dropping the message", () => {
+    const transcript = JSON.stringify({
+      type: "assistant",
+      message: { id: "m1", usage: { output_tokens: 9, cache_read_input_tokens: null } },
+    });
+
+    expect(sumTranscriptUsage(transcript)).toStrictEqual({
+      inputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      outputTokens: 9,
+      messages: 1,
+    } satisfies TokenUsage);
+  });
+
+  it("never collapses cache reads into fresh input", () => {
+    // Cache reads bill at roughly a tenth of fresh input. A single total would
+    // price a cache-heavy session as though none of it were cached.
+    const transcript = assistantLine({ id: "m1", inputTokens: 1, cacheRead: 1_000_000 });
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.inputTokens).toBe(1);
+    expect(actual.cacheReadInputTokens).toBe(1_000_000);
+  });
+
+  it.each([
+    ["an empty transcript", ""],
+    ["only blank lines", "\n\n   \n"],
+    ["only malformed lines", "{{{\nnot json\n"],
+  ])("returns an empty total for %s", (_label, transcript) => {
+    expect(sumTranscriptUsage(transcript)).toStrictEqual(emptyTokenUsage());
+  });
+});
+
+describe(addTokenUsage, () => {
+  it("folds a resumed session into the counts already recorded", () => {
+    const first = sumTranscriptUsage(assistantLine({ id: "m1", inputTokens: 5, outputTokens: 1 }));
+    const second = sumTranscriptUsage(assistantLine({ id: "m2", inputTokens: 3, outputTokens: 2 }));
+
+    expect(addTokenUsage(first, second)).toStrictEqual({
+      inputTokens: 8,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      outputTokens: 3,
+      messages: 2,
+    } satisfies TokenUsage);
+  });
+
+  it("leaves a total unchanged when folding in an empty one", () => {
+    const usage = sumTranscriptUsage(assistantLine({ id: "m1", outputTokens: 4 }));
+
+    expect(addTokenUsage(usage, emptyTokenUsage())).toStrictEqual(usage);
+  });
+});

--- a/src/lib/tokenUsage.test.ts
+++ b/src/lib/tokenUsage.test.ts
@@ -85,6 +85,45 @@ describe(sumTranscriptUsage, () => {
     expect(actual.messages).toBe(1);
   });
 
+  it("takes the highest value when a repeated record grows", () => {
+    // Some agent versions rewrite a streaming message with cumulative counts
+    // rather than repeating it verbatim. Keeping the first record would report
+    // 2 output tokens for a message that finished at 19.
+    const transcript = [
+      JSON.stringify({ message: { id: "m1", usage: { output_tokens: 2 } } }),
+      JSON.stringify({ message: { id: "m1", usage: { output_tokens: 7 } } }),
+      JSON.stringify({ message: { id: "m1", usage: { output_tokens: 19 } } }),
+    ].join("\n");
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.outputTokens).toBe(19);
+    expect(actual.messages).toBe(1);
+  });
+
+  it("takes the highest value even when the last record is smaller", () => {
+    // A trailing partial record must not undo a complete one, which is why
+    // this is a maximum rather than last-wins.
+    const transcript = [
+      JSON.stringify({ message: { id: "m1", usage: { output_tokens: 19 } } }),
+      JSON.stringify({ message: { id: "m1", usage: { output_tokens: 2 } } }),
+    ].join("\n");
+
+    expect(sumTranscriptUsage(transcript).outputTokens).toBe(19);
+  });
+
+  it("compares each field independently across repeats", () => {
+    const transcript = [
+      JSON.stringify({ message: { id: "m1", usage: { input_tokens: 9, output_tokens: 1 } } }),
+      JSON.stringify({ message: { id: "m1", usage: { input_tokens: 1, output_tokens: 8 } } }),
+    ].join("\n");
+
+    const actual = sumTranscriptUsage(transcript);
+
+    expect(actual.inputTokens).toBe(9);
+    expect(actual.outputTokens).toBe(8);
+  });
+
   it("keeps counting after a malformed line", () => {
     // Transcripts are appended to while the agent runs, so a half-written final
     // line is expected rather than exceptional.

--- a/src/lib/tokenUsage.test.ts
+++ b/src/lib/tokenUsage.test.ts
@@ -1,6 +1,7 @@
 import {
   addTokenUsage,
   emptyTokenUsage,
+  parseTokenUsage,
   sumTranscriptUsage,
   type TokenUsage,
   transcriptPathFromHookPayload,
@@ -188,5 +189,49 @@ describe(addTokenUsage, () => {
     const usage = sumTranscriptUsage(assistantLine({ id: "m1", outputTokens: 4 }));
 
     expect(addTokenUsage(usage, emptyTokenUsage())).toStrictEqual(usage);
+  });
+});
+
+describe(parseTokenUsage, () => {
+  it("reads a persisted total back", () => {
+    const usage: TokenUsage = {
+      inputTokens: 1,
+      cacheCreationInputTokens: 2,
+      cacheReadInputTokens: 3,
+      outputTokens: 4,
+      messages: 5,
+    };
+
+    expect(parseTokenUsage(JSON.parse(JSON.stringify(usage)))).toStrictEqual(usage);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["a number", 42],
+    ["a string", "usage"],
+    ["an array", [1, 2, 3]],
+  ])("returns undefined for %s, so absent stays distinguishable from zero", (_label, value) => {
+    expect(parseTokenUsage(value)).toBeUndefined();
+  });
+
+  it("zeroes fields that are missing or the wrong type rather than rejecting the record", () => {
+    // A record that fails to parse would lose every count; a field that fails to
+    // parse should lose only itself.
+    expect(parseTokenUsage({ outputTokens: 7, inputTokens: "many", messages: null })).toStrictEqual(
+      {
+        inputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        outputTokens: 7,
+        messages: 0,
+      } satisfies TokenUsage,
+    );
+  });
+
+  it("round-trips whatever sumTranscriptUsage produced", () => {
+    const summed = sumTranscriptUsage(assistantLine({ id: "m1", inputTokens: 9, outputTokens: 2 }));
+
+    expect(parseTokenUsage(JSON.parse(JSON.stringify(summed)))).toStrictEqual(summed);
   });
 });

--- a/src/lib/tokenUsage.ts
+++ b/src/lib/tokenUsage.ts
@@ -15,8 +15,9 @@
  * were distinct, and summing every record inflated the total 2.13x. The
  * inflation is not uniform across fields either (2.10x on cache reads against
  * 2.64x on output), so it cannot be corrected with a constant factor after the
- * fact: it distorts the mix as well as the total. Usage is therefore counted
- * once per `message.id`.
+ * fact: it distorts the mix as well as the total. Usage is therefore collapsed
+ * per `message.id`, taking the highest value seen for each field. See
+ * `highestPerField` for why the maximum rather than the first or the last.
  *
  * The second is keeping the four fields apart. Cache reads bill at roughly a
  * tenth of fresh input, so a single `totalTokens` would make a cached-heavy
@@ -88,7 +89,7 @@ export function transcriptPathFromHookPayload(stdin: string): string | undefined
  */
 export function sumTranscriptUsage(transcript: string): TokenUsage {
   const total = emptyTokenUsage();
-  const counted = new Set<string>();
+  const counted = new Map<string, TokenUsage>();
 
   for (const line of transcript.split("\n")) {
     const trimmed = line.trim();
@@ -103,34 +104,76 @@ export function sumTranscriptUsage(transcript: string): TokenUsage {
       continue;
     }
 
-    const record = asRecord(entry);
-    if (record === undefined) {
+    const entryRecord = asRecord(entry);
+    if (entryRecord === undefined) {
       continue;
     }
 
-    const message = asRecord(record["message"]);
-    const usage = asRecord(message?.["usage"] ?? record["usage"]);
+    const message = asRecord(entryRecord["message"]);
+    const usage = asRecord(message?.["usage"] ?? entryRecord["usage"]);
     if (usage === undefined) {
       continue;
     }
 
+    const record: TokenUsage = {
+      inputTokens: count(usage["input_tokens"]),
+      cacheCreationInputTokens: count(usage["cache_creation_input_tokens"]),
+      cacheReadInputTokens: count(usage["cache_read_input_tokens"]),
+      outputTokens: count(usage["output_tokens"]),
+      messages: 1,
+    };
+
     const id = message?.["id"];
     if (typeof id === "string" && id.length > 0) {
-      if (counted.has(id)) {
-        continue;
-      }
-
-      counted.add(id);
+      counted.set(id, highestPerField(counted.get(id), record));
+      continue;
     }
 
-    total.inputTokens += count(usage["input_tokens"]);
-    total.cacheCreationInputTokens += count(usage["cache_creation_input_tokens"]);
-    total.cacheReadInputTokens += count(usage["cache_read_input_tokens"]);
-    total.outputTokens += count(usage["output_tokens"]);
-    total.messages += 1;
+    // No id means nothing to collapse against, so it stands on its own.
+    accumulate(total, record);
+  }
+
+  for (const perMessage of counted.values()) {
+    accumulate(total, perMessage);
   }
 
   return total;
+}
+
+function accumulate(total: TokenUsage, record: TokenUsage): void {
+  total.inputTokens += record.inputTokens;
+  total.cacheCreationInputTokens += record.cacheCreationInputTokens;
+  total.cacheReadInputTokens += record.cacheReadInputTokens;
+  total.outputTokens += record.outputTokens;
+  total.messages += record.messages;
+}
+
+/**
+ * Reduce repeated records for one message to a single set of counts.
+ *
+ * Taking the highest value per field is correct under both shapes a transcript
+ * can take, which matters because the shape is not guaranteed across agent
+ * versions. Where repeats are exact duplicates, every candidate is equal and
+ * the maximum is that value. Where they are cumulative streaming snapshots,
+ * the maximum is the final complete count. Keeping the first record would
+ * undercount the second case badly, and keeping the last would undercount the
+ * first if a trailing record were ever partial.
+ */
+function highestPerField(existing: TokenUsage | undefined, record: TokenUsage): TokenUsage {
+  if (existing === undefined) {
+    return record;
+  }
+
+  return {
+    inputTokens: Math.max(existing.inputTokens, record.inputTokens),
+    cacheCreationInputTokens: Math.max(
+      existing.cacheCreationInputTokens,
+      record.cacheCreationInputTokens,
+    ),
+    cacheReadInputTokens: Math.max(existing.cacheReadInputTokens, record.cacheReadInputTokens),
+    outputTokens: Math.max(existing.outputTokens, record.outputTokens),
+    messages: 1,
+  };
 }
 
 /**

--- a/src/lib/tokenUsage.ts
+++ b/src/lib/tokenUsage.ts
@@ -133,6 +133,28 @@ export function sumTranscriptUsage(transcript: string): TokenUsage {
   return total;
 }
 
+/**
+ * Read a persisted total back off disk.
+ *
+ * Lives here rather than in the run state parser so that the field names exist
+ * in exactly one place: a reader that drifts from the writer loses counts
+ * silently, which is the failure this function is guarding against.
+ */
+export function parseTokenUsage(value: unknown): TokenUsage | undefined {
+  const usage = asRecord(value);
+  if (usage === undefined) {
+    return undefined;
+  }
+
+  return {
+    inputTokens: count(usage["inputTokens"]),
+    cacheCreationInputTokens: count(usage["cacheCreationInputTokens"]),
+    cacheReadInputTokens: count(usage["cacheReadInputTokens"]),
+    outputTokens: count(usage["outputTokens"]),
+    messages: count(usage["messages"]),
+  };
+}
+
 /** Fold a resumed session's counts into the ones already recorded. */
 export function addTokenUsage(left: TokenUsage, right: TokenUsage): TokenUsage {
   return {

--- a/src/lib/tokenUsage.ts
+++ b/src/lib/tokenUsage.ts
@@ -1,0 +1,145 @@
+/**
+ * Token accounting for agent sessions.
+ *
+ * `status` already records wall clock and pull request outcomes, so the only
+ * thing missing before cost per task is computable is the token count. Claude
+ * writes one JSONL transcript per session and stamps each assistant message
+ * with its own `usage`, so the numbers exist already and cost nothing extra to
+ * collect: no API call, no provider lookup, no second run.
+ *
+ * Two details decide whether the resulting number is trustworthy.
+ *
+ * The first is deduplication. A transcript contains the same assistant message
+ * more than once, because a message is rewritten as it streams and again when a
+ * session resumes. On a real 718-usage-record transcript only 327 message ids
+ * were distinct, and summing every record inflated the total 2.13x. The
+ * inflation is not uniform across fields either (2.10x on cache reads against
+ * 2.64x on output), so it cannot be corrected with a constant factor after the
+ * fact: it distorts the mix as well as the total. Usage is therefore counted
+ * once per `message.id`.
+ *
+ * The second is keeping the four fields apart. Cache reads bill at roughly a
+ * tenth of fresh input, so a single `totalTokens` would make a cached-heavy
+ * workload look far more expensive than it is. Pricing belongs downstream,
+ * where the rate sheet lives; this module counts and does not price.
+ */
+
+/** Token counts for one agent session, kept unpriced and unsummed. */
+export interface TokenUsage {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  outputTokens: number;
+  /** Distinct assistant messages the counts came from. */
+  messages: number;
+}
+
+export function emptyTokenUsage(): TokenUsage {
+  return {
+    inputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    outputTokens: 0,
+    messages: 0,
+  };
+}
+
+/** Absent, null and non-numeric all mean zero; a real 0 must survive as 0. */
+function count(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+/**
+ * The transcript path Claude hands a hook on stdin.
+ *
+ * Hooks receive `{"session_id":..,"transcript_path":..,"hook_event_name":..}`.
+ * A malformed or unexpected payload returns undefined rather than throwing, so
+ * a hook can never break the agent it is observing.
+ */
+export function transcriptPathFromHookPayload(stdin: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdin);
+  } catch {
+    return undefined;
+  }
+
+  const path = asRecord(parsed)?.["transcript_path"];
+
+  return typeof path === "string" && path.length > 0 ? path : undefined;
+}
+
+/**
+ * Sum a session transcript, counting each assistant message once.
+ *
+ * Malformed lines are skipped rather than fatal: a transcript is appended to
+ * while the agent runs, so reading one mid-write is expected and a partial
+ * final line should cost the caller nothing. Records carrying usage but no id
+ * are counted, since dropping them would undercount, and no id means there is
+ * nothing to double count against.
+ */
+export function sumTranscriptUsage(transcript: string): TokenUsage {
+  const total = emptyTokenUsage();
+  const counted = new Set<string>();
+
+  for (const line of transcript.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    let entry: unknown;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const record = asRecord(entry);
+    if (record === undefined) {
+      continue;
+    }
+
+    const message = asRecord(record["message"]);
+    const usage = asRecord(message?.["usage"] ?? record["usage"]);
+    if (usage === undefined) {
+      continue;
+    }
+
+    const id = message?.["id"];
+    if (typeof id === "string" && id.length > 0) {
+      if (counted.has(id)) {
+        continue;
+      }
+
+      counted.add(id);
+    }
+
+    total.inputTokens += count(usage["input_tokens"]);
+    total.cacheCreationInputTokens += count(usage["cache_creation_input_tokens"]);
+    total.cacheReadInputTokens += count(usage["cache_read_input_tokens"]);
+    total.outputTokens += count(usage["output_tokens"]);
+    total.messages += 1;
+  }
+
+  return total;
+}
+
+/** Fold a resumed session's counts into the ones already recorded. */
+export function addTokenUsage(left: TokenUsage, right: TokenUsage): TokenUsage {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    cacheCreationInputTokens: left.cacheCreationInputTokens + right.cacheCreationInputTokens,
+    cacheReadInputTokens: left.cacheReadInputTokens + right.cacheReadInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    messages: left.messages + right.messages,
+  };
+}


### PR DESCRIPTION
## Why

`status` already reports wall clock and pull request outcomes, so tokens were the
only thing missing before cost per task became computable. It turns out they cost
nothing to collect: Claude writes a JSONL transcript per session and stamps every
assistant message with its own `usage`, so there is no API call, no provider
lookup, and no second run involved. `usage.ts` currently tracks quota percentages
from codexbar, which tell you how close a run is to a limit but never what it
cost.

That gap is why `agent-any` routes on session headroom alone. Once the tokens are
recorded, the routing decision has a real input rather than a proxy for one.

## What

The `SessionEnd` hook groundcrew already installs now also invokes
`groundcrew record-usage`, which reads the transcript path from the hook payload
on stdin, sums the session, and folds the totals into the task's run state as
`RunState.usage`.

The hook is guarded on `GROUNDCREW_TASK_ID` and swallows every failure, the same
shape as the `set-progress` hook beside it, because a hook should never be able to
break the agent it is observing. A missing count degrades reporting rather than
failing a run.

## Two decisions worth reviewing

**Usage is counted once per message id.** A transcript contains the same assistant
message repeatedly, because it is rewritten while streaming and again when a
session resumes. On a real transcript, 718 records carried usage but only 327
message ids were distinct, and summing every record inflated the total **2.13x**.
The inflation is not uniform across fields either, 2.10x on cache reads against
2.64x on output, so it cannot be corrected with a constant after the fact. It
distorts the input/output mix as well as the total.

**The four fields stay separate.** Cache reads bill at roughly a tenth of fresh
input, so a single `totalTokens` would price a cache-heavy session as though none
of it had been cached. This module counts and deliberately does not price; a rate
sheet belongs wherever pricing is decided.

## Scope and limits

Claude only. Codex installs hooks through a different mechanism and I could not
verify that it exposes an equivalent transcript, so rather than report a confident
zero for codex runs, `usage` is simply absent there. **Consumers must read a
missing `usage` as unknown, never as zero.** Wiring codex up is a follow-up for
someone who knows that CLI better than I do.

Nothing consumes the field yet. Surfacing it in `status` output is deliberately
left out to keep this reviewable as a single concept.

## Validation

`node --run verify` passes, including the 100% coverage thresholds.

- 20 tests on the parser, covering partially written transcripts, records without
  ids, non-object JSON lines, and the deduplication above
- 13 tests on the command, covering the stdin payload path, a missing transcript,
  a session that outlives its run state, and lifecycle preservation
- 4 tests on the hook wiring
- Full suite: 2,209 tests passing, coverage 100% on statements, branches,
  functions and lines
