### PR TITLE
feat: add stable status JSON contract (TEM-3892)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ crew task get <TASK> [--source <name>] [--prompt]        # inspect one task or i
 crew task create "Title" --source <name> [--agent <name>] # create a source task
 crew task done <TASK> [--allow-dirty]                    # mark a no-PR task done
 crew task validate [<source>]                            # validate task content
-crew status [<TASK>] [--json [--local-only]]           # inspect current state, or emit it as JSON
+crew status [<TASK>] [--json]                          # inspect current state, or emit it as JSON
 crew run [--watch]                                       # one-shot or --watch forever
 crew start <TASK>                                      # provision + launch one task now
 crew stop <TASK> [--reason <text>]                     # stop workspace, keep worktree
@@ -127,49 +127,17 @@ crew completions <bash|zsh|fish>                        # print a shell completi
 
 See [command details](./docs/commands.md) for status output, doctor behavior, and the stop/resume workflow.
 
-### Status snapshots for external monitors
+### Status JSON for integrations
 
-`crew status --json` prints two documents and writes them beside the log file:
+`crew status --json` emits one inventory document. `crew status <TASK> --json`
+emits one task document. Each successful invocation writes exactly one JSON
+document to stdout and does not persist a snapshot. Partial probe failures are
+reported in `problems`; fatal failures write only to stderr and exit non-zero.
 
