### PR TITLE
fix: clean only delivered runs

### DIFF
--- a/v2/CONTEXT.md
+++ b/v2/CONTEXT.md
@@ -22,8 +22,8 @@ Status keeps those layers separate.
 
 Cleanup is always an explicit operator action. Source terminality affects dispatch eligibility
 but never closes a presented workspace or removes local task state. `crew cleanup <task>` tears
-down one Run, `crew cleanup --completed` tears down completed Runs without stopping active Runs,
-and `crew cleanup --all` tears down every local Run.
+down one Run, `crew cleanup --delivered` tears down delivered Runs without stopping active Runs or
+removing failed or stopped Runs, and `crew cleanup --all` tears down every local Run.
 
 A **source bundle** is a directory containing `source.json` and executable protocol commands.
 A configured **source instance** gives that bundle an instance name and environment. A

--- a/v2/e2e/dispatch.e2e.test.ts
+++ b/v2/e2e/dispatch.e2e.test.ts
@@ -424,34 +424,51 @@ describe("crew start", () => {
     await expect(stat(fixture.workspaceDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("cleans only completed runs with --completed", async () => {
+  it("cleans only delivered runs with --delivered", async () => {
     const fixture = await createDispatchFixture({
-      maximumInProgress: 2,
+      maximumInProgress: 4,
       tasks: [
-        task({ id: "DONE-1", priority: 1, repositories: [] }),
-        task({ id: "ACTIVE-1", priority: 2, repositories: [] }),
+        task({ id: "DELIVERED-1", priority: 1, repositories: [] }),
+        task({ id: "FAILED-1", priority: 2, repositories: [] }),
+        task({ id: "STOPPED-1", priority: 3, repositories: [] }),
+        task({ id: "ACTIVE-1", priority: 4, repositories: [] }),
       ],
     });
     await runCrew({ arguments: ["start"], environment: fixture.environment });
     await runCrew({
-      arguments: ["done", "--task", "DONE-1"],
+      arguments: ["done", "--task", "DELIVERED-1", "--outcome", "delivered"],
+      environment: fixture.environment,
+    });
+    await runCrew({
+      arguments: ["done", "--task", "FAILED-1", "--outcome", "failed"],
+      environment: fixture.environment,
+    });
+    await runCrew({
+      arguments: ["done", "--task", "STOPPED-1", "--outcome", "stopped"],
       environment: fixture.environment,
     });
 
     const result = await runCrew({
-      arguments: ["cleanup", "--completed"],
+      arguments: ["cleanup", "--delivered"],
       environment: fixture.environment,
     });
 
-    expect(result.stdout).toContain("Cleaned fixture:DONE-1");
+    expect(result.stdout).toContain("Cleaned fixture:DELIVERED-1");
+    expect(result.stdout).not.toContain("fixture:FAILED-1");
+    expect(result.stdout).not.toContain("fixture:STOPPED-1");
     expect(result.stdout).not.toContain("fixture:ACTIVE-1");
-    await expect(stat(join(fixture.runsDirectory, "fixture-done-1.json"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-    expect(
-      JSON.parse(await readFile(join(fixture.runsDirectory, "fixture-active-1.json"), "utf8")),
-    ).toMatchObject({ state: "running" });
-    expect(JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")).workspaces).toHaveLength(1);
+    await expect(
+      stat(join(fixture.runsDirectory, "fixture-delivered-1.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await Promise.all(
+      ["failed-1", "stopped-1", "active-1"].map(
+        async (id) =>
+          await expect(
+            stat(join(fixture.runsDirectory, `fixture-${id}.json`)),
+          ).resolves.toBeDefined(),
+      ),
+    );
+    expect(JSON.parse(await readFile(fixture.cmuxStatePath, "utf8")).workspaces).toHaveLength(3);
     const cmuxCalls = (await readFile(fixture.cmuxCallsPath, "utf8"))
       .trim()
       .split("\n")
@@ -465,20 +482,20 @@ describe("crew start", () => {
 
   it("requires exactly one cleanup selector", async () => {
     const fixture = await createDispatchFixture();
-    const expectedError = "cleanup requires exactly one of a task, --all, or --completed";
+    const expectedError = "cleanup requires exactly one of a task, --all, or --delivered";
 
     await expect(
       runCrew({ arguments: ["cleanup"], environment: fixture.environment }),
     ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });
     await expect(
       runCrew({
-        arguments: ["cleanup", "ENG-123", "--completed"],
+        arguments: ["cleanup", "ENG-123", "--delivered"],
         environment: fixture.environment,
       }),
     ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });
     await expect(
       runCrew({
-        arguments: ["cleanup", "--all", "--completed"],
+        arguments: ["cleanup", "--all", "--delivered"],
         environment: fixture.environment,
       }),
     ).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining(expectedError) });

--- a/v2/src/core/index.ts
+++ b/v2/src/core/index.ts
@@ -170,7 +170,7 @@ export interface Application {
   cleanup(input: {
     readonly task?: string | undefined;
     readonly all: boolean;
-    readonly completed: boolean;
+    readonly delivered: boolean;
     readonly allowDirty: boolean;
   }): Promise<{
     readonly cleaned: readonly string[];
@@ -814,7 +814,7 @@ async function cleanup(input: {
   readonly runtime: Runtime;
   readonly task?: string | undefined;
   readonly all: boolean;
-  readonly completed: boolean;
+  readonly delivered: boolean;
   readonly allowDirty: boolean;
 }): Promise<{
   readonly cleaned: readonly string[];
@@ -822,20 +822,22 @@ async function cleanup(input: {
 }> {
   const { runtime } = input;
   const selectorCount =
-    Number(input.task !== undefined) + Number(input.all) + Number(input.completed);
+    Number(input.task !== undefined) + Number(input.all) + Number(input.delivered);
   if (selectorCount !== 1) {
-    throw new Error("cleanup requires exactly one of a task, --all, or --completed");
+    throw new Error("cleanup requires exactly one of a task, --all, or --delivered");
   }
   const localRuns = await runtime.runs.list();
   let runs: readonly RunHandle[];
   if (input.all) {
     runs = localRuns;
-  } else if (input.completed) {
-    runs = localRuns.filter((run) => run.state === "complete");
+  } else if (input.delivered) {
+    runs = localRuns.filter(
+      (run) => run.state === "complete" && run.record.outcome === "delivered",
+    );
   } else if (input.task !== undefined) {
     runs = [await runtime.runs.resolve({ query: input.task })];
   } else {
-    throw new Error("cleanup requires exactly one of a task, --all, or --completed");
+    throw new Error("cleanup requires exactly one of a task, --all, or --delivered");
   }
   const cleaned: string[] = [];
   const preservedBranches: string[] = [];

--- a/v2/src/shell/index.ts
+++ b/v2/src/shell/index.ts
@@ -224,7 +224,7 @@ export async function main(input: MainInput): Promise<void> {
     .description("close presenters and safely remove task worktrees")
     .argument("[task]", "canonical or source-local task ID")
     .option("--all", "clean every local task")
-    .option("--completed", "clean every completed local run")
+    .option("--delivered", "clean every delivered local run")
     .option("--force", "permanently delete dirty worktrees and unique task branches")
     .option("--verbose", "include debug diagnostics")
     .action(async (task, options) => {
@@ -232,7 +232,7 @@ export async function main(input: MainInput): Promise<void> {
       const result = await application.cleanup({
         all: options.all === true,
         allowDirty: options.force === true,
-        completed: options.completed === true,
+        delivered: options.delivered === true,
         task,
       });
       for (const canonicalTaskId of result.cleaned) {


### PR DESCRIPTION
## Why

`crew cleanup --completed` treated every terminal run as disposable, so it removed failed and stopped runs along with delivered work. Those retained runs are useful for diagnosis and continuation. This has no direct customer impact; it reduces the operational risk of discarding local run state that still needs attention.

## Summary

- Rename the cleanup selector from `--completed` to `--delivered`.
- Remove only completed runs whose recorded outcome is `delivered`.
- Preserve failed, stopped, and active runs, with built-CLI e2e coverage for all four outcomes.
- Update the domain contract and CLI help.

## Validation

- `cd v2 && node --run verify` — 135 passed, 1 skipped.
- `cd v2 && node --run crew -- cleanup --help` — advertises `--delivered` and no longer advertises `--completed`.
- Pre-push repository checks — 2,187 tests passed with 100% coverage; all checks passed.

Agent session: `codex resume 01a0124d-7462-7270-94d0-0601f41c83cf`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>