-```text
-<state-dir>/status-local.json     # worktrees, run states, sessions, git status
-<state-dir>/status-remote.json    # board, pull requests
-```
-
-The two are split by cost. The local tier is local subprocess work, so it is
-safe to poll every few seconds. The remote tier is network-bound and
-rate-limited, so poll it near your `pollIntervalMilliseconds`.
-
-```bash
-crew status --json                # both tiers
-crew status --json --local-only   # local tier only; never touches the network
-```
-
-`--local-only` is a guarantee about that invocation, not a computed outcome, so
-a monitor's fast loop cannot stall on a slow board or a `gh` timeout.
-
-Three rules a reader must honor:
-
-- **Subtract locally.** `status-remote.json` ships board classification without
-  the local worktree subtraction. Remove tasks present in the local document
-  from `inProgress`, `queueReady`, and `queueBlocked` yourself. Precomputing
-  that join would report a just-dispatched task as still queued until the next
-  slow poll, which is a false statement rather than stale data.
-- **Join pull requests on the worktree directory.** `pullRequestsByWorktree` is
-  keyed by absolute worktree path, not by task, because a task with two
-  worktrees has two branches. An empty or missing entry means no pull requests
-  were found, or the `gh` lookup for that worktree failed; the two are not
-  distinguishable.
-- **Read the right timestamp.** `payload.capturedAt` describes the last
-  successful fetch; `lastAttemptAt` describes the most recent try. Read
-  `lastAttemptStatus` to answer "is the board healthy", and `capturedAt` to
-  answer "how old is this queue". A failed fetch keeps the previous payload, so
-  last-known-good data survives an outage while the document still says the
-  board is unreachable.
-
-Durations are never stored, only start instants, so a reader must derive
-elapsed time itself. A cached duration would show a frozen clock, which reads
-as "the agent stopped working" when it did not.
+The read-only integration command set is deliberately small: `crew --version`,
+`crew task list --json`, `crew task get <TASK> --json`, and the two status JSON
+modes above. See [Command details](./docs/commands.md#status-json-contract) for
+the complete field and compatibility contract.
 
 ## Configuration
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,18 +84,87 @@ crew task done todo:flaky-triage-1
 
 `crew status <TASK>` prints a read-only snapshot for one task: cached title and URL when present, recorded run state, live workspace presence, matching worktrees, git dirtiness, PR links for matching branches, recent log lines when present, and the task status from the configured task source.
 
-`crew status` with no task prints the current inventory: known worktrees with cached task metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. When the source fetch succeeds, status also prints any in-progress source tasks with no local worktree, slot usage, and Queue/Blocked sections for eligible Todo tasks. Worktree-less in-progress rows include the task title, URL when the source provides one, and repository when the source resolves one. If the source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted.
+`crew status` with no task prints the current inventory: known worktrees with cached task metadata, workspace/run-state agreement, attach hints, worktree paths, PR links, and stray sessions reported by the configured backend. When the source fetch succeeds, status also prints any in-progress source tasks with no local worktree, slot usage, and Queue/Blocked sections for eligible Todo tasks. Worktree-less in-progress rows include the task title, URL when the source provides one, and repository when the source resolves one. If every source fetch fails, Queue shows `unavailable: <reason>` and the slots line is omitted. If only some sources fail, healthy queue rows remain visible beside a Source problems section and slot usage is marked unknown.
 
 Status is informational only. Use `crew cleanup <TASK>` to tear down stale worktrees and `crew resume <TASK>` to reopen preserved work.
 
-`crew status --json` emits the same state as two JSON documents instead of text,
-and writes them beside the log file as `status-local.json` and
-`status-remote.json`. The split is by cost: the local document is subprocess
-work only, so an external monitor can poll it every few seconds, while the
-remote document holds the board fetch and PR lookups. `crew status --json
---local-only` collects the local document alone and never touches the network.
-See [Status snapshots for external monitors](../README.md#status-snapshots-for-external-monitors)
-for the reader contract. Text mode writes nothing.
+### Status JSON contract
+
+```bash
+crew status --json
+crew status TEAM-123 --json
+```
+
+Each successful command writes exactly one JSON document to stdout. It contains
+no headings, ANSI styling, diagnostic lines, or recent log contents. Status
+does not write snapshot files. A fatal error before a snapshot can be produced
+writes nothing to stdout, reports a human-readable message on stderr, and exits
+non-zero.
+
+Both documents have these required fields:
+
+| Field         | Type                    | Meaning                                            |
+| ------------- | ----------------------- | -------------------------------------------------- |
+| `kind`        | `"inventory" \| "task"` | Selects the document shape.                        |
+| `generatedAt` | ISO-8601 string         | Time collection for this snapshot started.         |
+| `problems`    | problem array           | Partial probe failures; empty when probes succeed. |
+
+An inventory document additionally contains:
+
+| Field                        | Type                  | Meaning                                                                                        |
+| ---------------------------- | --------------------- | ---------------------------------------------------------------------------------------------- |
+| `slots`                      | object                | `maximum` is configured capacity; `used` is present only when every task source was available. |
+| `worktrees`                  | inventory worktree[]  | One entry per local worktree.                                                                  |
+| `inProgressWithoutWorktrees` | queue entry[]         | In-progress source tasks that have no local worktree.                                          |
+| `queue.ready`                | queue entry[]         | Eligible Todo tasks with no open blocker and no local worktree.                                |
+| `queue.blocked`              | blocked queue entry[] | Eligible Todo tasks with open blockers and no local worktree.                                  |
+| `straySessions`              | stray session[]       | Live or exited workspaces with no matching local worktree.                                     |
+
+A task document additionally contains `task`, optional `repository`, `run`,
+`workspace`, `worktrees`, and `recommendedActions`. Its `worktrees` array is
+empty when no local worktree exists.
+
+Task identities contain required `naturalId` and optional canonical `id`,
+`title`, canonical `status`, and `url`. Queue entries add optional `repository`
+and `agent`, plus required `recommendedActions`. Blocked queue entries add
+`blockedBy`; each blocker contains `id`, `naturalId`, canonical `status`, and
+optional source-native `nativeStatus`.
+
+`run.lifecycle` is `idle` or a recorded Groundcrew lifecycle. The remaining run
+fields are optional: `agent`, `startedAt`, `updatedAt`, `resumeCount`, and `reason`.
+Consumers derive elapsed time from `startedAt`; durations are not stored.
+`workspace.state` is `live`, `exited`, `not-live`, or `unknown`.
+
+A task worktree contains `repository`, `kind`, `branch`, absolute `directory`,
+`dirtiness`, and `pullRequests`. Dirtiness has `kind: "clean"`,
+`kind: "unknown"`, or `kind: "dirty"` with `modified` and `untracked` counts.
+Each pull request contains `url`, `number`, lowercase `state`, and `title`.
+Inventory worktrees add their `task`, `run`, `workspace`, and
+`recommendedActions`.
+
+Recommended actions are stable codes: `stop` closes a workspace, `resume`
+reopens preserved work, `cleanup` removes a local worktree, `run` recreates
+work for an eligible in-progress task with no local worktree, and `open-task`,
+`open-pr`, and `open-worktree` navigate to the represented resource. An action
+is omitted when its required target data is unavailable: `run` requires a
+repository and agent, while each `open-*` action requires the represented URL
+or worktree. Consumers must tolerate unknown future action codes. A stray
+session contains its `name`, `state`, and `recommendedActions`.
+
+Problems contain required `code` and human-readable `message`, plus optional
+`source`, `task`, and `worktreeDirectory` context. Current codes are
+`source-probe-failed`, `workspace-probe-failed`, `git-probe-failed`, and
+`github-probe-failed`. A partial failure keeps the command successful and does
+not discard data from probes that succeeded. Consumers must tolerate unknown
+future problem codes. Messages are short public summaries and deliberately do
+not include raw subprocess output; use human-readable status or debug logs for
+detailed diagnostics.
+
+Groundcrew SemVer governs compatibility. Adding optional fields is compatible;
+existing required fields will not be removed, renamed, or change meaning in a
+compatible release. Consumers must ignore unknown fields. There is no embedded
+schema-version negotiation field. A future incompatible format requires either
+a new explicitly selectable JSON version or a Groundcrew major release.
 
 <details>
 <summary>Sample task status output</summary>

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -393,6 +393,16 @@ describe(run, () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("keeps stdout empty and reports a fatal status JSON failure on stderr", async () => {
+    statusMock.mockRejectedValue(new Error("worktree inventory unreadable"));
+
+    await run(["status", "--json"]);
+
+    expect(consoleLog.output()).toBe("");
+    expect(consoleError.output()).toBe("worktree inventory unreadable");
+    expect(process.exitCode).toBe(1);
+  });
+
   it("dispatches task namespace arguments to taskCli", async () => {
     await run(["task", "list", "--source", "todo"]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,7 +190,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   status: {
     summary: "Print read-only groundcrew state, or one task's local/Linear status",
-    usage: "[<task>] [--json [--local-only]]",
+    usage: "[<task>] [--json]",
     invoke: statusCli,
   },
   cleanup: {

--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -17,6 +17,12 @@ describe("crew completions", () => {
 
       expect(actual).toStrictEqual(expected);
     });
+
+    it("offers only --json for status", () => {
+      const statusCommand = COMPLETION_SPEC.find((command) => command.name === "status");
+
+      expect(statusCommand?.options?.map((option) => option.name)).toStrictEqual(["--json"]);
+    });
   });
 
   describe("script generation", () => {

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -176,6 +176,7 @@ export const COMPLETION_SPEC: readonly CompletionCommand[] = [
   {
     name: "status",
     summary: "Print groundcrew state or a task status",
+    options: [JSON_OPTION],
   },
   {
     name: "cleanup",

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable eslint/max-lines -- setup behavior shares one comprehensive mocked boundary. */
+
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 import path from "node:path";
@@ -123,6 +125,9 @@ vi.mock(import("../lib/board.ts"), async (importOriginal) => {
           description: "Body for repo-a",
         }),
       ),
+      resolveOneWithFailures: vi
+        .fn<Board["resolveOneWithFailures"]>()
+        .mockResolvedValue({ issue: undefined, failures: [] }),
       markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
       markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
       markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),
@@ -2028,6 +2033,9 @@ function fakeBoard(resolvedIssue: Issue | undefined): FakeBoard {
     resolveOne: vi
       .fn<(id: string) => Promise<Issue | undefined>>()
       .mockResolvedValue(resolvedIssue),
+    resolveOneWithFailures: vi
+      .fn<Board["resolveOneWithFailures"]>()
+      .mockResolvedValue({ issue: resolvedIssue, failures: [] }),
     markInProgress: vi.fn<(issue: Issue) => Promise<void>>().mockResolvedValue(),
     markInReview: vi.fn<Board["markInReview"]>().mockResolvedValue({ outcome: "applied" }),
     markDone: vi.fn<Board["markDone"]>().mockResolvedValue({ outcome: "applied" }),

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 
 import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
+import { probePullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import type { Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
 import { log, setVerbose } from "../lib/util.ts";
@@ -55,9 +55,9 @@ vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    findPullRequestsForBranch: vi
-      .fn<typeof actual.findPullRequestsForBranch>()
-      .mockResolvedValue([]),
+    probePullRequestsForBranch: vi
+      .fn<typeof actual.probePullRequestsForBranch>()
+      .mockResolvedValue({ pullRequests: [] }),
   };
 });
 vi.mock(import("../lib/worktreeRunState.ts"), async (importOriginal) => {
@@ -77,7 +77,7 @@ const findByTaskMock = vi.mocked(worktrees.findByTask);
 const listWorktreesMock = vi.mocked(worktrees.list);
 const probeWorkingTreeMock = vi.mocked(worktrees.probeWorkingTree);
 const buildSourcesMock = vi.mocked(buildSources);
-const findPullRequestsMock = vi.mocked(findPullRequestsForBranch);
+const findPullRequestsMock = vi.mocked(probePullRequestsForBranch);
 const probeEffectiveBranchMock = vi.mocked(probeEffectiveBranchNameFromRunState);
 
 function sourceIssue(overrides: Partial<SourceIssue> = {}): SourceIssue {
@@ -195,7 +195,9 @@ function worktree(overrides: Partial<WorktreeEntry> = {}): WorktreeEntry {
 
 /** Each worktree directory gets its own pull requests; anything else gets none. */
 function stubPullRequestsByDirectory(prsByDirectory: Record<string, PullRequestSummary[]>): void {
-  findPullRequestsMock.mockImplementation(async ({ cwd }) => prsByDirectory[cwd] ?? []);
+  findPullRequestsMock.mockImplementation(async ({ cwd }) => ({
+    pullRequests: prsByDirectory[cwd] ?? [],
+  }));
 }
 
 function runState(overrides: Partial<RunState> = {}): RunState {
@@ -228,7 +230,7 @@ describe(status, () => {
     readRunStateMock.mockReturnValue(runState({ reason: "manual pause" }));
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
     workspaceAccessHintMock.mockReset();
-    findPullRequestsMock.mockResolvedValue([]);
+    findPullRequestsMock.mockResolvedValue({ pullRequests: [] });
     buildSourcesMock.mockResolvedValue([]);
     findByTaskMock.mockReturnValue([worktree()]);
     listWorktreesMock.mockReturnValue([worktree()]);
@@ -680,14 +682,16 @@ describe(status, () => {
         branchName: "dev-team-2",
       }),
     ]);
-    findPullRequestsMock.mockRejectedValueOnce(new Error("gh rate limited")).mockResolvedValueOnce([
-      {
-        url: "https://github.com/acme/widgets/pull/42",
-        number: 42,
-        state: "open",
-        title: "Wire up auth",
-      },
-    ]);
+    findPullRequestsMock.mockRejectedValueOnce(new Error("gh rate limited")).mockResolvedValueOnce({
+      pullRequests: [
+        {
+          url: "https://github.com/acme/widgets/pull/42",
+          number: 42,
+          state: "open",
+          title: "Wire up auth",
+        },
+      ],
+    });
 
     await status(makeConfig());
 
@@ -870,14 +874,16 @@ describe(status, () => {
     listWorktreesMock.mockReturnValue([
       worktree({ task: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
     ]);
-    findPullRequestsMock.mockResolvedValue([
-      {
-        url: "https://github.com/acme/widgets/pull/42",
-        number: 42,
-        state: "open",
-        title: "Wire up auth",
-      },
-    ]);
+    findPullRequestsMock.mockResolvedValue({
+      pullRequests: [
+        {
+          url: "https://github.com/acme/widgets/pull/42",
+          number: 42,
+          state: "open",
+          title: "Wire up auth",
+        },
+      ],
+    });
 
     await status(makeConfig());
 
@@ -892,20 +898,22 @@ describe(status, () => {
 
   it("joins multiple PRs on one line in inventory rows", async () => {
     listWorktreesMock.mockReturnValue([worktree({ task: "team-1", repository: "repo-a" })]);
-    findPullRequestsMock.mockResolvedValue([
-      {
-        url: "https://x/pull/1",
-        number: 1,
-        state: "open",
-        title: "a",
-      },
-      {
-        url: "https://x/pull/2",
-        number: 2,
-        state: "merged",
-        title: "b",
-      },
-    ]);
+    findPullRequestsMock.mockResolvedValue({
+      pullRequests: [
+        {
+          url: "https://x/pull/1",
+          number: 1,
+          state: "open",
+          title: "a",
+        },
+        {
+          url: "https://x/pull/2",
+          number: 2,
+          state: "merged",
+          title: "b",
+        },
+      ],
+    });
 
     await status(makeConfig());
 
@@ -916,7 +924,7 @@ describe(status, () => {
 
   it("omits the `pr:` line in inventory rows when gh returns nothing", async () => {
     listWorktreesMock.mockReturnValue([worktree({ task: "team-1", repository: "repo-a" })]);
-    findPullRequestsMock.mockResolvedValue([]);
+    findPullRequestsMock.mockResolvedValue({ pullRequests: [] });
 
     await status(makeConfig());
 
@@ -927,14 +935,16 @@ describe(status, () => {
     findByTaskMock.mockReturnValue([
       worktree({ task: "team-1", repository: "repo-a", dir: "/work/repo-a-team-1" }),
     ]);
-    findPullRequestsMock.mockResolvedValue([
-      {
-        url: "https://github.com/acme/widgets/pull/99",
-        number: 99,
-        state: "open",
-        title: "Something",
-      },
-    ]);
+    findPullRequestsMock.mockResolvedValue({
+      pullRequests: [
+        {
+          url: "https://github.com/acme/widgets/pull/99",
+          number: 99,
+          state: "open",
+          title: "Something",
+        },
+      ],
+    });
 
     await status(makeConfig(), { task: "team-1" });
 
@@ -1476,14 +1486,16 @@ describe(status, () => {
         kind: "ok",
         names: new Set(["team-1", "orphan"]),
       });
-      findPullRequestsMock.mockResolvedValue([
-        {
-          url: "https://github.com/acme/widgets/pull/42",
-          number: 42,
-          state: "open",
-          title: "Wire up status JSON",
-        },
-      ]);
+      findPullRequestsMock.mockResolvedValue({
+        pullRequests: [
+          {
+            url: "https://github.com/acme/widgets/pull/42",
+            number: 42,
+            state: "open",
+            title: "Wire up status JSON",
+          },
+        ],
+      });
       buildSourcesMock.mockResolvedValue([
         fakeSource([
           sourceIssue({
@@ -1622,14 +1634,16 @@ describe(status, () => {
       const config = jsonConfig();
       writeFileSync(config.logging.file, "[09:01:00] team-1 private log contents\n");
       probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 1, untracked: 0 });
-      findPullRequestsMock.mockResolvedValue([
-        {
-          url: "https://github.com/acme/widgets/pull/99",
-          number: 99,
-          state: "open",
-          title: "Status contract",
-        },
-      ]);
+      findPullRequestsMock.mockResolvedValue({
+        pullRequests: [
+          {
+            url: "https://github.com/acme/widgets/pull/99",
+            number: 99,
+            state: "open",
+            title: "Status contract",
+          },
+        ],
+      });
       buildSourcesMock.mockResolvedValue([
         fakeSource([
           sourceIssue({
@@ -2130,7 +2144,7 @@ describe(statusCli, () => {
     findByTaskMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
     workspaceAccessHintMock.mockReset();
-    findPullRequestsMock.mockResolvedValue([]);
+    findPullRequestsMock.mockResolvedValue({ pullRequests: [] });
     readRunStateMock.mockReset();
     buildSourcesMock.mockResolvedValue([]);
   });

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1687,6 +1687,31 @@ describe(status, () => {
       expect(consoleLog.output()).not.toContain('"text"');
     });
 
+    it("accepts a canonical task id while using its natural id for local lookups", async () => {
+      const config = jsonConfig();
+      buildSourcesMock.mockResolvedValue([
+        fakeSource([
+          sourceIssue({
+            title: "Canonical task",
+            status: "in-progress",
+            url: "https://linear.app/example/issue/TEAM-1",
+          }),
+        ]),
+      ]);
+
+      await status(config, { task: "linear:team-1", json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        task: {
+          id: "linear:team-1",
+          naturalId: "team-1",
+          title: "Canonical task",
+        },
+      });
+      expect(readRunStateMock).toHaveBeenCalledWith(config, "team-1");
+      expect(findByTaskMock).toHaveBeenCalledWith(config, "team-1");
+    });
+
     it("does not collect recent logs for task JSON", async () => {
       const config = jsonConfig();
       writeFileSync(config.logging.file, "[09:01:00] team-1 private log contents\n");

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,11 +1,6 @@
-import {
-  appendFileSync,
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+/* oxlint-disable eslint/max-lines -- status text and JSON share one mocked collection boundary. */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -13,12 +8,13 @@ import { buildSources } from "../lib/buildSources.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import type { LocalStatusDocument, RemoteStatusDocument } from "../lib/statusSnapshot.ts";
 import type { Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
+import { log, setVerbose } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import { type WorktreeDirtiness, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { probeEffectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
-import { status, statusCli } from "./status.ts";
+import { collectStatus, renderStatusJson, renderStatusText, status, statusCli } from "./status.ts";
 
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -64,6 +60,14 @@ vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
       .mockResolvedValue([]),
   };
 });
+vi.mock(import("../lib/worktreeRunState.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    probeEffectiveBranchNameFromRunState:
+      vi.fn<typeof actual.probeEffectiveBranchNameFromRunState>(),
+  };
+});
 
 const loadConfigMock = vi.mocked(loadConfig);
 const readRunStateMock = vi.mocked(readRunState);
@@ -74,6 +78,7 @@ const listWorktreesMock = vi.mocked(worktrees.list);
 const probeWorkingTreeMock = vi.mocked(worktrees.probeWorkingTree);
 const buildSourcesMock = vi.mocked(buildSources);
 const findPullRequestsMock = vi.mocked(findPullRequestsForBranch);
+const probeEffectiveBranchMock = vi.mocked(probeEffectiveBranchNameFromRunState);
 
 function sourceIssue(overrides: Partial<SourceIssue> = {}): SourceIssue {
   return {
@@ -228,6 +233,9 @@ describe(status, () => {
     findByTaskMock.mockReturnValue([worktree()]);
     listWorktreesMock.mockReturnValue([worktree()]);
     probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
+    probeEffectiveBranchMock.mockImplementation(async ({ entry, runState }) => ({
+      branch: runState?.branchName ?? entry.branchName,
+    }));
   });
 
   afterEach(() => {
@@ -297,6 +305,36 @@ describe(status, () => {
     expect(output).not.toContain("Task source");
     expect(output).toContain("task: team-1  in-progress  https://linear.app/example/issue/TEAM-1");
     expect(output).toContain("title: Fix status");
+  });
+
+  it("collects silently and renders task text and JSON from the same snapshot", async () => {
+    const logFile = path.join(temporaryDirectory, "groundcrew.log");
+    writeFileSync(logFile, "[09:01:00] Workspace team-1 launched\n");
+    buildSourcesMock.mockResolvedValue([
+      fakeSource([
+        sourceIssue({
+          title: "Fix status",
+          status: "in-progress",
+          url: "https://linear.app/example/issue/TEAM-1",
+        }),
+      ]),
+    ]);
+
+    const snapshot = await collectStatus(makeConfig({ logging: { file: logFile } }), {
+      task: "team-1",
+    });
+
+    expect(consoleLog.output()).toBe("");
+    renderStatusText({ ...snapshot });
+    expect(consoleLog.output()).toContain("groundcrew status TEAM-1");
+    expect(consoleLog.output()).toContain("Workspace team-1 launched");
+    consoleLog.restore();
+    consoleLog = captureConsoleLog();
+
+    renderStatusJson(snapshot);
+
+    expect(JSON.parse(consoleLog.output())).toMatchObject({ kind: "task" });
+    expect(consoleLog.output()).not.toContain("Workspace team-1 launched");
   });
 
   it("shows the run-state branch (not the derived one) for an opened PR worktree", async () => {
@@ -373,6 +411,12 @@ describe(status, () => {
 
     expect(findByTaskMock).not.toHaveBeenCalled();
     expect(listWorktreesMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["   ", "-invalid"])("rejects invalid direct collection task %j", async (task) => {
+    await expect(collectStatus(makeConfig(), { task })).rejects.toThrow(
+      "task must be a non-empty value",
+    );
   });
 
   it("prints a run-state summary without optional detail and source status", async () => {
@@ -1367,6 +1411,28 @@ describe(status, () => {
     expect(consoleLog.output()).toContain("Queue\n-----\nunavailable: linear down");
   });
 
+  it("marks partial source inventory as degraded while retaining healthy queue rows", async () => {
+    listWorktreesMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    buildSourcesMock.mockResolvedValue([
+      fakeSource(
+        [sourceIssue({ id: "healthy:team-2", source: "healthy", title: "Healthy task" })],
+        { name: "healthy" },
+      ),
+      fakeSource([], {
+        name: "broken",
+        listTasks: async () => await Promise.reject(new Error("source unavailable")),
+      }),
+    ]);
+
+    await status(makeConfig());
+
+    const output = consoleLog.output();
+    expect(output).toContain("Source problems\n---------------\nbroken: source unavailable");
+    expect(output).toContain("slots: unknown/4 used (source data incomplete)");
+    expect(output).toContain("Healthy task");
+  });
+
   it("prints inventory probe failures and empty worktrees", async () => {
     listWorktreesMock.mockReturnValue([]);
     workspaceProbeMock.mockResolvedValue({
@@ -1400,235 +1466,543 @@ describe(status, () => {
   });
 
   describe("--json", () => {
-    function parseJsonOutput(): {
-      local: LocalStatusDocument;
-      remote?: RemoteStatusDocument;
-    } {
-      return JSON.parse(consoleLog.output());
-    }
-
-    // Every --json run persists two files beside the log, so each test needs
-    // its own directory or they read each other's snapshots.
     function jsonConfig(): ResolvedConfig {
       return makeConfig({ logging: { file: path.join(temporaryDirectory, "groundcrew.log") } });
     }
 
-    it("prints both documents under one root", async () => {
-      await status(jsonConfig(), { json: true });
-
-      const actual = parseJsonOutput();
-
-      expect(actual.local.schemaVersion).toBe(1);
-      expect(actual.remote?.lastAttemptStatus).toBe("ok");
-    });
-
-    it("timestamps each tier when its data collection starts", async () => {
-      const pollStartedAt = "2026-05-26T02:14:30.000Z";
-      const boardCapturedAt = "2026-05-26T02:15:00.000Z";
-      workspaceProbeMock.mockImplementation(async () => {
-        vi.setSystemTime(new Date(boardCapturedAt));
-        return { kind: "ok", names: new Set(["team-1"]) };
+    it("emits one stable inventory snapshot", async () => {
+      probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 2, untracked: 1 });
+      workspaceProbeMock.mockResolvedValue({
+        kind: "ok",
+        names: new Set(["team-1", "orphan"]),
       });
-      findPullRequestsMock.mockImplementation(async () => {
-        vi.setSystemTime(new Date("2026-05-26T02:16:00.000Z"));
-        return [];
-      });
-
-      await status(jsonConfig(), { json: true });
-
-      const actual = parseJsonOutput();
-      expect(actual.local.capturedAt).toBe(pollStartedAt);
-      expect(actual.remote?.lastAttemptAt).toBe(pollStartedAt);
-      expect(actual.remote?.payload?.capturedAt).toBe(boardCapturedAt);
-    });
-
-    it("publishes current source metadata for tasks outside queue states", async () => {
-      readRunStateMock.mockReturnValue(
-        runState({ title: "Title at dispatch", url: "https://example.test/old" }),
-      );
+      findPullRequestsMock.mockResolvedValue([
+        {
+          url: "https://github.com/acme/widgets/pull/42",
+          number: 42,
+          state: "open",
+          title: "Wire up status JSON",
+        },
+      ]);
       buildSourcesMock.mockResolvedValue([
         fakeSource([
           sourceIssue({
-            status: "done",
-            title: "Current source title",
-            url: "https://example.test/current",
+            status: "in-progress",
+            title: "Active task",
+            url: "https://linear.app/example/issue/TEAM-1",
+          }),
+          sourceIssue({
+            id: "linear:team-2",
+            title: "Ready task",
+            repository: "repo-b",
+          }),
+          sourceIssue({
+            id: "linear:team-3",
+            status: "in-progress",
+            title: "Remote slot holder",
+            repository: "repo-b",
+          }),
+          sourceIssue({
+            id: "linear:team-4",
+            title: "Blocked task",
+            repository: "repo-b",
+            blockers: [
+              {
+                id: "linear:team-0",
+                title: "Blocking task",
+                status: "in-progress",
+              },
+            ],
           }),
         ]),
       ]);
 
       await status(jsonConfig(), { json: true });
 
-      const actual = parseJsonOutput();
-      expect(actual.remote?.payload?.sourceByTask["team-1"]).toMatchObject({
-        status: "done",
-        title: "Current source title",
-        url: "https://example.test/current",
+      const actual: unknown = JSON.parse(consoleLog.output());
+      expect(actual).toMatchObject({
+        kind: "inventory",
+        generatedAt: "2026-05-26T02:14:30.000Z",
+        slots: { used: 2, maximum: 4 },
+        worktrees: [
+          {
+            task: {
+              id: "linear:team-1",
+              naturalId: "team-1",
+              title: "Active task",
+              status: "in-progress",
+              url: "https://linear.app/example/issue/TEAM-1",
+            },
+            run: {
+              lifecycle: "running",
+              agent: "claude",
+              startedAt: "2026-05-26T00:00:00.000Z",
+              updatedAt: "2026-05-26T00:01:00.000Z",
+              resumeCount: 0,
+              reason: "manual pause",
+            },
+            workspace: { state: "live" },
+            repository: "repo-a",
+            branch: "dev-team-1",
+            directory: "/work/repo-a-team-1",
+            dirtiness: { kind: "dirty", modified: 2, untracked: 1 },
+            pullRequests: [
+              {
+                url: "https://github.com/acme/widgets/pull/42",
+                number: 42,
+                state: "open",
+                title: "Wire up status JSON",
+              },
+            ],
+            recommendedActions: ["stop", "open-task", "open-pr", "open-worktree"],
+          },
+        ],
+        inProgressWithoutWorktrees: [
+          {
+            task: {
+              id: "linear:team-3",
+              naturalId: "team-3",
+              title: "Remote slot holder",
+              status: "in-progress",
+            },
+            repository: "repo-b",
+            agent: "claude",
+            recommendedActions: ["run"],
+          },
+        ],
+        queue: {
+          ready: [
+            {
+              task: {
+                id: "linear:team-2",
+                naturalId: "team-2",
+                title: "Ready task",
+                status: "todo",
+              },
+              repository: "repo-b",
+              agent: "claude",
+              recommendedActions: [],
+            },
+          ],
+          blocked: [
+            {
+              task: {
+                id: "linear:team-4",
+                naturalId: "team-4",
+                title: "Blocked task",
+                status: "todo",
+              },
+              repository: "repo-b",
+              agent: "claude",
+              recommendedActions: [],
+              blockedBy: [
+                {
+                  id: "linear:team-0",
+                  naturalId: "team-0",
+                  status: "in-progress",
+                },
+              ],
+            },
+          ],
+        },
+        straySessions: [
+          {
+            name: "orphan",
+            state: "live",
+            recommendedActions: ["stop"],
+          },
+        ],
+        problems: [],
+      });
+      expect(JSON.stringify(actual)).not.toContain("recentLogLines");
+      expect(JSON.stringify(actual)).not.toContain('"text"');
+    });
+
+    it("emits one stable task snapshot without recent logs", async () => {
+      const config = jsonConfig();
+      writeFileSync(config.logging.file, "[09:01:00] team-1 private log contents\n");
+      probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 1, untracked: 0 });
+      findPullRequestsMock.mockResolvedValue([
+        {
+          url: "https://github.com/acme/widgets/pull/99",
+          number: 99,
+          state: "open",
+          title: "Status contract",
+        },
+      ]);
+      buildSourcesMock.mockResolvedValue([
+        fakeSource([
+          sourceIssue({
+            title: "Current task title",
+            status: "in-progress",
+            url: "https://linear.app/example/issue/TEAM-1",
+          }),
+        ]),
+      ]);
+
+      await status(config, { task: "team-1", json: true });
+
+      const actual: unknown = JSON.parse(consoleLog.output());
+      expect(actual).toEqual({
+        kind: "task",
+        generatedAt: "2026-05-26T02:14:30.000Z",
+        task: {
+          id: "linear:team-1",
+          naturalId: "team-1",
+          title: "Current task title",
+          status: "in-progress",
+          url: "https://linear.app/example/issue/TEAM-1",
+        },
+        repository: "repo-a",
+        run: {
+          lifecycle: "running",
+          agent: "claude",
+          startedAt: "2026-05-26T00:00:00.000Z",
+          updatedAt: "2026-05-26T00:01:00.000Z",
+          resumeCount: 0,
+          reason: "manual pause",
+        },
+        workspace: { state: "live" },
+        worktrees: [
+          {
+            repository: "repo-a",
+            kind: "host",
+            branch: "dev-team-1",
+            directory: "/work/repo-a-team-1",
+            dirtiness: { kind: "dirty", modified: 1, untracked: 0 },
+            pullRequests: [
+              {
+                url: "https://github.com/acme/widgets/pull/99",
+                number: 99,
+                state: "open",
+                title: "Status contract",
+              },
+            ],
+          },
+        ],
+        recommendedActions: ["stop", "open-task", "open-pr", "open-worktree"],
+        problems: [],
+      });
+      expect(consoleLog.output()).not.toContain("private log contents");
+      expect(consoleLog.output()).not.toContain('"text"');
+    });
+
+    it("does not collect recent logs for task JSON", async () => {
+      const config = jsonConfig();
+      writeFileSync(config.logging.file, "[09:01:00] team-1 private log contents\n");
+
+      const snapshot = await collectStatus(config, { task: "team-1", json: true });
+
+      expect(snapshot).toMatchObject({
+        kind: "task",
+        text: { recentLogLines: [] },
       });
     });
 
-    it("publishes a task's recent lines even when they precede a large unrelated tail", async () => {
-      const config = jsonConfig();
-      const taskLine = "[09:00:00] team-1 dispatched";
-      const unrelatedTail = `${"x".repeat(200)}\n`.repeat(2000);
-      writeFileSync(config.logging.file, `${taskLine}\n${unrelatedTail}`);
+    it("falls back to the run repository when the task source omits it", async () => {
+      buildSourcesMock.mockResolvedValue([
+        fakeSource([sourceIssue({ repository: undefined, status: "in-progress" })]),
+      ]);
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { task: "team-1", json: true });
 
-      const actual = parseJsonOutput();
-      expect(actual.local.tasks[0]?.recentLogLines).toEqual([taskLine]);
+      expect(JSON.parse(consoleLog.output())).toMatchObject({ repository: "repo-a" });
     });
 
-    it("extends cached task log history from the previous poll's cursor", async () => {
-      const config = jsonConfig();
-      const historicalLine = "[09:00:00] team-1 dispatched";
-      const appendedLine = "[09:15:00] team-1 resumed";
-      const unrelatedTail = `${"x".repeat(200)}\n`.repeat(2000);
-      writeFileSync(config.logging.file, `${historicalLine}\n${unrelatedTail}`);
-
-      await status(config, { json: true });
-
-      const first = parseJsonOutput();
-      const firstOffset = first.local.logCursor?.offset;
-      expect(firstOffset).toBeGreaterThan(0);
-      consoleLog.restore();
-      consoleLog = captureConsoleLog();
-      appendFileSync(config.logging.file, `${appendedLine}\n`);
-
-      await status(config, { json: true });
-
-      const second = parseJsonOutput();
-      expect(second.local.logCursor?.offset).toBe(
-        Buffer.byteLength(`${historicalLine}\n${unrelatedTail}${appendedLine}\n`),
-      );
-      expect(second.local.tasks[0]?.recentLogLines).toEqual([historicalLine, appendedLine]);
-    });
-
-    it("omits the remote key entirely with --local-only", async () => {
-      await status(jsonConfig(), { json: true, localOnly: true });
-
-      const actual = parseJsonOutput();
-
-      expect(actual.local.schemaVersion).toBe(1);
-      expect("remote" in actual).toBe(false);
-    });
-
-    it("never constructs a task source or looks up a pull request with --local-only", async () => {
-      await status(jsonConfig(), { json: true, localOnly: true });
-
-      expect(buildSourcesMock).not.toHaveBeenCalled();
-      expect(findPullRequestsMock).not.toHaveBeenCalled();
-    });
-
-    it("reports an unavailable board without failing the command", async () => {
+    it("preserves inventory data when source, workspace, git, and GitHub probes fail", async () => {
       buildSourcesMock.mockRejectedValue(new Error("source down"));
+      workspaceProbeMock.mockResolvedValue({
+        kind: "unavailable",
+        error: new Error("workspace down"),
+      });
+      probeWorkingTreeMock.mockResolvedValue({ kind: "unknown" });
+      findPullRequestsMock.mockRejectedValue(new Error("GitHub down"));
 
       await status(jsonConfig(), { json: true });
 
-      const actual = parseJsonOutput();
-
-      expect(actual.remote?.lastAttemptStatus).toBe("unavailable");
-      expect(actual.remote?.lastAttemptError).toBe("source down");
-      expect(actual.remote?.payload).toBeUndefined();
+      const actual: unknown = JSON.parse(consoleLog.output());
+      expect(actual).toMatchObject({
+        kind: "inventory",
+        slots: { maximum: 4 },
+        worktrees: [
+          {
+            directory: "/work/repo-a-team-1",
+            dirtiness: { kind: "unknown" },
+            pullRequests: [],
+          },
+        ],
+        queue: { ready: [], blocked: [] },
+        problems: [
+          { code: "source-probe-failed", message: "Source probe failed" },
+          { code: "workspace-probe-failed", message: "Workspace probe failed" },
+          {
+            code: "git-probe-failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+          {
+            code: "github-probe-failed",
+            message: "GitHub probe failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+        ],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
     });
 
-    it("carries the previous payload forward when a later fetch fails", async () => {
-      const config = jsonConfig();
-      await status(config, { json: true });
+    it("retains healthy inventory data when one configured source fails", async () => {
+      buildSourcesMock.mockResolvedValue([
+        fakeSource(
+          [
+            sourceIssue({
+              id: "healthy:team-2",
+              source: "healthy",
+              title: "Healthy queue entry",
+            }),
+          ],
+          { name: "healthy" },
+        ),
+        fakeSource([], {
+          name: "broken",
+          listTasks: async () => await Promise.reject(new Error("source unavailable")),
+        }),
+      ]);
+
+      await status(jsonConfig(), { json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        queue: {
+          ready: [{ task: { naturalId: "team-2", title: "Healthy queue entry" } }],
+        },
+        slots: { maximum: 4 },
+        problems: [
+          {
+            code: "source-probe-failed",
+            source: "broken",
+            message: 'Source "broken" probe failed',
+          },
+        ],
+      });
+      expect(consoleLog.output()).not.toContain("source unavailable");
+    });
+
+    it("retains a resolved task while reporting a failed sibling source", async () => {
+      buildSourcesMock.mockResolvedValue([
+        fakeSource(
+          [sourceIssue({ id: "healthy:team-1", source: "healthy", title: "Healthy match" })],
+          { name: "healthy" },
+        ),
+        fakeSource([], {
+          name: "broken",
+          getTask: async () => await Promise.reject(new Error("token=private-source-detail")),
+        }),
+      ]);
+
+      await status(jsonConfig(), { task: "team-1", json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        task: { id: "healthy:team-1", title: "Healthy match" },
+        problems: [
+          {
+            code: "source-probe-failed",
+            source: "broken",
+            task: "team-1",
+            message: 'Source "broken" probe failed',
+          },
+        ],
+      });
+      expect(consoleLog.output()).not.toContain("private-source-detail");
+    });
+
+    it("preserves task data when source, workspace, git, and GitHub probes fail", async () => {
+      buildSourcesMock.mockRejectedValue(new Error("source down"));
+      workspaceProbeMock.mockResolvedValue({
+        kind: "unavailable",
+        error: new Error("workspace down"),
+      });
+      probeWorkingTreeMock.mockResolvedValue({ kind: "unknown" });
+      findPullRequestsMock.mockRejectedValue(new Error("GitHub down"));
+
+      await status(jsonConfig(), { task: "team-1", json: true });
+
+      const actual: unknown = JSON.parse(consoleLog.output());
+      expect(actual).toMatchObject({
+        kind: "task",
+        task: { naturalId: "team-1" },
+        repository: "repo-a",
+        run: { lifecycle: "running" },
+        workspace: { state: "unknown" },
+        worktrees: [
+          {
+            repository: "repo-a",
+            directory: "/work/repo-a-team-1",
+            dirtiness: { kind: "unknown" },
+            pullRequests: [],
+          },
+        ],
+        problems: [
+          { code: "source-probe-failed", message: "Source probe failed", task: "team-1" },
+          { code: "workspace-probe-failed", message: "Workspace probe failed", task: "team-1" },
+          {
+            code: "git-probe-failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+          {
+            code: "github-probe-failed",
+            message: "GitHub probe failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+        ],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+    });
+
+    it("distinguishes live and exited stray sessions", async () => {
+      listWorktreesMock.mockReturnValue([]);
+      workspaceProbeMock.mockResolvedValue({
+        kind: "ok",
+        names: new Set(["live-orphan", "exited-orphan"]),
+        exitedNames: new Set(["exited-orphan"]),
+      });
+
+      await status(jsonConfig(), { json: true });
+
+      const actual: unknown = JSON.parse(consoleLog.output());
+      expect(actual).toMatchObject({
+        straySessions: [
+          { name: "exited-orphan", state: "exited", recommendedActions: ["stop"] },
+          { name: "live-orphan", state: "live", recommendedActions: ["stop"] },
+        ],
+      });
+    });
+
+    it("uses cleanup and resume action codes for workspace reconciliation", async () => {
+      readRunStateMock.mockReset();
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+      await status(jsonConfig(), { json: true });
+
+      const straySnapshot: unknown = JSON.parse(consoleLog.output());
+      expect(straySnapshot).toMatchObject({
+        worktrees: [{ recommendedActions: ["cleanup", "open-worktree"] }],
+      });
       consoleLog.restore();
       consoleLog = captureConsoleLog();
-      buildSourcesMock.mockRejectedValue(new Error("source down"));
+      readRunStateMock.mockReturnValue(runState());
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { task: "team-1", json: true });
 
-      const actual = parseJsonOutput();
-
-      expect(actual.remote?.lastAttemptStatus).toBe("unavailable");
-      expect(actual.remote?.payload).toBeDefined();
+      const deadSnapshot: unknown = JSON.parse(consoleLog.output());
+      expect(deadSnapshot).toMatchObject({ recommendedActions: ["resume", "open-worktree"] });
     });
 
-    it("writes both documents beside the log file", async () => {
-      const config = jsonConfig();
+    it("offers resume for interrupted tasks only when the workspace is confirmed absent", async () => {
+      readRunStateMock.mockReturnValue(runState({ state: "interrupted" }));
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { task: "team-1", json: true });
 
-      const localOnDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
-      );
-      const remoteOnDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
-      );
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        recommendedActions: ["resume", "open-worktree"],
+      });
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
+      workspaceProbeMock.mockResolvedValue({ kind: "unavailable", error: new Error("probe down") });
 
-      expect(localOnDisk.schemaVersion).toBe(1);
-      expect(remoteOnDisk.lastAttemptStatus).toBe("ok");
+      await status(jsonConfig(), { task: "team-1", json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        recommendedActions: ["open-worktree"],
+      });
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+      await status(jsonConfig(), { json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        worktrees: [{ recommendedActions: ["resume", "open-worktree"] }],
+      });
     });
 
-    it("prints exactly what it wrote to the remote file", async () => {
-      const config = jsonConfig();
+    it("uses stop rather than cleanup for a live session with no worktree or run state", async () => {
+      readRunStateMock.mockReset();
+      findByTaskMock.mockReturnValue([]);
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { task: "team-1", json: true });
 
-      const printed = parseJsonOutput().remote;
-      const onDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
-      );
-
-      expect(printed).toEqual(onDisk);
+      expect(JSON.parse(consoleLog.output())).toMatchObject({ recommendedActions: ["stop"] });
     });
 
-    it("prints exactly what it wrote to the local file", async () => {
-      const config = jsonConfig();
+    it("omits queue actions whose required task data is unavailable", async () => {
+      listWorktreesMock.mockReturnValue([]);
+      workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+      const ineligibleIssue = {
+        ...sourceIssue({ id: "linear:team-2", status: "in-progress" }),
+        repository: undefined,
+        agent: undefined,
+      } satisfies SourceIssue;
+      buildSourcesMock.mockResolvedValue([fakeSource([ineligibleIssue])]);
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { json: true });
 
-      const printed = parseJsonOutput().local;
-      const onDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
-      );
-
-      expect(printed).toEqual(onDisk);
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        inProgressWithoutWorktrees: [{ recommendedActions: [] }],
+      });
     });
 
-    it("prints exactly what it wrote when the board fetch fails", async () => {
-      const config = jsonConfig();
-      buildSourcesMock.mockRejectedValue(new Error("source down"));
+    it("reports a degraded branch probe while retaining the fallback branch", async () => {
+      probeEffectiveBranchMock.mockResolvedValue({
+        branch: "dev-team-1",
+        problem: "Could not determine the current branch: HEAD is detached",
+      });
 
-      await status(config, { json: true });
+      await status(jsonConfig(), { json: true });
 
-      const printed = parseJsonOutput().remote;
-      const onDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-remote.json"), "utf8"),
-      );
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        worktrees: [{ branch: "dev-team-1" }],
+        problems: [
+          {
+            code: "git-probe-failed",
+            message: "Git probe failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+        ],
+      });
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
 
-      expect(printed).toEqual(onDisk);
-      expect(printed?.lastAttemptStatus).toBe("unavailable");
+      await status(jsonConfig(), { task: "team-1", json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({
+        worktrees: [{ branch: "dev-team-1" }],
+        problems: [
+          {
+            code: "git-probe-failed",
+            message: "Git probe failed",
+            task: "team-1",
+            worktreeDirectory: "/work/repo-a-team-1",
+          },
+        ],
+      });
     });
 
-    it("prints exactly what it wrote with --local-only", async () => {
-      const config = jsonConfig();
+    it("writes no JSON when inventory collection fails fatally", async () => {
+      listWorktreesMock.mockImplementation(() => {
+        throw new Error("worktree inventory unreadable");
+      });
 
-      await status(config, { json: true, localOnly: true });
-
-      const printed = parseJsonOutput().local;
-      const onDisk = JSON.parse(
-        readFileSync(path.join(temporaryDirectory, "status-local.json"), "utf8"),
+      await expect(status(jsonConfig(), { json: true })).rejects.toThrow(
+        "worktree inventory unreadable",
       );
 
-      expect(printed).toEqual(onDisk);
-    });
-
-    it("writes no snapshot in text mode", async () => {
-      const config = jsonConfig();
-
-      await status(config);
-
-      expect(existsSync(path.join(temporaryDirectory, "status-local.json"))).toBe(false);
-      expect(existsSync(path.join(temporaryDirectory, "status-remote.json"))).toBe(false);
-    });
-
-    it("rejects --json for a single task", async () => {
-      await expect(status(makeConfig(), { task: "team-1", json: true })).rejects.toThrow(
-        "crew status: --json is not supported for a single task",
-      );
+      expect(consoleLog.output()).toBe("");
     });
   });
 
@@ -1715,6 +2089,7 @@ describe(statusCli, () => {
   afterEach(() => {
     consoleLog.restore();
     vi.resetAllMocks();
+    setVerbose(false);
   });
 
   it("loads config and normalizes a task argument", async () => {
@@ -1733,6 +2108,20 @@ describe(statusCli, () => {
     expect(consoleLog.output()).toContain("Worktrees\n---------\n(none)");
   });
 
+  it("suppresses configuration diagnostics in JSON mode", async () => {
+    setVerbose(true);
+    loadConfigMock.mockImplementation(async () => {
+      log("configuration diagnostic");
+      return makeConfig();
+    });
+
+    await statusCli(["--json"]);
+
+    expect(consoleLog.calls).toHaveLength(1);
+    expect(JSON.parse(consoleLog.output())).toMatchObject({ kind: "inventory" });
+    expect(consoleLog.output()).not.toContain("configuration diagnostic");
+  });
+
   it("rejects an empty task argument", async () => {
     await expect(statusCli([""])).rejects.toThrow(/Usage: crew status/);
 
@@ -1745,18 +2134,12 @@ describe(statusCli, () => {
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
 
-  it("rejects --local-only without --json", async () => {
-    await expect(statusCli(["--local-only"])).rejects.toThrow(
-      "crew status: --local-only requires --json",
+  it("rejects --local-only because status exposes only the two documented JSON modes", async () => {
+    await expect(statusCli(["--json", "--local-only"])).rejects.toThrow(
+      "unknown option: --local-only",
     );
 
     expect(loadConfigMock).not.toHaveBeenCalled();
-  });
-
-  it("accepts --json and --local-only in either order", async () => {
-    await statusCli(["--local-only", "--json"]);
-
-    expect(loadConfigMock).toHaveBeenCalled();
   });
 
   it("rejects extra positional arguments", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -2018,6 +2018,30 @@ describe(status, () => {
       });
     });
 
+    it("reports one git problem when both branch and dirtiness probes fail", async () => {
+      probeEffectiveBranchMock.mockResolvedValue({
+        branch: "dev-team-1",
+        problem: "Could not determine the current branch: HEAD is detached",
+      });
+      probeWorkingTreeMock.mockResolvedValue({ kind: "unknown" });
+      const expectedProblem = {
+        code: "git-probe-failed",
+        message: "Git probe failed",
+        task: "team-1",
+        worktreeDirectory: "/work/repo-a-team-1",
+      };
+
+      await status(jsonConfig(), { json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({ problems: [expectedProblem] });
+      consoleLog.restore();
+      consoleLog = captureConsoleLog();
+
+      await status(jsonConfig(), { task: "team-1", json: true });
+
+      expect(JSON.parse(consoleLog.output())).toMatchObject({ problems: [expectedProblem] });
+    });
+
     it("writes no JSON when inventory collection fails fatally", async () => {
       listWorktreesMock.mockImplementation(() => {
         throw new Error("worktree inventory unreadable");

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -9,11 +9,7 @@ import { readFileSync } from "node:fs";
 
 import type { Board } from "../lib/board.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import {
-  findPullRequestsForBranch,
-  pullRequestProbeProblem,
-  type PullRequestSummary,
-} from "../lib/pullRequests.ts";
+import { probePullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type JoinedStatus,
@@ -1020,11 +1016,12 @@ async function collectTaskWorktree(input: {
   let pullRequests: readonly PullRequestSummary[] = [];
   let githubProblem: string | undefined;
   try {
-    pullRequests = await findPullRequestsForBranch({
+    const result = await probePullRequestsForBranch({
       cwd: entry.dir,
       branchName: branchProbe.branch,
     });
-    githubProblem = pullRequestProbeProblem({ pullRequests }).message;
+    pullRequests = result.pullRequests;
+    githubProblem = result.problem;
   } catch (error) {
     githubProblem = errorMessage(error);
   }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -859,15 +859,7 @@ function inventoryProblems(input: {
   }
   for (const task of joined.tasks) {
     for (const worktree of task.worktrees) {
-      if (worktree.branchProblem !== undefined) {
-        problems.push({
-          code: "git-probe-failed",
-          message: publicProblemMessage({ code: "git-probe-failed" }),
-          task: task.task,
-          worktreeDirectory: worktree.dir,
-        });
-      }
-      if (worktree.git.kind === "unknown") {
+      if (worktree.branchProblem !== undefined || worktree.git.kind === "unknown") {
         problems.push({
           code: "git-probe-failed",
           message: publicProblemMessage({ code: "git-probe-failed" }),
@@ -1131,15 +1123,7 @@ async function collectTaskSnapshot(input: {
     });
   }
   for (const collected of collectedWorktrees) {
-    if (collected.branchProblem !== undefined) {
-      problems.push({
-        code: "git-probe-failed",
-        message: publicProblemMessage({ code: "git-probe-failed" }),
-        task: localTask,
-        worktreeDirectory: collected.worktree.directory,
-      });
-    }
-    if (collected.worktree.dirtiness.kind === "unknown") {
+    if (collected.branchProblem !== undefined || collected.worktree.dirtiness.kind === "unknown") {
       problems.push({
         code: "git-probe-failed",
         message: publicProblemMessage({ code: "git-probe-failed" }),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,20 +1,19 @@
 /**
- * Renderers for `crew status`. Three output modes share this file.
- *
- * With no task it renders the inventory: it calls the collectors in
- * statusCollect.ts, joins the two tiers with joinStatus, and prints text.
- * With a task it renders that one task, doing its own I/O rather than using
- * the collectors, because it reads the whole log where they read a tail.
- * With --json it prints and persists the wire documents from statusSnapshot.ts.
- * Text mode persists nothing.
- *
- * @see README.md#status-snapshots-for-external-monitors for the reader contract.
+ * Deep status module: collection produces one discriminated snapshot without
+ * printing, then either renderer consumes that same snapshot. JSON exposes the
+ * stable integration fields while text keeps operator-only hints and log lines
+ * in private renderer details.
  */
 
 import { readFileSync } from "node:fs";
 
+import type { Board } from "../lib/board.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
+import {
+  findPullRequestsForBranch,
+  pullRequestProbeProblem,
+  type PullRequestSummary,
+} from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type JoinedStatus,
@@ -30,8 +29,7 @@ import {
   type StatusLifecycle,
   type StatusBoardIssue,
   type StatusQueueIssue,
-  writeLocalSnapshot,
-  writeRemoteSnapshot,
+  type StatusSourceIssue,
 } from "../lib/statusSnapshot.ts";
 import {
   type CanonicalStatus,
@@ -40,8 +38,8 @@ import {
 } from "../lib/taskSource.ts";
 import { errorMessage, withLogOutputSuppressed, writeOutput } from "../lib/util.ts";
 import { type WorkspaceAccessHint, type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
-import { type WorktreeDirtiness, worktrees } from "../lib/worktrees.ts";
-import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
+import { type WorktreeDirtiness, type WorktreeKind, worktrees } from "../lib/worktrees.ts";
+import { probeEffectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import {
   buildBoard,
   collectLocalStatus,
@@ -57,13 +55,218 @@ import {
 
 export interface StatusOptions {
   task?: string;
-  /** Emit the snapshot documents as JSON and persist them. */
+  /** Emit one stable status snapshot as JSON. */
   json?: boolean;
-  /** Collect the local tier only. Guarantees this run makes no network call. */
-  localOnly?: boolean;
 }
 
-const STATUS_USAGE = "Usage: crew status [<task>] [--json [--local-only]]";
+export type StatusRecommendedAction =
+  | "stop"
+  | "resume"
+  | "cleanup"
+  | "run"
+  | "open-task"
+  | "open-pr"
+  | "open-worktree";
+
+export type StatusProblemCode =
+  | "source-probe-failed"
+  | "workspace-probe-failed"
+  | "git-probe-failed"
+  | "github-probe-failed";
+
+export interface StatusProblem {
+  code: StatusProblemCode;
+  message: string;
+  task?: string | undefined;
+  source?: string | undefined;
+  worktreeDirectory?: string | undefined;
+}
+
+export interface StatusTaskIdentity {
+  id?: string | undefined;
+  naturalId: string;
+  title?: string | undefined;
+  status?: CanonicalStatus | undefined;
+  url?: string | undefined;
+}
+
+export interface StatusRun {
+  lifecycle: StatusLifecycle;
+  agent?: string | undefined;
+  startedAt?: string | undefined;
+  updatedAt?: string | undefined;
+  resumeCount?: number | undefined;
+  reason?: string | undefined;
+}
+
+export interface StatusWorkspace {
+  state: "live" | "exited" | "not-live" | "unknown";
+}
+
+export interface StatusPullRequest {
+  url: string;
+  number: number;
+  state: string;
+  title: string;
+}
+
+export interface TaskStatusWorktree {
+  repository: string;
+  kind: WorktreeKind;
+  branch: string;
+  directory: string;
+  dirtiness: WorktreeDirtiness;
+  pullRequests: StatusPullRequest[];
+}
+
+export interface StatusWorktreeSnapshot extends TaskStatusWorktree {
+  task: StatusTaskIdentity;
+  run: StatusRun;
+  workspace: StatusWorkspace;
+  recommendedActions: StatusRecommendedAction[];
+}
+
+export interface StatusQueueEntry {
+  task: StatusTaskIdentity;
+  repository?: string | undefined;
+  agent?: string | undefined;
+  recommendedActions: StatusRecommendedAction[];
+}
+
+export interface StatusBlockerSnapshot {
+  id: string;
+  naturalId: string;
+  status: CanonicalStatus;
+  nativeStatus?: string | undefined;
+}
+
+export interface StatusBlockedQueueEntry extends StatusQueueEntry {
+  blockedBy: StatusBlockerSnapshot[];
+}
+
+export interface StatusStraySession {
+  name: string;
+  state: "live" | "exited";
+  recommendedActions: StatusRecommendedAction[];
+}
+
+export interface InventoryStatusSnapshot {
+  kind: "inventory";
+  generatedAt: string;
+  slots: { used?: number | undefined; maximum: number };
+  worktrees: StatusWorktreeSnapshot[];
+  inProgressWithoutWorktrees: StatusQueueEntry[];
+  queue: { ready: StatusQueueEntry[]; blocked: StatusBlockedQueueEntry[] };
+  straySessions: StatusStraySession[];
+  problems: StatusProblem[];
+  text: InventoryTextDetails;
+}
+
+export interface TaskStatusSnapshot {
+  kind: "task";
+  generatedAt: string;
+  task: StatusTaskIdentity;
+  repository?: string | undefined;
+  run: StatusRun;
+  workspace: StatusWorkspace;
+  worktrees: TaskStatusWorktree[];
+  recommendedActions: StatusRecommendedAction[];
+  problems: StatusProblem[];
+  text: TaskTextDetails;
+}
+
+export type StatusSnapshot = InventoryStatusSnapshot | TaskStatusSnapshot;
+
+export async function collectStatus(
+  config: ResolvedConfig,
+  options: StatusOptions = {},
+): Promise<StatusSnapshot> {
+  const task = options.task?.trim().toLowerCase();
+  if (task !== undefined) {
+    if (task.length === 0 || task.startsWith("-")) {
+      throw new Error("task must be a non-empty value");
+    }
+    return await collectTaskSnapshot({ config, task, includeRecentLogs: options.json !== true });
+  }
+  const { local, attemptAt, result } = await collectBothTiers(config);
+  const remote = buildRemoteDocument({ previous: undefined, attemptAt, result });
+  const joined = joinStatus({ local, remote });
+  return inventorySnapshot({
+    generatedAt: attemptAt,
+    local,
+    joined,
+    sources: remote.payload?.sourceByTask ?? {},
+    githubProblems: result.pullRequestProblems,
+    sourceProblems: result.sourceProblems,
+    sourceError: remote.lastAttemptError,
+  });
+}
+
+export function renderStatusJson(snapshot: StatusSnapshot): void {
+  if (snapshot.kind === "inventory") {
+    writeOutput(
+      JSON.stringify(
+        {
+          kind: snapshot.kind,
+          generatedAt: snapshot.generatedAt,
+          slots: snapshot.slots,
+          worktrees: snapshot.worktrees,
+          inProgressWithoutWorktrees: snapshot.inProgressWithoutWorktrees,
+          queue: snapshot.queue,
+          straySessions: snapshot.straySessions,
+          problems: snapshot.problems,
+        },
+        undefined,
+        2,
+      ),
+    );
+    return;
+  }
+  writeOutput(
+    JSON.stringify(
+      {
+        kind: snapshot.kind,
+        generatedAt: snapshot.generatedAt,
+        task: snapshot.task,
+        repository: snapshot.repository,
+        run: snapshot.run,
+        workspace: snapshot.workspace,
+        worktrees: snapshot.worktrees,
+        recommendedActions: snapshot.recommendedActions,
+        problems: snapshot.problems,
+      },
+      undefined,
+      2,
+    ),
+  );
+}
+
+export function renderStatusText(snapshot: StatusSnapshot): void {
+  if (snapshot.kind === "inventory") {
+    writeInventoryStatus(snapshot.text);
+    return;
+  }
+  writeTaskStatus({ snapshot, details: snapshot.text });
+}
+
+interface InventoryTextDetails {
+  local: LocalStatusDocument;
+  joined: JoinedStatus;
+  boardError?: string | undefined;
+  sourceProblems: RemoteFetchResult["sourceProblems"];
+  renderedAt: Date;
+}
+
+interface TaskTextDetails {
+  task: string;
+  runState: RunState | undefined;
+  sourceStatus: TaskSourceStatus;
+  workspaceProbe: WorkspaceProbe;
+  accessHint?: WorkspaceAccessHint | undefined;
+  recentLogLines: string[];
+}
+
+const STATUS_USAGE = "Usage: crew status [<task>] [--json]";
 
 function parseArguments(argv: string[]): StatusOptions {
   const options: StatusOptions = {};
@@ -72,11 +275,10 @@ function parseArguments(argv: string[]): StatusOptions {
       options.json = true;
       continue;
     }
-    if (argument === "--local-only") {
-      options.localOnly = true;
-      continue;
+    if (argument.startsWith("-")) {
+      throw new Error(`crew status: unknown option: ${argument}\n${STATUS_USAGE}`);
     }
-    if (argument.length === 0 || argument.startsWith("-") || options.task !== undefined) {
+    if (argument.length === 0 || options.task !== undefined) {
       throw new Error(STATUS_USAGE);
     }
     options.task = argument.toLowerCase();
@@ -97,32 +299,19 @@ function formatDirtiness(dirtiness: WorktreeDirtiness): string {
   return dirtiness.kind;
 }
 
-async function writeTaskWorktrees(config: ResolvedConfig, task: string): Promise<void> {
+function writeTaskWorktrees(entries: readonly TaskStatusWorktree[]): void {
   writeSection("Worktrees");
-  const entries = worktrees.findByTask(config, task);
   if (entries.length === 0) {
     writeOutput("(none)");
     return;
   }
-  const runState = readRunState(config, task);
   for (const entry of entries) {
-    // oxlint-disable-next-line no-await-in-loop -- status output is easier to read in worktree order.
-    const branchName = await effectiveBranchNameFromRunState({ entry, runState });
-    // oxlint-disable-next-line no-await-in-loop -- status output is easier to read in worktree order.
-    const dirtiness = await worktrees.probeWorkingTree({
-      worktreeDir: entry.dir,
-    });
-    // oxlint-disable-next-line no-await-in-loop -- one gh lookup per worktree is acceptable; multi-worktree-per-task is rare.
-    const prs = await findPullRequestsForBranch({
-      cwd: entry.dir,
-      branchName,
-    });
     writeOutput(`- ${entry.repository} ${entry.kind}`);
-    writeOutput(`  branch: ${branchName}`);
-    writeOutput(`  dir: ${entry.dir}`);
-    writeOutput(`  git: ${formatDirtiness(dirtiness)}`);
-    if (prs.length > 0) {
-      writeOutput(`  pr: ${formatPullRequests(prs)}`);
+    writeOutput(`  branch: ${entry.branch}`);
+    writeOutput(`  dir: ${entry.directory}`);
+    writeOutput(`  git: ${formatDirtiness(entry.dirtiness)}`);
+    if (entry.pullRequests.length > 0) {
+      writeOutput(`  pr: ${formatPullRequests(entry.pullRequests)}`);
     }
   }
 }
@@ -164,13 +353,19 @@ function wholeLogLines(config: ResolvedConfig): string[] {
 async function resolveTaskSource(
   config: ResolvedConfig,
   task: string,
-): Promise<SourceIssue | undefined> {
-  const board = await buildBoard(config);
-  return await withLogOutputSuppressed(async () => await board.resolveOne(task));
+): Promise<Awaited<ReturnType<Board["resolveOneWithFailures"]>>> {
+  return await withLogOutputSuppressed(async () => {
+    const board = await buildBoard(config);
+    return await board.resolveOneWithFailures(task);
+  });
 }
 
 type TaskSourceStatus =
-  | { kind: "found"; issue: SourceIssue }
+  | {
+      kind: "found";
+      issue: SourceIssue;
+      failures: Array<{ source: string; reason: string }>;
+    }
   | { kind: "not-found" }
   | { kind: "unavailable"; reason: string };
 
@@ -179,18 +374,24 @@ async function readTaskSourceStatus(
   task: string,
 ): Promise<TaskSourceStatus> {
   try {
-    const issue = await resolveTaskSource(config, task);
-    if (issue === undefined) {
+    const resolution = await resolveTaskSource(config, task);
+    if (resolution.issue === undefined) {
       return { kind: "not-found" };
     }
-    return { kind: "found", issue };
+    return {
+      kind: "found",
+      issue: resolution.issue,
+      failures: resolution.failures.map((failure) => ({
+        source: failure.source,
+        reason: errorMessage(failure.reason),
+      })),
+    };
   } catch (error) {
     return { kind: "unavailable", reason: errorMessage(error) };
   }
 }
 
-function writeRecentLogs(config: ResolvedConfig, task: string): void {
-  const logLines = recentTaskLogLines({ lines: wholeLogLines(config), task });
+function writeRecentLogs(logLines: readonly string[]): void {
   if (logLines.length === 0) {
     return;
   }
@@ -248,18 +449,13 @@ function writeTaskTitle(runState: RunState | undefined, sourceStatus: TaskSource
   }
 }
 
-async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise<void> {
-  const task = rawTask.toLowerCase();
+function writeTaskStatus(input: { snapshot: TaskStatusSnapshot; details: TaskTextDetails }): void {
+  const { snapshot, details } = input;
+  const { task, runState, sourceStatus, workspaceProbe, accessHint, recentLogLines } = details;
   const displayTask = task.toUpperCase();
   writeOutput(`groundcrew status ${displayTask}`);
   writeOutput("=".repeat(`groundcrew status ${displayTask}`.length));
 
-  const runState = readRunState(config, task);
-  const [workspaceProbe, sourceStatus] = await Promise.all([
-    withLogOutputSuppressed(async () => await workspaces.probe(config)),
-    readTaskSourceStatus(config, task),
-  ]);
-  const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
   writeOutput(formatTaskLine(task, runState, sourceStatus));
   writeTaskTitle(runState, sourceStatus);
   const disagreement = probeDisagreement({
@@ -275,8 +471,8 @@ async function writeTaskStatus(config: ResolvedConfig, rawTask: string): Promise
     writeOutput(`attach: ${accessHint.command}`);
   }
 
-  await writeTaskWorktrees(config, task);
-  writeRecentLogs(config, task);
+  writeTaskWorktrees(snapshot.worktrees);
+  writeRecentLogs(recentLogLines);
 }
 
 /**
@@ -516,10 +712,6 @@ interface CollectedTiers {
 /**
  * Runs both tiers. The board fetch starts first because it needs nothing
  * local; only the pull request lookups wait on resolved branches.
- *
- * Returns the raw result rather than a built document: the JSON path needs
- * `writeRemoteSnapshot` to do the carry-forward merge against the same file
- * read its guard uses, and the text path deliberately merges against nothing.
  */
 async function collectBothTiers(config: ResolvedConfig): Promise<CollectedTiers> {
   const attemptAt = new Date().toISOString();
@@ -532,94 +724,506 @@ async function collectBothTiers(config: ResolvedConfig): Promise<CollectedTiers>
   return { local, attemptAt, result };
 }
 
-async function writeInventoryStatus(config: ResolvedConfig): Promise<void> {
-  const { local, attemptAt, result } = await collectBothTiers(config);
-  // `previous: undefined` on purpose: a one-shot run reports only what this
-  // attempt saw, so a failed fetch prints "unavailable" rather than a queue
-  // recovered from an old snapshot.
-  const remote = buildRemoteDocument({ previous: undefined, attemptAt, result });
-  const joined = joinStatus({ local, remote });
-  const now = new Date();
+function taskIdentity(input: {
+  naturalId: string;
+  cachedTitle?: string | undefined;
+  cachedUrl?: string | undefined;
+  source?: StatusSourceIssue | undefined;
+}): StatusTaskIdentity {
+  const { naturalId, cachedTitle, cachedUrl, source } = input;
+  return {
+    id: source?.id,
+    naturalId,
+    title: source?.title ?? cachedTitle,
+    status: source?.status,
+    url: source?.url ?? cachedUrl,
+  };
+}
 
-  writeInventoryWorktrees(joined, now);
+function runSnapshot(task: JoinedTask): StatusRun {
+  return {
+    lifecycle: task.lifecycle,
+    agent: task.agent,
+    startedAt: task.startedAt,
+    updatedAt: task.updatedAt,
+    resumeCount: task.resumeCount,
+    reason: task.reason,
+  };
+}
+
+function worktreeActions(input: {
+  task: JoinedTask;
+  identity: StatusTaskIdentity;
+  pullRequests: readonly PullRequestSummary[];
+}): StatusRecommendedAction[] {
+  const { task, identity, pullRequests } = input;
+  const actions: StatusRecommendedAction[] = [];
+  if (task.flags.includes("stray session") || task.flags.includes("stray exited session")) {
+    actions.push("cleanup");
+  } else if (task.flags.includes("session dead") || task.flags.includes("session exited")) {
+    actions.push("resume");
+  } else if (task.session === "live") {
+    actions.push("stop");
+  } else if (task.lifecycle === "interrupted" && task.session !== "unknown") {
+    actions.push("resume");
+  }
+  if (identity.url !== undefined) {
+    actions.push("open-task");
+  }
+  if (pullRequests.length > 0) {
+    actions.push("open-pr");
+  }
+  actions.push("open-worktree");
+  return actions;
+}
+
+interface QueueIdentityInput {
+  issue: StatusBoardIssue | StatusQueueIssue | StatusBlockedIssue;
+  canonicalStatus: CanonicalStatus;
+}
+
+function queueIdentity(input: QueueIdentityInput): StatusTaskIdentity {
+  const { issue, canonicalStatus } = input;
+  return {
+    id: issue.id,
+    naturalId: issue.naturalId,
+    title: issue.title,
+    status: canonicalStatus,
+    url: issue.url,
+  };
+}
+
+function queueEntry(input: QueueIdentityInput): StatusQueueEntry {
+  const { issue, canonicalStatus } = input;
+  const task = queueIdentity({ issue, canonicalStatus });
+  return {
+    task,
+    repository: issue.repository,
+    agent: issue.agent,
+    recommendedActions: task.url === undefined ? [] : ["open-task"],
+  };
+}
+
+function inProgressWithoutWorktreeEntry(issue: StatusBoardIssue): StatusQueueEntry {
+  const entry = queueEntry({ issue, canonicalStatus: "in-progress" });
+  const canRun = issue.repository !== undefined && issue.agent !== undefined;
+  return {
+    ...entry,
+    recommendedActions: canRun ? [...entry.recommendedActions, "run"] : entry.recommendedActions,
+  };
+}
+
+function publicProblemMessage(input: {
+  code: StatusProblemCode;
+  source?: string | undefined;
+}): string {
+  const { code, source } = input;
+  if (code === "source-probe-failed" && source !== undefined) {
+    return `Source "${source}" probe failed`;
+  }
+  return {
+    "source-probe-failed": "Source probe failed",
+    "workspace-probe-failed": "Workspace probe failed",
+    "git-probe-failed": "Git probe failed",
+    "github-probe-failed": "GitHub probe failed",
+  }[code];
+}
+
+function inventoryProblems(input: {
+  local: LocalStatusDocument;
+  joined: JoinedStatus;
+  githubProblems: RemoteFetchResult["pullRequestProblems"];
+  sourceProblems: RemoteFetchResult["sourceProblems"];
+  sourceError?: string | undefined;
+}): StatusProblem[] {
+  const { local, joined, githubProblems, sourceProblems, sourceError } = input;
+  const problems: StatusProblem[] = [];
+  if (sourceError !== undefined) {
+    problems.push({
+      code: "source-probe-failed",
+      message: publicProblemMessage({ code: "source-probe-failed" }),
+    });
+  }
+  for (const problem of sourceProblems) {
+    problems.push({
+      code: "source-probe-failed",
+      source: problem.source,
+      message: publicProblemMessage({ code: "source-probe-failed", source: problem.source }),
+    });
+  }
+  if (local.workspaceProbe.status === "unavailable") {
+    problems.push({
+      code: "workspace-probe-failed",
+      message: publicProblemMessage({ code: "workspace-probe-failed" }),
+    });
+  }
+  for (const task of joined.tasks) {
+    for (const worktree of task.worktrees) {
+      if (worktree.branchProblem !== undefined) {
+        problems.push({
+          code: "git-probe-failed",
+          message: publicProblemMessage({ code: "git-probe-failed" }),
+          task: task.task,
+          worktreeDirectory: worktree.dir,
+        });
+      }
+      if (worktree.git.kind === "unknown") {
+        problems.push({
+          code: "git-probe-failed",
+          message: publicProblemMessage({ code: "git-probe-failed" }),
+          task: task.task,
+          worktreeDirectory: worktree.dir,
+        });
+      }
+    }
+  }
+  for (const problem of githubProblems) {
+    const task = joined.tasks.find((candidate) =>
+      candidate.worktrees.some((worktree) => worktree.dir === problem.directory),
+    );
+    problems.push({
+      code: "github-probe-failed",
+      message: publicProblemMessage({ code: "github-probe-failed" }),
+      task: task?.task,
+      worktreeDirectory: problem.directory,
+    });
+  }
+  return problems;
+}
+
+function inventorySnapshot(input: {
+  generatedAt: string;
+  local: LocalStatusDocument;
+  joined: JoinedStatus;
+  sources: Record<string, StatusSourceIssue>;
+  githubProblems: RemoteFetchResult["pullRequestProblems"];
+  sourceProblems: RemoteFetchResult["sourceProblems"];
+  sourceError?: string | undefined;
+}): InventoryStatusSnapshot {
+  const { generatedAt, local, joined, sources, githubProblems, sourceProblems, sourceError } =
+    input;
+  const worktreeSnapshots = joined.tasks.flatMap((task) => {
+    const source = Object.hasOwn(sources, task.task) ? sources[task.task] : undefined;
+    const identity = taskIdentity({
+      naturalId: task.task,
+      cachedTitle: task.title,
+      cachedUrl: task.url,
+      source,
+    });
+    return task.worktrees.map((worktree) => ({
+      task: identity,
+      run: runSnapshot(task),
+      workspace: { state: task.session },
+      repository: worktree.repository,
+      kind: worktree.kind,
+      branch: worktree.branch,
+      directory: worktree.dir,
+      dirtiness: worktree.git,
+      pullRequests: [...worktree.pullRequests],
+      recommendedActions: worktreeActions({
+        task,
+        identity,
+        pullRequests: worktree.pullRequests,
+      }),
+    }));
+  });
+
+  return {
+    kind: "inventory",
+    generatedAt,
+    slots: {
+      used: sourceProblems.length === 0 ? joined.slots?.used : undefined,
+      maximum: local.maximumInProgress,
+    },
+    worktrees: worktreeSnapshots,
+    inProgressWithoutWorktrees: joined.inProgressWithoutWorktree.map(
+      inProgressWithoutWorktreeEntry,
+    ),
+    queue: {
+      ready: joined.queueReady.map((issue) => queueEntry({ issue, canonicalStatus: "todo" })),
+      blocked: joined.queueBlocked.map((issue) => ({
+        ...queueEntry({ issue, canonicalStatus: "todo" }),
+        blockedBy: issue.blockedBy,
+      })),
+    },
+    straySessions: local.orphanedSessions.map((name) => ({
+      name,
+      state: local.exitedOrphanedSessions?.includes(name) === true ? "exited" : "live",
+      recommendedActions: ["stop"],
+    })),
+    problems: inventoryProblems({
+      local,
+      joined,
+      githubProblems,
+      sourceProblems,
+      sourceError,
+    }),
+    text: {
+      local,
+      joined,
+      boardError: sourceError,
+      sourceProblems,
+      renderedAt: new Date(),
+    },
+  };
+}
+
+function taskIdentityFromStatus(input: {
+  task: string;
+  runState: RunState | undefined;
+  sourceStatus: TaskSourceStatus;
+}): StatusTaskIdentity {
+  const { task, runState, sourceStatus } = input;
+  if (sourceStatus.kind === "found") {
+    return {
+      id: sourceStatus.issue.id,
+      naturalId: naturalIdFromCanonical(sourceStatus.issue.id),
+      title: sourceStatus.issue.title,
+      status: sourceStatus.issue.status,
+      url: sourceStatus.issue.url ?? runState?.url,
+    };
+  }
+  return {
+    naturalId: task,
+    title: runState?.title,
+    url: runState?.url,
+  };
+}
+
+function runSnapshotFromState(runState: RunState | undefined): StatusRun {
+  return {
+    lifecycle: runState?.state ?? "idle",
+    agent: runState?.agent,
+    startedAt: runState?.createdAt,
+    updatedAt: runState?.updatedAt,
+    resumeCount: runState?.resumeCount,
+    reason: runState?.reason,
+  };
+}
+
+function workspaceSnapshot(input: { probe: WorkspaceProbe; task: string }): StatusWorkspace {
+  const { probe, task } = input;
+  if (probe.kind === "unavailable") {
+    return { state: "unknown" };
+  }
+  if (isWorkspaceExited({ probe, task })) {
+    return { state: "exited" };
+  }
+  return { state: probe.names.has(task) ? "live" : "not-live" };
+}
+
+async function collectTaskWorktree(input: {
+  entry: ReturnType<typeof worktrees.findByTask>[number];
+  runState: RunState | undefined;
+}): Promise<{
+  worktree: TaskStatusWorktree;
+  branchProblem?: string | undefined;
+  githubProblem?: string | undefined;
+}> {
+  const { entry, runState } = input;
+  const [branchProbe, dirtiness] = await Promise.all([
+    probeEffectiveBranchNameFromRunState({ entry, runState }),
+    worktrees.probeWorkingTree({ worktreeDir: entry.dir }),
+  ]);
+  let pullRequests: readonly PullRequestSummary[] = [];
+  let githubProblem: string | undefined;
+  try {
+    pullRequests = await findPullRequestsForBranch({
+      cwd: entry.dir,
+      branchName: branchProbe.branch,
+    });
+    githubProblem = pullRequestProbeProblem({ pullRequests }).message;
+  } catch (error) {
+    githubProblem = errorMessage(error);
+  }
+  return {
+    worktree: {
+      repository: entry.repository,
+      kind: entry.kind,
+      branch: branchProbe.branch,
+      directory: entry.dir,
+      dirtiness,
+      pullRequests: [...pullRequests],
+    },
+    branchProblem: branchProbe.problem,
+    githubProblem,
+  };
+}
+
+function taskRecommendedActions(input: {
+  identity: StatusTaskIdentity;
+  run: StatusRun;
+  workspace: StatusWorkspace;
+  worktrees: readonly TaskStatusWorktree[];
+}): StatusRecommendedAction[] {
+  const { identity, run, workspace, worktrees: taskWorktrees } = input;
+  const actions: StatusRecommendedAction[] = [];
+  if (run.lifecycle === "idle" && (workspace.state === "live" || workspace.state === "exited")) {
+    actions.push(taskWorktrees.length === 0 ? "stop" : "cleanup");
+  } else if (workspace.state === "live") {
+    actions.push("stop");
+  } else if (
+    taskWorktrees.length > 0 &&
+    (workspace.state === "not-live" || workspace.state === "exited") &&
+    (run.lifecycle === "interrupted" || run.lifecycle === "running" || run.lifecycle === "resumed")
+  ) {
+    actions.push("resume");
+  }
+  if (identity.url !== undefined) {
+    actions.push("open-task");
+  }
+  if (taskWorktrees.some((worktree) => worktree.pullRequests.length > 0)) {
+    actions.push("open-pr");
+  }
+  if (taskWorktrees.length > 0) {
+    actions.push("open-worktree");
+  }
+  return actions;
+}
+
+async function collectTaskSnapshot(input: {
+  config: ResolvedConfig;
+  task: string;
+  includeRecentLogs: boolean;
+}): Promise<TaskStatusSnapshot> {
+  const { config, task, includeRecentLogs } = input;
+  const generatedAt = new Date().toISOString();
+  const runState = readRunState(config, task);
+  const [workspaceProbe, sourceStatus] = await Promise.all([
+    withLogOutputSuppressed(async () => await workspaces.probe(config)),
+    readTaskSourceStatus(config, task),
+  ]);
+  const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
+  const entries = worktrees.findByTask(config, task);
+  const collectedWorktrees = await Promise.all(
+    entries.map(async (entry) => await collectTaskWorktree({ entry, runState })),
+  );
+  const taskWorktrees = collectedWorktrees.map((collected) => collected.worktree);
+  const identity = taskIdentityFromStatus({ task, runState, sourceStatus });
+  const run = runSnapshotFromState(runState);
+  const workspace = workspaceSnapshot({ probe: workspaceProbe, task });
+  const problems: StatusProblem[] = [];
+  if (sourceStatus.kind === "unavailable") {
+    problems.push({
+      code: "source-probe-failed",
+      message: publicProblemMessage({ code: "source-probe-failed" }),
+      task,
+    });
+  } else if (sourceStatus.kind === "found") {
+    for (const failure of sourceStatus.failures) {
+      problems.push({
+        code: "source-probe-failed",
+        message: publicProblemMessage({
+          code: "source-probe-failed",
+          source: failure.source,
+        }),
+        source: failure.source,
+        task,
+      });
+    }
+  }
+  if (workspaceProbe.kind === "unavailable") {
+    problems.push({
+      code: "workspace-probe-failed",
+      message: publicProblemMessage({ code: "workspace-probe-failed" }),
+      task,
+    });
+  }
+  for (const collected of collectedWorktrees) {
+    if (collected.branchProblem !== undefined) {
+      problems.push({
+        code: "git-probe-failed",
+        message: publicProblemMessage({ code: "git-probe-failed" }),
+        task,
+        worktreeDirectory: collected.worktree.directory,
+      });
+    }
+    if (collected.worktree.dirtiness.kind === "unknown") {
+      problems.push({
+        code: "git-probe-failed",
+        message: publicProblemMessage({ code: "git-probe-failed" }),
+        task,
+        worktreeDirectory: collected.worktree.directory,
+      });
+    }
+    if (collected.githubProblem === undefined) {
+      continue;
+    }
+    problems.push({
+      code: "github-probe-failed",
+      message: publicProblemMessage({ code: "github-probe-failed" }),
+      task,
+      worktreeDirectory: collected.worktree.directory,
+    });
+  }
+  const snapshot: TaskStatusSnapshot = {
+    kind: "task",
+    generatedAt,
+    task: identity,
+    repository:
+      sourceStatus.kind === "found"
+        ? (sourceStatus.issue.repository ?? runState?.repository)
+        : runState?.repository,
+    run,
+    workspace,
+    worktrees: taskWorktrees,
+    recommendedActions: taskRecommendedActions({
+      identity,
+      run,
+      workspace,
+      worktrees: taskWorktrees,
+    }),
+    problems,
+    text: {
+      task,
+      runState,
+      sourceStatus,
+      workspaceProbe,
+      accessHint,
+      recentLogLines: includeRecentLogs
+        ? recentTaskLogLines({ lines: wholeLogLines(config), task })
+        : [],
+    },
+  };
+  return snapshot;
+}
+
+function writeInventoryStatus(details: InventoryTextDetails): void {
+  const { local, joined, boardError, sourceProblems, renderedAt } = details;
+  writeInventoryWorktrees(joined, renderedAt);
   writeStraySessions(local);
   writeInProgressWithoutWorktree(joined);
+  if (sourceProblems.length > 0) {
+    writeSection("Source problems");
+    for (const problem of sourceProblems) {
+      writeOutput(`${problem.source}: ${problem.message}`);
+    }
+  }
   if (joined.slots !== undefined) {
     writeOutput();
-    writeOutput(`slots: ${joined.slots.used}/${joined.slots.maximum} used`);
+    writeOutput(
+      sourceProblems.length === 0
+        ? `slots: ${joined.slots.used}/${joined.slots.maximum} used`
+        : `slots: unknown/${joined.slots.maximum} used (source data incomplete)`,
+    );
   }
-  writeQueueSections({ joined, boardError: remote.lastAttemptError });
-}
-
-/**
- * Emits the snapshot documents on stdout and persists them beside the log
- * file. The persisted copies let a monitor start warm, and let any other
- * reader see state without spawning a process.
- *
- * `--local-only` omits the `remote` key rather than setting it null: absent
- * means "not collected", where null would mean "collected and empty".
- */
-async function writeJsonStatus(input: {
-  config: ResolvedConfig;
-  localOnly: boolean;
-}): Promise<void> {
-  const { config, localOnly } = input;
-  // --local-only takes its own path rather than a flag inside collectBothTiers,
-  // so this branch provably never starts a board fetch.
-  if (localOnly) {
-    const local = writeLocalSnapshot({ config, document: await collectLocalStatus({ config }) });
-    writeOutput(JSON.stringify({ local }, undefined, 2));
-    return;
-  }
-  const collected = await collectBothTiers(config);
-  // Print what landed on disk, not what we built. When a monotonic guard
-  // rejects our document because a concurrent run wrote a newer one, the two
-  // differ, and stdout must never contradict the file. writeRemoteSnapshot
-  // owns the carry-forward merge so it reads the file exactly once.
-  const local = writeLocalSnapshot({ config, document: collected.local });
-  const remote = writeRemoteSnapshot({
-    config,
-    attemptAt: collected.attemptAt,
-    result: collected.result,
-  });
-  writeOutput(JSON.stringify({ local, remote }, undefined, 2));
-}
-
-/**
- * The option combinations the command refuses. Lives apart from
- * `parseArguments` so the exported `status` enforces it too: a library caller
- * passing `localOnly` without `json` must not silently get the text path.
- */
-function assertSupportedOptions(options: StatusOptions): void {
-  if (options.localOnly === true && options.json !== true) {
-    throw new Error("crew status: --local-only requires --json");
-  }
-  if (options.json === true && options.task !== undefined) {
-    throw new Error("crew status: --json is not supported for a single task");
-  }
+  writeQueueSections({ joined, boardError });
 }
 
 export async function status(config: ResolvedConfig, options: StatusOptions = {}): Promise<void> {
-  assertSupportedOptions(options);
-  const task = options.task?.trim();
+  const snapshot = await collectStatus(config, options);
   if (options.json === true) {
-    await writeJsonStatus({ config, localOnly: options.localOnly === true });
-    return;
+    renderStatusJson(snapshot);
+  } else {
+    renderStatusText(snapshot);
   }
-  if (task === undefined) {
-    await writeInventoryStatus(config);
-    return;
-  }
-  if (task.length === 0 || task.startsWith("-")) {
-    throw new Error("task must be a non-empty value");
-  }
-  await writeTaskStatus(config, task);
 }
 
 export async function statusCli(argv: string[]): Promise<void> {
   const options = parseArguments(argv);
-  // Validate before loading config so a bad flag combination fails fast.
-  assertSupportedOptions(options);
-  const config = await loadConfig();
+  const config =
+    options.json === true
+      ? await withLogOutputSuppressed(async () => await loadConfig())
+      : await loadConfig();
   await status(config, options);
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1087,27 +1087,28 @@ async function collectTaskSnapshot(input: {
   includeRecentLogs: boolean;
 }): Promise<TaskStatusSnapshot> {
   const { config, task, includeRecentLogs } = input;
+  const localTask = naturalIdFromCanonical(task);
   const generatedAt = new Date().toISOString();
-  const runState = readRunState(config, task);
+  const runState = readRunState(config, localTask);
   const [workspaceProbe, sourceStatus] = await Promise.all([
     withLogOutputSuppressed(async () => await workspaces.probe(config)),
     readTaskSourceStatus(config, task),
   ]);
-  const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, task);
-  const entries = worktrees.findByTask(config, task);
+  const accessHint = await exitedWorkspaceAccessHint(config, workspaceProbe, localTask);
+  const entries = worktrees.findByTask(config, localTask);
   const collectedWorktrees = await Promise.all(
     entries.map(async (entry) => await collectTaskWorktree({ entry, runState })),
   );
   const taskWorktrees = collectedWorktrees.map((collected) => collected.worktree);
-  const identity = taskIdentityFromStatus({ task, runState, sourceStatus });
+  const identity = taskIdentityFromStatus({ task: localTask, runState, sourceStatus });
   const run = runSnapshotFromState(runState);
-  const workspace = workspaceSnapshot({ probe: workspaceProbe, task });
+  const workspace = workspaceSnapshot({ probe: workspaceProbe, task: localTask });
   const problems: StatusProblem[] = [];
   if (sourceStatus.kind === "unavailable") {
     problems.push({
       code: "source-probe-failed",
       message: publicProblemMessage({ code: "source-probe-failed" }),
-      task,
+      task: localTask,
     });
   } else if (sourceStatus.kind === "found") {
     for (const failure of sourceStatus.failures) {
@@ -1118,7 +1119,7 @@ async function collectTaskSnapshot(input: {
           source: failure.source,
         }),
         source: failure.source,
-        task,
+        task: localTask,
       });
     }
   }
@@ -1126,7 +1127,7 @@ async function collectTaskSnapshot(input: {
     problems.push({
       code: "workspace-probe-failed",
       message: publicProblemMessage({ code: "workspace-probe-failed" }),
-      task,
+      task: localTask,
     });
   }
   for (const collected of collectedWorktrees) {
@@ -1134,7 +1135,7 @@ async function collectTaskSnapshot(input: {
       problems.push({
         code: "git-probe-failed",
         message: publicProblemMessage({ code: "git-probe-failed" }),
-        task,
+        task: localTask,
         worktreeDirectory: collected.worktree.directory,
       });
     }
@@ -1142,7 +1143,7 @@ async function collectTaskSnapshot(input: {
       problems.push({
         code: "git-probe-failed",
         message: publicProblemMessage({ code: "git-probe-failed" }),
-        task,
+        task: localTask,
         worktreeDirectory: collected.worktree.directory,
       });
     }
@@ -1152,7 +1153,7 @@ async function collectTaskSnapshot(input: {
     problems.push({
       code: "github-probe-failed",
       message: publicProblemMessage({ code: "github-probe-failed" }),
-      task,
+      task: localTask,
       worktreeDirectory: collected.worktree.directory,
     });
   }
@@ -1175,13 +1176,13 @@ async function collectTaskSnapshot(input: {
     }),
     problems,
     text: {
-      task,
+      task: localTask,
       runState,
       sourceStatus,
       workspaceProbe,
       accessHint,
       recentLogLines: includeRecentLogs
-        ? recentTaskLogLines({ lines: wholeLogLines(config), task })
+        ? recentTaskLogLines({ lines: wholeLogLines(config), task: localTask })
         : [],
     },
   };

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -1,14 +1,15 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch } from "../lib/pullRequests.ts";
+import { findPullRequestsForBranch, pullRequestProbeProblem } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
-import type { Blocker, Issue as SourceIssue } from "../lib/taskSource.ts";
+import type { Blocker, Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import { probeEffectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import type { RemoteFetchResult, RemoteStatusPayload } from "../lib/statusSnapshot.ts";
 import {
   collectLocalStatus,
@@ -18,10 +19,6 @@ import {
   workspaceProbeUnavailableText,
 } from "./statusCollect.ts";
 
-vi.mock(import("../lib/board.ts"), async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual, createBoard: vi.fn<typeof actual.createBoard>() };
-});
 vi.mock(import("../lib/buildSources.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, buildSources: vi.fn<typeof actual.buildSources>().mockResolvedValue([]) };
@@ -33,6 +30,7 @@ vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
     findPullRequestsForBranch: vi
       .fn<typeof actual.findPullRequestsForBranch>()
       .mockResolvedValue([]),
+    pullRequestProbeProblem: vi.fn<typeof actual.pullRequestProbeProblem>().mockReturnValue({}),
   };
 });
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
@@ -68,8 +66,14 @@ vi.mock(import("../lib/worktreeRunState.ts"), async (importOriginal) => {
     effectiveBranchNameFromRunState: vi
       .fn<typeof actual.effectiveBranchNameFromRunState>()
       .mockResolvedValue("eng-220"),
+    probeEffectiveBranchNameFromRunState: vi
+      .fn<typeof actual.probeEffectiveBranchNameFromRunState>()
+      .mockResolvedValue({ branch: "eng-220" }),
   };
 });
+
+const buildSourcesMock = vi.mocked(buildSources);
+const probeEffectiveBranchMock = vi.mocked(probeEffectiveBranchNameFromRunState);
 
 let directory: string;
 let mockConfig: ResolvedConfig;
@@ -231,45 +235,25 @@ describe("collectLocalStatus", () => {
     expect(actual.tasks[0]?.worktrees[0]?.branch).toBe("eng-220");
   });
 
-  it("attaches only log lines that mention the task", async () => {
-    writeFileSync(
-      mockConfig.logging.file,
-      ["[10:00:00] eng-220 dispatched", "[10:00:01] eng-999 dispatched"].join("\n"),
-    );
+  it("retains branch-probe degradation beside the fallback branch", async () => {
+    probeEffectiveBranchMock.mockResolvedValue({
+      branch: "eng-220",
+      problem: "Could not determine the current branch: git probe failed",
+    });
 
     const actual = await collectLocalStatus({ config: mockConfig });
 
-    expect(actual.tasks[0]?.recentLogLines).toEqual(["[10:00:00] eng-220 dispatched"]);
+    expect(actual.tasks[0]?.worktrees[0]).toMatchObject({
+      branch: "eng-220",
+      branchProblem: "Could not determine the current branch: git probe failed",
+    });
   });
 
-  it("finds a task's recent line before a large unrelated tail", async () => {
-    const filler = `${"x".repeat(200)}\n`.repeat(2000);
-    writeFileSync(mockConfig.logging.file, `[09:00:00] eng-220 ancient\n${filler}`);
-
+  it("does not scan the shared log for inventory status", async () => {
     const actual = await collectLocalStatus({ config: mockConfig });
 
-    expect(actual.tasks[0]?.recentLogLines).toEqual(["[09:00:00] eng-220 ancient"]);
-  });
-
-  it("reassembles a matching line split across scan chunks", async () => {
-    const oversizedLine = `${"x".repeat(300_000)} eng-220 fragment`;
-    writeFileSync(
-      mockConfig.logging.file,
-      [oversizedLine, "[10:00:00] eng-220 real line"].join("\n"),
-    );
-
-    const actual = await collectLocalStatus({ config: mockConfig });
-
-    expect(actual.tasks[0]?.recentLogLines).toEqual([
-      oversizedLine,
-      "[10:00:00] eng-220 real line",
-    ]);
-  });
-
-  it("survives a missing log file", async () => {
-    const actual = await collectLocalStatus({ config: mockConfig });
-
-    expect(actual.tasks[0]?.recentLogLines).toEqual([]);
+    expect(actual.tasks[0]).not.toHaveProperty("recentLogLines");
+    expect(actual).not.toHaveProperty("logCursor");
   });
 });
 
@@ -294,26 +278,36 @@ function makeBlocker(overrides: Partial<Blocker> & { id: string }): Blocker {
   return { title: "a blocker", status: "in-progress", ...overrides };
 }
 
-function mockBoard(fetch: Board["fetch"]): void {
-  vi.mocked(createBoard).mockReturnValue({ fetch } as Board);
+async function noop(): Promise<void> {
+  await Promise.resolve();
+}
+
+async function noIssue(): Promise<SourceIssue | undefined> {
+  const issues: SourceIssue[] = [];
+  return issues[0];
+}
+
+function source(input: { name: string; listTasks: TaskSource["listTasks"] }): TaskSource {
+  return {
+    name: input.name,
+    verify: noop,
+    listTasks: input.listTasks,
+    getTask: async () => null,
+    fetch: input.listTasks,
+    resolveOne: noIssue,
+    markInProgress: noop,
+    markInReview: async () => ({ outcome: "applied" }),
+  };
 }
 
 function mockBoardFetch(issues: SourceIssue[]): void {
-  mockBoard(
-    vi.fn<Board["fetch"]>(async () => ({
-      timestamp: "2026-08-04T03:00:00.000Z",
-      issues,
-      parentSkips: [],
-    })),
-  );
+  buildSourcesMock.mockResolvedValue([
+    source({ name: "linear", listTasks: async () => await Promise.resolve(issues) }),
+  ]);
 }
 
 function mockBoardFetchRejection(error: Error): void {
-  mockBoard(
-    vi.fn<Board["fetch"]>(async () => {
-      throw error;
-    }),
-  );
+  buildSourcesMock.mockRejectedValue(error);
 }
 
 /**
@@ -383,6 +377,38 @@ describe("collectRemoteStatus", () => {
     expect(actual.inProgress.map((issue) => issue.naturalId)).toEqual(["eng-220"]);
     expect(actual.queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
     expect(actual.queueBlocked.map((issue) => issue.naturalId)).toEqual(["eng-215"]);
+  });
+
+  it("keeps successful source data when a sibling source fails", async () => {
+    buildSourcesMock.mockResolvedValue([
+      source({
+        name: "healthy",
+        listTasks: async () => [makeIssue({ id: "healthy:eng-225", source: "healthy" })],
+      }),
+      source({
+        name: "broken",
+        listTasks: async () => await Promise.reject(new Error("source unavailable")),
+      }),
+    ]);
+
+    const actual = await collectRemoteStatus({
+      board: await fetchBoardIssues(mockConfig),
+      pullRequestTargets: [],
+    });
+
+    expect(expectPayload(actual).queueReady.map((issue) => issue.naturalId)).toEqual(["eng-225"]);
+    expect(actual.sourceProblems).toEqual([{ source: "broken", message: "source unavailable" }]);
+  });
+
+  it("reports every source when all configured sources fail", async () => {
+    buildSourcesMock.mockResolvedValue([
+      source({ name: "first", listTasks: async () => await Promise.reject(new Error("down")) }),
+      source({ name: "second", listTasks: async () => await Promise.reject(new Error("offline")) }),
+    ]);
+
+    const actual = await fetchBoardIssues(mockConfig);
+
+    expect(actual).toEqual({ kind: "error", message: "first: down\nsecond: offline" });
   });
 
   it("keeps an in-progress issue in the payload even when it has a local worktree", async () => {
@@ -487,6 +513,18 @@ describe("collectRemoteStatus", () => {
     });
   });
 
+  it("keeps GitHub probe failures separate from an empty pull request result", async () => {
+    vi.mocked(findPullRequestsForBranch).mockResolvedValue([]);
+    vi.mocked(pullRequestProbeProblem).mockReturnValue({ message: "gh unavailable" });
+
+    const actual = await collectWithBoard([], [{ dir: "/repos/eng-220", branch: "eng-220" }]);
+
+    expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toEqual([]);
+    expect(actual.pullRequestProblems).toEqual([
+      { directory: "/repos/eng-220", message: "gh unavailable" },
+    ]);
+  });
+
   it("never reads run state, since the local tier already did", async () => {
     await collectWithBoard([], [{ dir: "/repos/eng-220", branch: "eng-220" }]);
 
@@ -512,6 +550,7 @@ describe("collectRemoteStatus", () => {
     });
 
     expect(actual.board).toEqual({ kind: "error", message: "Linear: 401 unauthorized" });
+    expect(actual.sourceProblems).toEqual([]);
     expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toHaveLength(1);
   });
 });

--- a/src/commands/statusCollect.test.ts
+++ b/src/commands/statusCollect.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { buildSources } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch, pullRequestProbeProblem } from "../lib/pullRequests.ts";
+import { probePullRequestsForBranch } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import type { Blocker, Issue as SourceIssue, TaskSource } from "../lib/taskSource.ts";
 import { workspaces } from "../lib/workspaces.ts";
@@ -27,10 +27,9 @@ vi.mock(import("../lib/pullRequests.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    findPullRequestsForBranch: vi
-      .fn<typeof actual.findPullRequestsForBranch>()
-      .mockResolvedValue([]),
-    pullRequestProbeProblem: vi.fn<typeof actual.pullRequestProbeProblem>().mockReturnValue({}),
+    probePullRequestsForBranch: vi
+      .fn<typeof actual.probePullRequestsForBranch>()
+      .mockResolvedValue({ pullRequests: [] }),
   };
 });
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
@@ -497,9 +496,9 @@ describe("collectRemoteStatus", () => {
   });
 
   it("looks up pull requests with the branch the local tier already resolved", async () => {
-    vi.mocked(findPullRequestsForBranch).mockResolvedValue([
-      { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
-    ]);
+    vi.mocked(probePullRequestsForBranch).mockResolvedValue({
+      pullRequests: [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
+    });
 
     const actual = await collectWithBoard(
       [],
@@ -507,15 +506,17 @@ describe("collectRemoteStatus", () => {
     );
 
     expect(actual.pullRequestsByWorktree["/repos/eng-220"]).toHaveLength(1);
-    expect(findPullRequestsForBranch).toHaveBeenCalledWith({
+    expect(probePullRequestsForBranch).toHaveBeenCalledWith({
       cwd: "/repos/eng-220",
       branchName: "adopted-branch",
     });
   });
 
   it("keeps GitHub probe failures separate from an empty pull request result", async () => {
-    vi.mocked(findPullRequestsForBranch).mockResolvedValue([]);
-    vi.mocked(pullRequestProbeProblem).mockReturnValue({ message: "gh unavailable" });
+    vi.mocked(probePullRequestsForBranch).mockResolvedValue({
+      pullRequests: [],
+      problem: "gh unavailable",
+    });
 
     const actual = await collectWithBoard([], [{ dir: "/repos/eng-220", branch: "eng-220" }]);
 
@@ -534,15 +535,15 @@ describe("collectRemoteStatus", () => {
   it("skips pull request lookups entirely when no task has a worktree", async () => {
     await collectWithBoard([]);
 
-    expect(findPullRequestsForBranch).not.toHaveBeenCalled();
+    expect(probePullRequestsForBranch).not.toHaveBeenCalled();
   });
 
   // The board and `gh` share no data, so one failing must not hide the other.
   it("still collects pull requests when the board fetch fails", async () => {
     mockBoardFetchRejection(new Error("Linear: 401 unauthorized"));
-    vi.mocked(findPullRequestsForBranch).mockResolvedValue([
-      { url: "https://example.test/1", number: 1, state: "open", title: "PR" },
-    ]);
+    vi.mocked(probePullRequestsForBranch).mockResolvedValue({
+      pullRequests: [{ url: "https://example.test/1", number: 1, state: "open", title: "PR" }],
+    });
 
     const actual = await collectRemoteStatus({
       board: await fetchBoardIssues(mockConfig),

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -6,11 +6,7 @@
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
-import {
-  findPullRequestsForBranch,
-  pullRequestProbeProblem,
-  type PullRequestSummary,
-} from "../lib/pullRequests.ts";
+import { probePullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type LocalStatusDocument,
@@ -463,13 +459,14 @@ async function collectPullRequests(targets: readonly PullRequestTarget[]): Promi
   const results = await Promise.all(
     targets.map(async (target) => {
       try {
+        const probe = await probePullRequestsForBranch({
+          cwd: target.dir,
+          branchName: target.branch,
+        });
         return {
           kind: "ok" as const,
           target,
-          pullRequests: await findPullRequestsForBranch({
-            cwd: target.dir,
-            branchName: target.branch,
-          }),
+          ...probe,
         };
       } catch (error) {
         return { kind: "error" as const, target, message: errorMessage(error) };
@@ -484,9 +481,8 @@ async function collectPullRequests(targets: readonly PullRequestTarget[]): Promi
       continue;
     }
     byWorktree[result.target.dir] = [...result.pullRequests];
-    const { message } = pullRequestProbeProblem({ pullRequests: result.pullRequests });
-    if (message !== undefined) {
-      problems.push({ directory: result.target.dir, message });
+    if (result.problem !== undefined) {
+      problems.push({ directory: result.target.dir, message: result.problem });
     }
   }
   return { pullRequestsByWorktree: byWorktree, problems };

--- a/src/commands/statusCollect.ts
+++ b/src/commands/statusCollect.ts
@@ -1,31 +1,29 @@
 /**
- * Gathers the two status tiers that the `crew status` inventory renders and
- * that `crew status --json` publishes. Owns every subprocess and network call
- * on that path, so the join and the wire format do no I/O.
- *
- * The per-task view in status.ts is deliberately not on this path: it reads
- * its own state, because it reads the whole log where this reads a tail.
+ * Internal inventory collectors. They normalize local and remote probes for
+ * status.ts; only StatusSnapshot from that module is rendered to users.
  */
-
-import { closeSync, fstatSync, openSync, readSync } from "node:fs";
 
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import type { ResolvedConfig } from "../lib/config.ts";
-import { findPullRequestsForBranch, type PullRequestSummary } from "../lib/pullRequests.ts";
+import {
+  findPullRequestsForBranch,
+  pullRequestProbeProblem,
+  type PullRequestSummary,
+} from "../lib/pullRequests.ts";
 import { readRunState, type RunState } from "../lib/runState.ts";
 import {
   type LocalStatusDocument,
-  readLocalSnapshot,
   type RemoteFetchResult,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
   type StatusBlockedIssue,
   type StatusBoardIssue,
   type StatusLifecycle,
-  type StatusLogCursor,
+  type StatusPullRequestProblem,
   type StatusQueueIssue,
   type StatusSessionState,
   type StatusSourceIssue,
+  type StatusSourceProbeProblem,
   type StatusTask,
   type StatusWorktree,
 } from "../lib/statusSnapshot.ts";
@@ -37,18 +35,11 @@ import {
 } from "../lib/taskSource.ts";
 import { errorMessage, withLogOutputSuppressed } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
-import { effectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
+import { probeEffectiveBranchNameFromRunState } from "../lib/worktreeRunState.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 
 // Enough lines to show what a task just did, short enough for a status row.
 const RECENT_LOG_LINE_COUNT = 10;
-
-/**
- * Reverse-scan chunk size for the append-only shared log. Active tasks are
- * normally found in the first chunk; older tasks make the scan continue only
- * until their ten most recent matching lines have been found.
- */
-const LOG_SCAN_CHUNK_BYTES = 256 * 1024;
 
 export interface CollectLocalStatusInput {
   config: ResolvedConfig;
@@ -63,13 +54,11 @@ export async function collectLocalStatus(
 ): Promise<LocalStatusDocument> {
   const { config } = input;
   const capturedAt = new Date().toISOString();
-  const previous = readLocalSnapshot(config);
   const entries = worktrees
     .list(config)
     .toSorted((left, right) => left.task.localeCompare(right.task));
   const uniqueTasks = [...new Set(entries.map((entry) => entry.task))];
   const runStates = new Map(uniqueTasks.map((task) => [task, readRunState(config, task)]));
-  const recentLogs = readRecentLogLines({ config, previous, tasks: uniqueTasks });
 
   // The probe and the git fan-out share no data, so overlap them. Access hints
   // wait for the probe: resolving the workspace adapter is only cached after
@@ -100,18 +89,20 @@ export async function collectLocalStatus(
       attachCommand: accessHints.get(task)?.command,
       hint: disagreement === undefined ? undefined : disagreementHint({ disagreement, task }),
       worktrees: taskWorktrees,
-      recentLogLines: recentLogs.linesByTask.get(task) ?? [],
     };
   });
+  const orphaned = orphanedSessions({ probe, entries });
+  const exitedOrphaned =
+    probe.kind === "ok" ? orphaned.filter((task) => probe.exitedNames?.has(task) === true) : [];
 
   return {
     schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
     capturedAt,
-    logCursor: recentLogs.cursor,
     maximumInProgress: config.orchestrator.maximumInProgress,
     workspaceProbe: probeState(probe),
     tasks,
-    orphanedSessions: orphanedSessions({ probe, entries }),
+    orphanedSessions: orphaned,
+    ...(exitedOrphaned.length === 0 ? {} : { exitedOrphanedSessions: exitedOrphaned }),
   };
 }
 
@@ -134,7 +125,12 @@ export interface CollectRemoteStatusInput {
 
 /** One board fetch attempt. A failure is a value here, never a throw. */
 export type BoardFetch =
-  | { kind: "ok"; capturedAt: string; issues: readonly SourceIssue[] }
+  | {
+      kind: "ok";
+      capturedAt: string;
+      issues: readonly SourceIssue[];
+      sourceProblems: StatusSourceProbeProblem[];
+    }
   | { kind: "error"; message: string };
 
 /**
@@ -143,9 +139,47 @@ export type BoardFetch =
  */
 export async function fetchBoardIssues(config: ResolvedConfig): Promise<BoardFetch> {
   try {
-    const board = await buildBoard(config);
-    const state = await withLogOutputSuppressed(async () => await board.fetch());
-    return { kind: "ok", capturedAt: state.timestamp, issues: state.issues };
+    const attempts = await withLogOutputSuppressed(async () => {
+      const sources = await buildSources(sourcesFromConfig(config), { globalConfig: config });
+      return await Promise.all(
+        sources.map(async (source) => {
+          try {
+            return { kind: "ok" as const, source: source.name, issues: await source.listTasks() };
+          } catch (error) {
+            return {
+              kind: "error" as const,
+              source: source.name,
+              message: errorMessage(error),
+            };
+          }
+        }),
+      );
+    });
+    const sourceProblems = attempts.flatMap((attempt) =>
+      attempt.kind === "ok"
+        ? []
+        : [
+            {
+              source: attempt.source,
+              message: attempt.message,
+            } satisfies StatusSourceProbeProblem,
+          ],
+    );
+    if (attempts.length > 0 && sourceProblems.length === attempts.length) {
+      return {
+        kind: "error",
+        message:
+          sourceProblems.length === 1
+            ? sourceProblems.map((problem) => problem.message).join("")
+            : sourceProblems.map((problem) => `${problem.source}: ${problem.message}`).join("\n"),
+      };
+    }
+    return {
+      kind: "ok",
+      capturedAt: new Date().toISOString(),
+      issues: attempts.flatMap((attempt) => (attempt.kind === "ok" ? attempt.issues : [])),
+      sourceProblems,
+    };
   } catch (error) {
     return { kind: "error", message: errorMessage(error) };
   }
@@ -164,9 +198,10 @@ export async function collectRemoteStatus(
   input: CollectRemoteStatusInput,
 ): Promise<RemoteFetchResult> {
   const { board, pullRequestTargets } = input;
-  const pullRequestsByWorktree = await collectPullRequests(pullRequestTargets);
+  const { pullRequestsByWorktree, problems: pullRequestProblems } =
+    await collectPullRequests(pullRequestTargets);
   if (board.kind === "error") {
-    return { board, pullRequestsByWorktree };
+    return { board, pullRequestsByWorktree, pullRequestProblems, sourceProblems: [] };
   }
   const { issues } = board;
 
@@ -176,6 +211,8 @@ export async function collectRemoteStatus(
 
   return {
     pullRequestsByWorktree,
+    pullRequestProblems,
+    sourceProblems: board.sourceProblems,
     board: {
       kind: "ok",
       payload: {
@@ -319,11 +356,18 @@ async function collectWorktree(input: {
   runState: RunState | undefined;
 }): Promise<StatusWorktree> {
   const { entry, runState } = input;
-  const [branch, git] = await Promise.all([
-    effectiveBranchNameFromRunState({ entry, runState }),
+  const [branchProbe, git] = await Promise.all([
+    probeEffectiveBranchNameFromRunState({ entry, runState }),
     worktrees.probeWorkingTree({ worktreeDir: entry.dir }),
   ]);
-  return { repository: entry.repository, kind: entry.kind, dir: entry.dir, branch, git };
+  return {
+    repository: entry.repository,
+    kind: entry.kind,
+    dir: entry.dir,
+    branch: branchProbe.branch,
+    branchProblem: branchProbe.problem,
+    git,
+  };
 }
 
 async function collectAccessHints(input: {
@@ -352,149 +396,6 @@ function orphanedSessions(input: {
   }
   const worktreeTasks = new Set(entries.map((entry) => entry.task));
   return [...probe.names].filter((name) => !worktreeTasks.has(name)).toSorted();
-}
-
-interface RecentLogResult {
-  linesByTask: Map<string, string[]>;
-  cursor?: StatusLogCursor | undefined;
-}
-
-function readRecentLogLines(input: {
-  config: ResolvedConfig;
-  previous: LocalStatusDocument | undefined;
-  tasks: readonly string[];
-}): RecentLogResult {
-  const { config, previous, tasks } = input;
-  if (tasks.length === 0) {
-    return { linesByTask: new Map() };
-  }
-  let handle: number;
-  try {
-    handle = openSync(config.logging.file, "r");
-  } catch {
-    return { linesByTask: new Map() };
-  }
-  try {
-    const stats = fstatSync(handle);
-    const cursor: StatusLogCursor = {
-      device: stats.dev,
-      inode: stats.ino,
-      offset: stats.size,
-    };
-    const previousCursor = previous?.logCursor;
-    const canResume =
-      previousCursor !== undefined &&
-      previousCursor.device === cursor.device &&
-      previousCursor.inode === cursor.inode &&
-      previousCursor.offset <= cursor.offset;
-    const previousTasks = new Map(previous?.tasks.map((task) => [task.task, task]) ?? []);
-    const reusableTasks = canResume ? tasks.filter((task) => previousTasks.has(task)) : [];
-    const tasksNeedingHistory = tasks.filter((task) => !reusableTasks.includes(task));
-    const appendedLines = scanRecentLogLines({
-      handle,
-      startOffset: previousCursor?.offset ?? 0,
-      endOffset: cursor.offset,
-      tasks: reusableTasks,
-    });
-    const historicalLines = scanRecentLogLines({
-      handle,
-      startOffset: 0,
-      endOffset: cursor.offset,
-      tasks: tasksNeedingHistory,
-    });
-    const linesByTask = new Map<string, string[]>();
-    for (const task of reusableTasks) {
-      const cached = requiredMapValue(previousTasks, task).recentLogLines;
-      linesByTask.set(
-        task,
-        [...cached, ...requiredMapValue(appendedLines, task)].slice(-RECENT_LOG_LINE_COUNT),
-      );
-    }
-    for (const task of tasksNeedingHistory) {
-      linesByTask.set(task, requiredMapValue(historicalLines, task));
-    }
-    return { linesByTask, cursor };
-  } finally {
-    closeSync(handle);
-  }
-}
-
-function scanRecentLogLines(input: {
-  handle: number;
-  startOffset: number;
-  endOffset: number;
-  tasks: readonly string[];
-}): Map<string, string[]> {
-  const { handle, startOffset, endOffset, tasks } = input;
-  const matchers = tasks.map((task) => ({
-    task,
-    pattern: taskLogPattern(task),
-    linesNewestFirst: [] as string[],
-  }));
-  let startsAtLineBoundary = startOffset === 0;
-  if (startOffset > 0) {
-    const priorByte = Buffer.alloc(1);
-    startsAtLineBoundary =
-      readSync(handle, priorByte, 0, 1, startOffset - 1) === 1 && priorByte[0] === 10;
-  }
-  let leadingFragment: Buffer = Buffer.alloc(0);
-  let position = endOffset;
-
-  while (
-    position > startOffset &&
-    matchers.some((matcher) => matcher.linesNewestFirst.length < RECENT_LOG_LINE_COUNT)
-  ) {
-    const length = Math.min(position - startOffset, LOG_SCAN_CHUNK_BYTES);
-    const start = position - length;
-    const buffer = Buffer.alloc(length);
-    const bytesRead = readSync(handle, buffer, 0, length, start);
-    const split = splitLogBuffer(Buffer.concat([buffer.subarray(0, bytesRead), leadingFragment]));
-    const includeFirst = start === startOffset && startsAtLineBoundary;
-    const lines = includeFirst ? [split.first, ...split.rest] : split.rest;
-    leadingFragment = start > startOffset ? split.first : Buffer.alloc(0);
-
-    for (const lineBuffer of lines.toReversed()) {
-      const line = lineBuffer.toString("utf8");
-      for (const matcher of matchers) {
-        if (matcher.linesNewestFirst.length < RECENT_LOG_LINE_COUNT && matcher.pattern.test(line)) {
-          matcher.linesNewestFirst.push(line);
-        }
-      }
-    }
-    position = start;
-  }
-
-  return new Map(
-    matchers.map((matcher) => [matcher.task, matcher.linesNewestFirst.toReversed()] as const),
-  );
-}
-
-function requiredMapValue<Key, Value>(map: ReadonlyMap<Key, Value>, key: Key): Value {
-  const value = map.get(key);
-  /* v8 ignore next @preserve -- callers pass keys used to construct these maps */
-  if (value === undefined) {
-    throw new Error("Missing expected map value");
-  }
-  return value;
-}
-
-function splitLogBuffer(buffer: Buffer): {
-  first: Buffer;
-  rest: Buffer[];
-} {
-  const firstNewline = buffer.indexOf("\n");
-  if (firstNewline === -1) {
-    return { first: buffer, rest: [] };
-  }
-  const rest: Buffer[] = [];
-  let start = firstNewline + 1;
-  for (let newline = buffer.indexOf("\n", start); newline !== -1;) {
-    rest.push(buffer.subarray(start, newline));
-    start = newline + 1;
-    newline = buffer.indexOf("\n", start);
-  }
-  rest.push(buffer.subarray(start));
-  return { first: buffer.subarray(0, firstNewline), rest };
 }
 
 function hasOpenBlocker(issue: SourceIssue): boolean {
@@ -554,30 +455,41 @@ function sourceByTask(issues: readonly SourceIssue[]): Record<string, StatusSour
   return Object.fromEntries(sources);
 }
 
-async function collectPullRequests(
-  targets: readonly PullRequestTarget[],
-): Promise<Record<string, PullRequestSummary[]>> {
-  // allSettled, not all: one worktree whose lookup throws must not take down
-  // the whole status run, which is what the base command guaranteed. An empty
-  // or missing entry therefore means "none found, or the lookup failed".
-  const results = await Promise.allSettled(
-    targets.map(
-      async (target) =>
-        [
-          target.dir,
-          await findPullRequestsForBranch({ cwd: target.dir, branchName: target.branch }),
-        ] as const,
-    ),
+async function collectPullRequests(targets: readonly PullRequestTarget[]): Promise<{
+  pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
+  problems: StatusPullRequestProblem[];
+}> {
+  // One worktree whose lookup throws must not take down the whole status run.
+  const results = await Promise.all(
+    targets.map(async (target) => {
+      try {
+        return {
+          kind: "ok" as const,
+          target,
+          pullRequests: await findPullRequestsForBranch({
+            cwd: target.dir,
+            branchName: target.branch,
+          }),
+        };
+      } catch (error) {
+        return { kind: "error" as const, target, message: errorMessage(error) };
+      }
+    }),
   );
   const byWorktree: Record<string, PullRequestSummary[]> = {};
+  const problems: StatusPullRequestProblem[] = [];
   for (const result of results) {
-    if (result.status !== "fulfilled") {
+    if (result.kind === "error") {
+      problems.push({ directory: result.target.dir, message: result.message });
       continue;
     }
-    const [dir, pullRequests] = result.value;
-    byWorktree[dir] = [...pullRequests];
+    byWorktree[result.target.dir] = [...result.pullRequests];
+    const { message } = pullRequestProbeProblem({ pullRequests: result.pullRequests });
+    if (message !== undefined) {
+      problems.push({ directory: result.target.dir, message });
+    }
   }
-  return byWorktree;
+  return { pullRequestsByWorktree: byWorktree, problems };
 }
 
 function escapeRegExp(value: string): string {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,9 @@ describe("package root", () => {
     expect(packageRoot).not.toHaveProperty("readRemoteSnapshot");
     expect(packageRoot).not.toHaveProperty("writeLocalSnapshot");
     expect(packageRoot).not.toHaveProperty("writeRemoteSnapshot");
+    expect(packageRoot).not.toHaveProperty("collectStatus");
+    expect(packageRoot).not.toHaveProperty("renderStatusText");
+    expect(packageRoot).not.toHaveProperty("renderStatusJson");
   });
 
   it("keeps pull-request lookup result types private", () => {

--- a/src/lib/board.test.ts
+++ b/src/lib/board.test.ts
@@ -161,6 +161,25 @@ describe("Board.resolveOne", () => {
     expect(result?.id).toBe("b:x");
   });
 
+  it("retains a failed sibling source beside a resolved natural id", async () => {
+    const issue = fakeIssue("healthy:x", "healthy");
+    const board = createBoard([
+      fakeSource("healthy", {
+        getTask: vi.fn<(id: string) => Promise<Issue | null>>().mockResolvedValue(issue),
+      }),
+      fakeSource("broken", {
+        getTask: vi
+          .fn<(id: string) => Promise<Issue | null>>()
+          .mockRejectedValue(new Error("token=private-source-detail")),
+      }),
+    ]);
+
+    await expect(board.resolveOneWithFailures("x")).resolves.toEqual({
+      issue,
+      failures: [{ source: "broken", reason: new Error("token=private-source-detail") }],
+    });
+  });
+
   it("resolves a unique natural id prefix from listed current tasks when exact lookup misses", async () => {
     const listTasks = vi
       .fn<() => Promise<Issue[]>>()

--- a/src/lib/board.ts
+++ b/src/lib/board.ts
@@ -16,6 +16,11 @@ import {
 } from "./taskSource.ts";
 import { resolveTaskIdMatches, type TaskResolutionMatches } from "./taskResolution.ts";
 
+export interface BoardTaskResolution {
+  issue: Issue | undefined;
+  failures: TaskResolutionMatches["sourceFailures"];
+}
+
 export interface Board {
   verify: () => Promise<void>;
   fetch: () => Promise<BoardState>;
@@ -25,6 +30,8 @@ export interface Board {
    * sources; ambiguous matches throw.
    */
   resolveOne: (canonicalOrNaturalId: string) => Promise<Issue | undefined>;
+  /** Resolves one task while retaining failed sibling-source probes for status diagnostics. */
+  resolveOneWithFailures: (canonicalOrNaturalId: string) => Promise<BoardTaskResolution>;
   /** Routes to the adapter whose `name` matches `issue.source`. Unknown source throws. */
   markInProgress: (issue: Issue) => Promise<void>;
   /**
@@ -92,6 +99,28 @@ export function createBoard(sources: readonly TaskSource[]): Board {
     byName.set(source.name, source);
   }
 
+  async function resolveOneWithFailures(idArgument: string): Promise<BoardTaskResolution> {
+    const colonIndex = idArgument.indexOf(":");
+    if (colonIndex !== -1) {
+      const sourceName = idArgument.slice(0, colonIndex);
+      const naturalId = idArgument.slice(colonIndex + 1);
+      const source = byName.get(sourceName);
+      if (!source) {
+        throw new Error(`unknown source "${sourceName}" in canonical id "${idArgument}"`);
+      }
+      const resolution = await resolveTaskIdMatches({ sources: [source], naturalId });
+      return {
+        issue: uniqueResolvedIssue({ idArgument, resolution }),
+        failures: resolution.sourceFailures,
+      };
+    }
+    const resolution = await resolveTaskIdMatches({ sources, naturalId: idArgument });
+    return {
+      issue: uniqueResolvedIssue({ idArgument, resolution }),
+      failures: resolution.sourceFailures,
+    };
+  }
+
   return {
     async verify(): Promise<void> {
       const results = await Promise.allSettled(sources.map(callVerify));
@@ -130,31 +159,10 @@ export function createBoard(sources: readonly TaskSource[]): Board {
     },
 
     async resolveOne(idArgument: string): Promise<Issue | undefined> {
-      const colonIndex = idArgument.indexOf(":");
-      if (colonIndex !== -1) {
-        const sourceName = idArgument.slice(0, colonIndex);
-        const naturalId = idArgument.slice(colonIndex + 1);
-        const source = byName.get(sourceName);
-        if (!source) {
-          throw new Error(`unknown source "${sourceName}" in canonical id "${idArgument}"`);
-        }
-        return uniqueResolvedIssue({
-          idArgument,
-          resolution: await resolveTaskIdMatches({ sources: [source], naturalId }),
-        });
-      }
-      // Per-source resolveOne errors must not poison sibling resolutions.
-      // A source that rejects on a natural-id lookup is treated as "I don't
-      // have this task" (or "I can't say"). If any source resolved we use
-      // it; only when none resolved AND at least one rejected do we surface
-      // the rejection — so the user sees a real Linear/network error when
-      // there's no fallback, but a stray "not found" from one source doesn't
-      // mask a successful match from another.
-      return uniqueResolvedIssue({
-        idArgument,
-        resolution: await resolveTaskIdMatches({ sources, naturalId: idArgument }),
-      });
+      return (await resolveOneWithFailures(idArgument)).issue;
     },
+
+    resolveOneWithFailures,
 
     async markInProgress(issue: Issue): Promise<void> {
       await routeWriteback(byName, issue).markInProgress(issue);

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -151,6 +151,9 @@ describe(findPullRequestsForBranch, () => {
     });
 
     expect(prs).toStrictEqual([]);
+    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
+      message: "Unexpected non-JSON response from 'gh pr list'.",
+    });
   });
 
   it("returns empty when gh emits a non-array JSON value", async () => {
@@ -162,14 +165,17 @@ describe(findPullRequestsForBranch, () => {
     });
 
     expect(prs).toStrictEqual([]);
+    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
+      message: "Unexpected response shape from 'gh pr list'.",
+    });
   });
 
   it("skips entries that don't match the expected PR shape", async () => {
     runCommandMock.mockResolvedValue(
       JSON.stringify([
         rawPullRequest({ url: "https://x/pull/1", number: 1, state: "OPEN", title: "valid" }),
-        { url: 42, number: "not a number" }, // malformed; dropped silently
-        null, // also dropped
+        { url: 42, number: "not a number" },
+        null,
       ]),
     );
 
@@ -179,6 +185,9 @@ describe(findPullRequestsForBranch, () => {
     });
 
     expect(prs.map((p) => p.number)).toStrictEqual([1]);
+    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
+      message: "Some pull requests from 'gh pr list' had an unexpected shape.",
+    });
   });
 
   it("forwards the AbortSignal to runCommandAsync alongside cwd when provided", async () => {

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -1,7 +1,7 @@
 import type { RunCommandOptions } from "./commandRunner.ts";
 import {
   findPullRequestsForBranch,
-  pullRequestProbeProblem,
+  probePullRequestsForBranch,
   resolvePullRequest,
 } from "./pullRequests.ts";
 
@@ -114,14 +114,14 @@ describe(findPullRequestsForBranch, () => {
   it("returns empty when gh fails (not installed / not authenticated / network)", async () => {
     runCommandMock.mockRejectedValue(new Error("gh: command not found"));
 
-    const prs = await findPullRequestsForBranch({
+    const result = await probePullRequestsForBranch({
       cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
-    expect(prs).toStrictEqual([]);
-    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
-      message: "gh: command not found",
+    expect({ ...result, pullRequests: [...result.pullRequests] }).toEqual({
+      pullRequests: [],
+      problem: "gh: command not found",
     });
   });
 
@@ -145,28 +145,28 @@ describe(findPullRequestsForBranch, () => {
   it("returns empty when gh emits non-JSON output", async () => {
     runCommandMock.mockResolvedValue("not json at all");
 
-    const prs = await findPullRequestsForBranch({
+    const result = await probePullRequestsForBranch({
       cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
-    expect(prs).toStrictEqual([]);
-    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
-      message: "Unexpected non-JSON response from 'gh pr list'.",
+    expect(result).toEqual({
+      pullRequests: [],
+      problem: "Unexpected non-JSON response from 'gh pr list'.",
     });
   });
 
   it("returns empty when gh emits a non-array JSON value", async () => {
     runCommandMock.mockResolvedValue("null");
 
-    const prs = await findPullRequestsForBranch({
+    const result = await probePullRequestsForBranch({
       cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
-    expect(prs).toStrictEqual([]);
-    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
-      message: "Unexpected response shape from 'gh pr list'.",
+    expect(result).toEqual({
+      pullRequests: [],
+      problem: "Unexpected response shape from 'gh pr list'.",
     });
   });
 
@@ -179,15 +179,13 @@ describe(findPullRequestsForBranch, () => {
       ]),
     );
 
-    const prs = await findPullRequestsForBranch({
+    const result = await probePullRequestsForBranch({
       cwd: "/work/widgets-team-1",
       branchName: "x",
     });
 
-    expect(prs.map((p) => p.number)).toStrictEqual([1]);
-    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
-      message: "Some pull requests from 'gh pr list' had an unexpected shape.",
-    });
+    expect(result.pullRequests.map((pullRequest) => pullRequest.number)).toStrictEqual([1]);
+    expect(result.problem).toBe("Some pull requests from 'gh pr list' had an unexpected shape.");
   });
 
   it("forwards the AbortSignal to runCommandAsync alongside cwd when provided", async () => {

--- a/src/lib/pullRequests.test.ts
+++ b/src/lib/pullRequests.test.ts
@@ -1,5 +1,9 @@
 import type { RunCommandOptions } from "./commandRunner.ts";
-import { findPullRequestsForBranch, resolvePullRequest } from "./pullRequests.ts";
+import {
+  findPullRequestsForBranch,
+  pullRequestProbeProblem,
+  resolvePullRequest,
+} from "./pullRequests.ts";
 
 type RunCommandAsyncMock = (
   command: string,
@@ -116,6 +120,9 @@ describe(findPullRequestsForBranch, () => {
     });
 
     expect(prs).toStrictEqual([]);
+    expect(pullRequestProbeProblem({ pullRequests: prs })).toEqual({
+      message: "gh: command not found",
+    });
   });
 
   it("rethrows the original error when the lookup is aborted", async () => {

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -29,27 +29,6 @@ export interface PullRequestSummary {
   title: string;
 }
 
-const PULL_REQUEST_PROBE_PROBLEMS = new WeakMap<readonly PullRequestSummary[], string>();
-
-export interface PullRequestProbeProblemInput {
-  pullRequests: readonly PullRequestSummary[];
-}
-
-export interface PullRequestProbeProblemResult {
-  message?: string | undefined;
-}
-
-/**
- * Returns the command failure hidden by the best-effort PR lookup. Status uses
- * this to distinguish "no pull requests" from "GitHub could not be probed"
- * without changing the lookup's long-standing never-throw contract.
- */
-export function pullRequestProbeProblem(
-  input: PullRequestProbeProblemInput,
-): PullRequestProbeProblemResult {
-  return { message: PULL_REQUEST_PROBE_PROBLEMS.get(input.pullRequests) };
-}
-
 const GH_PR_LIST_LIMIT = 5;
 const STATE_MAP: Record<string, string> = {
   OPEN: "open",
@@ -72,12 +51,12 @@ interface RawPullRequest {
   title: string;
 }
 
-interface ParsePullRequestsResult {
-  pullRequests: PullRequestSummary[];
+export interface PullRequestProbeResult {
+  pullRequests: readonly PullRequestSummary[];
   problem?: string | undefined;
 }
 
-function parsePullRequests(output: string): ParsePullRequestsResult {
+function parsePullRequests(output: string): PullRequestProbeResult {
   let parsed: unknown;
   try {
     parsed = JSON.parse(output);
@@ -223,9 +202,13 @@ export async function resolvePullRequest(
   };
 }
 
-export async function findPullRequestsForBranch(
+/**
+ * Best-effort status probe that keeps data and diagnostics together so callers
+ * cannot lose the failure reason when they copy the pull request list.
+ */
+export async function probePullRequestsForBranch(
   arguments_: LookupArgs,
-): Promise<readonly PullRequestSummary[]> {
+): Promise<PullRequestProbeResult> {
   const { cwd, branchName, signal } = arguments_;
   const options = signal === undefined ? { cwd } : { cwd, signal };
   try {
@@ -245,20 +228,20 @@ export async function findPullRequestsForBranch(
       ],
       options,
     );
-    const parsed = parsePullRequests(output);
-    if (parsed.problem !== undefined) {
-      PULL_REQUEST_PROBE_PROBLEMS.set(parsed.pullRequests, parsed.problem);
-    }
-    return parsed.pullRequests;
+    return parsePullRequests(output);
   } catch (error) {
     if (signal?.aborted === true) {
       throw error;
     }
     // gh not installed / not authenticated / non-GitHub remote / network
-    // error / etc. All resolve to "no PR info available" for legacy callers;
-    // status can still expose the failure through pullRequestProbeProblem.
-    const pullRequests: PullRequestSummary[] = [];
-    PULL_REQUEST_PROBE_PROBLEMS.set(pullRequests, errorMessage(error));
-    return pullRequests;
+    // error / etc. All resolve to "no PR info available" for legacy callers.
+    return { pullRequests: [], problem: errorMessage(error) };
   }
+}
+
+/** Legacy never-throw lookup for callers that only need the pull request list. */
+export async function findPullRequestsForBranch(
+  arguments_: LookupArgs,
+): Promise<readonly PullRequestSummary[]> {
+  return (await probePullRequestsForBranch(arguments_)).pullRequests;
 }

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -19,6 +19,7 @@
  */
 
 import { runCommandAsync } from "./commandRunner.ts";
+import { errorMessage } from "./util.ts";
 
 export interface PullRequestSummary {
   url: string;
@@ -26,6 +27,27 @@ export interface PullRequestSummary {
   /** Lowercased lifecycle: "open" | "merged" | "closed". */
   state: string;
   title: string;
+}
+
+const PULL_REQUEST_PROBE_PROBLEMS = new WeakMap<readonly PullRequestSummary[], string>();
+
+export interface PullRequestProbeProblemInput {
+  pullRequests: readonly PullRequestSummary[];
+}
+
+export interface PullRequestProbeProblemResult {
+  message?: string | undefined;
+}
+
+/**
+ * Returns the command failure hidden by the best-effort PR lookup. Status uses
+ * this to distinguish "no pull requests" from "GitHub could not be probed"
+ * without changing the lookup's long-standing never-throw contract.
+ */
+export function pullRequestProbeProblem(
+  input: PullRequestProbeProblemInput,
+): PullRequestProbeProblemResult {
+  return { message: PULL_REQUEST_PROBE_PROBLEMS.get(input.pullRequests) };
 }
 
 const GH_PR_LIST_LIMIT = 5;
@@ -211,7 +233,10 @@ export async function findPullRequestsForBranch(
       throw error;
     }
     // gh not installed / not authenticated / non-GitHub remote / network
-    // error / etc. All resolve to "no PR info available" for display.
-    return [];
+    // error / etc. All resolve to "no PR info available" for legacy callers;
+    // status can still expose the failure through pullRequestProbeProblem.
+    const pullRequests: PullRequestSummary[] = [];
+    PULL_REQUEST_PROBE_PROBLEMS.set(pullRequests, errorMessage(error));
+    return pullRequests;
   }
 }

--- a/src/lib/pullRequests.ts
+++ b/src/lib/pullRequests.ts
@@ -72,19 +72,32 @@ interface RawPullRequest {
   title: string;
 }
 
-function parsePullRequests(output: string): PullRequestSummary[] {
+interface ParsePullRequestsResult {
+  pullRequests: PullRequestSummary[];
+  problem?: string | undefined;
+}
+
+function parsePullRequests(output: string): ParsePullRequestsResult {
   let parsed: unknown;
   try {
     parsed = JSON.parse(output);
   } catch {
-    return [];
+    return {
+      pullRequests: [],
+      problem: "Unexpected non-JSON response from 'gh pr list'.",
+    };
   }
   if (!Array.isArray(parsed)) {
-    return [];
+    return {
+      pullRequests: [],
+      problem: "Unexpected response shape from 'gh pr list'.",
+    };
   }
   const summaries: PullRequestSummary[] = [];
+  let hasInvalidEntry = false;
   for (const entry of parsed) {
     if (!isRawPullRequest(entry)) {
+      hasInvalidEntry = true;
       continue;
     }
     summaries.push({
@@ -94,7 +107,12 @@ function parsePullRequests(output: string): PullRequestSummary[] {
       title: entry.title,
     });
   }
-  return summaries;
+  return {
+    pullRequests: summaries,
+    ...(hasInvalidEntry
+      ? { problem: "Some pull requests from 'gh pr list' had an unexpected shape." }
+      : {}),
+  };
 }
 
 function isRawPullRequest(value: unknown): value is RawPullRequest {
@@ -227,7 +245,11 @@ export async function findPullRequestsForBranch(
       ],
       options,
     );
-    return parsePullRequests(output);
+    const parsed = parsePullRequests(output);
+    if (parsed.problem !== undefined) {
+      PULL_REQUEST_PROBE_PROBLEMS.set(parsed.pullRequests, parsed.problem);
+    }
+    return parsed.pullRequests;
   } catch (error) {
     if (signal?.aborted === true) {
       throw error;

--- a/src/lib/statusJoin.test.ts
+++ b/src/lib/statusJoin.test.ts
@@ -31,7 +31,6 @@ function makeTask(task: string): StatusTask {
         git: { kind: "clean" },
       },
     ],
-    recentLogLines: [],
   };
 }
 

--- a/src/lib/statusJoin.ts
+++ b/src/lib/statusJoin.ts
@@ -1,8 +1,4 @@
-/**
- * Combines the local and remote status tiers at read time. Lives apart from
- * the collectors because an external monitor reimplements this step against
- * the published documents, and the text renderer consumes its output.
- */
+/** Combines the internal local and remote status collection tiers. */
 
 import type { PullRequestSummary } from "./pullRequests.ts";
 import type {

--- a/src/lib/statusSnapshot.test.ts
+++ b/src/lib/statusSnapshot.test.ts
@@ -1,28 +1,10 @@
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-
-import type { ResolvedConfig } from "./config.ts";
 import {
   buildRemoteDocument,
   type RemoteFetchResult,
-  type LocalStatusDocument,
-  localSnapshotPath,
-  readLocalSnapshot,
-  readRemoteSnapshot,
   type RemoteStatusDocument,
   type RemoteStatusPayload,
-  remoteSnapshotPath,
   STATUS_SNAPSHOT_SCHEMA_VERSION,
-  writeLocalSnapshot,
-  writeRemoteSnapshot,
 } from "./statusSnapshot.ts";
-
-type LoggingConfig = Pick<ResolvedConfig, "logging">;
-
-function makeConfig(directory: string): LoggingConfig {
-  return { logging: { file: path.join(directory, "groundcrew.log") } };
-}
 
 function makePayload(capturedAt: string): RemoteStatusPayload {
   return {
@@ -41,29 +23,16 @@ function makePayload(capturedAt: string): RemoteStatusPayload {
   };
 }
 
-function okResult(capturedAt: string): RemoteFetchResult {
-  return {
-    board: { kind: "ok", payload: makePayload(capturedAt) },
-    pullRequestsByWorktree: {},
-  };
-}
-
 function errorResult(message: string): RemoteFetchResult {
-  return { board: { kind: "error", message }, pullRequestsByWorktree: {} };
-}
-
-function makeLocal(capturedAt: string): LocalStatusDocument {
   return {
-    schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
-    capturedAt,
-    maximumInProgress: 4,
-    workspaceProbe: { status: "ok" },
-    tasks: [],
-    orphanedSessions: [],
+    board: { kind: "error", message },
+    pullRequestsByWorktree: {},
+    pullRequestProblems: [],
+    sourceProblems: [],
   };
 }
 
-function makeDocument(overrides: Partial<RemoteStatusDocument> = {}): RemoteStatusDocument {
+function makeDocument(): RemoteStatusDocument {
   return {
     schemaVersion: STATUS_SNAPSHOT_SCHEMA_VERSION,
     lastAttemptAt: "2026-08-04T03:00:00.000Z",
@@ -71,41 +40,46 @@ function makeDocument(overrides: Partial<RemoteStatusDocument> = {}): RemoteStat
     lastAttemptError: undefined,
     payload: makePayload("2026-08-04T03:00:00.000Z"),
     pullRequestsByWorktree: {},
-    ...overrides,
   };
 }
 
 describe("buildRemoteDocument", () => {
-  it("replaces the payload on a successful attempt", () => {
+  it("uses the current payload on a successful attempt", () => {
     const input = makePayload("2026-08-04T03:00:00.000Z");
 
     const actual = buildRemoteDocument({
       previous: undefined,
       attemptAt: "2026-08-04T03:00:00.000Z",
-      result: { board: { kind: "ok", payload: input }, pullRequestsByWorktree: {} },
+      result: {
+        board: { kind: "ok", payload: input },
+        pullRequestsByWorktree: {},
+        pullRequestProblems: [],
+        sourceProblems: [],
+      },
     });
 
-    expect(actual.lastAttemptStatus).toBe("ok");
-    expect(actual.lastAttemptError).toBeUndefined();
-    expect(actual.payload).toEqual(input);
+    expect(actual).toMatchObject({
+      lastAttemptStatus: "ok",
+      payload: input,
+    });
   });
 
   it("keeps the previous payload when the attempt fails", () => {
-    const mockPrevious = makeDocument();
-
     const actual = buildRemoteDocument({
-      previous: mockPrevious,
+      previous: makeDocument(),
       attemptAt: "2026-08-04T03:05:00.000Z",
       result: errorResult("Linear: 401 unauthorized"),
     });
 
-    expect(actual.lastAttemptAt).toBe("2026-08-04T03:05:00.000Z");
-    expect(actual.lastAttemptStatus).toBe("unavailable");
-    expect(actual.lastAttemptError).toBe("Linear: 401 unauthorized");
-    expect(actual.payload?.capturedAt).toBe("2026-08-04T03:00:00.000Z");
+    expect(actual).toMatchObject({
+      lastAttemptAt: "2026-08-04T03:05:00.000Z",
+      lastAttemptStatus: "unavailable",
+      lastAttemptError: "Linear: 401 unauthorized",
+      payload: { capturedAt: "2026-08-04T03:00:00.000Z" },
+    });
   });
 
-  it("leaves the payload undefined when the first attempt ever fails", () => {
+  it("leaves the payload undefined when the first attempt fails", () => {
     const actual = buildRemoteDocument({
       previous: undefined,
       attemptAt: "2026-08-04T03:05:00.000Z",
@@ -114,256 +88,5 @@ describe("buildRemoteDocument", () => {
 
     expect(actual.payload).toBeUndefined();
     expect(actual.lastAttemptStatus).toBe("unavailable");
-  });
-});
-
-describe("writeLocalSnapshot", () => {
-  let directory: string;
-
-  beforeEach(() => {
-    directory = mkdtempSync(path.join(tmpdir(), "gc-local-"));
-  });
-
-  afterEach(() => {
-    rmSync(directory, { force: true, recursive: true });
-  });
-
-  it("round-trips a document through disk", () => {
-    const config = makeConfig(directory);
-    const input = makeLocal("2026-08-04T03:00:00.000Z");
-
-    const actual = writeLocalSnapshot({ config, document: input });
-
-    expect(actual).toEqual(input);
-    expect(readLocalSnapshot(config)).toEqual(input);
-  });
-
-  it("discards a write captured earlier than the file's", () => {
-    const config = makeConfig(directory);
-    const mockNewer = makeLocal("2026-08-04T03:05:00.000Z");
-    writeLocalSnapshot({ config, document: mockNewer });
-
-    const actual = writeLocalSnapshot({ config, document: makeLocal("2026-08-04T03:00:00.000Z") });
-
-    expect(actual).toEqual(mockNewer);
-    expect(readLocalSnapshot(config)).toEqual(mockNewer);
-  });
-
-  it("returns undefined for a document that is not a local snapshot", () => {
-    const config = makeConfig(directory);
-    writeFileSync(localSnapshotPath(config), JSON.stringify({ schemaVersion: 1 }));
-
-    expect(readLocalSnapshot(config)).toBeUndefined();
-  });
-});
-
-describe("writeRemoteSnapshot", () => {
-  let directory: string;
-
-  beforeEach(() => {
-    directory = mkdtempSync(path.join(tmpdir(), "gc-snapshot-"));
-  });
-
-  afterEach(() => {
-    rmSync(directory, { force: true, recursive: true });
-  });
-
-  it("round-trips a document through disk", () => {
-    const config = makeConfig(directory);
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-
-    expect(actual).toEqual(makeDocument());
-    expect(readRemoteSnapshot(config)).toEqual(makeDocument());
-  });
-
-  // One read serves the merge and the guard, so a failure cannot reinstate a
-  // payload that a concurrent success already replaced.
-  it("merges against the file it guards on, not an earlier read", () => {
-    const config = makeConfig(directory);
-    writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:05:00.000Z",
-      result: okResult("2026-08-04T03:05:00.000Z"),
-    });
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:06:00.000Z",
-      result: errorResult("source down"),
-    });
-
-    expect(actual.lastAttemptStatus).toBe("unavailable");
-    expect(actual.payload?.capturedAt).toBe("2026-08-04T03:05:00.000Z");
-  });
-
-  it("discards a write whose attempt is older than the file's", () => {
-    const config = makeConfig(directory);
-    const mockNewer = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:05:00.000Z",
-      result: okResult("2026-08-04T03:05:00.000Z"),
-    });
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: errorResult("stale writer"),
-    });
-
-    expect(readRemoteSnapshot(config)).toEqual(mockNewer);
-    expect(actual).toEqual(mockNewer);
-  });
-
-  it("accepts a write whose attempt matches the file's", () => {
-    const config = makeConfig(directory);
-    writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: errorResult("source down"),
-    });
-
-    expect(actual.lastAttemptStatus).toBe("unavailable");
-    expect(readRemoteSnapshot(config)?.lastAttemptStatus).toBe("unavailable");
-  });
-
-  // Without an upper bound, one future-dated file pins the snapshot forever.
-  it("replaces a file dated in the future", () => {
-    const config = makeConfig(directory);
-    writeFileSync(
-      remoteSnapshotPath(config),
-      JSON.stringify(makeDocument({ lastAttemptAt: "2099-01-01T00:00:00.000Z" })),
-    );
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-
-    expect(actual.lastAttemptAt).toBe("2026-08-04T03:00:00.000Z");
-  });
-
-  it("replaces a file whose attempt timestamp is not ISO-8601", () => {
-    const config = makeConfig(directory);
-    writeFileSync(
-      remoteSnapshotPath(config),
-      JSON.stringify({ ...makeDocument(), lastAttemptAt: "not a timestamp" }),
-    );
-
-    const actual = writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-
-    expect(actual.lastAttemptAt).toBe("2026-08-04T03:00:00.000Z");
-  });
-
-  it("returns undefined for a missing file", () => {
-    const config = makeConfig(directory);
-
-    expect(readRemoteSnapshot(config)).toBeUndefined();
-  });
-
-  it("returns undefined for an unparseable file", () => {
-    const config = makeConfig(directory);
-    writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-    writeFileSync(remoteSnapshotPath(config), "not json");
-
-    expect(readRemoteSnapshot(config)).toBeUndefined();
-  });
-
-  // A snapshot is a contract between two separately versioned programs, so
-  // anything that does not match the shape is rejected rather than misread.
-  it.each([
-    ["a JSON null", "null"],
-    ["a JSON scalar", "42"],
-    ["a document with no attempt timestamp", JSON.stringify({ schemaVersion: 1 })],
-    [
-      "a document with an unknown attempt status",
-      JSON.stringify({
-        schemaVersion: 1,
-        lastAttemptAt: "2026-08-04T03:00:00.000Z",
-        lastAttemptStatus: "maybe",
-      }),
-    ],
-    [
-      "a document with no pull request record",
-      JSON.stringify({
-        schemaVersion: 1,
-        lastAttemptAt: "2026-08-04T03:00:00.000Z",
-        lastAttemptStatus: "ok",
-      }),
-    ],
-    [
-      "a document whose payload is not an object",
-      JSON.stringify({
-        schemaVersion: 1,
-        lastAttemptAt: "2026-08-04T03:00:00.000Z",
-        lastAttemptStatus: "ok",
-        pullRequestsByWorktree: {},
-        payload: "nope",
-      }),
-    ],
-    [
-      "a document whose payload lists are not arrays",
-      JSON.stringify({
-        schemaVersion: 1,
-        lastAttemptAt: "2026-08-04T03:00:00.000Z",
-        lastAttemptStatus: "ok",
-        pullRequestsByWorktree: {},
-        payload: {
-          capturedAt: "2026-08-04T03:00:00.000Z",
-          sourceByTask: {},
-          inProgress: "nope",
-          queueReady: [],
-          queueBlocked: [],
-        },
-      }),
-    ],
-  ])("returns undefined for %s", (_label, contents) => {
-    const config = makeConfig(directory);
-    writeFileSync(remoteSnapshotPath(config), contents);
-
-    expect(readRemoteSnapshot(config)).toBeUndefined();
-  });
-
-  it("returns undefined for a document from an unknown schema version", () => {
-    const config = makeConfig(directory);
-    writeFileSync(
-      remoteSnapshotPath(config),
-      JSON.stringify({ ...makeDocument(), schemaVersion: 999 }),
-    );
-
-    expect(readRemoteSnapshot(config)).toBeUndefined();
-  });
-
-  it("leaves no temp file behind", () => {
-    const config = makeConfig(directory);
-
-    writeRemoteSnapshot({
-      config,
-      attemptAt: "2026-08-04T03:00:00.000Z",
-      result: okResult("2026-08-04T03:00:00.000Z"),
-    });
-
-    const actual = readdirSync(directory);
-
-    expect(actual).toEqual(["status-remote.json"]);
   });
 });

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -1,24 +1,11 @@
-/**
- * Wire format for the two status documents an external monitor reads, plus
- * their atomic persistence. Knows nothing about boards, worktrees, or
- * sessions — collectors build these shapes, `statusJoin` combines them.
- */
+/** Internal collection models used before status.ts builds StatusSnapshot. */
 
-import { readFileSync } from "node:fs";
-import path from "node:path";
-
-import { writeJsonAtomic } from "./atomicJson.ts";
-
-import type { ResolvedConfig } from "./config.ts";
 import type { PullRequestSummary } from "./pullRequests.ts";
 import type { RunLifecycleState } from "./runState.ts";
 import type { CanonicalStatus } from "./taskSource.ts";
 import type { WorktreeDirtiness, WorktreeKind } from "./worktrees.ts";
 
-/**
- * Contract version for both documents. Bump on any breaking shape change;
- * readers refuse a version they don't know rather than misreading fields.
- */
+/** Internal model version retained for the status join. */
 export const STATUS_SNAPSHOT_SCHEMA_VERSION = 1;
 
 /**
@@ -40,6 +27,7 @@ export interface StatusWorktree {
   kind: WorktreeKind;
   dir: string;
   branch: string;
+  branchProblem?: string | undefined;
   git: WorktreeDirtiness;
 }
 
@@ -66,18 +54,6 @@ export interface StatusTask {
   attachCommand?: string | undefined;
   hint?: string | undefined;
   worktrees: StatusWorktree[];
-  /**
-   * The same ten most recent matching lines shown by `crew status <task>`.
-   */
-  recentLogLines: string[];
-}
-
-export interface StatusLogCursor {
-  /** File identity, so a rotated log never reuses lines from its predecessor. */
-  device: number;
-  inode: number;
-  /** Exclusive byte offset covered by `tasks[].recentLogLines`. */
-  offset: number;
 }
 
 interface StatusProbeState {
@@ -85,24 +61,17 @@ interface StatusProbeState {
   error?: string | undefined;
 }
 
-/**
- * The local tier. Every field here comes from a local subprocess or a file
- * read, so a monitor can poll this document every few seconds.
- *
- * Placement rule for a new field: if producing it needs the network, it
- * belongs in `RemoteStatusPayload`. `--local-only` is a promise about this
- * whole document, and one network-backed field voids it.
- */
+/** The local tier. Every field comes from a local subprocess or file read. */
 export interface LocalStatusDocument {
   schemaVersion: StatusSchemaVersion;
   capturedAt: string;
-  /** Incremental progress through the append-only shared log. */
-  logCursor?: StatusLogCursor | undefined;
   /** From config, never the network, so capacity renders before any fetch. */
   maximumInProgress: number;
   workspaceProbe: StatusProbeState;
   tasks: StatusTask[];
   orphanedSessions: string[];
+  /** Orphaned sessions whose backend reports an exited process. */
+  exitedOrphanedSessions?: string[] | undefined;
 }
 
 export interface StatusBoardIssue {
@@ -139,9 +108,7 @@ export interface StatusBlockedIssue extends StatusQueueIssue {
 }
 
 /**
- * The remote tier. Placement rule for a new field: it belongs here when
- * producing it needs the network, because this tier polls slowly, near
- * `pollIntervalMilliseconds`.
+ * The remote tier contains facts whose collection needs the network.
  *
  * Board-derived facts only. Board-side classification is applied; the local
  * worktree subtraction deliberately is not. Precomputing that join here would
@@ -172,8 +139,8 @@ export interface RemoteStatusDocument {
    *
    * Always from the current attempt, never carried forward: the lookups do not
    * depend on the board, so a board outage must not freeze or hide them. An
-   * empty array means none were found OR the lookup failed; `gh` failures are
-   * not distinguishable here.
+   * Empty means no pull requests were found or the lookup failed; callers use
+   * `RemoteFetchResult.pullRequestProblems` to distinguish those outcomes.
    */
   pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
 }
@@ -186,6 +153,18 @@ type BoardOutcome =
 export interface RemoteFetchResult {
   board: BoardOutcome;
   pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
+  pullRequestProblems: StatusPullRequestProblem[];
+  sourceProblems: StatusSourceProbeProblem[];
+}
+
+export interface StatusPullRequestProblem {
+  directory: string;
+  message: string;
+}
+
+export interface StatusSourceProbeProblem {
+  source: string;
+  message: string;
 }
 
 export interface BuildRemoteDocumentInput {
@@ -223,170 +202,4 @@ export function buildRemoteDocument(input: BuildRemoteDocumentInput): RemoteStat
     lastAttemptError: result.board.message,
     payload: previous?.payload,
   };
-}
-
-type LoggingConfig = Pick<ResolvedConfig, "logging">;
-
-/** Both documents sit beside the log file and the per-task run states. */
-function statusSnapshotDirectory(config: LoggingConfig): string {
-  return path.resolve(path.dirname(config.logging.file));
-}
-
-export function localSnapshotPath(config: LoggingConfig): string {
-  return path.resolve(statusSnapshotDirectory(config), "status-local.json");
-}
-
-export function remoteSnapshotPath(config: LoggingConfig): string {
-  return path.resolve(statusSnapshotDirectory(config), "status-remote.json");
-}
-
-export interface WriteLocalSnapshotInput {
-  config: LoggingConfig;
-  document: LocalStatusDocument;
-}
-
-/**
- * Same monotonic rule as `writeRemoteSnapshot`, for the same reason: a slow
- * run must not republish stale session state over a fresher poll. Returns what
- * is on disk afterwards so callers print the file's true contents.
- */
-export function writeLocalSnapshot(input: WriteLocalSnapshotInput): LocalStatusDocument {
-  const { config, document } = input;
-  const existing = readLocalSnapshot(config);
-  if (existing !== undefined && isStrictlyNewer(existing.capturedAt, document.capturedAt)) {
-    return existing;
-  }
-  writeJsonAtomic(localSnapshotPath(config), document);
-  return document;
-}
-
-/** A missing or unreadable snapshot is an ordinary first-run state, not an error. */
-export function readLocalSnapshot(config: LoggingConfig): LocalStatusDocument | undefined {
-  const parsed = readJsonFile(localSnapshotPath(config));
-  return isLocalStatusDocument(parsed) ? parsed : undefined;
-}
-
-function isLocalStatusDocument(value: unknown): value is LocalStatusDocument {
-  if (!isRecord(value)) {
-    return false;
-  }
-  const logCursor = value["logCursor"];
-  return (
-    value["schemaVersion"] === STATUS_SNAPSHOT_SCHEMA_VERSION &&
-    typeof value["capturedAt"] === "string" &&
-    (logCursor === undefined ||
-      (isRecord(logCursor) &&
-        typeof logCursor["device"] === "number" &&
-        typeof logCursor["inode"] === "number" &&
-        typeof logCursor["offset"] === "number")) &&
-    typeof value["maximumInProgress"] === "number" &&
-    isRecord(value["workspaceProbe"]) &&
-    Array.isArray(value["tasks"]) &&
-    Array.isArray(value["orphanedSessions"])
-  );
-}
-
-export interface WriteRemoteSnapshotInput {
-  config: LoggingConfig;
-  attemptAt: string;
-  result: RemoteFetchResult;
-}
-
-/**
- * Refuses to write a document whose attempt is strictly older than the one on
- * disk. Equal timestamps are accepted: same-millisecond attempts are equally
- * current, and rejecting them would drop a legitimate result.
- *
- * This narrows the race, it does not close it. The read and the rename are
- * separate syscalls, so two processes can still interleave such that the older
- * attempt lands last. Closing it would need a lock file, which is not worth it
- * for a cache whose next poll corrects any regression.
- *
- * Returns whatever is on disk afterwards, which is the caller's document
- * unless the guard rejected it. Callers print the return value rather than
- * their own document, so stdout can never disagree with the file.
- */
-export function writeRemoteSnapshot(input: WriteRemoteSnapshotInput): RemoteStatusDocument {
-  const { config, attemptAt, result } = input;
-  // The merge and the guard share this one read. Reading twice let a failed
-  // run carry forward a payload that a concurrent success had already
-  // replaced, then write it back under a newer timestamp.
-  const existing = readRemoteSnapshot(config);
-  if (existing !== undefined && isStrictlyNewer(existing.lastAttemptAt, attemptAt)) {
-    return existing;
-  }
-  const document = buildRemoteDocument({ previous: existing, attemptAt, result });
-  writeJsonAtomic(remoteSnapshotPath(config), document);
-  return document;
-}
-
-/** A missing or unreadable snapshot is an ordinary first-run state, not an error. */
-export function readRemoteSnapshot(config: LoggingConfig): RemoteStatusDocument | undefined {
-  const parsed = readJsonFile(remoteSnapshotPath(config));
-  return isRemoteStatusDocument(parsed) ? parsed : undefined;
-}
-
-function readJsonFile(filePath: string): unknown {
-  try {
-    return JSON.parse(readFileSync(filePath, "utf8"));
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * True when `existing` is a later instant than `candidate`. An unparseable
- * or future-dated existing timestamp counts as older, so neither a foreign
- * timestamp format nor a clock that jumped forward can pin the file forever.
- */
-function isStrictlyNewer(existing: string, candidate: string): boolean {
-  const existingMs = Date.parse(existing);
-  // A timestamp that is unparseable, or that this clock has not reached, is
-  // not evidence of a newer run. Without the upper bound one future-dated file
-  // pins the snapshot forever, with no command to clear it.
-  if (Number.isNaN(existingMs) || existingMs > Date.now()) {
-    return false;
-  }
-  return existingMs > Date.parse(candidate);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/**
- * Structural only: it checks the containers a reader walks, not the elements
- * inside them. That catches the corruption a single writer can plausibly
- * produce. A hand-edited file with a malformed element still reaches the
- * reader, so this is a sanity check, not a schema validator.
- */
-function isRemoteStatusPayload(value: unknown): value is RemoteStatusPayload {
-  if (!isRecord(value)) {
-    return false;
-  }
-  return (
-    typeof value["capturedAt"] === "string" &&
-    isRecord(value["sourceByTask"]) &&
-    Array.isArray(value["inProgress"]) &&
-    Array.isArray(value["queueReady"]) &&
-    Array.isArray(value["queueBlocked"])
-  );
-}
-
-function isRemoteStatusDocument(value: unknown): value is RemoteStatusDocument {
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (
-    value["schemaVersion"] !== STATUS_SNAPSHOT_SCHEMA_VERSION ||
-    typeof value["lastAttemptAt"] !== "string" ||
-    (value["lastAttemptStatus"] !== "ok" && value["lastAttemptStatus"] !== "unavailable")
-  ) {
-    return false;
-  }
-  if (!isRecord(value["pullRequestsByWorktree"])) {
-    return false;
-  }
-  const payload = value["payload"];
-  return payload === undefined || isRemoteStatusPayload(payload);
 }

--- a/src/lib/statusSnapshot.ts
+++ b/src/lib/statusSnapshot.ts
@@ -138,9 +138,11 @@ export interface RemoteStatusDocument {
    * branches, each with its own pull requests.
    *
    * Always from the current attempt, never carried forward: the lookups do not
-   * depend on the board, so a board outage must not freeze or hide them. An
-   * Empty means no pull requests were found or the lookup failed; callers use
-   * `RemoteFetchResult.pullRequestProblems` to distinguish those outcomes.
+   * depend on the board, so a board outage must not freeze or hide them.
+   *
+   * An empty entry means either no pull requests were found or the lookup
+   * failed. Callers use `RemoteFetchResult.pullRequestProblems` to distinguish
+   * those outcomes.
    */
   pullRequestsByWorktree: Record<string, PullRequestSummary[]>;
 }

--- a/src/lib/taskResolution.ts
+++ b/src/lib/taskResolution.ts
@@ -5,7 +5,13 @@ type TaskMatchKind = "exact" | "prefix" | "none";
 export interface TaskResolutionMatches {
   matches: Task[];
   rejections: unknown[];
+  sourceFailures: TaskSourceFailure[];
   matchKind: TaskMatchKind;
+}
+
+interface TaskSourceFailure {
+  source: string;
+  reason: unknown;
 }
 
 interface CollectExactTaskMatchesArguments {
@@ -36,53 +42,71 @@ export async function resolveTaskIdMatches(
     naturalIdPrefix: arguments_.naturalId,
   });
   const rejections = [...exact.rejections, ...prefix.rejections];
+  const sourceFailures = [...exact.sourceFailures, ...prefix.sourceFailures];
   if (prefix.matches.length > 0) {
-    return { matches: prefix.matches, rejections, matchKind: "prefix" };
+    return { matches: prefix.matches, rejections, sourceFailures, matchKind: "prefix" };
   }
-  return { matches: [], rejections, matchKind: "none" };
+  return { matches: [], rejections, sourceFailures, matchKind: "none" };
 }
 
 async function collectExactTaskMatches({
   sources,
   naturalId,
 }: CollectExactTaskMatchesArguments): Promise<Omit<TaskResolutionMatches, "matchKind">> {
-  const results = await Promise.allSettled(
-    sources.map(async (source) => await source.getTask(naturalId)),
+  const results = await Promise.all(
+    sources.map(async (source) => {
+      try {
+        return { kind: "ok" as const, task: await source.getTask(naturalId) };
+      } catch (reason) {
+        return { kind: "error" as const, source: source.name, reason };
+      }
+    }),
   );
   const matches: Task[] = [];
   const rejections: unknown[] = [];
+  const sourceFailures: TaskSourceFailure[] = [];
   for (const result of results) {
-    if (result.status === "fulfilled") {
-      if (result.value !== null) {
-        matches.push(result.value);
+    if (result.kind === "ok") {
+      if (result.task !== null) {
+        matches.push(result.task);
       }
       continue;
     }
     rejections.push(result.reason);
+    sourceFailures.push({ source: result.source, reason: result.reason });
   }
-  return { matches, rejections };
+  return { matches, rejections, sourceFailures };
 }
 
 async function collectPrefixTaskMatches({
   sources,
   naturalIdPrefix,
 }: CollectPrefixTaskMatchesArguments): Promise<Omit<TaskResolutionMatches, "matchKind">> {
-  const results = await Promise.allSettled(
+  const results = await Promise.all(
     sources.map(async (source) => {
-      const tasks = await source.listTasks();
-      return tasks.filter((task) => taskMatchesNaturalIdPrefix({ task, naturalIdPrefix }));
+      try {
+        const tasks = await source.listTasks();
+        return {
+          kind: "ok" as const,
+          tasks: tasks.filter((task) => taskMatchesNaturalIdPrefix({ task, naturalIdPrefix })),
+        };
+      } catch (reason) {
+        return { kind: "error" as const, source: source.name, reason };
+      }
     }),
   );
   const matches: Task[] = [];
   const rejections: unknown[] = [];
+  const sourceFailures: TaskSourceFailure[] = [];
   for (const result of results) {
-    if (result.status === "fulfilled") {
-      matches.push(...result.value);
+    if (result.kind === "ok") {
+      matches.push(...result.tasks);
       continue;
     }
     rejections.push(result.reason);
+    sourceFailures.push({ source: result.source, reason: result.reason });
   }
-  return { matches, rejections };
+  return { matches, rejections, sourceFailures };
 }
 
 function taskMatchesNaturalIdPrefix({

--- a/src/lib/worktreeRunState.test.ts
+++ b/src/lib/worktreeRunState.test.ts
@@ -1,6 +1,9 @@
 import type { RunCommandOptions } from "./commandRunner.ts";
 import type { RunState } from "./runState.ts";
-import { effectiveBranchNameFromRunState as resolveBranch } from "./worktreeRunState.ts";
+import {
+  effectiveBranchNameFromRunState as resolveBranch,
+  probeEffectiveBranchNameFromRunState as probeBranch,
+} from "./worktreeRunState.ts";
 
 type RunCommandAsyncMock = (
   command: string,
@@ -152,5 +155,33 @@ describe(resolveBranch, () => {
     });
 
     expect(result).toBe(ENTRY_BRANCH);
+  });
+});
+
+describe(probeBranch, () => {
+  beforeEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it("marks a detached HEAD fallback as degraded", async () => {
+    mockGitBranch("");
+
+    const actual = await probeBranch({ entry: entry(), runState: runState() });
+
+    expect(actual).toEqual({
+      branch: RUN_STATE_BRANCH,
+      problem: `Could not determine the current branch for ${WORKTREE_DIR}: HEAD is detached`,
+    });
+  });
+
+  it("marks a failed branch command fallback as degraded", async () => {
+    mockGitFailure();
+
+    const actual = await probeBranch({ entry: entry(), runState: undefined });
+
+    expect(actual).toEqual({
+      branch: ENTRY_BRANCH,
+      problem: `Could not determine the current branch for ${WORKTREE_DIR}: git probe failed`,
+    });
   });
 });

--- a/src/lib/worktreeRunState.ts
+++ b/src/lib/worktreeRunState.ts
@@ -53,6 +53,11 @@ interface EffectiveBranchNameFromRunStateInput {
   runState: RunState | undefined;
 }
 
+export interface EffectiveBranchNameProbe {
+  branch: string;
+  problem?: string | undefined;
+}
+
 /**
  * Resolves the worktree's checked-out branch name. Git is the source of truth:
  * run state records the branch we *requested* at creation, but a template hook
@@ -65,22 +70,45 @@ interface EffectiveBranchNameFromRunStateInput {
 export async function effectiveBranchNameFromRunState(
   input: EffectiveBranchNameFromRunStateInput,
 ): Promise<string> {
-  const checkedOut = await resolveCheckedOutBranch(input.entry.dir);
-  if (checkedOut !== undefined) {
-    return checkedOut;
+  return (await probeEffectiveBranchNameFromRunState(input)).branch;
+}
+
+export async function probeEffectiveBranchNameFromRunState(
+  input: EffectiveBranchNameFromRunStateInput,
+): Promise<EffectiveBranchNameProbe> {
+  const checkedOut = await probeCheckedOutBranch({ directory: input.entry.dir });
+  if (checkedOut.kind === "found") {
+    return { branch: checkedOut.branch };
   }
+  const branch = fallbackBranch(input);
+  const reason = checkedOut.kind === "detached" ? "HEAD is detached" : "git probe failed";
+  return {
+    branch,
+    problem: `Could not determine the current branch for ${input.entry.dir}: ${reason}`,
+  };
+}
+
+function fallbackBranch(input: EffectiveBranchNameFromRunStateInput): string {
   if (input.runState !== undefined && runStateMatchesEntry(input)) {
     return input.runState.branchName;
   }
   return input.entry.branchName;
 }
 
-async function resolveCheckedOutBranch(dir: string): Promise<string | undefined> {
+type CheckedOutBranchProbe =
+  | { kind: "found"; branch: string }
+  | { kind: "detached" }
+  | { kind: "failed" };
+
+async function probeCheckedOutBranch(input: { directory: string }): Promise<CheckedOutBranchProbe> {
+  const { directory } = input;
   try {
-    const output = await runCommandAsync("git", ["branch", "--show-current"], { cwd: dir });
-    return output === "" ? undefined : output;
+    const output = await runCommandAsync("git", ["branch", "--show-current"], {
+      cwd: directory,
+    });
+    return output === "" ? { kind: "detached" } : { kind: "found", branch: output };
   } catch {
-    return undefined;
+    return { kind: "failed" };
   }
 }
 

--- a/src/testHelpers/boardFixtures.ts
+++ b/src/testHelpers/boardFixtures.ts
@@ -9,6 +9,9 @@ export function makeBoard(overrides: Partial<Board> = {}): Board {
       .mockResolvedValue({ timestamp: "", issues: [], parentSkips: [] }),
     // eslint-disable-next-line unicorn/no-useless-undefined -- mockResolvedValue requires a value for non-void return type
     resolveOne: vi.fn<() => Promise<undefined>>().mockResolvedValue(undefined),
+    resolveOneWithFailures: vi
+      .fn<Board["resolveOneWithFailures"]>()
+      .mockResolvedValue({ issue: undefined, failures: [] }),
     markInProgress: vi.fn<() => Promise<void>>().mockResolvedValue(),
     markInReview: vi
       .fn<() => Promise<MarkInReviewResult>>()


### PR DESCRIPTION
## Why

Raycast needs a stable, read-only status contract that it can consume from the installed `crew` executable without scraping human output.

## Summary

- add inventory and task-scoped JSON modes for `crew status`
- collect one typed status snapshot for both text and JSON renderers
- expose structured recommended actions and partial probe failures while preserving successful data
- document the JSON fields, stdout/stderr behavior, and SemVer compatibility policy
- preserve the existing human status output and the existing task/source JSON contracts

## Test plan

- `node --run verify`
- focused status and pull-request probe tests
- exact-HEAD implementation review

## Notes

- Linear: https://linear.app/clipboardhealth/issue/TEM-3892/add-crew-status-json-as-a-stable-public-contract
- Closes tem-3892

<!-- cb-ship:created v1 skill@1.0.3 -->
