### PR TITLE
feat: add typed lifecycle results (TEM-3893)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,18 +114,20 @@ crew task done <TASK> [--allow-dirty]                    # mark a no-PR task don
 crew task validate [<source>]                            # validate task content
 crew status [<TASK>] [--json [--local-only]]           # inspect current state, or emit it as JSON
 crew run [--watch]                                       # one-shot or --watch forever
-crew start <TASK>                                      # provision + launch one task now
-crew stop <TASK> [--reason <text>]                     # stop workspace, keep worktree
-crew resume [--new] <TASK>                             # reopen a paused task (--new: fresh conversation)
+crew start <TASK> [--json]                             # provision + launch one task now
+crew stop <TASK> [--reason <text>] [--json]            # stop workspace, keep worktree
+crew resume [--new] <TASK> [--json]                    # reopen a paused task (--new: fresh conversation)
 crew open <pr> | --branch <name> [--repo <owner/repo>] # iterate on an existing PR or branch
          [--prompt <text> | --prompt-file <path>] [--task <id>] [--dry-run]
-crew cleanup [--force] <TASK>                          # tear down every worktree for a task
+crew cleanup [--force] <TASK> [--json]                 # tear down every worktree for a task
 crew cleanup [--force] --all                           # tear down every idle worktree (no live workspace)
 crew upgrade [<version>]                                 # reinstall crew globally through npm
 crew completions <bash|zsh|fish>                        # print a shell completion script
 ```
 
-See [command details](./docs/commands.md) for status output, doctor behavior, and the stop/resume workflow.
+See [command details](./docs/commands.md) for status output, doctor behavior,
+and the stop/resume workflow. Automation should also follow the stable
+[lifecycle JSON result contract](./docs/lifecycle-results.md).
 
 ### Status snapshots for external monitors
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -136,6 +136,7 @@ Doctor's command introspection is intentionally shallow. It reports the resolved
 ```bash
 crew start ENG-123
 crew start ENG-123 --dry-run
+crew start ENG-123 --json
 ```
 
 ## Stop
@@ -152,11 +153,23 @@ The command closes the cmux/tmux/zellij workspace if present, records local run 
 
 ## Resume
 
-`crew resume [--new] <TASK>` reopens an existing task worktree with a continuation prompt. Resume never creates a new worktree; if none exists it fails and leaves re-dispatch to `crew start <task>`.
+`crew resume [--new] <TASK>` reopens an existing task worktree with a continuation prompt. Resume never creates a new worktree; if none exists it returns `not-found` and leaves re-dispatch to `crew start <task>`.
 
-The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded agent, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume falls back to Linear resolution for the agent and task context.
+The resume prompt tells the agent to inspect git status and diff before editing, includes the previous interrupt reason when recorded, and reuses the recorded agent, repository, branch, runner, sandbox, and workspace backend. When no run-state file exists but a worktree does, resume resolves the agent and task context through the configured Board/task-source interface.
 
 `crew resume <TASK>` reopens the agent's previous conversation in the worktree by default — the built-in `claude`, `codex`, `cursor`, `cursor-grok`, and `pi` presets ship a [`resumeArgs`](./configuration.md#resuming-the-agents-conversation) default (`--continue`, `resume --last`, `--continue`, `--continue`, `--continue`) that groundcrew appends to the agent's command. `crew resume --new <TASK>` ignores `resumeArgs` and forces a fresh conversation. Custom agents cold-start unless they set `resumeArgs`. groundcrew stores no session id — it relies on one conversation per worktree.
+
+Start, stop, resume, and task-scoped cleanup accept `--json`. See the
+[lifecycle command result contract](./lifecycle-results.md) for fields,
+outcomes, problem codes, exit behavior, cancellation, SemVer compatibility,
+and the required full `crew status --json` refresh after each mutation.
+
+## Cleanup
+
+`crew cleanup <TASK>` tears down the task's local worktrees. Without `--force`,
+it refuses live workspaces, dirty worktrees, and worktrees whose cleanliness
+cannot be verified. `--force` is an operator-only escape hatch and must not be
+used or recommended by automation.
 
 ## Open
 

--- a/docs/lifecycle-results.md
+++ b/docs/lifecycle-results.md
@@ -1,0 +1,113 @@
+# Lifecycle command results
+
+The lifecycle commands used by external automation accept `--json`:
+
+```bash
+crew start <task> --json
+crew stop <task> [--reason <text>] --json
+crew resume <task> --json
+crew cleanup <task> --json
+```
+
+These results are action receipts. They describe what that invocation changed;
+they are not task status snapshots. After every receipt—including a conflict,
+refusal, partial result, or cancellation—the consumer must refresh the full
+legacy `crew status --json` inventory and filter the affected task locally.
+There is no task-scoped status JSON dependency.
+
+## Output and exit behavior
+
+On a classified completion, JSON mode writes exactly one JSON document to
+stdout. Progress messages, headings, ANSI styling, and remediation shell
+commands are excluded. Diagnostics may be written to stderr and to the
+configured Groundcrew log.
+
+Successful and idempotent outcomes exit zero. The `partial`, `conflict`, and
+`refused` outcomes write their typed receipt and exit non-zero. Invocation,
+configuration, task-resolution, and unexpected internal failures that prevent
+a trustworthy receipt write no JSON to stdout, write a human-readable error to
+stderr, and exit non-zero. Groundcrew does not emit a generic JSON error
+envelope.
+
+Without `--json`, the same typed result drives the existing human-readable
+completion output.
+
+## Common fields
+
+Every action-specific result has these required fields:
+
+| Field              | Meaning                                                                                                               |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `action`           | `start`, `stop`, `resume`, or `cleanup`. This is the discriminant.                                                    |
+| `task.id`          | Lower-cased local task key used by worktrees and workspaces.                                                          |
+| `task.canonicalId` | Optional source-qualified ID, when task resolution or persisted state supplies it.                                    |
+| `task.url`         | Optional source URL, when known.                                                                                      |
+| `outcome`          | Action-specific classified outcome.                                                                                   |
+| `state`            | Best observed state: `provisioning`, `running`, `interrupted`, `resumed`, `failed-to-launch`, `absent`, or `unknown`. |
+| `resources`        | Action-specific repository, branch, worktree, and workspace resources observed or affected.                           |
+| `problems`         | Array of `{ code, message }` records. Empty on a complete result with no known problem.                               |
+
+Start, stop, and resume expose singular resource fields when known:
+`repository`, `branch`, `worktreeDir`, `workspace.name`, optional
+`workspace.accessCommand`, and `agent`. Cleanup exposes `worktrees[]` with
+`repository`, `branch`, `worktreeDir`, and `removed`, plus `workspaces[]` with
+`name` and `closed`. A partial cleanup preserves successful removals and every
+reported failure rather than collapsing to the first error.
+
+## Outcomes
+
+| Action  | Outcomes                                                                              |
+| ------- | ------------------------------------------------------------------------------------- |
+| Start   | `started`, `already-running`, `dry-run`, `partial`, `conflict`                        |
+| Stop    | `stopped`, `already-stopped`, `workspace-missing`, `not-found`, `partial`, `conflict` |
+| Resume  | `resumed`, `already-running`, `not-found`, `partial`, `conflict`                      |
+| Cleanup | `cleaned`, `nothing-to-clean`, `state-cleared`, `refused`, `partial`, `conflict`      |
+
+`already-running`, `already-stopped`, `workspace-missing`, `not-found`,
+`nothing-to-clean`, and `state-cleared` are idempotent zero-exit receipts. A
+Start whose local workspace opened but whose task-source status write failed is
+`partial`, retains the running resources, and includes
+`task-status-update-failed`.
+
+Cleanup without `--force` refuses a live workspace, a dirty worktree, or a
+worktree whose cleanliness cannot be verified before teardown. JSON refusal
+messages intentionally do not recommend force cleanup. `--force` remains a
+direct operator option; automation such as the Raycast extension must never
+pass, expose, or recommend it.
+
+## Problem codes
+
+The current stable codes are:
+
+| Code                           | Meaning                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `cancelled`                    | Cooperative `SIGINT` or `SIGTERM` interrupted the operation.            |
+| `lifecycle-lock-held`          | Another lifecycle mutation currently owns the task.                     |
+| `task-status-update-failed`    | Start succeeded locally but source status writeback failed.             |
+| `state-write-failed`           | An observed external mutation could not be fully recorded in run state. |
+| `workspace-busy`               | Cleanup found a live workspace and refused teardown.                    |
+| `workspace-conflict`           | A live workspace did not match trustworthy local task context.          |
+| `workspace-status-unavailable` | Groundcrew could not verify workspace state.                            |
+| `worktree-conflict`            | Existing local state or a stale worktree blocks Start.                  |
+| `worktree-dirty`               | Cleanup found uncommitted changes.                                      |
+| `worktree-status-unknown`      | Cleanup could not verify worktree cleanliness.                          |
+| `workspace-close-failed`       | Teardown could not close an affected workspace.                         |
+| `worktree-remove-failed`       | Teardown could not remove an affected worktree.                         |
+
+Lifecycle mutations are serialized per task. Lock ownership is recorded by
+process and dead owners are recoverable, so a crashed command does not
+permanently strand the task.
+
+`SIGINT` and `SIGTERM` are cooperative: Groundcrew passes an `AbortSignal`
+through workspace and worktree operations, preserves completed teardown steps,
+and reconciles the best observed durable run state before returning a partial
+receipt. `SIGKILL` and equivalent forced termination cannot guarantee recovery
+or a final JSON document; the caller must still refresh `crew status --json`.
+
+## Compatibility
+
+This contract follows Groundcrew SemVer. Removing or renaming a required field,
+or changing its meaning, requires a major release. Additive optional fields,
+new outcome values, and new problem codes are compatible changes. Consumers
+must ignore unknown fields and tolerate unknown outcome and problem codes while
+refreshing status after the mutation.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -12,6 +12,12 @@ import { resumeWorkspaceCli } from "./commands/resumeWorkspace.ts";
 import { setupWorkspaceCli } from "./commands/setupWorkspace.ts";
 import { statusCli } from "./commands/status.ts";
 import { taskCli } from "./commands/task.ts";
+import type {
+  CleanupResult,
+  ResumeResult,
+  StartResult,
+  StopResult,
+} from "./commands/lifecycleResult.ts";
 import {
   createDefaultUpgradeCliOptions,
   upgradeCli,
@@ -98,6 +104,50 @@ function makeFakeUpgradeOptions(): UpgradeCliOptions {
   };
 }
 
+function fakeStartResult(): StartResult {
+  return {
+    action: "start",
+    task: { id: "team-1" },
+    outcome: "started",
+    state: "running",
+    resources: {},
+    problems: [],
+  };
+}
+
+function fakeStopResult(): StopResult {
+  return {
+    action: "stop",
+    task: { id: "team-1" },
+    outcome: "stopped",
+    state: "interrupted",
+    resources: {},
+    problems: [],
+  };
+}
+
+function fakeResumeResult(): ResumeResult {
+  return {
+    action: "resume",
+    task: { id: "team-1" },
+    outcome: "resumed",
+    state: "resumed",
+    resources: {},
+    problems: [],
+  };
+}
+
+function fakeCleanupResult(): CleanupResult {
+  return {
+    action: "cleanup",
+    task: { id: "team-1" },
+    outcome: "cleaned",
+    state: "absent",
+    resources: { worktrees: [], workspaces: [] },
+    problems: [],
+  };
+}
+
 function expectUpgradeOptionsFactory(
   optionsInput: UpgradeCliOptionsInput,
 ): () => Promise<UpgradeCliOptions> {
@@ -117,10 +167,10 @@ describe(run, () => {
     process.exitCode = undefined;
     orchestrateMock.mockResolvedValue();
     doctorMock.mockResolvedValue(true);
-    interruptMock.mockResolvedValue();
-    resumeMock.mockResolvedValue();
-    setupMock.mockResolvedValue();
-    cleanupMock.mockResolvedValue();
+    interruptMock.mockResolvedValue(fakeStopResult());
+    resumeMock.mockResolvedValue(fakeResumeResult());
+    setupMock.mockResolvedValue(fakeStartResult());
+    cleanupMock.mockResolvedValue(fakeCleanupResult());
     statusMock.mockResolvedValue();
     taskMock.mockResolvedValue();
     upgradeCliMock.mockResolvedValue();
@@ -328,7 +378,7 @@ describe(run, () => {
   it("dispatches `start <task>` to setupWorkspaceCli with no deprecation warning", async () => {
     await run(["start", "team-220"]);
 
-    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: false });
+    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: false, json: false });
     expect(orchestrateMock).not.toHaveBeenCalled();
     expect(consoleError.calls).toStrictEqual([]);
   });
@@ -336,7 +386,13 @@ describe(run, () => {
   it("forwards --dry-run to setupWorkspaceCli under `start`", async () => {
     await run(["start", "team-220", "--dry-run"]);
 
-    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: true });
+    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: true, json: false });
+  });
+
+  it("forwards --json to setupWorkspaceCli under `start`", async () => {
+    await run(["start", "team-220", "--json"]);
+
+    expect(setupMock).toHaveBeenCalledWith("team-220", { dryRun: false, json: true });
   });
 
   it("rejects `start` with no task", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,6 @@ import { taskCli } from "./commands/task.ts";
 import { createDefaultUpgradeCliOptions, upgradeCli } from "./commands/upgrade.ts";
 import {
   errorMessage,
-  parseDryRunPositionals,
   readEnvironmentVariable,
   readTaskArgument,
   setVerbose,
@@ -38,7 +37,7 @@ interface Subcommand {
   summary: string;
   usage: string;
   hidden?: boolean;
-  invoke: (argv: string[]) => Promise<void>;
+  invoke: (argv: string[]) => Promise<unknown>;
   // Deprecated aliases keep working but are hidden from `crew --help`.
   deprecated?: boolean;
 }
@@ -108,15 +107,31 @@ async function runCli(argv: string[]): Promise<void> {
   await setupWorkspaceCli(task, { dryRun });
 }
 
-const START_USAGE = "crew start <task> [--dry-run]";
+const START_USAGE = "crew start <task> [--dry-run] [--json]";
 
 async function startCli(argv: string[]): Promise<void> {
-  const { dryRun, positionals } = parseDryRunPositionals(argv, START_USAGE);
+  let dryRun = false;
+  let json = false;
+  const positionals: string[] = [];
+  for (const argument of argv) {
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (argument === "--json") {
+      json = true;
+      continue;
+    }
+    if (argument.startsWith("-")) {
+      throw new Error(`Unknown option: ${argument}\nUsage: ${START_USAGE}`);
+    }
+    positionals.push(argument);
+  }
   const [task, ...extras] = positionals;
   if (task === undefined || task.length === 0 || extras.length > 0) {
     throw new Error(`Usage: ${START_USAGE}`);
   }
-  await setupWorkspaceCli(task, { dryRun });
+  await setupWorkspaceCli(task, { dryRun, json });
 }
 
 async function upgradeCliInvoke(argv: string[]): Promise<void> {
@@ -170,7 +185,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   start: {
     summary: "Launch one task immediately, bypassing eligibility",
-    usage: "<task> [--dry-run]",
+    usage: "<task> [--dry-run] [--json]",
     invoke: startCli,
   },
   doctor: {
@@ -195,12 +210,12 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   cleanup: {
     summary: "Tear down a worktree, or every idle worktree with --all",
-    usage: "[--force] <task> | [--force] --all",
+    usage: "[--force] <task> [--json] | [--force] --all",
     invoke: cleanupWorkspaceCli,
   },
   stop: {
     summary: "Stop a live task workspace while preserving its worktree",
-    usage: "<task> [--reason <text>]",
+    usage: "<task> [--reason <text>] [--json]",
     invoke: interruptWorkspaceCli,
   },
   interrupt: {
@@ -214,7 +229,7 @@ const SUBCOMMANDS: Record<string, Subcommand> = {
   },
   resume: {
     summary: "Reopen an existing task worktree, resuming the agent's chat session",
-    usage: "[--new] <task>",
+    usage: "[--new] <task> [--json]",
     invoke: resumeWorkspaceCli,
   },
   open: {

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -753,7 +753,9 @@ describe(cleanupWorkspaceCli, () => {
   });
 
   it("throws a usage error when no task is provided", async () => {
-    await expect(cleanupWorkspaceCli([])).rejects.toThrow(/Usage: crew cleanup/);
+    await expect(cleanupWorkspaceCli([])).rejects.toThrow(
+      /Usage: crew cleanup \[--force\] <task> \[--json\]/,
+    );
   });
 
   it("rejects unknown options instead of treating them as the task", async () => {

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -6,6 +6,7 @@ import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import { cleanupAllWorkspaces, cleanupWorkspace, cleanupWorkspaceCli } from "./cleanupWorkspace.ts";
+import { acquireLifecycleLock } from "./lifecycleCommand.ts";
 
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -20,6 +21,7 @@ vi.mock(import("../lib/worktrees.ts"), async (importOriginal) => {
       list: vi.fn<typeof actual.worktrees.list>(),
       findByTask: vi.fn<typeof actual.worktrees.findByTask>(),
       teardown: vi.fn<typeof actual.worktrees.teardown>(),
+      probeWorkingTree: vi.fn<typeof actual.worktrees.probeWorkingTree>(),
     },
   };
 });
@@ -46,6 +48,7 @@ const loadConfigMock = vi.mocked(loadConfig);
 const listMock = vi.mocked(worktrees.list);
 const findByTaskMock = vi.mocked(worktrees.findByTask);
 const teardownMock = vi.mocked(worktrees.teardown);
+const probeWorkingTreeMock = vi.mocked(worktrees.probeWorkingTree);
 const readRunStateMock = vi.mocked(readRunState);
 const removeRunStateMock = vi.mocked(removeRunState);
 const workspaceProbeMock = vi.mocked(workspaces.probe);
@@ -105,8 +108,17 @@ const config: ResolvedConfig = {
     safehouse: { enable: [] },
     readOnlyDirs: [],
   },
-  logging: { file: "/tmp/groundcrew-test.log" },
+  logging: { file: "/tmp/groundcrew-cleanup-workspace-test.log" },
 };
+
+function requireAcquiredLock(
+  lock: ReturnType<typeof acquireLifecycleLock>,
+): Extract<ReturnType<typeof acquireLifecycleLock>, { kind: "acquired" }> {
+  if (lock.kind !== "acquired") {
+    throw new Error("test could not acquire lifecycle lock");
+  }
+  return lock;
+}
 
 describe(cleanupWorkspace, () => {
   let consoleLog: ConsoleCapture;
@@ -114,6 +126,7 @@ describe(cleanupWorkspace, () => {
   beforeEach(() => {
     consoleLog = captureConsoleLog();
     teardownMock.mockResolvedValue(emptyTeardownResult());
+    probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
     // `readRunStateMock` defaults to returning undefined (no orphaned
     // run-state); cases exercising the orphan path override it per-test.
@@ -148,49 +161,124 @@ describe(cleanupWorkspace, () => {
     expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: true });
   });
 
-  it("logs and returns without calling teardown when no worktree is found", async () => {
+  it("refuses a dirty worktree before closing or removing anything", async () => {
+    findByTaskMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    probeWorkingTreeMock.mockResolvedValue({ kind: "dirty", modified: 2, untracked: 1 });
+
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
+
+    expect(actual).toMatchObject({
+      outcome: "refused",
+      problems: [{ code: "worktree-dirty" }],
+    });
+    expect(actual.problems[0]?.message).not.toContain("--force");
+    expect(teardownMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses cleanup when worktree cleanliness cannot be verified", async () => {
+    findByTaskMock.mockReturnValue([hostEntry]);
+    probeWorkingTreeMock.mockResolvedValue({ kind: "unknown" });
+
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
+
+    expect(actual).toMatchObject({
+      outcome: "refused",
+      problems: [{ code: "worktree-status-unknown" }],
+    });
+    expect(teardownMock).not.toHaveBeenCalled();
+  });
+
+  it("returns nothing-to-clean when no local artifacts are found", async () => {
     findByTaskMock.mockReturnValue([]);
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
     expect(teardownMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("nothing to clean up");
+    expect(actual).toMatchObject({ outcome: "nothing-to-clean", state: "absent" });
+    expect(consoleLog.output()).toBe("");
     expect(removeRunStateMock).not.toHaveBeenCalled();
-    expect(workspaceProbeMock).not.toHaveBeenCalled();
+    expect(workspaceProbeMock).toHaveBeenCalledWith(config);
   });
 
   it("clears an orphaned run-state when no worktree is found", async () => {
     findByTaskMock.mockReturnValue([]);
     readRunStateMock.mockReturnValue(orphanRunState);
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
     expect(teardownMock).not.toHaveBeenCalled();
     expect(removeRunStateMock).toHaveBeenCalledWith(config, "team-1");
-    expect(consoleLog.output()).toContain("cleared stale run-state");
-    expect(consoleLog.output()).not.toContain("nothing to clean up");
+    expect(actual).toMatchObject({ outcome: "state-cleared", state: "absent" });
   });
 
-  it("leaves run-state intact when no worktree is found but a workspace is present", async () => {
+  it("returns partial when stale run-state cannot be cleared", async () => {
+    findByTaskMock.mockReturnValue([]);
+    readRunStateMock.mockReturnValue(orphanRunState);
+    removeRunStateMock.mockImplementation(() => {
+      throw new Error("state directory is read-only");
+    });
+
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      state: "running",
+      problems: [{ code: "state-write-failed", message: expect.stringContaining("read-only") }],
+    });
+  });
+
+  it("refuses cleanup when no worktree is found but a workspace is present", async () => {
     findByTaskMock.mockReturnValue([]);
     readRunStateMock.mockReturnValue(orphanRunState);
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
     expect(removeRunStateMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("workspace still present; leaving run-state intact");
+    expect(actual).toMatchObject({ outcome: "refused", state: "running" });
   });
 
-  it("leaves run-state intact when no worktree is found and workspace probing is unavailable", async () => {
+  it("returns conflict when workspace probing is unavailable", async () => {
     findByTaskMock.mockReturnValue([]);
     readRunStateMock.mockReturnValue(orphanRunState);
     workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
     expect(removeRunStateMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("workspace probe unavailable, leaving run-state intact");
+    expect(actual).toMatchObject({ outcome: "conflict" });
+  });
+
+  it("returns unknown state when probing is unavailable without persisted context", async () => {
+    findByTaskMock.mockReturnValue([]);
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      state: "unknown",
+    });
+  });
+
+  it("refuses a live workspace before inspecting its worktree", async () => {
+    findByTaskMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "refused",
+      state: "running",
+      problems: [{ code: "workspace-busy" }],
+    });
+    expect(probeWorkingTreeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict before inspecting a worktree when workspace status is unavailable", async () => {
+    findByTaskMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [{ code: "workspace-status-unavailable" }],
+    });
+    expect(probeWorkingTreeMock).not.toHaveBeenCalled();
   });
 
   it("clears an orphaned run-state without requiring --force", async () => {
@@ -207,15 +295,15 @@ describe(cleanupWorkspace, () => {
     // Second call falls through to the default undefined return.
     readRunStateMock.mockReturnValueOnce(orphanRunState);
 
-    await cleanupWorkspace(config, { task: "team-1" });
-    await cleanupWorkspace(config, { task: "team-1" });
+    const first = await cleanupWorkspace(config, { task: "team-1" });
+    const second = await cleanupWorkspace(config, { task: "team-1" });
 
     expect(removeRunStateMock).toHaveBeenCalledTimes(1);
-    expect(consoleLog.output()).toContain("cleared stale run-state");
-    expect(consoleLog.output()).toContain("nothing to clean up");
+    expect(first.outcome).toBe("state-cleared");
+    expect(second.outcome).toBe("nothing-to-clean");
   });
 
-  it("logs `workspace list failed: ...` when teardown reports a probe-throw error", async () => {
+  it("preserves a teardown workspace-probe failure in the result", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(
       emptyTeardownResult({
@@ -224,9 +312,14 @@ describe(cleanupWorkspace, () => {
       }),
     );
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
-    expect(consoleLog.output()).toContain("workspace list failed: cmux exploded");
+    expect(actual).toMatchObject({
+      outcome: "partial",
+      problems: [
+        { code: "workspace-status-unavailable", message: expect.stringContaining("cmux exploded") },
+      ],
+    });
   });
 
   it("logs and continues when marking removed run state fails", async () => {
@@ -255,28 +348,32 @@ describe(cleanupWorkspace, () => {
     expect(consoleLog.output()).not.toContain("workspace list failed");
   });
 
-  it("logs Closed workspace lines for each task teardown reports closed", async () => {
+  it("returns each workspace teardown reports closed", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(
       emptyTeardownResult({ closed: ["team-1"], removed: [hostEntry] }),
     );
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
-    expect(consoleLog.output()).toContain("Closed workspace team-1");
+    expect(actual.resources.workspaces).toContainEqual({ name: "team-1", closed: true });
   });
 
-  it("logs Cleanup complete with each removed worktree's dir and kind", async () => {
+  it("returns each removed worktree", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
-    expect(consoleLog.output()).toContain("Cleanup complete for team-1 (host)");
-    expect(consoleLog.output()).toContain("/work/repo-a-team-1 (removed)");
+    expect(actual.resources.worktrees).toContainEqual({
+      repository: "repo-a",
+      branch: "dev-team-1",
+      worktreeDir: "/work/repo-a-team-1",
+      removed: true,
+    });
   });
 
-  it("re-throws the first failure reported by teardown", async () => {
+  it("returns partial with every teardown failure", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(
       emptyTeardownResult({
@@ -286,10 +383,59 @@ describe(cleanupWorkspace, () => {
       }),
     );
 
-    await expect(cleanupWorkspace(config, { task: "team-1" })).rejects.toThrow(/worktree busy/);
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      problems: [
+        { code: "worktree-remove-failed", message: expect.stringContaining("worktree busy") },
+      ],
+    });
   });
 
-  it("logs workspace close failures from teardown", async () => {
+  it("preserves removed worktrees alongside failures in a partial result", async () => {
+    const failedEntry: WorktreeEntry = {
+      ...hostEntry,
+      repository: "repo-b",
+      branchName: "dev-team-1-b",
+      dir: "/work/repo-b-team-1",
+    };
+    findByTaskMock.mockReturnValue([hostEntry, failedEntry]);
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        removed: [hostEntry],
+        failures: [{ entry: failedEntry, step: "worktree_remove", error: new Error("git busy") }],
+      }),
+    );
+
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
+
+    expect(actual.outcome).toBe("partial");
+    expect(actual.resources.worktrees).toEqual([
+      expect.objectContaining({ worktreeDir: hostEntry.dir, removed: true }),
+      expect.objectContaining({ worktreeDir: failedEntry.dir, removed: false }),
+    ]);
+    expect(actual.problems).toEqual([expect.objectContaining({ code: "worktree-remove-failed" })]);
+  });
+
+  it("preserves teardown progress when cooperative cancellation stops cleanup", async () => {
+    findByTaskMock.mockReturnValue([hostEntry, secondEntry]);
+    teardownMock.mockResolvedValue({
+      ...emptyTeardownResult({ removed: [hostEntry] }),
+      cancelled: true,
+    });
+
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
+
+    expect(actual).toMatchObject({
+      outcome: "partial",
+      problems: [{ code: "cancelled" }],
+    });
+    expect(actual.resources.worktrees).toEqual([
+      expect.objectContaining({ worktreeDir: hostEntry.dir, removed: true }),
+      expect.objectContaining({ worktreeDir: secondEntry.dir, removed: false }),
+    ]);
+  });
+
+  it("returns workspace close failures from teardown", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(
       emptyTeardownResult({
@@ -297,11 +443,13 @@ describe(cleanupWorkspace, () => {
       }),
     );
 
-    await expect(cleanupWorkspace(config, { task: "team-1" })).rejects.toThrow(/cmux down/);
-    expect(consoleLog.output()).toContain("workspace close failed for team-1: cmux down");
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      problems: [{ code: "workspace-close-failed", message: expect.stringContaining("cmux down") }],
+    });
   });
 
-  it("logs Cleanup failed for a worktree_remove failure", async () => {
+  it("returns worktree removal failures", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
     teardownMock.mockResolvedValue(
       emptyTeardownResult({
@@ -309,8 +457,35 @@ describe(cleanupWorkspace, () => {
       }),
     );
 
-    await expect(cleanupWorkspace(config, { task: "team-1" })).rejects.toThrow(/busy/);
-    expect(consoleLog.output()).toContain("Cleanup failed for team-1 (host): busy");
+    await expect(cleanupWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      problems: [{ code: "worktree-remove-failed", message: expect.stringContaining("busy") }],
+    });
+  });
+
+  it("removes shell remediation flags from JSON teardown problems", async () => {
+    findByTaskMock.mockReturnValue([hostEntry]);
+    teardownMock.mockResolvedValue(
+      emptyTeardownResult({
+        failures: [
+          {
+            entry: hostEntry,
+            step: "worktree_remove",
+            error: new Error("git worktree remove --force failed"),
+          },
+        ],
+      }),
+    );
+
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
+
+    expect(actual.problems).toEqual([
+      {
+        code: "worktree-remove-failed",
+        message: "Worktree could not be removed safely; inspect it for uncommitted changes.",
+      },
+    ]);
+    expect(JSON.stringify(actual)).not.toContain("--force");
   });
 });
 
@@ -325,7 +500,53 @@ describe(cleanupAllWorkspaces, () => {
 
   afterEach(() => {
     consoleLog.restore();
+    process.exitCode = undefined;
     vi.resetAllMocks();
+  });
+
+  it("emits exactly one structured cleanup receipt in JSON mode", async () => {
+    const jsonLog = captureConsoleLog();
+    loadConfigMock.mockResolvedValue(config);
+    readRunStateMock.mockReturnValue({
+      ...orphanRunState,
+      completionTaskId: "linear:TEAM-1",
+      url: "https://example.test/TEAM-1",
+    });
+    findByTaskMock.mockReturnValue([hostEntry]);
+    workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
+    teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
+
+    try {
+      const actual = await cleanupWorkspaceCli(["team-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "cleanup",
+        task: {
+          id: "team-1",
+          canonicalId: "linear:TEAM-1",
+          url: "https://example.test/TEAM-1",
+        },
+        outcome: "cleaned",
+        state: "absent",
+        resources: {
+          worktrees: [
+            {
+              repository: "repo-a",
+              branch: "dev-team-1",
+              worktreeDir: "/work/repo-a-team-1",
+              removed: true,
+            },
+          ],
+          workspaces: [{ name: "team-1", closed: false }],
+        },
+        problems: [],
+      });
+      expect(jsonLog.calls).toHaveLength(1);
+      expect(JSON.parse(jsonLog.output())).toStrictEqual(actual);
+    } finally {
+      jsonLog.restore();
+    }
   });
 
   it("tears down every worktree when no workspace is in use", async () => {
@@ -427,10 +648,12 @@ describe(cleanupWorkspaceCli, () => {
     loadConfigMock.mockResolvedValue(config);
     teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
     workspaceProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    probeWorkingTreeMock.mockResolvedValue({ kind: "clean" });
   });
 
   afterEach(() => {
     consoleLog.restore();
+    process.exitCode = undefined;
     vi.resetAllMocks();
   });
 
@@ -449,7 +672,71 @@ describe(cleanupWorkspaceCli, () => {
   it("recognizes --force anywhere in argv", async () => {
     await cleanupWorkspaceCli(["--force", "team-1"]);
 
-    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], { force: true });
+    expect(teardownMock).toHaveBeenCalledWith(config, [hostEntry], {
+      force: true,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("returns a stable conflict when another lifecycle command owns the task", async () => {
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+
+    try {
+      const actual = await cleanupWorkspaceCli(["team-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "cleanup",
+        outcome: "conflict",
+        problems: [{ code: "lifecycle-lock-held" }],
+      });
+      expect(teardownMock).not.toHaveBeenCalled();
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      lock.release();
+    }
+  });
+
+  it("returns partial when cooperative cancellation escapes cleanup", async () => {
+    teardownMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+
+    const actual = await cleanupWorkspaceCli(["team-1", "--json"]);
+
+    expect(actual).toMatchObject({
+      action: "cleanup",
+      outcome: "partial",
+      problems: [{ code: "cancelled", message: expect.stringContaining("SIGTERM") }],
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("preserves persisted lifecycle state in a cancellation receipt", async () => {
+    readRunStateMock.mockReturnValue(orphanRunState);
+    teardownMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+
+    await expect(cleanupWorkspaceCli(["team-1", "--json"])).resolves.toMatchObject({
+      outcome: "partial",
+      state: "running",
+    });
+  });
+
+  it("reports absent when cancellation finds no state or worktree", async () => {
+    findByTaskMock.mockReturnValue([]);
+    workspaceProbeMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+
+    await expect(cleanupWorkspaceCli(["unknown-1", "--json"])).resolves.toMatchObject({
+      outcome: "partial",
+      state: "absent",
+      resources: { worktrees: [], workspaces: [] },
+    });
   });
 
   it("throws a usage error when no task is provided", async () => {
@@ -492,5 +779,12 @@ describe(cleanupWorkspaceCli, () => {
     await expect(cleanupWorkspaceCli(["--all", "team-1"])).rejects.toThrow(/Usage: crew cleanup/);
     expect(listMock).not.toHaveBeenCalled();
     expect(findByTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects JSON mode for batch cleanup", async () => {
+    await expect(cleanupWorkspaceCli(["--all", "--json"])).rejects.toThrow(
+      /--json requires a task argument/,
+    );
+    expect(listMock).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -322,15 +322,26 @@ describe(cleanupWorkspace, () => {
     });
   });
 
-  it("logs and continues when marking removed run state fails", async () => {
+  it("returns partial with removed resources when clearing durable run state fails", async () => {
     findByTaskMock.mockReturnValue([hostEntry]);
+    readRunStateMock.mockReturnValue(orphanRunState);
     teardownMock.mockResolvedValue(emptyTeardownResult({ removed: [hostEntry] }));
     removeRunStateMock.mockImplementation(() => {
       throw new Error("state write failed");
     });
 
-    await cleanupWorkspace(config, { task: "team-1" });
+    const actual = await cleanupWorkspace(config, { task: "team-1" });
 
+    expect(actual).toMatchObject({
+      outcome: "partial",
+      state: "running",
+      resources: {
+        worktrees: [{ worktreeDir: hostEntry.dir, removed: true }],
+      },
+      problems: [
+        { code: "state-write-failed", message: expect.stringContaining("state write failed") },
+      ],
+    });
     expect(consoleLog.output()).toContain("Run state cleanup failed");
   });
 

--- a/src/commands/cleanupWorkspace.test.ts
+++ b/src/commands/cleanupWorkspace.test.ts
@@ -172,6 +172,7 @@ describe(cleanupWorkspace, () => {
       outcome: "refused",
       problems: [{ code: "worktree-dirty" }],
     });
+    expect(actual.problems[0]?.message).toContain(hostEntry.dir);
     expect(actual.problems[0]?.message).not.toContain("--force");
     expect(teardownMock).not.toHaveBeenCalled();
   });
@@ -186,6 +187,7 @@ describe(cleanupWorkspace, () => {
       outcome: "refused",
       problems: [{ code: "worktree-status-unknown" }],
     });
+    expect(actual.problems[0]?.message).toContain(hostEntry.dir);
     expect(teardownMock).not.toHaveBeenCalled();
   });
 

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -25,7 +25,7 @@ import {
 } from "./lifecycleResult.ts";
 
 const USAGE = [
-  "Usage: crew cleanup [--force] <task>",
+  "Usage: crew cleanup [--force] <task> [--json]",
   "       crew cleanup [--force] --all",
   "Example: crew cleanup team-220",
 ].join("\n");

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -326,7 +326,7 @@ async function cleanupRefusal(arguments_: {
       worktreeDir: entry.dir,
       ...(signal === undefined ? {} : { signal }),
     });
-    const refusal = dirtinessRefusal({ task, state, entries, dirtiness });
+    const refusal = dirtinessRefusal({ task, state, entries, entry, dirtiness });
     if (refusal !== undefined) {
       return refusal;
     }
@@ -338,6 +338,7 @@ function dirtinessRefusal(arguments_: {
   task: string;
   state: ReturnType<typeof readRunState>;
   entries: readonly WorktreeEntry[];
+  entry: WorktreeEntry;
   dirtiness: WorktreeDirtiness;
 }): CleanupResult | undefined {
   if (arguments_.dirtiness.kind === "clean") {
@@ -347,11 +348,11 @@ function dirtinessRefusal(arguments_: {
     arguments_.dirtiness.kind === "dirty"
       ? {
           code: LIFECYCLE_PROBLEM_CODES.worktreeDirty,
-          message: `Worktree has ${arguments_.dirtiness.modified} modified and ${arguments_.dirtiness.untracked} untracked files; no cleanup was attempted.`,
+          message: `Worktree ${arguments_.entry.dir} has ${arguments_.dirtiness.modified} modified and ${arguments_.dirtiness.untracked} untracked files; no cleanup was attempted.`,
         }
       : {
           code: LIFECYCLE_PROBLEM_CODES.worktreeStatusUnknown,
-          message: "Worktree cleanliness could not be verified; no cleanup was attempted.",
+          message: `Worktree cleanliness could not be verified for ${arguments_.entry.dir}; no cleanup was attempted.`,
         };
   return cleanupClassifiedResult({
     task: arguments_.task,

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -1,10 +1,27 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, removeRunState } from "../lib/runState.ts";
 import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
-import { log } from "../lib/util.ts";
+import { errorMessage, log } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
-import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import {
+  type TeardownFailure,
+  type TeardownResult,
+  type WorktreeDirtiness,
+  type WorktreeEntry,
+  worktrees,
+} from "../lib/worktrees.ts";
 import { logTeardown } from "./teardownReporter.ts";
+import {
+  executeLifecycleMutation,
+  lifecycleCancellationSuffix,
+  type LifecycleCancellationContext,
+} from "./lifecycleCommand.ts";
+import {
+  LIFECYCLE_PROBLEM_CODES,
+  type CleanupResources,
+  type CleanupResult,
+  type LifecycleProblem,
+} from "./lifecycleResult.ts";
 
 const USAGE = [
   "Usage: crew cleanup [--force] <task>",
@@ -23,13 +40,18 @@ export interface CleanupAllOptions {
   force?: boolean;
 }
 
+export interface CleanupWorkspaceRunOptions {
+  signal?: AbortSignal;
+}
+
 type CleanupArguments =
-  | { mode: "task"; task: string; force: boolean }
-  | { mode: "all"; force: boolean };
+  | { mode: "task"; task: string; force: boolean; json: boolean }
+  | { mode: "all"; force: boolean; json: false };
 
 function parseArguments(argv: string[]): CleanupArguments {
   let force = false;
   let all = false;
+  let json = false;
   const positionals: string[] = [];
   for (const argument of argv) {
     if (argument === "--force") {
@@ -40,22 +62,29 @@ function parseArguments(argv: string[]): CleanupArguments {
       all = true;
       continue;
     }
+    if (argument === "--json") {
+      json = true;
+      continue;
+    }
     if (argument.startsWith("-")) {
       throw new Error(`Unknown option: ${argument}\n${USAGE}`);
     }
     positionals.push(argument);
   }
   if (all) {
+    if (json) {
+      throw new Error(`crew cleanup --json requires a task argument.\n${USAGE}`);
+    }
     if (positionals.length > 0) {
       throw new Error(`crew cleanup --all takes no task argument.\n${USAGE}`);
     }
-    return { mode: "all", force };
+    return { mode: "all", force, json: false };
   }
   const [task, ...extras] = positionals;
   if (task === undefined || task.length === 0 || extras.length > 0) {
     throw new Error(USAGE);
   }
-  return { mode: "task", task: task.toLowerCase(), force };
+  return { mode: "task", task: task.toLowerCase(), force, json };
 }
 
 /**
@@ -87,30 +116,110 @@ async function teardownEntries(
 export async function cleanupWorkspace(
   config: ResolvedConfig,
   options: CleanupWorkspaceOptions,
-): Promise<void> {
+  runOptions: CleanupWorkspaceRunOptions = {},
+): Promise<CleanupResult> {
   const { task, force = false } = options;
   const entries = worktrees.findByTask(config, task);
+  const state = readRunState(config, task);
+  const workspaceProbe =
+    runOptions.signal === undefined
+      ? await workspaces.probe(config)
+      : await workspaces.probe(config, runOptions.signal);
 
-  if (entries.length === 0) {
-    if (readRunState(config, task) === undefined) {
-      log(`No worktree found for ${task}; nothing to clean up.`);
-      return;
+  switch (entries[0]) {
+    case undefined: {
+      if (workspaceProbe.kind === "unavailable") {
+        return cleanupClassifiedResult({
+          task,
+          state,
+          outcome: "conflict",
+          lifecycleState: state?.state ?? "unknown",
+          resources: emptyCleanupResources(),
+          problems: [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+              message: "Workspace status is unavailable; no cleanup was attempted.",
+            },
+          ],
+        });
+      }
+      if (workspaceProbe.names.has(task)) {
+        return cleanupClassifiedResult({
+          task,
+          state,
+          outcome: "refused",
+          lifecycleState: "running",
+          resources: {
+            worktrees: [],
+            workspaces: [{ name: task, closed: false }],
+          },
+          problems: [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.workspaceBusy,
+              message: "The task workspace is still running; no cleanup was attempted.",
+            },
+          ],
+        });
+      }
+      if (state === undefined) {
+        return cleanupClassifiedResult({
+          task,
+          state,
+          outcome: "nothing-to-clean",
+          lifecycleState: "absent",
+          resources: emptyCleanupResources(),
+          problems: [],
+        });
+      }
+      try {
+        removeRunState(config, task);
+        return cleanupClassifiedResult({
+          task,
+          state,
+          outcome: "state-cleared",
+          lifecycleState: "absent",
+          resources: emptyCleanupResources(),
+          problems: [],
+        });
+      } catch (error) {
+        return cleanupClassifiedResult({
+          task,
+          state,
+          outcome: "partial",
+          lifecycleState: state.state,
+          resources: emptyCleanupResources(),
+          problems: [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+              message: `Stale run state could not be cleared: ${errorMessage(error)}`,
+            },
+          ],
+        });
+      }
     }
-    const workspaceProbe = await workspaces.probe(config);
-    if (workspaceProbe.kind === "unavailable") {
-      log(`No worktree found for ${task}; workspace probe unavailable, leaving run-state intact.`);
-      return;
-    }
-    if (workspaceProbe.names.has(task)) {
-      log(`No worktree found for ${task}; workspace still present; leaving run-state intact.`);
-      return;
-    }
-    removeRunState(config, task);
-    log(`No worktree found for ${task}; cleared stale run-state.`);
-    return;
+    default:
+      break;
   }
 
-  await teardownEntries(config, entries, force);
+  if (!force) {
+    const refusal = await cleanupRefusal({
+      task,
+      state,
+      entries,
+      workspaceProbe,
+      signal: runOptions.signal,
+    });
+    if (refusal !== undefined) {
+      return refusal;
+    }
+  }
+
+  const result = await worktrees.teardown(config, entries, {
+    force,
+    ...(runOptions.signal === undefined ? {} : { signal: runOptions.signal }),
+  });
+  recordCleanedUpRuns(config, result.removed);
+  return cleanupResultFromTeardown({ task, state, entries, result });
 }
 
 /**
@@ -153,12 +262,246 @@ export async function cleanupAllWorkspaces(
   await teardownEntries(config, idle, force);
 }
 
-export async function cleanupWorkspaceCli(argv: string[]): Promise<void> {
-  const config = await loadConfig();
+export async function cleanupWorkspaceCli(argv: string[]): Promise<CleanupResult | undefined> {
   const parsed = parseArguments(argv);
+  const config = await loadConfig();
   if (parsed.mode === "all") {
     await cleanupAllWorkspaces(config, { force: parsed.force });
-    return;
+    return undefined;
   }
-  await cleanupWorkspace(config, { task: parsed.task, force: parsed.force });
+  return await executeLifecycleMutation({
+    config,
+    task: parsed.task,
+    json: parsed.json,
+    conflictResult: () => cleanupLockConflictResult({ config, task: parsed.task }),
+    operation: async ({ signal }) =>
+      await cleanupWorkspace(config, { task: parsed.task, force: parsed.force }, { signal }),
+    cancelledResult: async (context) =>
+      await cancelledCleanupResult({ config, task: parsed.task, context }),
+  });
+}
+
+async function cleanupRefusal(arguments_: {
+  task: string;
+  state: ReturnType<typeof readRunState>;
+  entries: readonly WorktreeEntry[];
+  workspaceProbe: WorkspaceProbe;
+  signal: AbortSignal | undefined;
+}): Promise<CleanupResult | undefined> {
+  const { task, state, entries, workspaceProbe, signal } = arguments_;
+  if (isWorkspaceInUse(workspaceProbe, task)) {
+    return cleanupClassifiedResult({
+      task,
+      state,
+      outcome: "refused",
+      lifecycleState: "running",
+      resources: cleanupResources(entries, [], []),
+      problems: [
+        {
+          code: LIFECYCLE_PROBLEM_CODES.workspaceBusy,
+          message: "The task workspace is still running; no cleanup was attempted.",
+        },
+      ],
+    });
+  }
+  if (workspaceProbe.kind === "unavailable") {
+    return cleanupClassifiedResult({
+      task,
+      state,
+      outcome: "conflict",
+      lifecycleState: state?.state ?? "unknown",
+      resources: cleanupResources(entries, [], []),
+      problems: [
+        {
+          code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+          message: "Workspace status is unavailable; no cleanup was attempted.",
+        },
+      ],
+    });
+  }
+  for (const entry of entries) {
+    // oxlint-disable-next-line no-await-in-loop -- preflight is sequential to avoid concurrent git probes
+    const dirtiness = await worktrees.probeWorkingTree({
+      worktreeDir: entry.dir,
+      ...(signal === undefined ? {} : { signal }),
+    });
+    const refusal = dirtinessRefusal({ task, state, entries, dirtiness });
+    if (refusal !== undefined) {
+      return refusal;
+    }
+  }
+  return undefined;
+}
+
+function dirtinessRefusal(arguments_: {
+  task: string;
+  state: ReturnType<typeof readRunState>;
+  entries: readonly WorktreeEntry[];
+  dirtiness: WorktreeDirtiness;
+}): CleanupResult | undefined {
+  if (arguments_.dirtiness.kind === "clean") {
+    return undefined;
+  }
+  const problem: LifecycleProblem =
+    arguments_.dirtiness.kind === "dirty"
+      ? {
+          code: LIFECYCLE_PROBLEM_CODES.worktreeDirty,
+          message: `Worktree has ${arguments_.dirtiness.modified} modified and ${arguments_.dirtiness.untracked} untracked files; no cleanup was attempted.`,
+        }
+      : {
+          code: LIFECYCLE_PROBLEM_CODES.worktreeStatusUnknown,
+          message: "Worktree cleanliness could not be verified; no cleanup was attempted.",
+        };
+  return cleanupClassifiedResult({
+    task: arguments_.task,
+    state: arguments_.state,
+    outcome: "refused",
+    lifecycleState: arguments_.state?.state ?? "unknown",
+    resources: cleanupResources(arguments_.entries, [], []),
+    problems: [problem],
+  });
+}
+
+function cleanupResultFromTeardown(arguments_: {
+  task: string;
+  state: ReturnType<typeof readRunState>;
+  entries: readonly WorktreeEntry[];
+  result: TeardownResult;
+}): CleanupResult {
+  const { task, state, entries, result } = arguments_;
+  const problems = result.failures.map(problemFromTeardownFailure);
+  if (result.workspaceProbe.kind === "unavailable") {
+    problems.push({
+      code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+      message:
+        result.workspaceProbe.error === undefined
+          ? "Workspace status was unavailable during cleanup."
+          : `Workspace status was unavailable during cleanup: ${errorMessage(result.workspaceProbe.error)}`,
+    });
+  }
+  if (result.cancelled === true) {
+    problems.push({
+      code: LIFECYCLE_PROBLEM_CODES.cancelled,
+      message: "Cleanup was cancelled before every resource was reconciled.",
+    });
+  }
+  return cleanupClassifiedResult({
+    task,
+    state,
+    outcome: problems.length === 0 ? "cleaned" : "partial",
+    lifecycleState:
+      result.removed.length === entries.length && problems.length === 0
+        ? "absent"
+        : (state?.state ?? "unknown"),
+    resources: cleanupResources(entries, result.removed, result.closed),
+    problems,
+  });
+}
+
+function problemFromTeardownFailure(failure: TeardownFailure): LifecycleProblem {
+  if (failure.step === "workspace_close") {
+    return {
+      code: LIFECYCLE_PROBLEM_CODES.workspaceCloseFailed,
+      message: `Workspace close failed: ${errorMessage(failure.error)}`,
+    };
+  }
+  const detail = errorMessage(failure.error);
+  return {
+    code: LIFECYCLE_PROBLEM_CODES.worktreeRemoveFailed,
+    message: detail.includes("--force")
+      ? "Worktree could not be removed safely; inspect it for uncommitted changes."
+      : `Worktree removal failed: ${detail}`,
+  };
+}
+
+function cleanupResources(
+  entries: readonly WorktreeEntry[],
+  removed: readonly WorktreeEntry[],
+  closed: readonly string[],
+): CleanupResources {
+  const removedDirs = new Set(removed.map((entry) => entry.dir));
+  const workspaceNames = new Set(entries.map((entry) => entry.task));
+  for (const name of closed) {
+    workspaceNames.add(name);
+  }
+  return {
+    worktrees: entries.map((entry) => ({
+      repository: entry.repository,
+      branch: entry.branchName,
+      worktreeDir: entry.dir,
+      removed: removedDirs.has(entry.dir),
+    })),
+    workspaces: [...workspaceNames].map((name) => ({ name, closed: closed.includes(name) })),
+  };
+}
+
+function emptyCleanupResources(): CleanupResources {
+  return { worktrees: [], workspaces: [] };
+}
+
+function cleanupClassifiedResult(arguments_: {
+  task: string;
+  state: ReturnType<typeof readRunState>;
+  outcome: CleanupResult["outcome"];
+  lifecycleState: CleanupResult["state"];
+  resources: CleanupResources;
+  problems: LifecycleProblem[];
+}): CleanupResult {
+  return {
+    action: "cleanup",
+    task: {
+      id: arguments_.task,
+      ...(arguments_.state?.completionTaskId === undefined
+        ? {}
+        : { canonicalId: arguments_.state.completionTaskId }),
+      ...(arguments_.state?.url === undefined ? {} : { url: arguments_.state.url }),
+    },
+    outcome: arguments_.outcome,
+    state: arguments_.lifecycleState,
+    resources: arguments_.resources,
+    problems: arguments_.problems,
+  };
+}
+
+function cleanupLockConflictResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+}): CleanupResult {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const entries = worktrees.findByTask(arguments_.config, arguments_.task);
+  return cleanupClassifiedResult({
+    task: arguments_.task,
+    state,
+    outcome: "conflict",
+    lifecycleState: state?.state ?? "unknown",
+    resources: cleanupResources(entries, [], []),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.lifecycleLockHeld,
+        message: "Another lifecycle mutation owns this task.",
+      },
+    ],
+  });
+}
+
+async function cancelledCleanupResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  context: LifecycleCancellationContext;
+}): Promise<CleanupResult> {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const entries = worktrees.findByTask(arguments_.config, arguments_.task);
+  return cleanupClassifiedResult({
+    task: arguments_.task,
+    state,
+    outcome: "partial",
+    lifecycleState: state?.state ?? (entries.length === 0 ? "absent" : "unknown"),
+    resources: cleanupResources(entries, [], []),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.cancelled,
+        message: `Cleanup cancelled${lifecycleCancellationSuffix(arguments_.context)}.`,
+      },
+    ],
+  });
 }

--- a/src/commands/cleanupWorkspace.ts
+++ b/src/commands/cleanupWorkspace.ts
@@ -1,6 +1,6 @@
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
 import { readRunState, removeRunState } from "../lib/runState.ts";
-import { recordCleanedUpRuns } from "../lib/runStateCleanup.ts";
+import { recordCleanedUpRuns, type RunStateCleanupFailure } from "../lib/runStateCleanup.ts";
 import { errorMessage, log } from "../lib/util.ts";
 import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import {
@@ -14,6 +14,7 @@ import { logTeardown } from "./teardownReporter.ts";
 import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
+  loadLifecycleConfig,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -218,8 +219,8 @@ export async function cleanupWorkspace(
     force,
     ...(runOptions.signal === undefined ? {} : { signal: runOptions.signal }),
   });
-  recordCleanedUpRuns(config, result.removed);
-  return cleanupResultFromTeardown({ task, state, entries, result });
+  const stateFailures = recordCleanedUpRuns(config, result.removed);
+  return cleanupResultFromTeardown({ task, state, entries, result, stateFailures });
 }
 
 /**
@@ -264,7 +265,7 @@ export async function cleanupAllWorkspaces(
 
 export async function cleanupWorkspaceCli(argv: string[]): Promise<CleanupResult | undefined> {
   const parsed = parseArguments(argv);
-  const config = await loadConfig();
+  const config = await loadLifecycleConfig(parsed.mode === "task" && parsed.json);
   if (parsed.mode === "all") {
     await cleanupAllWorkspaces(config, { force: parsed.force });
     return undefined;
@@ -367,9 +368,16 @@ function cleanupResultFromTeardown(arguments_: {
   state: ReturnType<typeof readRunState>;
   entries: readonly WorktreeEntry[];
   result: TeardownResult;
+  stateFailures: readonly RunStateCleanupFailure[];
 }): CleanupResult {
-  const { task, state, entries, result } = arguments_;
+  const { task, state, entries, result, stateFailures } = arguments_;
   const problems = result.failures.map(problemFromTeardownFailure);
+  for (const failure of stateFailures) {
+    problems.push({
+      code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+      message: `Removed resources for ${failure.task}, but run state could not be cleared: ${errorMessage(failure.error)}`,
+    });
+  }
   if (result.workspaceProbe.kind === "unavailable") {
     problems.push({
       code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -95,7 +95,7 @@ export const COMPLETION_SPEC: readonly CompletionCommand[] = [
   {
     name: "start",
     summary: "Launch one task immediately",
-    options: [DRY_RUN_OPTION],
+    options: [DRY_RUN_OPTION, JSON_OPTION],
   },
   {
     name: "doctor",
@@ -183,17 +183,18 @@ export const COMPLETION_SPEC: readonly CompletionCommand[] = [
     options: [
       { name: "--force", summary: "Skip confirmations" },
       { name: "--all", summary: "Clean up every idle worktree" },
+      JSON_OPTION,
     ],
   },
   {
     name: "stop",
     summary: "Stop a live task workspace",
-    options: [{ name: "--reason", summary: "Reason text", arg: { kind: "string" } }],
+    options: [{ name: "--reason", summary: "Reason text", arg: { kind: "string" } }, JSON_OPTION],
   },
   {
     name: "resume",
     summary: "Reopen an existing task worktree",
-    options: [{ name: "--new", summary: "Start a fresh chat session" }],
+    options: [{ name: "--new", summary: "Start a fresh chat session" }, JSON_OPTION],
   },
   {
     name: "open",

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -8,6 +8,7 @@ import type { WorktreeEntry } from "../lib/worktrees.ts";
 import { setVerbose } from "../lib/util.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { createDispatcher, formatActiveSlotList } from "./dispatcher.ts";
+import type { StartResult } from "./lifecycleResult.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
 vi.mock(import("./setupWorkspace.ts"), async (importOriginal) => {
@@ -101,12 +102,23 @@ function hostEntryFor(repository: string, task: string): WorktreeEntry {
   };
 }
 
+function startedResult(): StartResult {
+  return {
+    action: "start",
+    task: { id: "team-1", canonicalId: "TEAM-1" },
+    outcome: "started",
+    state: "running",
+    resources: {},
+    problems: [],
+  };
+}
+
 describe(createDispatcher, () => {
   let consoleLog: ConsoleCapture;
 
   beforeEach(() => {
     consoleLog = captureConsoleLog();
-    setupMock.mockResolvedValue();
+    setupMock.mockResolvedValue(startedResult());
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
     // Dispatch telemetry (event= lines) is diagnostic, so it only reaches the
     // console under verbose — many cases assert that wording.

--- a/src/commands/dispatcher.test.ts
+++ b/src/commands/dispatcher.test.ts
@@ -1019,6 +1019,31 @@ describe(createDispatcher, () => {
   });
 
   describe("setup failures", () => {
+    it("marks partial starts in progress while logging their problem codes as failed", async () => {
+      setupMock.mockResolvedValue({
+        ...startedResult(),
+        outcome: "partial",
+        problems: [{ code: "state-write-failed", message: "Could not persist run state." }],
+      });
+      const board = makeBoard();
+      const dispatcher = createDispatcher({ config: makeConfig(), board });
+
+      await dispatcher.runOnce({
+        state: boardOf([todoIssue()]),
+        worktreeEntries: [],
+        usage: async () => ({}),
+        dryRun: false,
+      });
+
+      expect(board.markInProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "linear:team-1" }),
+      );
+      expect(consoleLog.output()).toContain(
+        "event=dispatch outcome=failed task=team-1 agent=claude repository=repo-a problems=state-write-failed",
+      );
+      expect(consoleLog.output()).not.toContain("event=dispatch outcome=started");
+    });
+
     it("logs setupWorkspace failures without crashing the loop", async () => {
       setupMock.mockRejectedValue(new Error("boom"));
       const board = makeBoard();

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -31,7 +31,7 @@ import {
   type SkipVerdict,
   type StartVerdict,
 } from "./eligibility.ts";
-import { renderLifecycleResult } from "./lifecycleResult.ts";
+import { renderLifecycleResult, type StartResult } from "./lifecycleResult.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
 interface DispatcherDeps {
@@ -129,6 +129,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     }
 
     try {
+      let setupResult: StartResult | undefined;
       if (recovery) {
         log(`Worktree and workspace already exist for ${taskId}; resuming with markInProgress`);
       } else {
@@ -150,12 +151,22 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
             ...(issue.url === undefined ? {} : { url: issue.url }),
           },
         };
-        const result = await (signal === undefined
+        setupResult = await (signal === undefined
           ? setupWorkspace(config, setupOptions)
           : setupWorkspace(config, setupOptions, { signal }));
-        renderLifecycleResult({ result, json: false });
+        renderLifecycleResult({ result: setupResult, json: false });
       }
       await board.markInProgress(issue);
+      if (setupResult?.outcome === "partial") {
+        logEvent("dispatch", {
+          outcome: "failed",
+          task: taskId,
+          agent: issue.agent,
+          repository: issue.repository,
+          problems: setupResult.problems.map((problem) => problem.code),
+        });
+        return;
+      }
       logEvent("dispatch", {
         outcome: recovery ? "resumed" : "started",
         task: taskId,

--- a/src/commands/dispatcher.ts
+++ b/src/commands/dispatcher.ts
@@ -31,6 +31,7 @@ import {
   type SkipVerdict,
   type StartVerdict,
 } from "./eligibility.ts";
+import { renderLifecycleResult } from "./lifecycleResult.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
 interface DispatcherDeps {
@@ -149,9 +150,10 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
             ...(issue.url === undefined ? {} : { url: issue.url }),
           },
         };
-        await (signal === undefined
+        const result = await (signal === undefined
           ? setupWorkspace(config, setupOptions)
           : setupWorkspace(config, setupOptions, { signal }));
+        renderLifecycleResult({ result, json: false });
       }
       await board.markInProgress(issue);
       logEvent("dispatch", {

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -521,7 +521,9 @@ describe(interruptWorkspaceCli, () => {
   });
 
   it("rejects missing task", async () => {
-    await expect(interruptWorkspaceCli([])).rejects.toThrow(/Usage: crew stop/);
+    await expect(interruptWorkspaceCli([])).rejects.toThrow(
+      "Usage: crew stop <task> [--reason <text>] [--json]",
+    );
   });
 
   it("rejects missing reason text", async () => {
@@ -532,7 +534,7 @@ describe(interruptWorkspaceCli, () => {
 
   it("rejects unknown options", async () => {
     await expect(interruptWorkspaceCli(["--bogus", "team-1"])).rejects.toThrow(
-      /Unknown option: --bogus/,
+      /Unknown option: --bogus.*\[--json\]/s,
     );
   });
 });

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -359,7 +359,12 @@ describe(interruptWorkspaceCli, () => {
     const consoleLog = captureConsoleLog();
 
     try {
-      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+      const actual = await interruptWorkspaceCli([
+        "TEAM-1",
+        "--reason",
+        "wrong direction",
+        "--json",
+      ]);
 
       expect(actual).toMatchObject({
         action: "stop",
@@ -371,6 +376,7 @@ describe(interruptWorkspaceCli, () => {
         task: "team-1",
         state: "interrupted",
         detail: "workspace missing after cancellation",
+        reason: "wrong direction",
       });
       expect(consoleLog.calls).toHaveLength(1);
       expect(process.exitCode).toBe(1);

--- a/src/commands/interruptWorkspace.test.ts
+++ b/src/commands/interruptWorkspace.test.ts
@@ -4,6 +4,7 @@ import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { interruptWorkspace, interruptWorkspaceCli } from "./interruptWorkspace.ts";
+import { acquireLifecycleLock } from "./lifecycleCommand.ts";
 
 vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
@@ -24,6 +25,7 @@ vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
     workspaces: {
       ...actual.workspaces,
       interrupt: vi.fn<typeof actual.workspaces.interrupt>(),
+      probe: vi.fn<typeof actual.workspaces.probe>(),
     },
   };
 });
@@ -43,6 +45,7 @@ const loadConfigMock = vi.mocked(loadConfig);
 const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
 const interruptMock = vi.mocked(workspaces.interrupt);
+const probeMock = vi.mocked(workspaces.probe);
 const findByTaskMock = vi.mocked(worktrees.findByTask);
 const teardownMock = vi.mocked(worktrees.teardown);
 
@@ -83,7 +86,7 @@ function makeConfig(): ResolvedConfig {
       safehouse: { enable: [] },
       readOnlyDirs: [],
     },
-    logging: { file: "/tmp/groundcrew-test.log" },
+    logging: { file: "/tmp/groundcrew-interrupt-workspace-test.log" },
   };
 }
 
@@ -113,6 +116,15 @@ function makeWorktree(): WorktreeEntry {
   };
 }
 
+function requireAcquiredLock(
+  lock: ReturnType<typeof acquireLifecycleLock>,
+): Extract<ReturnType<typeof acquireLifecycleLock>, { kind: "acquired" }> {
+  if (lock.kind !== "acquired") {
+    throw new Error("test could not acquire lifecycle lock");
+  }
+  return lock;
+}
+
 describe(interruptWorkspace, () => {
   let consoleLog: ConsoleCapture;
   const config = makeConfig();
@@ -122,6 +134,7 @@ describe(interruptWorkspace, () => {
     readRunStateMock.mockReturnValue(makeRunState());
     findByTaskMock.mockReturnValue([makeWorktree()]);
     interruptMock.mockResolvedValue({ kind: "interrupted" });
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set() });
   });
 
   afterEach(() => {
@@ -130,7 +143,10 @@ describe(interruptWorkspace, () => {
   });
 
   it("interrupts the recorded workspace and preserves the worktree", async () => {
-    await interruptWorkspace(config, { task: "TEAM-1", reason: "wrong direction" });
+    const actual = await interruptWorkspace(config, {
+      task: "TEAM-1",
+      reason: "wrong direction",
+    });
 
     expect(interruptMock).toHaveBeenCalledWith(config, "team-1");
     expect(lastRecordedRunState()).toMatchObject({
@@ -140,7 +156,8 @@ describe(interruptWorkspace, () => {
       worktreeDir: "/work/repo-a-team-1",
     });
     expect(teardownMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("worktree preserved");
+    expect(actual).toMatchObject({ outcome: "stopped", state: "interrupted" });
+    expect(consoleLog.output()).toBe("");
   });
 
   it("records an interrupted state from a worktree when state is missing", async () => {
@@ -158,49 +175,137 @@ describe(interruptWorkspace, () => {
   it("records workspace missing detail without failing", async () => {
     interruptMock.mockResolvedValue({ kind: "missing" });
 
-    await interruptWorkspace(config, { task: "team-1" });
+    const actual = await interruptWorkspace(config, { task: "team-1" });
 
     expect(lastRecordedRunState()).toMatchObject({
       state: "interrupted",
       detail: "workspace missing",
     });
+    expect(actual.outcome).toBe("workspace-missing");
+  });
+
+  it("returns already-stopped when persisted state and workspace absence agree", async () => {
+    readRunStateMock.mockReturnValue(makeRunState({ state: "interrupted" }));
+    interruptMock.mockResolvedValue({ kind: "missing" });
+
+    const actual = await interruptWorkspace(config, { task: "team-1" });
+
+    expect(actual).toMatchObject({ outcome: "already-stopped", state: "interrupted" });
   });
 
   it("closes the live workspace when there is no run state or worktree", async () => {
     readRunStateMock.mockReset();
     findByTaskMock.mockReturnValue([]);
 
-    await interruptWorkspace(config, { task: "orphan-1" });
+    const actual = await interruptWorkspace(config, { task: "orphan-1" });
 
     expect(interruptMock).toHaveBeenCalledWith(config, "orphan-1");
     expect(recordRunStateMock).not.toHaveBeenCalled();
-    expect(consoleLog.output()).toContain("Closed orphaned workspace orphan-1");
+    expect(actual).toMatchObject({ outcome: "stopped", state: "absent" });
+    expect(consoleLog.output()).toBe("");
   });
 
-  it("fails when there is no run state, no worktree, and no live workspace", async () => {
+  it("returns not-found when there is no local context or live workspace", async () => {
     readRunStateMock.mockReset();
     findByTaskMock.mockReturnValue([]);
     interruptMock.mockResolvedValue({ kind: "missing" });
 
-    await expect(interruptWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      /nothing to interrupt/,
-    );
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "not-found",
+      state: "absent",
+    });
     expect(recordRunStateMock).not.toHaveBeenCalled();
   });
 
-  it("fails when the workspace backend is unavailable", async () => {
+  it("returns conflict when the workspace backend is unavailable", async () => {
     interruptMock.mockResolvedValue({ kind: "unavailable", error: new Error("cmux down") });
 
-    await expect(interruptWorkspace(config, { task: "team-1" })).rejects.toThrow(/cmux down/);
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [
+        { code: "workspace-status-unavailable", message: expect.stringContaining("cmux down") },
+      ],
+    });
     expect(recordRunStateMock).not.toHaveBeenCalled();
   });
 
-  it("uses a generic error when the workspace backend is unavailable without details", async () => {
+  it("uses a generic problem when the workspace backend is unavailable without details", async () => {
     interruptMock.mockResolvedValue({ kind: "unavailable" });
 
-    await expect(interruptWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      /workspace adapter unavailable/,
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [{ message: expect.stringContaining("workspace adapter unavailable") }],
+    });
+  });
+
+  it("returns partial when the workspace stops but durable state cannot be recorded", async () => {
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      state: "interrupted",
+      problems: [{ code: "state-write-failed", message: expect.stringContaining("disk full") }],
+    });
+  });
+
+  it("preserves canonical task identity from durable state", async () => {
+    readRunStateMock.mockReturnValue(
+      makeRunState({ completionTaskId: "linear:TEAM-1", url: "https://example.test/TEAM-1" }),
     );
+
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      task: {
+        id: "team-1",
+        canonicalId: "linear:TEAM-1",
+        url: "https://example.test/TEAM-1",
+      },
+    });
+  });
+
+  it("returns conflict when an orphan workspace cannot be inspected", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockResolvedValue({ kind: "unavailable", error: new Error("backend down") });
+
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      resources: {},
+      problems: [{ code: "workspace-status-unavailable" }],
+    });
+  });
+
+  it("uses a generic conflict when an orphan workspace probe has no error detail", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [{ message: expect.stringContaining("workspace adapter unavailable") }],
+    });
+  });
+
+  it("threads an AbortSignal into an orphan workspace interruption", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockResolvedValue({ kind: "unavailable" });
+    const signal = new AbortController().signal;
+
+    await interruptWorkspace(config, { task: "team-1" }, { signal });
+
+    expect(interruptMock).toHaveBeenCalledWith(config, "team-1", signal);
+  });
+
+  it("reports unknown state when a worktree-only workspace cannot be inspected", async () => {
+    readRunStateMock.mockReset();
+    interruptMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(interruptWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      state: "unknown",
+    });
   });
 });
 
@@ -212,10 +317,185 @@ describe(interruptWorkspaceCli, () => {
     readRunStateMock.mockReturnValue(makeRunState());
     findByTaskMock.mockReturnValue([makeWorktree()]);
     interruptMock.mockResolvedValue({ kind: "interrupted" });
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set() });
   });
 
   afterEach(() => {
+    process.exitCode = undefined;
     vi.resetAllMocks();
+  });
+
+  it("emits exactly one structured stop receipt in JSON mode", async () => {
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "stopped",
+        state: "interrupted",
+        resources: {
+          repository: "repo-a",
+          branch: "dev-team-1",
+          worktreeDir: "/work/repo-a-team-1",
+          workspace: { name: "team-1" },
+        },
+        problems: [],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reconciles durable stopped state after cooperative cancellation", async () => {
+    interruptMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "stop",
+        outcome: "partial",
+        state: "interrupted",
+        problems: [{ code: "cancelled", message: expect.stringContaining("SIGTERM") }],
+      });
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        state: "interrupted",
+        detail: "workspace missing after cancellation",
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("returns a stable conflict when another lifecycle command owns the task", async () => {
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "stop",
+        outcome: "conflict",
+        problems: [{ code: "lifecycle-lock-held" }],
+      });
+      expect(interruptMock).not.toHaveBeenCalled();
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("returns a lock conflict without inventing resources for an unknown task", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "unknown-1" }));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["unknown-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        outcome: "conflict",
+        state: "unknown",
+        resources: {},
+      });
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("reports cancellation reconciliation failure alongside cancellation", async () => {
+    interruptMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual.problems).toEqual([
+        expect.objectContaining({ code: "cancelled" }),
+        expect.objectContaining({ code: "state-write-failed" }),
+      ]);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("does not record interruption when cancellation still observes a live workspace", async () => {
+    interruptMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({ outcome: "partial", state: "running" });
+      expect(recordRunStateMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("does not invent run state when an orphan interruption is cancelled", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await interruptWorkspaceCli(["orphan-1", "--json"]);
+
+      expect(actual).toMatchObject({ outcome: "partial", state: "interrupted", resources: {} });
+      expect(recordRunStateMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reports unknown state when a cancelled orphan workspace remains live", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    interruptMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set(["orphan-1"]) });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(interruptWorkspaceCli(["orphan-1", "--json"])).resolves.toMatchObject({
+        outcome: "partial",
+        state: "unknown",
+      });
+    } finally {
+      consoleLog.restore();
+    }
   });
 
   it("parses task and reason", async () => {

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -7,6 +7,7 @@ import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
   loadLifecycleConfig,
+  probeWorkspaceForLifecycleReconciliation,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -59,13 +60,15 @@ function parseArguments(argv: string[]): { options: InterruptWorkspaceOptions; j
       continue;
     }
     if (argument.startsWith("-")) {
-      throw new Error(`Unknown option: ${argument}\nUsage: crew stop <task> [--reason <text>]`);
+      throw new Error(
+        `Unknown option: ${argument}\nUsage: crew stop <task> [--reason <text>] [--json]`,
+      );
     }
     positionals.push(argument);
   }
   const [task, ...extras] = positionals;
   if (task === undefined || task.length === 0 || extras.length > 0) {
-    throw new Error("Usage: crew stop <task> [--reason <text>]");
+    throw new Error("Usage: crew stop <task> [--reason <text>] [--json]");
   }
   return {
     options: { task: task.toLowerCase(), ...(reason === undefined ? {} : { reason }) },
@@ -363,7 +366,7 @@ async function cancelledStopResult(arguments_: {
     state,
     entry,
   });
-  const probe = await workspaces.probe(config);
+  const probe = await probeWorkspaceForLifecycleReconciliation(config);
   const workspaceAbsent = probe.kind === "ok" && !probe.names.has(options.task);
   let stateProblem: LifecycleProblem | undefined;
   if (workspaceAbsent && source !== undefined) {

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -1,12 +1,27 @@
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
-import { errorMessage, log } from "../lib/util.ts";
+import { errorMessage } from "../lib/util.ts";
 import { workspaces, type WorkspaceInterruptResult } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
+import {
+  executeLifecycleMutation,
+  lifecycleCancellationSuffix,
+  type LifecycleCancellationContext,
+} from "./lifecycleCommand.ts";
+import {
+  LIFECYCLE_PROBLEM_CODES,
+  type LifecycleProblem,
+  type LifecycleResources,
+  type StopResult,
+} from "./lifecycleResult.ts";
 
 export interface InterruptWorkspaceOptions {
   task: string;
   reason?: string;
+}
+
+export interface InterruptWorkspaceRunOptions {
+  signal?: AbortSignal;
 }
 
 interface InterruptSource {
@@ -19,8 +34,9 @@ interface InterruptSource {
   resumeCount: number;
 }
 
-function parseArguments(argv: string[]): InterruptWorkspaceOptions {
+function parseArguments(argv: string[]): { options: InterruptWorkspaceOptions; json: boolean } {
   let reason: string | undefined;
+  let json = false;
   const positionals: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
@@ -37,6 +53,10 @@ function parseArguments(argv: string[]): InterruptWorkspaceOptions {
       index += 1;
       continue;
     }
+    if (argument === "--json") {
+      json = true;
+      continue;
+    }
     if (argument.startsWith("-")) {
       throw new Error(`Unknown option: ${argument}\nUsage: crew stop <task> [--reason <text>]`);
     }
@@ -46,7 +66,10 @@ function parseArguments(argv: string[]): InterruptWorkspaceOptions {
   if (task === undefined || task.length === 0 || extras.length > 0) {
     throw new Error("Usage: crew stop <task> [--reason <text>]");
   }
-  return { task: task.toLowerCase(), ...(reason === undefined ? {} : { reason }) };
+  return {
+    options: { task: task.toLowerCase(), ...(reason === undefined ? {} : { reason }) },
+    json,
+  };
 }
 
 function sourceFromState(state: RunState): InterruptSource {
@@ -99,65 +122,269 @@ function interruptDetail(result: WorkspaceInterruptResult): string | undefined {
   return undefined;
 }
 
-function failOnUnavailable(result: WorkspaceInterruptResult): void {
-  if (result.kind !== "unavailable") {
-    return;
-  }
-  const detail =
-    result.error === undefined ? "workspace adapter unavailable" : errorMessage(result.error);
-  throw new Error(`Could not interrupt workspace: ${detail}`);
-}
-
 export async function interruptWorkspace(
   config: ResolvedConfig,
   options: InterruptWorkspaceOptions,
-): Promise<void> {
+  runOptions: InterruptWorkspaceRunOptions = {},
+): Promise<StopResult> {
   const task = options.task.toLowerCase();
   const state = readRunState(config, task);
   const [entry] = worktrees.findByTask(config, task);
   const source = resolveInterruptSource({ config, task, state, entry });
   if (source === undefined) {
-    await interruptOrphanWorkspace(config, task);
-    return;
+    return await interruptOrphanWorkspace(config, task, runOptions.signal);
   }
-  const result = await workspaces.interrupt(config, source.workspaceName);
-  failOnUnavailable(result);
-  const detail = interruptDetail(result);
-  recordRunState({
-    config,
-    state: {
-      task,
-      repository: source.repository,
-      agent: source.agent,
-      worktreeDir: source.worktreeDir,
-      branchName: source.branchName,
-      workspaceName: source.workspaceName,
-      state: "interrupted",
-      resumeCount: source.resumeCount,
-      ...(options.reason === undefined ? {} : { reason: options.reason }),
-      ...(detail === undefined ? {} : { detail }),
-    },
-  });
-  log(`Interrupted ${task}; worktree preserved at ${source.worktreeDir}`);
-  log(`Next: crew status ${task}`);
+  const result =
+    runOptions.signal === undefined
+      ? await workspaces.interrupt(config, source.workspaceName)
+      : await workspaces.interrupt(config, source.workspaceName, runOptions.signal);
+  switch (result.kind) {
+    case "unavailable": {
+      const detail =
+        result.error === undefined ? "workspace adapter unavailable" : errorMessage(result.error);
+      return stopResult({
+        task,
+        state,
+        source,
+        outcome: "conflict",
+        lifecycleState: state?.state ?? "unknown",
+        problems: [
+          {
+            code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+            message: `Could not interrupt workspace: ${detail}`,
+          },
+        ],
+      });
+    }
+    case "interrupted":
+    case "missing": {
+      const detail = interruptDetail(result);
+      const problem = recordInterruptedState({ config, task, source, options, detail });
+      const outcome =
+        problem === undefined
+          ? result.kind === "interrupted"
+            ? "stopped"
+            : state?.state === "interrupted"
+              ? "already-stopped"
+              : "workspace-missing"
+          : "partial";
+      return stopResult({
+        task,
+        state,
+        source,
+        outcome,
+        lifecycleState: "interrupted",
+        problems: problem === undefined ? [] : [problem],
+      });
+    }
+    /* v8 ignore next 2 @preserve -- WorkspaceInterruptResult is exhaustively discriminated above */
+    default:
+      throw new Error("Unexpected workspace interrupt result");
+  }
 }
 
 // Orphan path: a tmux session/window for `task` exists but neither a run-state
 // record nor a worktree does, so there's no lifecycle to record `interrupted`
 // against — just close the workspace. Reported in `crew status` under
 // "Orphaned sessions" and pointed at `crew stop`.
-async function interruptOrphanWorkspace(config: ResolvedConfig, task: string): Promise<void> {
-  const result = await workspaces.interrupt(config, task);
-  failOnUnavailable(result);
-  if (result.kind === "missing") {
-    throw new Error(
-      `No run state, worktree, or live workspace found for ${task}; nothing to interrupt.`,
-    );
+async function interruptOrphanWorkspace(
+  config: ResolvedConfig,
+  task: string,
+  signal: AbortSignal | undefined,
+): Promise<StopResult> {
+  const result =
+    signal === undefined
+      ? await workspaces.interrupt(config, task)
+      : await workspaces.interrupt(config, task, signal);
+  switch (result.kind) {
+    case "unavailable": {
+      const detail =
+        result.error === undefined ? "workspace adapter unavailable" : errorMessage(result.error);
+      return {
+        action: "stop",
+        task: { id: task },
+        outcome: "conflict",
+        state: "unknown",
+        resources: {},
+        problems: [
+          {
+            code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+            message: `Could not interrupt workspace: ${detail}`,
+          },
+        ],
+      };
+    }
+    case "missing":
+      return {
+        action: "stop",
+        task: { id: task },
+        outcome: "not-found",
+        state: "absent",
+        resources: {},
+        problems: [],
+      };
+    case "interrupted":
+      return {
+        action: "stop",
+        task: { id: task },
+        outcome: "stopped",
+        state: "absent",
+        resources: { workspace: { name: task } },
+        problems: [],
+      };
+    /* v8 ignore next 2 @preserve -- WorkspaceInterruptResult is exhaustively discriminated above */
+    default:
+      throw new Error("Unexpected workspace interrupt result");
   }
-  log(`Closed orphaned workspace ${task}`);
 }
 
-export async function interruptWorkspaceCli(argv: string[]): Promise<void> {
+export async function interruptWorkspaceCli(argv: string[]): Promise<StopResult> {
+  const parsed = parseArguments(argv);
   const config = await loadConfig();
-  await interruptWorkspace(config, parseArguments(argv));
+  return await executeLifecycleMutation({
+    config,
+    task: parsed.options.task,
+    json: parsed.json,
+    conflictResult: () => stopLockConflictResult({ config, task: parsed.options.task }),
+    operation: async ({ signal }) => await interruptWorkspace(config, parsed.options, { signal }),
+    cancelledResult: async (context) =>
+      await cancelledStopResult({ config, task: parsed.options.task, context }),
+  });
+}
+
+function recordInterruptedState(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  source: InterruptSource;
+  options: InterruptWorkspaceOptions;
+  detail: string | undefined;
+}): LifecycleProblem | undefined {
+  const { config, task, source, options, detail } = arguments_;
+  try {
+    recordRunState({
+      config,
+      state: {
+        task,
+        repository: source.repository,
+        agent: source.agent,
+        worktreeDir: source.worktreeDir,
+        branchName: source.branchName,
+        workspaceName: source.workspaceName,
+        state: "interrupted",
+        resumeCount: source.resumeCount,
+        ...(options.reason === undefined ? {} : { reason: options.reason }),
+        ...(detail === undefined ? {} : { detail }),
+      },
+    });
+    return undefined;
+  } catch (error) {
+    return {
+      code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+      message: `Workspace was stopped but run state could not be updated: ${errorMessage(error)}`,
+    };
+  }
+}
+
+function stopResult(arguments_: {
+  task: string;
+  state: RunState | undefined;
+  source: InterruptSource;
+  outcome: StopResult["outcome"];
+  lifecycleState: StopResult["state"];
+  problems: LifecycleProblem[];
+}): StopResult {
+  return {
+    action: "stop",
+    task: taskIdentity(arguments_.task, arguments_.state),
+    outcome: arguments_.outcome,
+    state: arguments_.lifecycleState,
+    resources: resourcesFromSource(arguments_.source),
+    problems: arguments_.problems,
+  };
+}
+
+function taskIdentity(task: string, state: RunState | undefined): StopResult["task"] {
+  return {
+    id: task,
+    ...(state?.completionTaskId === undefined ? {} : { canonicalId: state.completionTaskId }),
+    ...(state?.url === undefined ? {} : { url: state.url }),
+  };
+}
+
+function resourcesFromSource(source: InterruptSource | undefined): LifecycleResources {
+  if (source === undefined) {
+    return {};
+  }
+  return {
+    repository: source.repository,
+    branch: source.branchName,
+    worktreeDir: source.worktreeDir,
+    workspace: { name: source.workspaceName },
+    agent: source.agent,
+  };
+}
+
+function stopLockConflictResult(arguments_: { config: ResolvedConfig; task: string }): StopResult {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const [entry] = worktrees.findByTask(arguments_.config, arguments_.task);
+  const source = resolveInterruptSource({
+    config: arguments_.config,
+    task: arguments_.task,
+    state,
+    entry,
+  });
+  return {
+    action: "stop",
+    task: taskIdentity(arguments_.task, state),
+    outcome: "conflict",
+    state: state?.state ?? "unknown",
+    resources: resourcesFromSource(source),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.lifecycleLockHeld,
+        message: "Another lifecycle mutation owns this task.",
+      },
+    ],
+  };
+}
+
+async function cancelledStopResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  context: LifecycleCancellationContext;
+}): Promise<StopResult> {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const [entry] = worktrees.findByTask(arguments_.config, arguments_.task);
+  const source = resolveInterruptSource({
+    config: arguments_.config,
+    task: arguments_.task,
+    state,
+    entry,
+  });
+  const probe = await workspaces.probe(arguments_.config);
+  const workspaceAbsent = probe.kind === "ok" && !probe.names.has(arguments_.task);
+  let stateProblem: LifecycleProblem | undefined;
+  if (workspaceAbsent && source !== undefined) {
+    stateProblem = recordInterruptedState({
+      config: arguments_.config,
+      task: arguments_.task,
+      source,
+      options: { task: arguments_.task },
+      detail: "workspace missing after cancellation",
+    });
+  }
+  return {
+    action: "stop",
+    task: taskIdentity(arguments_.task, state),
+    outcome: "partial",
+    state: workspaceAbsent ? "interrupted" : (state?.state ?? "unknown"),
+    resources: resourcesFromSource(source),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.cancelled,
+        message: `Stop cancelled${lifecycleCancellationSuffix(arguments_.context)}.`,
+      },
+      ...(stateProblem === undefined ? [] : [stateProblem]),
+    ],
+  };
 }

--- a/src/commands/interruptWorkspace.ts
+++ b/src/commands/interruptWorkspace.ts
@@ -1,4 +1,4 @@
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { errorMessage } from "../lib/util.ts";
 import { workspaces, type WorkspaceInterruptResult } from "../lib/workspaces.ts";
@@ -6,6 +6,7 @@ import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
+  loadLifecycleConfig,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -240,7 +241,7 @@ async function interruptOrphanWorkspace(
 
 export async function interruptWorkspaceCli(argv: string[]): Promise<StopResult> {
   const parsed = parseArguments(argv);
-  const config = await loadConfig();
+  const config = await loadLifecycleConfig(parsed.json);
   return await executeLifecycleMutation({
     config,
     task: parsed.options.task,
@@ -248,7 +249,7 @@ export async function interruptWorkspaceCli(argv: string[]): Promise<StopResult>
     conflictResult: () => stopLockConflictResult({ config, task: parsed.options.task }),
     operation: async ({ signal }) => await interruptWorkspace(config, parsed.options, { signal }),
     cancelledResult: async (context) =>
-      await cancelledStopResult({ config, task: parsed.options.task, context }),
+      await cancelledStopResult({ config, options: parsed.options, context }),
   });
 }
 
@@ -350,39 +351,40 @@ function stopLockConflictResult(arguments_: { config: ResolvedConfig; task: stri
 
 async function cancelledStopResult(arguments_: {
   config: ResolvedConfig;
-  task: string;
+  options: InterruptWorkspaceOptions;
   context: LifecycleCancellationContext;
 }): Promise<StopResult> {
-  const state = readRunState(arguments_.config, arguments_.task);
-  const [entry] = worktrees.findByTask(arguments_.config, arguments_.task);
+  const { config, options, context } = arguments_;
+  const state = readRunState(config, options.task);
+  const [entry] = worktrees.findByTask(config, options.task);
   const source = resolveInterruptSource({
-    config: arguments_.config,
-    task: arguments_.task,
+    config,
+    task: options.task,
     state,
     entry,
   });
-  const probe = await workspaces.probe(arguments_.config);
-  const workspaceAbsent = probe.kind === "ok" && !probe.names.has(arguments_.task);
+  const probe = await workspaces.probe(config);
+  const workspaceAbsent = probe.kind === "ok" && !probe.names.has(options.task);
   let stateProblem: LifecycleProblem | undefined;
   if (workspaceAbsent && source !== undefined) {
     stateProblem = recordInterruptedState({
-      config: arguments_.config,
-      task: arguments_.task,
+      config,
+      task: options.task,
       source,
-      options: { task: arguments_.task },
+      options,
       detail: "workspace missing after cancellation",
     });
   }
   return {
     action: "stop",
-    task: taskIdentity(arguments_.task, state),
+    task: taskIdentity(options.task, state),
     outcome: "partial",
     state: workspaceAbsent ? "interrupted" : (state?.state ?? "unknown"),
     resources: resourcesFromSource(source),
     problems: [
       {
         code: LIFECYCLE_PROBLEM_CODES.cancelled,
-        message: `Stop cancelled${lifecycleCancellationSuffix(arguments_.context)}.`,
+        message: `Stop cancelled${lifecycleCancellationSuffix(context)}.`,
       },
       ...(stateProblem === undefined ? [] : [stateProblem]),
     ],

--- a/src/commands/lifecycleCommand.test.ts
+++ b/src/commands/lifecycleCommand.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { log } from "../lib/util.ts";
+import { workspaces } from "../lib/workspaces.ts";
 import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 import {
   acquireLifecycleLock,
@@ -13,6 +14,7 @@ import {
   lifecycleCancellationSuffix,
   lifecycleLockPath,
   loadLifecycleConfig,
+  probeWorkspaceForLifecycleReconciliation,
   type LifecycleCancellationContext,
   withLifecycleCancellation,
 } from "./lifecycleCommand.ts";
@@ -22,8 +24,16 @@ vi.mock(import("../lib/config.ts"), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
 });
+vi.mock(import("../lib/workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: { ...actual.workspaces, probe: vi.fn<typeof actual.workspaces.probe>() },
+  };
+});
 
 const loadConfigMock = vi.mocked(loadConfig);
+const workspaceProbeMock = vi.mocked(workspaces.probe);
 
 function loggingConfig(directory: string): { logging: { file: string } } {
   return { logging: { file: path.join(directory, "groundcrew.log") } };
@@ -220,6 +230,29 @@ describe(loadLifecycleConfig, () => {
     } finally {
       consoleLog.restore();
     }
+  });
+});
+
+describe(probeWorkspaceForLifecycleReconciliation, () => {
+  it("uses a fresh bounded signal after the command signal was cancelled", async () => {
+    const config = loggingConfig("/tmp/reconciliation-probe") as ResolvedConfig;
+    workspaceProbeMock.mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(probeWorkspaceForLifecycleReconciliation(config)).resolves.toMatchObject({
+      kind: "ok",
+    });
+    expect(workspaceProbeMock).toHaveBeenCalledWith(config, expect.any(AbortSignal));
+    expect(workspaceProbeMock.mock.calls[0]?.[1]?.aborted).toBe(false);
+  });
+
+  it("falls back to unavailable when the bounded reconciliation probe fails", async () => {
+    const config = loggingConfig("/tmp/reconciliation-probe") as ResolvedConfig;
+    workspaceProbeMock.mockRejectedValueOnce(new Error("probe timed out"));
+
+    await expect(probeWorkspaceForLifecycleReconciliation(config)).resolves.toMatchObject({
+      kind: "unavailable",
+      error: expect.objectContaining({ message: "probe timed out" }),
+    });
   });
 });
 

--- a/src/commands/lifecycleCommand.test.ts
+++ b/src/commands/lifecycleCommand.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
-import type { ResolvedConfig } from "../lib/config.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { log } from "../lib/util.ts";
 import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 import {
@@ -12,9 +12,18 @@ import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
   lifecycleLockPath,
+  loadLifecycleConfig,
+  type LifecycleCancellationContext,
   withLifecycleCancellation,
 } from "./lifecycleCommand.ts";
 import type { StartResult } from "./lifecycleResult.ts";
+
+vi.mock(import("../lib/config.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadConfig: vi.fn<typeof loadConfig>() };
+});
+
+const loadConfigMock = vi.mocked(loadConfig);
 
 function loggingConfig(directory: string): { logging: { file: string } } {
   return { logging: { file: path.join(directory, "groundcrew.log") } };
@@ -180,6 +189,40 @@ describe(lifecycleCancellationSuffix, () => {
   });
 });
 
+describe(loadLifecycleConfig, () => {
+  it("suppresses configuration progress in JSON mode", async () => {
+    const config = loggingConfig("/tmp/json-config") as ResolvedConfig;
+    loadConfigMock.mockImplementationOnce(async () => {
+      log("configuration progress");
+      return config;
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(loadLifecycleConfig(true)).resolves.toBe(config);
+      expect(consoleLog.calls).toHaveLength(0);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("preserves configuration progress in human mode", async () => {
+    const config = loggingConfig("/tmp/human-config") as ResolvedConfig;
+    loadConfigMock.mockImplementationOnce(async () => {
+      log("configuration progress");
+      return config;
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(loadLifecycleConfig(false)).resolves.toBe(config);
+      expect(consoleLog.output()).toContain("configuration progress");
+    } finally {
+      consoleLog.restore();
+    }
+  });
+});
+
 describe(executeLifecycleMutation, () => {
   afterEach(() => {
     process.exitCode = undefined;
@@ -232,6 +275,43 @@ describe(executeLifecycleMutation, () => {
       expect(actual.outcome).toBe("partial");
       expect(consoleLog.calls).toHaveLength(1);
       expect(consoleLog.output()).not.toContain("suppressed progress");
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("changes a completed mutation to partial when cancellation arrived before return", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory) as ResolvedConfig;
+    const consoleLog = captureConsoleLog();
+    const cancelledResult = vi
+      .fn<(context: LifecycleCancellationContext) => Promise<StartResult>>()
+      .mockResolvedValue(startResult("partial"));
+
+    try {
+      const actual = await executeLifecycleMutation({
+        config,
+        task: "team-1",
+        json: true,
+        conflictResult: () => startResult("conflict"),
+        operation: async (): Promise<StartResult> => {
+          process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+          return {
+            ...startResult(),
+            resources: { repository: "repo-a", worktreeDir: "/work/team-1" },
+          };
+        },
+        cancelledResult,
+      });
+
+      expect(actual).toMatchObject({
+        outcome: "partial",
+        resources: { repository: "repo-a", worktreeDir: "/work/team-1" },
+        problems: [{ code: "cancelled", message: expect.stringContaining("SIGTERM") }],
+      });
+      expect(cancelledResult).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
     } finally {
       consoleLog.restore();
     }

--- a/src/commands/lifecycleCommand.test.ts
+++ b/src/commands/lifecycleCommand.test.ts
@@ -1,0 +1,260 @@
+import { mkdirSync, mkdtempSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ResolvedConfig } from "../lib/config.ts";
+import { log } from "../lib/util.ts";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+import {
+  acquireLifecycleLock,
+  executeLifecycleMutation,
+  lifecycleCancellationSuffix,
+  lifecycleLockPath,
+  withLifecycleCancellation,
+} from "./lifecycleCommand.ts";
+import type { StartResult } from "./lifecycleResult.ts";
+
+function loggingConfig(directory: string): { logging: { file: string } } {
+  return { logging: { file: path.join(directory, "groundcrew.log") } };
+}
+
+function requireAcquiredLock(
+  lock: ReturnType<typeof acquireLifecycleLock>,
+): Extract<ReturnType<typeof acquireLifecycleLock>, { kind: "acquired" }> {
+  if (lock.kind !== "acquired") {
+    throw new Error("test could not acquire lifecycle lock");
+  }
+  return lock;
+}
+
+function startResult(outcome: StartResult["outcome"] = "started"): StartResult {
+  return {
+    action: "start",
+    task: { id: "team-1" },
+    outcome,
+    state: outcome === "started" ? "running" : "unknown",
+    resources: {},
+    problems: [],
+  };
+}
+
+describe(acquireLifecycleLock, () => {
+  it("serializes the same task and permits it again after release", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const first = requireAcquiredLock(acquireLifecycleLock({ config, task: "TEAM-1" }));
+
+    expect(first.kind).toBe("acquired");
+    expect(acquireLifecycleLock({ config, task: "team-1" }).kind).toBe("conflict");
+
+    first.release();
+    const afterRelease = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    expect(afterRelease.kind).toBe("acquired");
+    afterRelease.release();
+  });
+
+  it("recovers a lock whose owning process no longer exists", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const lockPath = lifecycleLockPath({ config, task: "team-1" });
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 2_147_483_647, token: "dead", createdAt: new Date().toISOString() }),
+    );
+
+    const actual = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+
+    expect(actual.kind).toBe("acquired");
+    actual.release();
+  });
+
+  it("does not remove a lock that a newer owner replaced", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const lockPath = lifecycleLockPath({ config, task: "team-1" });
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    unlinkSync(lockPath);
+    symlinkSync(
+      JSON.stringify({ pid: process.pid, token: "newer", createdAt: new Date().toISOString() }),
+      lockPath,
+    );
+
+    lock.release();
+    lock.release();
+
+    expect(acquireLifecycleLock({ config, task: "team-1" }).kind).toBe("conflict");
+    unlinkSync(lockPath);
+  });
+
+  it("tolerates a lock disappearing before its original owner releases it", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const lockPath = lifecycleLockPath({ config, task: "team-1" });
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    unlinkSync(lockPath);
+
+    expect(lock.release).not.toThrow();
+  });
+
+  it("treats a corrupt lock owned by an unknown process as a conflict", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const lockPath = lifecycleLockPath({ config, task: "team-1" });
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, "not-json");
+
+    expect(acquireLifecycleLock({ config, task: "team-1" }).kind).toBe("conflict");
+  });
+
+  it.each([
+    null,
+    "owner",
+    [],
+    {},
+    { pid: 1.5, token: "token", createdAt: "now" },
+    { pid: 0, token: "token", createdAt: "now" },
+    { pid: 1, token: 2, createdAt: "now" },
+    { pid: 1, token: "", createdAt: "now" },
+    { pid: 1, token: "token", createdAt: 2 },
+    { pid: 1, token: "token", createdAt: "" },
+  ])("treats invalid lock owner %# as a conflict", (owner) => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory);
+    const lockPath = lifecycleLockPath({ config, task: "team-1" });
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(lockPath, JSON.stringify(owner));
+
+    expect(acquireLifecycleLock({ config, task: "team-1" }).kind).toBe("conflict");
+  });
+});
+
+describe(withLifecycleCancellation, () => {
+  it("shares SIGTERM through an AbortSignal and removes both handlers", async () => {
+    const beforeSigint = process.listenerCount("SIGINT");
+    const beforeSigterm = process.listenerCount("SIGTERM");
+    const observed = vi.fn<(aborted: boolean, signal: NodeJS.Signals | undefined) => void>();
+
+    await withLifecycleCancellation(async ({ signal, requestedSignal }) => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      observed(signal.aborted, requestedSignal());
+    });
+
+    expect(observed).toHaveBeenCalledWith(true, "SIGTERM");
+    expect(process.listenerCount("SIGINT")).toBe(beforeSigint);
+    expect(process.listenerCount("SIGTERM")).toBe(beforeSigterm);
+  });
+
+  it("shares SIGINT through the same AbortSignal", async () => {
+    const observed = vi.fn<(aborted: boolean, signal: NodeJS.Signals | undefined) => void>();
+
+    await withLifecycleCancellation(async ({ signal, requestedSignal }) => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      observed(signal.aborted, requestedSignal());
+    });
+
+    expect(observed).toHaveBeenCalledWith(true, "SIGINT");
+  });
+});
+
+describe(lifecycleCancellationSuffix, () => {
+  it("renders a recorded signal", () => {
+    expect(
+      lifecycleCancellationSuffix({
+        signal: new AbortController().signal,
+        requestedSignal: () => "SIGTERM",
+      }),
+    ).toBe(" by SIGTERM");
+  });
+
+  it("renders no suffix before a signal is recorded", () => {
+    expect(
+      lifecycleCancellationSuffix({
+        signal: new AbortController().signal,
+        requestedSignal: vi.fn<() => "SIGINT" | "SIGTERM" | undefined>(),
+      }),
+    ).toBe("");
+  });
+});
+
+describe(executeLifecycleMutation, () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("returns a typed conflict while another command owns the task", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory) as ResolvedConfig;
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await executeLifecycleMutation({
+        config,
+        task: "team-1",
+        json: true,
+        conflictResult: () => startResult("conflict"),
+        operation: async () => startResult(),
+        cancelledResult: async () => startResult("partial"),
+      });
+
+      expect(actual.outcome).toBe("conflict");
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("classifies an exception raised after cooperative cancellation", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory) as ResolvedConfig;
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await executeLifecycleMutation({
+        config,
+        task: "team-1",
+        json: true,
+        conflictResult: () => startResult("conflict"),
+        operation: async () => {
+          log("suppressed progress");
+          process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+          throw new Error("cancelled operation");
+        },
+        cancelledResult: async () => startResult("partial"),
+      });
+
+      expect(actual.outcome).toBe("partial");
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(consoleLog.output()).not.toContain("suppressed progress");
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("releases its lock when an unexpected operation error escapes", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "groundcrew-lock-test-"));
+    const config = loggingConfig(directory) as ResolvedConfig;
+
+    await expect(
+      executeLifecycleMutation({
+        config,
+        task: "team-1",
+        json: false,
+        conflictResult: () => startResult("conflict"),
+        operation: async () => {
+          throw new Error("fatal");
+        },
+        cancelledResult: async () => startResult("partial"),
+      }),
+    ).rejects.toThrow("fatal");
+
+    const next = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    next.release();
+  });
+});

--- a/src/commands/lifecycleCommand.ts
+++ b/src/commands/lifecycleCommand.ts
@@ -1,0 +1,251 @@
+import { mkdirSync, readFileSync, readlinkSync, symlinkSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { ResolvedConfig } from "../lib/config.ts";
+import { naturalIdFromCanonical } from "../lib/taskSource.ts";
+import { normalizePlainTaskId } from "../lib/taskId.ts";
+import { withConsoleOutputSuppressed } from "../lib/util.ts";
+import {
+  lifecycleResultExitCode,
+  renderLifecycleResult,
+  type LifecycleResult,
+} from "./lifecycleResult.ts";
+
+type LifecycleSignal = "SIGINT" | "SIGTERM";
+
+interface LifecycleLockOwner {
+  pid: number;
+  token: string;
+  createdAt: string;
+}
+
+export type LifecycleLock = { kind: "acquired"; release: () => void } | { kind: "conflict" };
+
+export interface LifecycleCancellationContext {
+  signal: AbortSignal;
+  requestedSignal: () => LifecycleSignal | undefined;
+}
+
+interface ExecuteLifecycleMutationArguments<Result extends LifecycleResult> {
+  config: ResolvedConfig;
+  task: string;
+  json: boolean;
+  conflictResult: () => Result;
+  operation: (context: LifecycleCancellationContext) => Promise<Result>;
+  cancelledResult: (context: LifecycleCancellationContext) => Promise<Result>;
+}
+
+export function lifecycleLockPath(arguments_: {
+  config: Pick<ResolvedConfig, "logging">;
+  task: string;
+}): string {
+  const task = normalizePlainTaskId(naturalIdFromCanonical(arguments_.task));
+  return path.resolve(
+    path.dirname(arguments_.config.logging.file),
+    "lifecycle-locks",
+    `${task}.lock`,
+  );
+}
+
+export function acquireLifecycleLock(arguments_: {
+  config: Pick<ResolvedConfig, "logging">;
+  task: string;
+}): LifecycleLock {
+  const lockPath = lifecycleLockPath(arguments_);
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+  const owner: LifecycleLockOwner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAt: new Date().toISOString(),
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      // A symlink publishes its target atomically, so another process never
+      // observes a partially-written owner record between create and write.
+      symlinkSync(JSON.stringify(owner), lockPath);
+      return {
+        kind: "acquired",
+        release: createLockRelease({ lockPath, token: owner.token }),
+      };
+    } catch (error) {
+      /* v8 ignore next 3 @preserve -- non-EEXIST symlink failures are host filesystem/configuration failures surfaced unchanged */
+      if (errorCode(error) !== "EEXIST") {
+        throw error;
+      }
+      const currentOwner = readLockOwner(lockPath);
+      if (currentOwner === undefined || processIsAlive(currentOwner.pid)) {
+        return { kind: "conflict" };
+      }
+      try {
+        unlinkSync(lockPath);
+      } catch (unlinkError) {
+        /* v8 ignore next 3 @preserve -- requires another process replacing the dead lock during this unlink */
+        if (errorCode(unlinkError) !== "ENOENT") {
+          return { kind: "conflict" };
+        }
+      }
+    }
+  }
+  /* v8 ignore next @preserve -- two consecutive lock replacement races are not deterministic in a unit test */
+  return { kind: "conflict" };
+}
+
+export async function withLifecycleCancellation<T>(
+  operation: (context: LifecycleCancellationContext) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let receivedSignal: LifecycleSignal | undefined;
+  function requestCancellation(signal: LifecycleSignal): void {
+    receivedSignal ??= signal;
+    if (!controller.signal.aborted) {
+      controller.abort(new Error(`Lifecycle command cancelled by ${signal}`));
+    }
+  }
+  function handleSigint(): void {
+    requestCancellation("SIGINT");
+  }
+  function handleSigterm(): void {
+    requestCancellation("SIGTERM");
+  }
+  process.on("SIGINT", handleSigint);
+  process.on("SIGTERM", handleSigterm);
+  try {
+    return await operation({
+      signal: controller.signal,
+      requestedSignal: () => receivedSignal,
+    });
+  } finally {
+    process.off("SIGINT", handleSigint);
+    process.off("SIGTERM", handleSigterm);
+  }
+}
+
+export function lifecycleCancellationSuffix(context: LifecycleCancellationContext): string {
+  const signal = context.requestedSignal();
+  return signal === undefined ? "" : ` by ${signal}`;
+}
+
+export async function executeLifecycleMutation<Result extends LifecycleResult>(
+  arguments_: ExecuteLifecycleMutationArguments<Result>,
+): Promise<Result> {
+  const { config, task, json } = arguments_;
+  return await withLifecycleCancellation(async (context) => {
+    const lock = acquireLifecycleLock({ config, task });
+    if (lock.kind === "conflict") {
+      return finishLifecycleMutation({ result: arguments_.conflictResult(), json });
+    }
+    try {
+      const run = async (): Promise<Result> => {
+        try {
+          return await arguments_.operation(context);
+        } catch (error) {
+          if (!context.signal.aborted) {
+            throw error;
+          }
+          return await arguments_.cancelledResult(context);
+        }
+      };
+      const result = json ? await withConsoleOutputSuppressed(run) : await run();
+      return finishLifecycleMutation({ result, json });
+    } finally {
+      lock.release();
+    }
+  });
+}
+
+function finishLifecycleMutation<Result extends LifecycleResult>(arguments_: {
+  result: Result;
+  json: boolean;
+}): Result {
+  renderLifecycleResult(arguments_);
+  if (lifecycleResultExitCode(arguments_.result) !== 0) {
+    process.exitCode = 1;
+  }
+  return arguments_.result;
+}
+
+function createLockRelease(arguments_: { lockPath: string; token: string }): () => void {
+  let released = false;
+  return function release(): void {
+    if (released) {
+      return;
+    }
+    released = true;
+    const owner = readLockOwner(arguments_.lockPath);
+    if (owner?.token !== arguments_.token) {
+      return;
+    }
+    try {
+      unlinkSync(arguments_.lockPath);
+    } catch (error) {
+      /* v8 ignore next 3 @preserve -- requires another process changing permissions after the owner token was verified */
+      if (errorCode(error) !== "ENOENT") {
+        throw error;
+      }
+    }
+  };
+}
+
+function readLockOwner(lockPath: string): LifecycleLockOwner | undefined {
+  let raw: string;
+  try {
+    raw = readlinkSync(lockPath);
+  } catch {
+    try {
+      raw = readFileSync(lockPath, "utf8");
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    return parseLockOwner(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+function parseLockOwner(value: unknown): LifecycleLockOwner | undefined {
+  if (!isUnknownRecord(value)) {
+    return undefined;
+  }
+  const pid = value["pid"];
+  const token = value["token"];
+  const createdAt = value["createdAt"];
+  if (
+    typeof pid !== "number" ||
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    typeof token !== "string" ||
+    token.length === 0 ||
+    typeof createdAt !== "string" ||
+    createdAt.length === 0
+  ) {
+    return undefined;
+  }
+  return { pid, token, createdAt };
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  /* v8 ignore next 3 @preserve -- every internal caller passes a Node system error; guard protects the unknown boundary */
+  if (!isUnknownRecord(error)) {
+    return undefined;
+  }
+  const code = error["code"];
+  /* v8 ignore next @preserve -- Node system error codes are strings */
+  return typeof code === "string" ? code : undefined;
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/commands/lifecycleCommand.ts
+++ b/src/commands/lifecycleCommand.ts
@@ -6,6 +6,7 @@ import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { normalizePlainTaskId } from "../lib/taskId.ts";
 import { withConsoleOutputSuppressed } from "../lib/util.ts";
+import { type WorkspaceProbe, workspaces } from "../lib/workspaces.ts";
 import {
   LIFECYCLE_PROBLEM_CODES,
   lifecycleResultExitCode,
@@ -130,6 +131,17 @@ export function lifecycleCancellationSuffix(context: LifecycleCancellationContex
 
 export async function loadLifecycleConfig(json: boolean): Promise<ResolvedConfig> {
   return json ? await withConsoleOutputSuppressed(loadConfig) : await loadConfig();
+}
+
+export async function probeWorkspaceForLifecycleReconciliation(
+  config: ResolvedConfig,
+): Promise<WorkspaceProbe> {
+  const signal = AbortSignal.timeout(5_000);
+  try {
+    return await workspaces.probe(config, signal);
+  } catch (error) {
+    return { kind: "unavailable", error };
+  }
 }
 
 export async function executeLifecycleMutation<Result extends LifecycleResult>(

--- a/src/commands/lifecycleCommand.ts
+++ b/src/commands/lifecycleCommand.ts
@@ -2,11 +2,12 @@ import { mkdirSync, readFileSync, readlinkSync, symlinkSync, unlinkSync } from "
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import type { ResolvedConfig } from "../lib/config.ts";
+import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { naturalIdFromCanonical } from "../lib/taskSource.ts";
 import { normalizePlainTaskId } from "../lib/taskId.ts";
 import { withConsoleOutputSuppressed } from "../lib/util.ts";
 import {
+  LIFECYCLE_PROBLEM_CODES,
   lifecycleResultExitCode,
   renderLifecycleResult,
   type LifecycleResult,
@@ -127,6 +128,10 @@ export function lifecycleCancellationSuffix(context: LifecycleCancellationContex
   return signal === undefined ? "" : ` by ${signal}`;
 }
 
+export async function loadLifecycleConfig(json: boolean): Promise<ResolvedConfig> {
+  return json ? await withConsoleOutputSuppressed(loadConfig) : await loadConfig();
+}
+
 export async function executeLifecycleMutation<Result extends LifecycleResult>(
   arguments_: ExecuteLifecycleMutationArguments<Result>,
 ): Promise<Result> {
@@ -139,7 +144,10 @@ export async function executeLifecycleMutation<Result extends LifecycleResult>(
     try {
       const run = async (): Promise<Result> => {
         try {
-          return await arguments_.operation(context);
+          const result = await arguments_.operation(context);
+          return context.signal.aborted && lifecycleResultExitCode(result) === 0
+            ? completedResultCancelled(result, context)
+            : result;
         } catch (error) {
           if (!context.signal.aborted) {
             throw error;
@@ -153,6 +161,27 @@ export async function executeLifecycleMutation<Result extends LifecycleResult>(
       lock.release();
     }
   });
+}
+
+function completedResultCancelled<Result extends LifecycleResult>(
+  result: Result,
+  context: LifecycleCancellationContext,
+): Result {
+  return {
+    ...result,
+    outcome: "partial",
+    problems: [
+      ...result.problems,
+      {
+        code: LIFECYCLE_PROBLEM_CODES.cancelled,
+        message: `${capitalize(result.action)} cancelled${lifecycleCancellationSuffix(context)} after completing the observed mutations.`,
+      },
+    ],
+  };
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }
 
 function finishLifecycleMutation<Result extends LifecycleResult>(arguments_: {

--- a/src/commands/lifecycleResult.test.ts
+++ b/src/commands/lifecycleResult.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+import {
+  lifecycleResultExitCode,
+  renderLifecycleResult,
+  type LifecycleResult,
+} from "./lifecycleResult.ts";
+
+function renderHuman(result: LifecycleResult): string {
+  const consoleLog = captureConsoleLog();
+  try {
+    renderLifecycleResult({ result, json: false });
+    return consoleLog.output();
+  } finally {
+    consoleLog.restore();
+  }
+}
+
+describe(renderLifecycleResult, () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("writes exactly one JSON document for a successful result", () => {
+    const consoleLog = captureConsoleLog();
+    const result: LifecycleResult = {
+      action: "start",
+      task: {
+        id: "team-1",
+        canonicalId: "linear:team-1",
+        url: "https://linear.app/example/issue/TEAM-1",
+      },
+      outcome: "started",
+      state: "running",
+      resources: {
+        repository: "repo-a",
+        branch: "dev-team-1",
+        worktreeDir: "/work/repo-a-team-1",
+        workspace: { name: "team-1" },
+      },
+      problems: [],
+    };
+
+    try {
+      renderLifecycleResult({ result, json: true });
+
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(result);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it.each<{ result: LifecycleResult; output: string }>([
+    {
+      result: {
+        action: "start",
+        task: { id: "team-1" },
+        outcome: "started",
+        state: "running",
+        resources: {},
+        problems: [],
+      },
+      output: '✓ "team-1" launched',
+    },
+    {
+      result: {
+        action: "start",
+        task: { id: "team-1" },
+        outcome: "started",
+        state: "running",
+        resources: {
+          agent: "codex",
+          worktreeDir: "/work/team-1",
+          workspace: { name: "team-1", accessCommand: "cmux attach team-1" },
+        },
+        problems: [],
+      },
+      output: '✓ "team-1" launched (codex)  worktree /work/team-1\nAttach: cmux attach team-1',
+    },
+    {
+      result: {
+        action: "start",
+        task: { id: "team-1" },
+        outcome: "already-running",
+        state: "running",
+        resources: {},
+        problems: [],
+      },
+      output: "Task team-1 is already running; no changes made.",
+    },
+    {
+      result: {
+        action: "start",
+        task: { id: "team-1" },
+        outcome: "dry-run",
+        state: "absent",
+        resources: { worktreePreparation: "skip" },
+        problems: [],
+      },
+      output:
+        "[dry-run] Would launch team-1 in the resolved repository (the resolved agent); prepareWorktree skipped",
+    },
+    {
+      result: {
+        action: "start",
+        task: { id: "team-1" },
+        outcome: "conflict",
+        state: "unknown",
+        resources: {},
+        problems: [{ code: "workspace-conflict", message: "Workspace conflicts." }],
+      },
+      output: "Start conflict for team-1: Workspace conflicts.",
+    },
+    {
+      result: {
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "stopped",
+        state: "interrupted",
+        resources: {},
+        problems: [],
+      },
+      output: "Interrupted team-1\nNext: crew status team-1",
+    },
+    {
+      result: {
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "already-stopped",
+        state: "interrupted",
+        resources: {},
+        problems: [],
+      },
+      output: "Workspace for team-1 is already absent; local context was preserved.",
+    },
+    {
+      result: {
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "workspace-missing",
+        state: "interrupted",
+        resources: {},
+        problems: [],
+      },
+      output: "Workspace for team-1 is already absent; local context was preserved.",
+    },
+    {
+      result: {
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "not-found",
+        state: "absent",
+        resources: {},
+        problems: [],
+      },
+      output: "No run state, worktree, or live workspace found for team-1; nothing to stop.",
+    },
+    {
+      result: {
+        action: "stop",
+        task: { id: "team-1" },
+        outcome: "partial",
+        state: "unknown",
+        resources: {},
+        problems: [],
+      },
+      output: "Stop partial for team-1",
+    },
+    {
+      result: {
+        action: "resume",
+        task: { id: "team-1" },
+        outcome: "resumed",
+        state: "resumed",
+        resources: {},
+        problems: [],
+      },
+      output: "Resumed team-1",
+    },
+    {
+      result: {
+        action: "resume",
+        task: { id: "team-1" },
+        outcome: "already-running",
+        state: "running",
+        resources: {},
+        problems: [],
+      },
+      output: "Workspace for team-1 is already live; no changes made.",
+    },
+    {
+      result: {
+        action: "resume",
+        task: { id: "team-1" },
+        outcome: "not-found",
+        state: "absent",
+        resources: {},
+        problems: [],
+      },
+      output: "No worktree found for team-1; cannot resume.",
+    },
+    {
+      result: {
+        action: "resume",
+        task: { id: "team-1" },
+        outcome: "conflict",
+        state: "unknown",
+        resources: {},
+        problems: [{ code: "workspace-conflict", message: "Workspace conflicts." }],
+      },
+      output: "Resume conflict for team-1: Workspace conflicts.",
+    },
+    {
+      result: {
+        action: "cleanup",
+        task: { id: "team-1" },
+        outcome: "nothing-to-clean",
+        state: "absent",
+        resources: { worktrees: [], workspaces: [] },
+        problems: [],
+      },
+      output: "No worktree found for team-1; nothing to clean up.",
+    },
+    {
+      result: {
+        action: "cleanup",
+        task: { id: "team-1" },
+        outcome: "state-cleared",
+        state: "absent",
+        resources: { worktrees: [], workspaces: [] },
+        problems: [],
+      },
+      output: "No worktree found for team-1; cleared stale run-state.",
+    },
+    {
+      result: {
+        action: "cleanup",
+        task: { id: "team-1" },
+        outcome: "cleaned",
+        state: "absent",
+        resources: {
+          worktrees: [
+            {
+              repository: "repo-a",
+              branch: "dev-team-1",
+              worktreeDir: "/work/team-1",
+              removed: true,
+            },
+          ],
+          workspaces: [{ name: "team-1", closed: true }],
+        },
+        problems: [],
+      },
+      output:
+        "Closed workspace team-1\n✓ Cleanup complete for team-1 (host)\n  Worktree: /work/team-1 (removed)",
+    },
+    {
+      result: {
+        action: "cleanup",
+        task: { id: "team-1" },
+        outcome: "partial",
+        state: "unknown",
+        resources: {
+          worktrees: [
+            {
+              repository: "repo-a",
+              branch: "dev-team-1",
+              worktreeDir: "/work/team-1",
+              removed: false,
+            },
+          ],
+          workspaces: [{ name: "team-1", closed: false }],
+        },
+        problems: [{ code: "worktree-remove-failed", message: "Remove failed." }],
+      },
+      output: "Cleanup partial for team-1: Remove failed.",
+    },
+  ])("renders $result.action/$result.outcome for humans", ({ result, output }) => {
+    expect(renderHuman(result)).toBe(output);
+  });
+
+  it.each<LifecycleResult>([
+    {
+      action: "start",
+      task: { id: "team-1" },
+      outcome: "partial",
+      state: "running",
+      resources: {},
+      problems: [{ code: "task-status-update-failed", message: "Task status update failed." }],
+    },
+    {
+      action: "cleanup",
+      task: { id: "team-1" },
+      outcome: "refused",
+      state: "running",
+      resources: { worktrees: [], workspaces: [] },
+      problems: [{ code: "workspace-busy", message: "Workspace is still running." }],
+    },
+  ])("maps $action/$outcome to a non-zero exit", (result) => {
+    expect(lifecycleResultExitCode(result)).toBe(1);
+  });
+
+  it.each<LifecycleResult>([
+    {
+      action: "start",
+      task: { id: "team-1" },
+      outcome: "already-running",
+      state: "running",
+      resources: {},
+      problems: [],
+    },
+    {
+      action: "stop",
+      task: { id: "team-1" },
+      outcome: "not-found",
+      state: "absent",
+      resources: {},
+      problems: [],
+    },
+    {
+      action: "cleanup",
+      task: { id: "team-1" },
+      outcome: "nothing-to-clean",
+      state: "absent",
+      resources: { worktrees: [], workspaces: [] },
+      problems: [],
+    },
+  ])("maps $action/$outcome to a zero exit", (result) => {
+    expect(lifecycleResultExitCode(result)).toBe(0);
+  });
+});

--- a/src/commands/lifecycleResult.ts
+++ b/src/commands/lifecycleResult.ts
@@ -1,0 +1,258 @@
+import { writeOutput } from "../lib/util.ts";
+
+export type LifecycleState =
+  | "provisioning"
+  | "running"
+  | "interrupted"
+  | "resumed"
+  | "failed-to-launch"
+  | "absent"
+  | "unknown";
+
+export interface LifecycleTaskIdentity {
+  /** Lower-cased local lifecycle key used for worktrees and workspaces. */
+  id: string;
+  /** Source-qualified task id, when task resolution or persisted state supplies it. */
+  canonicalId?: string;
+  url?: string;
+}
+
+export interface LifecycleProblem {
+  /** Stable machine-readable code. Consumers must tolerate codes added in later releases. */
+  code: string;
+  message: string;
+}
+
+export interface LifecycleWorkspaceResource {
+  name: string;
+  accessCommand?: string;
+}
+
+export interface LifecycleResources {
+  repository?: string;
+  branch?: string;
+  worktreeDir?: string;
+  workspace?: LifecycleWorkspaceResource;
+  agent?: string;
+  worktreePreparation?: "skip";
+}
+
+export interface CleanupWorktreeResource {
+  repository: string;
+  branch: string;
+  worktreeDir: string;
+  removed: boolean;
+}
+
+export interface CleanupWorkspaceResource {
+  name: string;
+  closed: boolean;
+}
+
+export interface CleanupResources {
+  worktrees: CleanupWorktreeResource[];
+  workspaces: CleanupWorkspaceResource[];
+}
+
+export interface StartResult {
+  action: "start";
+  task: LifecycleTaskIdentity;
+  outcome: "started" | "already-running" | "dry-run" | "partial" | "conflict";
+  state: LifecycleState;
+  resources: LifecycleResources;
+  problems: LifecycleProblem[];
+}
+
+export interface StopResult {
+  action: "stop";
+  task: LifecycleTaskIdentity;
+  outcome:
+    | "stopped"
+    | "already-stopped"
+    | "workspace-missing"
+    | "not-found"
+    | "partial"
+    | "conflict";
+  state: LifecycleState;
+  resources: LifecycleResources;
+  problems: LifecycleProblem[];
+}
+
+export interface ResumeResult {
+  action: "resume";
+  task: LifecycleTaskIdentity;
+  outcome: "resumed" | "already-running" | "not-found" | "partial" | "conflict";
+  state: LifecycleState;
+  resources: LifecycleResources;
+  problems: LifecycleProblem[];
+}
+
+export interface CleanupResult {
+  action: "cleanup";
+  task: LifecycleTaskIdentity;
+  outcome: "cleaned" | "nothing-to-clean" | "state-cleared" | "refused" | "partial" | "conflict";
+  state: LifecycleState;
+  resources: CleanupResources;
+  problems: LifecycleProblem[];
+}
+
+export type LifecycleResult = StartResult | StopResult | ResumeResult | CleanupResult;
+
+export const LIFECYCLE_PROBLEM_CODES = {
+  cancelled: "cancelled",
+  lifecycleLockHeld: "lifecycle-lock-held",
+  taskStatusUpdateFailed: "task-status-update-failed",
+  stateWriteFailed: "state-write-failed",
+  workspaceBusy: "workspace-busy",
+  workspaceConflict: "workspace-conflict",
+  workspaceStatusUnavailable: "workspace-status-unavailable",
+  worktreeConflict: "worktree-conflict",
+  worktreeDirty: "worktree-dirty",
+  worktreeStatusUnknown: "worktree-status-unknown",
+  workspaceCloseFailed: "workspace-close-failed",
+  worktreeRemoveFailed: "worktree-remove-failed",
+} as const;
+
+export function lifecycleResultExitCode(result: LifecycleResult): 0 | 1 {
+  if (
+    result.outcome === "partial" ||
+    result.outcome === "conflict" ||
+    result.outcome === "refused"
+  ) {
+    return 1;
+  }
+  return 0;
+}
+
+export function renderLifecycleResult(arguments_: {
+  result: LifecycleResult;
+  json: boolean;
+}): void {
+  const { result, json } = arguments_;
+  if (json) {
+    writeOutput(JSON.stringify(result));
+    return;
+  }
+  renderHumanResult(result);
+}
+
+function renderHumanResult(result: LifecycleResult): void {
+  if (result.action === "start") {
+    renderStartResult(result);
+    return;
+  }
+  if (result.action === "stop") {
+    renderStopResult(result);
+    return;
+  }
+  if (result.action === "resume") {
+    renderResumeResult(result);
+    return;
+  }
+  renderCleanupResult(result);
+}
+
+function renderStartResult(result: StartResult): void {
+  const { id } = result.task;
+  if (result.outcome === "started") {
+    const agent = result.resources.agent === undefined ? "" : ` (${result.resources.agent})`;
+    const worktree =
+      result.resources.worktreeDir === undefined
+        ? ""
+        : `  worktree ${result.resources.worktreeDir}`;
+    writeOutput(`✓ "${id}" launched${agent}${worktree}`);
+  } else if (result.outcome === "already-running") {
+    writeOutput(`Task ${id} is already running; no changes made.`);
+  } else if (result.outcome === "dry-run") {
+    const repository = result.resources.repository ?? "the resolved repository";
+    const agent = result.resources.agent ?? "the resolved agent";
+    const preparation =
+      result.resources.worktreePreparation === "skip" ? "; prepareWorktree skipped" : "";
+    writeOutput(`[dry-run] Would launch ${id} in ${repository} (${agent})${preparation}`);
+  } else {
+    writeOutcomeWithProblems("Start", id, result.outcome, result.problems);
+  }
+  renderAccessCommand(result.resources.workspace);
+}
+
+function renderStopResult(result: StopResult): void {
+  const { id } = result.task;
+  if (result.outcome === "stopped") {
+    const suffix =
+      result.resources.worktreeDir === undefined
+        ? ""
+        : `; worktree preserved at ${result.resources.worktreeDir}`;
+    writeOutput(`Interrupted ${id}${suffix}`);
+    writeOutput(`Next: crew status ${id}`);
+    return;
+  }
+  if (result.outcome === "already-stopped" || result.outcome === "workspace-missing") {
+    writeOutput(`Workspace for ${id} is already absent; local context was preserved.`);
+    return;
+  }
+  if (result.outcome === "not-found") {
+    writeOutput(`No run state, worktree, or live workspace found for ${id}; nothing to stop.`);
+    return;
+  }
+  writeOutcomeWithProblems("Stop", id, result.outcome, result.problems);
+}
+
+function renderResumeResult(result: ResumeResult): void {
+  const { id } = result.task;
+  if (result.outcome === "resumed") {
+    const directory =
+      result.resources.worktreeDir === undefined ? "" : ` in ${result.resources.worktreeDir}`;
+    const agent = result.resources.agent === undefined ? "" : ` (${result.resources.agent})`;
+    writeOutput(`Resumed ${id}${directory}${agent}`);
+  } else if (result.outcome === "already-running") {
+    writeOutput(`Workspace for ${id} is already live; no changes made.`);
+  } else if (result.outcome === "not-found") {
+    writeOutput(`No worktree found for ${id}; cannot resume.`);
+  } else {
+    writeOutcomeWithProblems("Resume", id, result.outcome, result.problems);
+  }
+  renderAccessCommand(result.resources.workspace);
+}
+
+function renderCleanupResult(result: CleanupResult): void {
+  const { id } = result.task;
+  if (result.outcome === "nothing-to-clean") {
+    writeOutput(`No worktree found for ${id}; nothing to clean up.`);
+    return;
+  }
+  if (result.outcome === "state-cleared") {
+    writeOutput(`No worktree found for ${id}; cleared stale run-state.`);
+    return;
+  }
+  for (const workspace of result.resources.workspaces) {
+    if (workspace.closed) {
+      writeOutput(`Closed workspace ${workspace.name}`);
+    }
+  }
+  for (const worktree of result.resources.worktrees) {
+    if (worktree.removed) {
+      writeOutput(`✓ Cleanup complete for ${id} (host)`);
+      writeOutput(`  Worktree: ${worktree.worktreeDir} (removed)`);
+    }
+  }
+  if (result.outcome !== "cleaned") {
+    writeOutcomeWithProblems("Cleanup", id, result.outcome, result.problems);
+  }
+}
+
+function renderAccessCommand(workspace: LifecycleWorkspaceResource | undefined): void {
+  if (workspace?.accessCommand !== undefined) {
+    writeOutput(`Attach: ${workspace.accessCommand}`);
+  }
+}
+
+function writeOutcomeWithProblems(
+  action: string,
+  task: string,
+  outcome: string,
+  problems: readonly LifecycleProblem[],
+): void {
+  const detail =
+    problems.length === 0 ? "" : `: ${problems.map((problem) => problem.message).join("; ")}`;
+  writeOutput(`${action} ${outcome} for ${task}${detail}`);
+}

--- a/src/commands/orchestrator.test.ts
+++ b/src/commands/orchestrator.test.ts
@@ -15,6 +15,7 @@ import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { captureConsoleLog, type ConsoleCapture } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
+import type { StartResult } from "./lifecycleResult.ts";
 import { orchestrate } from "./orchestrator.ts";
 import { setupWorkspace } from "./setupWorkspace.ts";
 
@@ -295,6 +296,17 @@ function hostEntryFor(repository: string, task: string): WorktreeEntry {
   };
 }
 
+function startedResult(): StartResult {
+  return {
+    action: "start",
+    task: { id: "team-1", canonicalId: "TEAM-1" },
+    outcome: "started",
+    state: "running",
+    resources: {},
+    problems: [],
+  };
+}
+
 interface InvocationOrderRecorder {
   mock: { invocationCallOrder: readonly number[] };
 }
@@ -367,7 +379,7 @@ describe(orchestrate, () => {
     teardownMock.mockResolvedValue(emptyTeardownResult());
     sleepMock.mockResolvedValue();
     usageMock.mockResolvedValue({});
-    setupMock.mockResolvedValue();
+    setupMock.mockResolvedValue(startedResult());
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
     findPullRequestsMock.mockResolvedValue([]);
     // Telemetry (event= lines) and teardown sub-steps are diagnostic, surfacing
@@ -1825,6 +1837,7 @@ JSON
     setupMock.mockImplementation(async (_config, _options, runOptions) => {
       setupSignal = runOptions?.signal;
       process.listeners("SIGINT").at(-1)?.("SIGINT");
+      return startedResult();
     });
 
     await orchestrate({ watch: true, dryRun: false });
@@ -1910,6 +1923,7 @@ JSON
       await new Promise<void>((resolve) => {
         releaseSetup = resolve;
       });
+      return startedResult();
     });
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((): never => {
       throw new Error("__exit__");

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -618,7 +618,7 @@ describe(resumeWorkspace, () => {
     );
   });
 
-  it("resolves cold resume through the configured Board", async () => {
+  it("resolves cold resume through an injected Board without configured sources", async () => {
     readRunStateMock.mockReset();
     const resolved = canonicalShellIssue({
       naturalId: "team-1",
@@ -639,16 +639,7 @@ describe(resumeWorkspace, () => {
     };
     const todoConfig: ResolvedConfig = {
       ...config,
-      sources: [
-        {
-          kind: "todo-txt",
-          name: "todo",
-          todoPath: "todo.txt",
-          tasksDir: ".tasks",
-          idPrefix: "TEAM",
-          timezone: "UTC",
-        },
-      ],
+      sources: [],
     };
 
     await resumeWorkspace(todoConfig, { task: "team-1", taskSourceId: "todo:team-1" }, { board });
@@ -660,6 +651,39 @@ describe(resumeWorkspace, () => {
         name: "team-1",
         url: "https://tasks.example/team-1",
       }),
+    );
+  });
+
+  it("preserves a source-qualified id while reconstructing state through an injected Board", async () => {
+    const sourceFreeConfig: ResolvedConfig = { ...config, sources: [] };
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      resolveOne: vi.fn<Board["resolveOne"]>().mockResolvedValue(
+        canonicalShellIssue({
+          naturalId: "team-1",
+          sourceName: "todo",
+          repository: "repo-a",
+          agent: "claude",
+          title: "Board title",
+        }),
+      ),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+
+    await resumeWorkspace(
+      sourceFreeConfig,
+      { task: "team-1", taskSourceId: "todo:team-1" },
+      { board },
+    );
+
+    expect(board.resolveOne).toHaveBeenCalledWith("todo:team-1");
+    expect(lastRecordedRunState()).toMatchObject({ completionTaskId: "todo:team-1" });
+    expect(writeFileMock).toHaveBeenCalledWith(
+      "/tmp/groundcrew-resume-team-1-x/prompt.txt",
+      expect.stringContaining("task team-1 (Board title)"),
     );
   });
 
@@ -1149,6 +1173,49 @@ describe(resumeWorkspaceCli, () => {
     }
   });
 
+  it("reconciles source identity and resolved agent when a cold resume is cancelled before state persistence", async () => {
+    const coldConfig: ResolvedConfig = {
+      ...config,
+      agents: {
+        ...config.agents,
+        definitions: {
+          ...config.agents.definitions,
+          codex: { cmd: "codex --auto", color: "#000" },
+        },
+      },
+    };
+    loadConfigMock.mockResolvedValue(coldConfig);
+    readRunStateMock.mockReset();
+    fetchResolvedIssueMock.mockResolvedValue(resolvedLinearTask({ agent: "codex" }));
+    workspacesProbeMock
+      .mockResolvedValueOnce({ kind: "ok", names: new Set() })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["linear:TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        outcome: "partial",
+        task: { canonicalId: "linear:team-1" },
+        resources: { agent: "codex", workspace: { name: "team-1" } },
+        problems: [{ code: "cancelled" }],
+      });
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        agent: "codex",
+        completionTaskId: "linear:team-1",
+        state: "resumed",
+      });
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
   it("preserves the observed interrupted state when cancellation opens no workspace", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
     workspacesOpenMock.mockImplementationOnce(async () => {
@@ -1194,7 +1261,7 @@ describe(resumeWorkspaceCli, () => {
     }
   });
 
-  it("does not invent durable context when cancellation finds only a live workspace", async () => {
+  it("uses the resolved launch context when cancellation later loses local context", async () => {
     readRunStateMock
       .mockReturnValueOnce(makeRunState())
       .mockReturnValueOnce(makeRunState())
@@ -1221,13 +1288,20 @@ describe(resumeWorkspaceCli, () => {
         state: "resumed",
         resources: { workspace: { name: "team-1" } },
       });
-      expect(recordRunStateMock).not.toHaveBeenCalled();
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        completionTaskId: "TEAM-1",
+        state: "resumed",
+        resumeCount: 2,
+      });
     } finally {
       consoleLog.restore();
     }
   });
 
-  it("reconciles a cancelled live workspace from its remaining worktree context", async () => {
+  it("prefers resolved launch context while reconciling a cancelled live workspace", async () => {
     readRunStateMock
       .mockReturnValueOnce(makeRunState())
       .mockReturnValueOnce(makeRunState())
@@ -1255,9 +1329,9 @@ describe(resumeWorkspaceCli, () => {
         agent: "claude",
         workspaceName: "team-1",
         state: "resumed",
-        resumeCount: 1,
+        resumeCount: 2,
+        reason: "wrong direction",
       });
-      expect(lastRecordedRunState()).not.toHaveProperty("reason");
     } finally {
       consoleLog.restore();
     }

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1173,6 +1173,56 @@ describe(resumeWorkspaceCli, () => {
     }
   });
 
+  it("reconciles existing state when cancellation happens before resume context resolution", async () => {
+    workspacesProbeMock
+      .mockImplementationOnce(async () => {
+        process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+        throw new Error("Signal: SIGTERM");
+      })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        completionTaskId: "TEAM-1",
+        state: "resumed",
+        resumeCount: 2,
+      });
+      expect(workspacesOpenMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("does not invent state when pre-context cancellation observes only a live workspace", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    workspacesProbeMock
+      .mockImplementationOnce(async () => {
+        process.listeners("SIGINT").at(-1)?.("SIGINT");
+        throw new Error("Signal: SIGINT");
+      })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(resumeWorkspaceCli(["TEAM-1", "--json"])).resolves.toMatchObject({
+        outcome: "partial",
+        state: "resumed",
+        resources: { workspace: { name: "team-1" } },
+      });
+      expect(recordRunStateMock).not.toHaveBeenCalled();
+      expect(workspacesOpenMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
   it("reconciles source identity and resolved agent when a cold resume is cancelled before state persistence", async () => {
     const coldConfig: ResolvedConfig = {
       ...config,

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -2,18 +2,20 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 
 import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-health/clearance";
-import * as agentLaunch from "../lib/agentLaunch.ts";
 import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
 import { getLinearClient } from "../lib/adapters/linear/client.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { Board } from "../lib/board.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
+import { canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
-import { log } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { resumeWorkspace, resumeWorkspaceCli } from "./resumeWorkspace.ts";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
+import { acquireLifecycleLock } from "./lifecycleCommand.ts";
 
 interface NodeFsMock extends Omit<typeof nodeFs, "mkdtempSync" | "rmSync" | "writeFileSync"> {
   mkdtempSync: ReturnType<typeof vi.fn<typeof mkdtempSync>>;
@@ -124,17 +126,14 @@ const loadConfigMock = vi.mocked(loadConfig);
 const detectHostMock = vi.mocked(detectHostCapabilities);
 const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
-const logMock = vi.mocked(log);
 const getLinearClientMock = vi.mocked(getLinearClient);
 const seedLaunchWorkspaceTrustMock = vi.mocked(seedLaunchWorkspaceTrust);
-const workspacesCloseMock = vi.mocked(workspaces.close);
 const workspacesOpenMock = vi.mocked(workspaces.open);
 const workspacesProbeMock = vi.mocked(workspaces.probe);
 const findByTaskMock = vi.mocked(worktrees.findByTask);
 const createMock = vi.mocked(worktrees.create);
 
 type RecordedRunState = Parameters<typeof recordRunState>[0]["state"];
-type FetchResolvedIssueInput = Parameters<typeof fetchResolvedIssue>[0];
 type IssueLookup = (id: string) => Promise<{
   title: string;
   description?: string | undefined;
@@ -147,14 +146,6 @@ function lastRecordedRunState(): RecordedRunState {
     throw new Error("recordRunState was not called");
   }
   return input.state;
-}
-
-function firstFetchResolvedIssueInput(): FetchResolvedIssueInput {
-  const input = fetchResolvedIssueMock.mock.calls[0]?.[0];
-  if (input === undefined) {
-    throw new Error("fetchResolvedIssue was not called");
-  }
-  return input;
 }
 
 function stagedLaunchScript(): string {
@@ -210,7 +201,7 @@ function makeConfig(): ResolvedConfig {
       safehouse: { enable: [] },
       readOnlyDirs: [],
     },
-    logging: { file: "/tmp/groundcrew-test.log" },
+    logging: { file: "/tmp/groundcrew-resume-workspace-test.log" },
   };
 }
 
@@ -222,6 +213,15 @@ function makeWorktree(): WorktreeEntry {
     dir: "/work/repo-a-team-1",
     kind: "host",
   };
+}
+
+function requireAcquiredLock(
+  lock: ReturnType<typeof acquireLifecycleLock>,
+): Extract<ReturnType<typeof acquireLifecycleLock>, { kind: "acquired" }> {
+  if (lock.kind !== "acquired") {
+    throw new Error("test could not acquire lifecycle lock");
+  }
+  return lock;
 }
 
 function makeRunState(overrides: Partial<RunState> = {}): RunState {
@@ -255,6 +255,29 @@ function mockLinearIssue(): void {
   } as unknown as ReturnType<typeof getLinearClient>);
 }
 
+function resolvedLinearTask(
+  overrides: Partial<Awaited<ReturnType<typeof fetchResolvedIssue>>> = {},
+): Awaited<ReturnType<typeof fetchResolvedIssue>> {
+  return {
+    uuid: "uuid-1",
+    title: "Resolved title",
+    description: "Resolved body for repo-a",
+    repository: "repo-a",
+    agent: "claude",
+    teamId: "team-1",
+    stateType: "unstarted",
+    status: "Todo",
+    statusId: "state-todo",
+    assignee: "Alice",
+    updatedAt: "2026-01-01T00:00:00Z",
+    blockers: [],
+    hasMoreBlockers: false,
+    url: "https://linear.app/example/issue/TEAM-1",
+    priority: 0,
+    ...overrides,
+  };
+}
+
 describe(resumeWorkspace, () => {
   const config = makeConfig();
 
@@ -265,7 +288,6 @@ describe(resumeWorkspace, () => {
     readRunStateMock.mockReturnValue(makeRunState());
     findByTaskMock.mockReturnValue([makeWorktree()]);
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set<string>() });
-    workspacesCloseMock.mockResolvedValue({ kind: "closed" });
     workspacesOpenMock.mockResolvedValue();
     detectHostMock.mockResolvedValue(host());
     ensureClearanceMock.mockResolvedValue({
@@ -321,13 +343,9 @@ describe(resumeWorkspace, () => {
   });
 
   it("uses the source URL fetched for legacy run state without one", async () => {
-    getLinearClientMock.mockReturnValue({
-      issue: vi.fn<IssueLookup>().mockResolvedValue({
-        title: "Title",
-        description: "Body",
-        url: "https://linear.app/example/issue/TEAM-1/fetched-slug",
-      }),
-    } as unknown as ReturnType<typeof getLinearClient>);
+    fetchResolvedIssueMock.mockResolvedValue(
+      resolvedLinearTask({ url: "https://linear.app/example/issue/TEAM-1/fetched-slug" }),
+    );
 
     await resumeWorkspace(config, { task: "team-1" });
 
@@ -338,6 +356,25 @@ describe(resumeWorkspace, () => {
         url: "https://linear.app/example/issue/TEAM-1/fetched-slug",
       }),
     );
+  });
+
+  it("omits the task URL when an injected Board resolves details without one", async () => {
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      resolveOne: vi
+        .fn<Board["resolveOne"]>()
+        .mockResolvedValue(
+          canonicalShellIssue({ naturalId: "team-1", repository: "repo-a", agent: "claude" }),
+        ),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+
+    await resumeWorkspace(config, { task: "team-1" }, { board });
+
+    expect(workspacesOpenMock.mock.calls[0]?.[1]).not.toHaveProperty("url");
   });
 
   it("does not attach a colliding Linear URL to a URL-less task from another source", async () => {
@@ -581,42 +618,72 @@ describe(resumeWorkspace, () => {
     );
   });
 
-  it("falls back to Linear resolution when state is missing", async () => {
+  it("resolves cold resume through the configured Board", async () => {
     readRunStateMock.mockReset();
-    fetchResolvedIssueMock.mockResolvedValue({
-      uuid: "uuid-1",
-      title: "Resolved title",
-      description: "Resolved body for repo-a",
+    const resolved = canonicalShellIssue({
+      naturalId: "team-1",
+      sourceName: "todo",
       repository: "repo-a",
       agent: "claude",
-      teamId: "team-1",
-      stateType: "unstarted",
-      status: "Todo",
-      statusId: "state-todo",
-      assignee: "Alice",
-      updatedAt: "2026-01-01T00:00:00Z",
-      blockers: [],
-      hasMoreBlockers: false,
-      url: "https://linear.app/example/issue/TEAM-1",
-      priority: 0,
+      title: "Resolved title",
+      description: "Resolved body for repo-a",
+      url: "https://tasks.example/team-1",
     });
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      resolveOne: vi.fn<Board["resolveOne"]>().mockResolvedValue(resolved),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+    const todoConfig: ResolvedConfig = {
+      ...config,
+      sources: [
+        {
+          kind: "todo-txt",
+          name: "todo",
+          todoPath: "todo.txt",
+          tasksDir: ".tasks",
+          idPrefix: "TEAM",
+          timezone: "UTC",
+        },
+      ],
+    };
 
-    await resumeWorkspace(config, { task: "team-1" });
+    await resumeWorkspace(todoConfig, { task: "team-1", taskSourceId: "todo:team-1" }, { board });
 
-    const fetchInput = firstFetchResolvedIssueInput();
-    expect(fetchInput.config).toBe(config);
-    expect(fetchInput.task).toBe("team-1");
-    expect(fetchInput.client).toBeDefined();
+    expect(board.resolveOne).toHaveBeenCalledWith("todo:team-1");
     expect(workspacesOpenMock).toHaveBeenCalledWith(
-      config,
+      todoConfig,
       expect.objectContaining({
         name: "team-1",
-        url: "https://linear.app/example/issue/TEAM-1",
+        url: "https://tasks.example/team-1",
       }),
     );
   });
 
-  it("rejects with a clear error when state is missing and Linear is disabled", async () => {
+  it("cold-resumes an eligible Board task without inventing a URL", async () => {
+    readRunStateMock.mockReset();
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      resolveOne: vi
+        .fn<Board["resolveOne"]>()
+        .mockResolvedValue(
+          canonicalShellIssue({ naturalId: "team-1", repository: "repo-a", agent: "claude" }),
+        ),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+
+    await resumeWorkspace(config, { task: "team-1" }, { board });
+
+    expect(workspacesOpenMock.mock.calls[0]?.[1]).not.toHaveProperty("url");
+  });
+
+  it("rejects clearly when state is missing and no source is configured", async () => {
     readRunStateMock.mockReset();
     const noLinearConfig: ResolvedConfig = {
       ...makeConfig(),
@@ -624,9 +691,80 @@ describe(resumeWorkspace, () => {
     };
 
     await expect(resumeWorkspace(noLinearConfig, { task: "team-1" })).rejects.toThrow(
-      /no run state recorded and Linear is disabled/,
+      /no run state recorded and no task source is configured/,
     );
     expect(getLinearClientMock).not.toHaveBeenCalled();
+  });
+
+  it("builds the configured task sources for a cold resume when no Board is injected", async () => {
+    readRunStateMock.mockReset();
+    fetchResolvedIssueMock.mockResolvedValue(resolvedLinearTask());
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      action: "resume",
+      outcome: "resumed",
+      task: { canonicalId: "linear:team-1" },
+    });
+    expect(fetchResolvedIssueMock).toHaveBeenCalled();
+  });
+
+  it("rejects a cold-resolved task that is not groundcrew eligible", async () => {
+    readRunStateMock.mockReset();
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      resolveOne: vi
+        .fn<Board["resolveOne"]>()
+        .mockResolvedValue(canonicalShellIssue({ naturalId: "team-1" })),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+
+    await expect(resumeWorkspace(config, { task: "team-1" }, { board })).rejects.toThrow(
+      /isn't groundcrew-eligible/,
+    );
+  });
+
+  it("rejects a cold task that the configured Board cannot resolve", async () => {
+    readRunStateMock.mockReset();
+    const board: Board = {
+      verify: vi.fn<Board["verify"]>(),
+      fetch: vi.fn<Board["fetch"]>(),
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- explicitly model no task match
+      resolveOne: vi.fn<Board["resolveOne"]>().mockResolvedValue(undefined),
+      markInProgress: vi.fn<Board["markInProgress"]>(),
+      markInReview: vi.fn<Board["markInReview"]>(),
+      markDone: vi.fn<Board["markDone"]>(),
+    };
+
+    await expect(resumeWorkspace(config, { task: "team-1" }, { board })).rejects.toThrow(
+      /Task team-1 not found across configured sources/,
+    );
+  });
+
+  it("returns already-running when the matching workspace is already live", async () => {
+    readRunStateMock.mockReturnValue(makeRunState({ state: "resumed" }));
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "already-running",
+      state: "resumed",
+      resources: { workspace: { name: "team-1" } },
+    });
+    expect(workspacesOpenMock).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict for a live workspace without matching local context", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      state: "running",
+      problems: [{ code: "workspace-conflict" }],
+    });
   });
 
   it("wraps with bare safehouse and skips the clearance daemon when networkEgress is open", async () => {
@@ -718,10 +856,13 @@ describe(resumeWorkspace, () => {
     expect(stagedLaunchScript()).toContain("cd '/work/repo-a-team-1/services/api'");
   });
 
-  it("fails when the worktree is absent", async () => {
+  it("returns not-found when the worktree is absent", async () => {
     findByTaskMock.mockReturnValue([]);
 
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(/No worktree found/);
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "not-found",
+      state: "absent",
+    });
   });
 
   it("fails when recorded run state refers to an unknown agent", async () => {
@@ -732,19 +873,23 @@ describe(resumeWorkspace, () => {
     );
   });
 
-  it("fails when the workspace is already live", async () => {
+  it("returns already-running when the same workspace is already live", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
 
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(/already live/);
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "already-running",
+      state: "running",
+    });
     expect(workspacesOpenMock).not.toHaveBeenCalled();
   });
 
-  it("fails closed when workspace liveness cannot be verified", async () => {
+  it("returns conflict when workspace liveness cannot be verified", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
 
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      /Could not verify whether workspace for team-1 is already live/,
-    );
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [{ code: "workspace-status-unavailable" }],
+    });
     expect(workspacesOpenMock).not.toHaveBeenCalled();
     expect(recordRunStateMock).not.toHaveBeenCalled();
     expect(mkdtempMock).not.toHaveBeenCalled();
@@ -756,11 +901,40 @@ describe(resumeWorkspace, () => {
       error: new Error("cmux down"),
     });
 
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      /cmux down.*inspect the workspace backend/,
-    );
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      problems: [{ message: expect.stringContaining("cmux down") }],
+    });
     expect(workspacesOpenMock).not.toHaveBeenCalled();
     expect(recordRunStateMock).not.toHaveBeenCalled();
+  });
+
+  it("reports unknown state when liveness fails without persisted state", async () => {
+    readRunStateMock.mockReset();
+    workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "conflict",
+      state: "unknown",
+    });
+  });
+
+  it("preserves canonical identity when liveness cannot be verified", async () => {
+    readRunStateMock.mockReturnValue(
+      makeRunState({
+        completionTaskId: "linear:TEAM-1",
+        url: "https://example.test/TEAM-1",
+      }),
+    );
+    workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      task: {
+        id: "team-1",
+        canonicalId: "linear:TEAM-1",
+        url: "https://example.test/TEAM-1",
+      },
+    });
   });
 
   it("removes the staged prompt directory when opening the workspace fails", async () => {
@@ -774,97 +948,33 @@ describe(resumeWorkspace, () => {
     expect(recordRunStateMock).not.toHaveBeenCalled();
   });
 
-  it("closes the live workspace when recording resumed run state fails", async () => {
+  it("preserves the workspace failure when staged prompt cleanup also fails", async () => {
+    workspacesOpenMock.mockRejectedValue(new Error("cmux failed"));
+    rmSyncMock.mockImplementationOnce(() => {
+      throw new Error("cleanup failed");
+    });
+
+    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(/cmux failed/);
+  });
+
+  it("returns partial while preserving the opened workspace when run-state write fails", async () => {
     recordRunStateMock.mockImplementation(() => {
       throw new Error("state directory is read-only");
     });
 
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      "state directory is read-only",
-    );
-    expect(workspacesCloseMock).toHaveBeenCalledWith(config, "team-1");
-    expect(rmSyncMock).toHaveBeenCalledWith("/tmp/groundcrew-resume-team-1-x", {
-      recursive: true,
-      force: true,
+    await expect(resumeWorkspace(config, { task: "team-1" })).resolves.toMatchObject({
+      outcome: "partial",
+      state: "resumed",
+      problems: [
+        {
+          code: "state-write-failed",
+          message: expect.stringContaining("state directory is read-only"),
+        },
+      ],
     });
+    expect(workspaces.close).not.toHaveBeenCalled();
+    expect(rmSyncMock).not.toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
-  });
-
-  it("surfaces the state failure when closing the resumed workspace also fails", async () => {
-    recordRunStateMock.mockImplementation(() => {
-      throw new Error("state directory is read-only");
-    });
-    workspacesCloseMock.mockRejectedValue(new Error("cmux close failed"));
-
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      "state directory is read-only",
-    );
-    expect(logMock).toHaveBeenCalledWith(
-      "Workspace close failed during resume rollback for team-1: cmux close failed. Close it manually in the configured workspace backend.",
-    );
-  });
-
-  it("surfaces the state failure when resumed workspace closure is unavailable", async () => {
-    recordRunStateMock.mockImplementation(() => {
-      throw new Error("state directory is read-only");
-    });
-    workspacesCloseMock.mockResolvedValue({
-      kind: "unavailable",
-      error: new Error("cmux unavailable"),
-    });
-
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      "state directory is read-only",
-    );
-    expect(logMock).toHaveBeenCalledWith(
-      "Workspace close was not confirmed during resume rollback for team-1: cmux unavailable. Close it manually in the configured workspace backend.",
-    );
-  });
-
-  it("surfaces the state failure when resumed workspace closure has no diagnostic", async () => {
-    recordRunStateMock.mockImplementation(() => {
-      throw new Error("state directory is read-only");
-    });
-    workspacesCloseMock.mockResolvedValue({ kind: "unavailable" });
-
-    await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-      "state directory is read-only",
-    );
-    expect(logMock).toHaveBeenCalledWith(
-      "Workspace close was not confirmed during resume rollback for team-1: workspace backend unavailable. Close it manually in the configured workspace backend.",
-    );
-  });
-
-  it("preserves the state failure when launch and prompt cleanup fail", async () => {
-    const cleanup = vi.fn<() => void>(() => {
-      throw new Error("launch cleanup failed");
-    });
-    const composeAgentLaunchMock = vi
-      .spyOn(agentLaunch, "composeAgentLaunch")
-      .mockReturnValue({ command: "claude", cleanup });
-    recordRunStateMock.mockImplementation(() => {
-      throw new Error("state directory is read-only");
-    });
-    rmSyncMock.mockImplementation(() => {
-      throw new Error("prompt cleanup failed");
-    });
-
-    try {
-      await expect(resumeWorkspace(config, { task: "team-1" })).rejects.toThrow(
-        "state directory is read-only",
-      );
-    } finally {
-      composeAgentLaunchMock.mockRestore();
-    }
-
-    expect(workspacesCloseMock).toHaveBeenCalledWith(config, "team-1");
-    expect(cleanup).toHaveBeenCalledOnce();
-    expect(logMock).toHaveBeenCalledWith(
-      "Agent launch cleanup failed during resume rollback for team-1: launch cleanup failed",
-    );
-    expect(logMock).toHaveBeenCalledWith(
-      "Staged prompt cleanup failed during resume rollback for team-1: prompt cleanup failed",
-    );
   });
 });
 
@@ -889,7 +999,268 @@ describe(resumeWorkspaceCli, () => {
   });
 
   afterEach(() => {
+    process.exitCode = undefined;
     vi.resetAllMocks();
+  });
+
+  it("emits exactly one structured resume receipt in JSON mode", async () => {
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "resume",
+        task: { id: "team-1" },
+        outcome: "resumed",
+        state: "resumed",
+        resources: {
+          repository: "repo-a",
+          branch: "dev-team-1",
+          worktreeDir: "/work/repo-a-team-1",
+          workspace: { name: "team-1" },
+          agent: "claude",
+        },
+        problems: [],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reconciles a live resumed workspace after cooperative cancellation", async () => {
+    workspacesProbeMock
+      .mockResolvedValueOnce({ kind: "ok", names: new Set() })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "resume",
+        outcome: "partial",
+        state: "resumed",
+        problems: [{ code: "cancelled", message: expect.stringContaining("SIGTERM") }],
+      });
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        state: "resumed",
+        resumeCount: 2,
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("finishes durable reconciliation when cancellation arrives after workspace open", async () => {
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        outcome: "partial",
+        state: "resumed",
+        problems: [{ code: "cancelled", message: expect.stringContaining("opened") }],
+      });
+      expect(lastRecordedRunState()).toMatchObject({ state: "resumed", resumeCount: 2 });
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reports a stable conflict when another lifecycle command owns the task", async () => {
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "team-1" }));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        action: "resume",
+        outcome: "conflict",
+        problems: [{ code: "lifecycle-lock-held" }],
+      });
+      expect(workspacesOpenMock).not.toHaveBeenCalled();
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("reports unknown state when a lock is held for a task without local context", async () => {
+    readRunStateMock.mockReset();
+    findByTaskMock.mockReturnValue([]);
+    const lock = requireAcquiredLock(acquireLifecycleLock({ config, task: "unknown-1" }));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(resumeWorkspaceCli(["unknown-1", "--json"])).resolves.toMatchObject({
+        outcome: "conflict",
+        state: "unknown",
+      });
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("reports state reconciliation failure after a cancelled live resume", async () => {
+    readRunStateMock.mockReturnValue(
+      makeRunState({
+        completionTaskId: "linear:TEAM-1",
+        url: "https://example.test/TEAM-1",
+      }),
+    );
+    workspacesProbeMock
+      .mockResolvedValueOnce({ kind: "ok", names: new Set() })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+    recordRunStateMock.mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual.problems).toEqual([
+        expect.objectContaining({ code: "cancelled" }),
+        expect.objectContaining({ code: "state-write-failed" }),
+      ]);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("preserves the observed interrupted state when cancellation opens no workspace", async () => {
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({ outcome: "partial", state: "interrupted" });
+      expect(recordRunStateMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reports unknown when cancellation loses state and observes no workspace", async () => {
+    readRunStateMock
+      .mockReturnValueOnce(makeRunState())
+      .mockReturnValueOnce(makeRunState())
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- simulate state disappearing during reconciliation
+      .mockReturnValueOnce(undefined);
+    findByTaskMock
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([]);
+    workspacesProbeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(resumeWorkspaceCli(["TEAM-1", "--json"])).resolves.toMatchObject({
+        outcome: "partial",
+        state: "unknown",
+      });
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("does not invent durable context when cancellation finds only a live workspace", async () => {
+    readRunStateMock
+      .mockReturnValueOnce(makeRunState())
+      .mockReturnValueOnce(makeRunState())
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- simulate state disappearing during reconciliation
+      .mockReturnValueOnce(undefined);
+    findByTaskMock
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([]);
+    workspacesProbeMock
+      .mockResolvedValueOnce({ kind: "ok", names: new Set() })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(actual).toMatchObject({
+        outcome: "partial",
+        state: "resumed",
+        resources: { workspace: { name: "team-1" } },
+      });
+      expect(recordRunStateMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reconciles a cancelled live workspace from its remaining worktree context", async () => {
+    readRunStateMock
+      .mockReturnValueOnce(makeRunState())
+      .mockReturnValueOnce(makeRunState())
+      // oxlint-disable-next-line unicorn/no-useless-undefined -- simulate state disappearing during reconciliation
+      .mockReturnValueOnce(undefined);
+    findByTaskMock
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([makeWorktree()])
+      .mockReturnValueOnce([makeWorktree()]);
+    workspacesProbeMock
+      .mockResolvedValueOnce({ kind: "ok", names: new Set() })
+      .mockResolvedValueOnce({ kind: "ok", names: new Set(["team-1"]) });
+    workspacesOpenMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await resumeWorkspaceCli(["TEAM-1", "--json"]);
+
+      expect(lastRecordedRunState()).toMatchObject({
+        task: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        workspaceName: "team-1",
+        state: "resumed",
+        resumeCount: 1,
+      });
+      expect(lastRecordedRunState()).not.toHaveProperty("reason");
+    } finally {
+      consoleLog.restore();
+    }
   });
 
   it("parses the task argument", async () => {
@@ -899,6 +1270,7 @@ describe(resumeWorkspaceCli, () => {
     expect(workspacesOpenMock).toHaveBeenCalledWith(
       config,
       expect.objectContaining({ name: "team-1" }),
+      expect.any(AbortSignal),
     );
   });
 
@@ -909,6 +1281,7 @@ describe(resumeWorkspaceCli, () => {
     expect(workspacesOpenMock).toHaveBeenCalledWith(
       config,
       expect.objectContaining({ name: "team-1" }),
+      expect.any(AbortSignal),
     );
   });
 
@@ -926,6 +1299,7 @@ describe(resumeWorkspaceCli, () => {
     expect(workspacesOpenMock).toHaveBeenCalledWith(
       config,
       expect.objectContaining({ name: "team-1" }),
+      expect.any(AbortSignal),
     );
   });
 
@@ -935,6 +1309,7 @@ describe(resumeWorkspaceCli, () => {
     expect(workspacesOpenMock).toHaveBeenCalledWith(
       config,
       expect.objectContaining({ name: "team-1" }),
+      expect.any(AbortSignal),
     );
   });
 });

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1286,7 +1286,9 @@ describe(resumeWorkspaceCli, () => {
   });
 
   it("rejects missing task", async () => {
-    await expect(resumeWorkspaceCli([])).rejects.toThrow(/Usage: crew resume/);
+    await expect(resumeWorkspaceCli([])).rejects.toThrow(
+      "Usage: crew resume [--new] [--json] <task>",
+    );
   });
 
   it("rejects extra positional args", async () => {

--- a/src/commands/resumeWorkspace.test.ts
+++ b/src/commands/resumeWorkspace.test.ts
@@ -1257,6 +1257,7 @@ describe(resumeWorkspaceCli, () => {
       });
       expect(lastRecordedRunState()).toMatchObject({
         task: "team-1",
+        title: "Resolved title",
         agent: "codex",
         completionTaskId: "linear:team-1",
         state: "resumed",

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -516,7 +516,7 @@ export async function resumeWorkspaceCli(argv: string[]): Promise<ResumeResult> 
       await cancelledResumeResult({
         config,
         task: parsed.options.task,
-        taskSourceId: parsed.options.taskSourceId,
+        taskSourceId: parsed.options.taskSourceId ?? parsed.options.task,
         resolvedContext,
         context,
       }),
@@ -611,41 +611,53 @@ function resumeLockConflictResult(arguments_: {
 }
 
 function reconciledResumeRunState(arguments_: {
-  config: ResolvedConfig;
   task: string;
-  state: RunState | undefined;
-  repository: string;
-  worktreeDir: string;
-  branchName: string;
-  taskSourceId: string | undefined;
-  resolvedContext: ResumeContext | undefined;
+  observed: ResumeReconciliationSeed;
+  taskSourceId: string;
 }): Parameters<typeof recordRunState>[0]["state"] {
-  const observed = {
-    ...resumeContextRunStateSeed(arguments_.resolvedContext),
-    ...arguments_.state,
-  };
-  const completionTaskId = observed.completionTaskId ?? arguments_.taskSourceId;
+  const { observed } = arguments_;
   return {
     task: arguments_.task,
-    repository: arguments_.repository,
-    agent: observed.agent ?? arguments_.config.agents.default,
-    worktreeDir: arguments_.worktreeDir,
-    branchName: arguments_.branchName,
-    workspaceName: observed.workspaceName ?? arguments_.task,
+    repository: observed.repository,
+    agent: observed.agent,
+    worktreeDir: observed.worktreeDir,
+    branchName: observed.branchName,
+    workspaceName: observed.workspaceName,
     state: "resumed",
-    resumeCount: (observed.resumeCount ?? 0) + 1,
-    ...(completionTaskId === undefined ? {} : { completionTaskId }),
+    resumeCount: observed.resumeCount + 1,
+    completionTaskId: observed.completionTaskId ?? arguments_.taskSourceId,
     ...(observed.url === undefined ? {} : { url: observed.url }),
     ...(observed.reason === undefined ? {} : { reason: observed.reason }),
   };
 }
 
-function resumeContextRunStateSeed(context: ResumeContext | undefined): Partial<RunState> {
+interface ResumeReconciliationSeed {
+  repository: string;
+  agent: string;
+  worktreeDir: string;
+  branchName: string;
+  workspaceName: string;
+  resumeCount: number;
+  completionTaskId?: string;
+  url?: string;
+  reason?: string;
+}
+
+function resumeReconciliationSeed(
+  state: RunState | undefined,
+  context: ResumeContext | undefined,
+): ResumeReconciliationSeed | undefined {
+  if (state !== undefined) {
+    return state;
+  }
   if (context === undefined) {
-    return {};
+    return undefined;
   }
   return {
+    repository: context.repository,
     agent: context.agent,
+    worktreeDir: context.worktree.dir,
+    branchName: context.worktree.branchName,
     workspaceName: context.task,
     resumeCount: context.resumeCount,
     completionTaskId: context.completionTaskId,
@@ -658,30 +670,24 @@ function reconcileCancelledResumeState(arguments_: {
   config: ResolvedConfig;
   task: string;
   state: RunState | undefined;
-  entries: readonly WorktreeEntry[];
   isLive: boolean;
-  taskSourceId: string | undefined;
+  taskSourceId: string;
   resolvedContext: ResumeContext | undefined;
 }): LifecycleProblem | undefined {
   if (!arguments_.isLive) {
     return undefined;
   }
-  const { repository, worktreeDir, branchName } = resumeReconciliationResourceContext(arguments_);
-  if (repository === undefined || worktreeDir === undefined || branchName === undefined) {
+  const observed = resumeReconciliationSeed(arguments_.state, arguments_.resolvedContext);
+  if (observed === undefined) {
     return undefined;
   }
   try {
     recordRunState({
       config: arguments_.config,
       state: reconciledResumeRunState({
-        config: arguments_.config,
         task: arguments_.task,
-        state: arguments_.state,
-        repository,
-        worktreeDir,
-        branchName,
+        observed,
         taskSourceId: arguments_.taskSourceId,
-        resolvedContext: arguments_.resolvedContext,
       }),
     });
     return undefined;
@@ -693,36 +699,10 @@ function reconcileCancelledResumeState(arguments_: {
   }
 }
 
-function resumeReconciliationResourceContext(arguments_: {
-  state: RunState | undefined;
-  entries: readonly WorktreeEntry[];
-  resolvedContext: ResumeContext | undefined;
-}): {
-  repository: string | undefined;
-  worktreeDir: string | undefined;
-  branchName: string | undefined;
-} {
-  const entry =
-    arguments_.entries.find(
-      (candidate) =>
-        candidate.repository ===
-        (arguments_.state?.repository ?? arguments_.resolvedContext?.repository),
-    ) ?? arguments_.entries[0];
-  const repository =
-    arguments_.state?.repository ?? arguments_.resolvedContext?.repository ?? entry?.repository;
-  const worktreeDir =
-    arguments_.state?.worktreeDir ?? arguments_.resolvedContext?.worktree.dir ?? entry?.dir;
-  const branchName =
-    arguments_.state?.branchName ??
-    arguments_.resolvedContext?.worktree.branchName ??
-    entry?.branchName;
-  return { repository, worktreeDir, branchName };
-}
-
 async function cancelledResumeResult(arguments_: {
   config: ResolvedConfig;
   task: string;
-  taskSourceId: string | undefined;
+  taskSourceId: string;
   resolvedContext: ResumeContext | undefined;
   context: LifecycleCancellationContext;
 }): Promise<ResumeResult> {
@@ -734,7 +714,6 @@ async function cancelledResumeResult(arguments_: {
     config: arguments_.config,
     task: arguments_.task,
     state,
-    entries,
     isLive,
     taskSourceId: arguments_.taskSourceId,
     resolvedContext: arguments_.resolvedContext,
@@ -772,12 +751,12 @@ async function cancelledResumeResult(arguments_: {
 }
 
 function resumeCancellationIdentityFallback(
-  taskSourceId: string | undefined,
+  taskSourceId: string,
   context: ResumeContext | undefined,
 ): { canonicalId?: string; url?: string } {
   const canonicalId = context?.completionTaskId ?? taskSourceId;
   return {
-    ...(canonicalId === undefined ? {} : { canonicalId }),
+    canonicalId,
     ...(context?.url === undefined ? {} : { url: context.url }),
   };
 }

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -53,6 +53,10 @@ export interface ResumeWorkspaceRunOptions {
   board?: Board;
 }
 
+interface ResumeWorkspaceOperationOptions extends ResumeWorkspaceRunOptions {
+  contextResolved?: (context: ResumeContext) => void;
+}
+
 interface TaskDetails {
   title: string;
   description: string;
@@ -108,7 +112,7 @@ async function resolveTaskDetails(
   board?: Board,
 ): Promise<TaskDetails | undefined> {
   const rawSources = sourcesFromConfig(config);
-  if (rawSources.length === 0) {
+  if (board === undefined && rawSources.length === 0) {
     return undefined;
   }
   try {
@@ -137,7 +141,7 @@ async function contextFromBoard(
   board?: Board,
 ): Promise<ResumeContext> {
   const rawSources = sourcesFromConfig(config);
-  if (rawSources.length === 0) {
+  if (board === undefined && rawSources.length === 0) {
     throw new Error(
       `Cannot resume ${task}: no run state recorded and no task source is configured.`,
     );
@@ -173,11 +177,12 @@ async function contextFromBoard(
 async function contextFromState(
   config: ResolvedConfig,
   task: string,
+  taskId: string,
   state: RunState,
   worktree: WorktreeEntry,
   board?: Board,
 ): Promise<ResumeContext> {
-  const completionTaskId = state.completionTaskId ?? task;
+  const completionTaskId = state.completionTaskId ?? taskId;
   const details = await resolveTaskDetails(config, completionTaskId, board);
   const url = state.url ?? details?.url;
   return {
@@ -217,7 +222,14 @@ async function buildResumeContext(
     return undefined;
   }
   if (state !== undefined) {
-    return await contextFromState(config, task, state, worktree, board);
+    return await contextFromState(
+      config,
+      task,
+      options.taskSourceId ?? task,
+      state,
+      worktree,
+      board,
+    );
   }
   return await contextFromBoard(config, task, options.taskSourceId ?? task, worktree, board);
 }
@@ -270,6 +282,14 @@ export async function resumeWorkspace(
   options: ResumeWorkspaceOptions,
   runOptions: ResumeWorkspaceRunOptions = {},
 ): Promise<ResumeResult> {
+  return await resumeWorkspaceWithContextObservation(config, options, runOptions);
+}
+
+async function resumeWorkspaceWithContextObservation(
+  config: ResolvedConfig,
+  options: ResumeWorkspaceOptions,
+  runOptions: ResumeWorkspaceOperationOptions,
+): Promise<ResumeResult> {
   return await withConsoleOutputSuppressed(
     async () => await resumeWorkspaceOperation(config, options, runOptions),
   );
@@ -279,7 +299,7 @@ export async function resumeWorkspace(
 async function resumeWorkspaceOperation(
   config: ResolvedConfig,
   options: ResumeWorkspaceOptions,
-  runOptions: ResumeWorkspaceRunOptions,
+  runOptions: ResumeWorkspaceOperationOptions,
 ): Promise<ResumeResult> {
   const task = options.task.toLowerCase();
   const state = readRunState(config, task);
@@ -336,6 +356,7 @@ async function resumeWorkspaceOperation(
       problems: [],
     });
   }
+  runOptions.contextResolved?.(context);
   const definition = config.agents.definitions[context.agent];
   if (definition === undefined) {
     throw new Error(`Unknown agent: ${context.agent}`);
@@ -478,14 +499,27 @@ async function resumeWorkspaceOperation(
 export async function resumeWorkspaceCli(argv: string[]): Promise<ResumeResult> {
   const parsed = parseArguments(argv);
   const config = await loadLifecycleConfig(parsed.json);
+  let resolvedContext: ResumeContext | undefined;
   return await executeLifecycleMutation({
     config,
     task: parsed.options.task,
     json: parsed.json,
     conflictResult: () => resumeLockConflictResult({ config, task: parsed.options.task }),
-    operation: async ({ signal }) => await resumeWorkspace(config, parsed.options, { signal }),
+    operation: async ({ signal }) =>
+      await resumeWorkspaceWithContextObservation(config, parsed.options, {
+        signal,
+        contextResolved: (context) => {
+          resolvedContext = context;
+        },
+      }),
     cancelledResult: async (context) =>
-      await cancelledResumeResult({ config, task: parsed.options.task, context }),
+      await cancelledResumeResult({
+        config,
+        task: parsed.options.task,
+        taskSourceId: parsed.options.taskSourceId,
+        resolvedContext,
+        context,
+      }),
   });
 }
 
@@ -496,10 +530,11 @@ function resumeClassifiedResult(arguments_: {
   outcome: ResumeResult["outcome"];
   lifecycleState: ResumeResult["state"];
   problems: LifecycleProblem[];
+  fallbackIdentity?: { canonicalId?: string; url?: string };
 }): ResumeResult {
   return {
     action: "resume",
-    task: resumeTaskIdentity(arguments_.task, arguments_.state),
+    task: resumeTaskIdentity(arguments_.task, arguments_.state, arguments_.fallbackIdentity),
     outcome: arguments_.outcome,
     state: arguments_.lifecycleState,
     resources: arguments_.resources,
@@ -507,11 +542,17 @@ function resumeClassifiedResult(arguments_: {
   };
 }
 
-function resumeTaskIdentity(task: string, state: RunState | undefined): ResumeResult["task"] {
+function resumeTaskIdentity(
+  task: string,
+  state: RunState | undefined,
+  fallback?: { canonicalId?: string; url?: string },
+): ResumeResult["task"] {
+  const canonicalId = state?.completionTaskId ?? fallback?.canonicalId;
+  const url = state?.url ?? fallback?.url;
   return {
     id: task,
-    ...(state?.completionTaskId === undefined ? {} : { canonicalId: state.completionTaskId }),
-    ...(state?.url === undefined ? {} : { url: state.url }),
+    ...(canonicalId === undefined ? {} : { canonicalId }),
+    ...(url === undefined ? {} : { url }),
   };
 }
 
@@ -576,21 +617,40 @@ function reconciledResumeRunState(arguments_: {
   repository: string;
   worktreeDir: string;
   branchName: string;
+  taskSourceId: string | undefined;
+  resolvedContext: ResumeContext | undefined;
 }): Parameters<typeof recordRunState>[0]["state"] {
+  const observed = {
+    ...resumeContextRunStateSeed(arguments_.resolvedContext),
+    ...arguments_.state,
+  };
+  const completionTaskId = observed.completionTaskId ?? arguments_.taskSourceId;
   return {
     task: arguments_.task,
     repository: arguments_.repository,
-    agent: arguments_.state?.agent ?? arguments_.config.agents.default,
+    agent: observed.agent ?? arguments_.config.agents.default,
     worktreeDir: arguments_.worktreeDir,
     branchName: arguments_.branchName,
-    workspaceName: arguments_.state?.workspaceName ?? arguments_.task,
+    workspaceName: observed.workspaceName ?? arguments_.task,
     state: "resumed",
-    resumeCount: (arguments_.state?.resumeCount ?? 0) + 1,
-    ...(arguments_.state?.completionTaskId === undefined
-      ? {}
-      : { completionTaskId: arguments_.state.completionTaskId }),
-    ...(arguments_.state?.url === undefined ? {} : { url: arguments_.state.url }),
-    ...(arguments_.state?.reason === undefined ? {} : { reason: arguments_.state.reason }),
+    resumeCount: (observed.resumeCount ?? 0) + 1,
+    ...(completionTaskId === undefined ? {} : { completionTaskId }),
+    ...(observed.url === undefined ? {} : { url: observed.url }),
+    ...(observed.reason === undefined ? {} : { reason: observed.reason }),
+  };
+}
+
+function resumeContextRunStateSeed(context: ResumeContext | undefined): Partial<RunState> {
+  if (context === undefined) {
+    return {};
+  }
+  return {
+    agent: context.agent,
+    workspaceName: context.task,
+    resumeCount: context.resumeCount,
+    completionTaskId: context.completionTaskId,
+    ...(context.url === undefined ? {} : { url: context.url }),
+    ...(context.reason === undefined ? {} : { reason: context.reason }),
   };
 }
 
@@ -600,14 +660,13 @@ function reconcileCancelledResumeState(arguments_: {
   state: RunState | undefined;
   entries: readonly WorktreeEntry[];
   isLive: boolean;
+  taskSourceId: string | undefined;
+  resolvedContext: ResumeContext | undefined;
 }): LifecycleProblem | undefined {
   if (!arguments_.isLive) {
     return undefined;
   }
-  const [entry] = arguments_.entries;
-  const repository = arguments_.state?.repository ?? entry?.repository;
-  const worktreeDir = arguments_.state?.worktreeDir ?? entry?.dir;
-  const branchName = arguments_.state?.branchName ?? entry?.branchName;
+  const { repository, worktreeDir, branchName } = resumeReconciliationResourceContext(arguments_);
   if (repository === undefined || worktreeDir === undefined || branchName === undefined) {
     return undefined;
   }
@@ -621,6 +680,8 @@ function reconcileCancelledResumeState(arguments_: {
         repository,
         worktreeDir,
         branchName,
+        taskSourceId: arguments_.taskSourceId,
+        resolvedContext: arguments_.resolvedContext,
       }),
     });
     return undefined;
@@ -632,9 +693,37 @@ function reconcileCancelledResumeState(arguments_: {
   }
 }
 
+function resumeReconciliationResourceContext(arguments_: {
+  state: RunState | undefined;
+  entries: readonly WorktreeEntry[];
+  resolvedContext: ResumeContext | undefined;
+}): {
+  repository: string | undefined;
+  worktreeDir: string | undefined;
+  branchName: string | undefined;
+} {
+  const entry =
+    arguments_.entries.find(
+      (candidate) =>
+        candidate.repository ===
+        (arguments_.state?.repository ?? arguments_.resolvedContext?.repository),
+    ) ?? arguments_.entries[0];
+  const repository =
+    arguments_.state?.repository ?? arguments_.resolvedContext?.repository ?? entry?.repository;
+  const worktreeDir =
+    arguments_.state?.worktreeDir ?? arguments_.resolvedContext?.worktree.dir ?? entry?.dir;
+  const branchName =
+    arguments_.state?.branchName ??
+    arguments_.resolvedContext?.worktree.branchName ??
+    entry?.branchName;
+  return { repository, worktreeDir, branchName };
+}
+
 async function cancelledResumeResult(arguments_: {
   config: ResolvedConfig;
   task: string;
+  taskSourceId: string | undefined;
+  resolvedContext: ResumeContext | undefined;
   context: LifecycleCancellationContext;
 }): Promise<ResumeResult> {
   const state = readRunState(arguments_.config, arguments_.task);
@@ -647,12 +736,23 @@ async function cancelledResumeResult(arguments_: {
     state,
     entries,
     isLive,
+    taskSourceId: arguments_.taskSourceId,
+    resolvedContext: arguments_.resolvedContext,
   });
+  const observedResources =
+    arguments_.resolvedContext === undefined
+      ? resumeResourcesFromLocal({ state, entries })
+      : {
+          repository: arguments_.resolvedContext.repository,
+          branch: arguments_.resolvedContext.worktree.branchName,
+          worktreeDir: arguments_.resolvedContext.worktree.dir,
+          agent: arguments_.resolvedContext.agent,
+        };
   return resumeClassifiedResult({
     task: arguments_.task,
     state,
     resources: {
-      ...resumeResourcesFromLocal({ state, entries }),
+      ...observedResources,
       ...(isLive ? { workspace: { name: arguments_.task } } : {}),
     },
     outcome: "partial",
@@ -664,5 +764,20 @@ async function cancelledResumeResult(arguments_: {
       },
       ...(stateProblem === undefined ? [] : [stateProblem]),
     ],
+    fallbackIdentity: resumeCancellationIdentityFallback(
+      arguments_.taskSourceId,
+      arguments_.resolvedContext,
+    ),
   });
+}
+
+function resumeCancellationIdentityFallback(
+  taskSourceId: string | undefined,
+  context: ResumeContext | undefined,
+): { canonicalId?: string; url?: string } {
+  const canonicalId = context?.completionTaskId ?? taskSourceId;
+  return {
+    ...(canonicalId === undefined ? {} : { canonicalId }),
+    ...(context?.url === undefined ? {} : { url: context.url }),
+  };
 }

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -77,7 +77,10 @@ interface ResumeContext {
   resumeCount: number;
 }
 
-function parseArguments(argv: string[]): { options: ResumeWorkspaceOptions; json: boolean } {
+function parseArguments(argv: string[]): {
+  options: ResumeWorkspaceOptions & { taskSourceId: string };
+  json: boolean;
+} {
   let fresh = false;
   let json = false;
   const positionals: string[] = [];
@@ -516,7 +519,7 @@ export async function resumeWorkspaceCli(argv: string[]): Promise<ResumeResult> 
       await cancelledResumeResult({
         config,
         task: parsed.options.task,
-        taskSourceId: parsed.options.taskSourceId ?? parsed.options.task,
+        taskSourceId: parsed.options.taskSourceId,
         resolvedContext,
         context,
       }),

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,6 +1,6 @@
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
-import { type AgentDefinition, loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { AgentDefinition, ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import {
   inferAgentCommandName,
@@ -25,6 +25,7 @@ import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
+  loadLifecycleConfig,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -475,7 +476,7 @@ async function resumeWorkspaceOperation(
 
 export async function resumeWorkspaceCli(argv: string[]): Promise<ResumeResult> {
   const parsed = parseArguments(argv);
-  const config = await loadConfig();
+  const config = await loadLifecycleConfig(parsed.json);
   return await executeLifecycleMutation({
     config,
     task: parsed.options.task,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -621,6 +621,7 @@ function reconciledResumeRunState(arguments_: {
   const { observed } = arguments_;
   return {
     task: arguments_.task,
+    ...(observed.title === undefined ? {} : { title: observed.title }),
     repository: observed.repository,
     agent: observed.agent,
     worktreeDir: observed.worktreeDir,
@@ -635,6 +636,7 @@ function reconciledResumeRunState(arguments_: {
 }
 
 interface ResumeReconciliationSeed {
+  title?: string;
   repository: string;
   agent: string;
   worktreeDir: string;
@@ -657,6 +659,7 @@ function resumeReconciliationSeed(
     return undefined;
   }
   return {
+    title: context.title,
     repository: context.repository,
     agent: context.agent,
     worktreeDir: context.worktree.dir,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -26,6 +26,7 @@ import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
   loadLifecycleConfig,
+  probeWorkspaceForLifecycleReconciliation,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -89,7 +90,7 @@ function parseArguments(argv: string[]): { options: ResumeWorkspaceOptions; json
   }
   const [task, ...extras] = positionals;
   if (task === undefined || task.length === 0 || extras.length > 0 || task.startsWith("-")) {
-    throw new Error("Usage: crew resume [--new] <task>");
+    throw new Error("Usage: crew resume [--new] [--json] <task>");
   }
   return {
     options: {
@@ -638,7 +639,7 @@ async function cancelledResumeResult(arguments_: {
 }): Promise<ResumeResult> {
   const state = readRunState(arguments_.config, arguments_.task);
   const entries = worktrees.findByTask(arguments_.config, arguments_.task);
-  const probe = await workspaces.probe(arguments_.config);
+  const probe = await probeWorkspaceForLifecycleReconciliation(arguments_.config);
   const isLive = probe.kind === "ok" && probe.names.has(arguments_.task);
   const stateProblem = reconcileCancelledResumeState({
     config: arguments_.config,

--- a/src/commands/resumeWorkspace.ts
+++ b/src/commands/resumeWorkspace.ts
@@ -1,6 +1,5 @@
-import { fetchResolvedIssue } from "../lib/adapters/linear/fetch.ts";
-import { getLinearClient } from "../lib/adapters/linear/client.ts";
-import { isLinearEnabled, sourcesFromConfig } from "../lib/buildSources.ts";
+import { type Board, createBoard } from "../lib/board.ts";
+import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { type AgentDefinition, loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import {
@@ -10,7 +9,7 @@ import {
 } from "../lib/launchCommand.ts";
 import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
-import { summarizeSource, taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
+import { taskSupportsCompletionCommand } from "../lib/sourceCapabilities.ts";
 import {
   removeStagedPrompt,
   stageBuildSecrets,
@@ -18,21 +17,38 @@ import {
   stageWorkspaceLaunchCommand,
 } from "../lib/stagedLaunch.ts";
 import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
-import { naturalIdFromCanonical, toCanonicalId } from "../lib/taskSource.ts";
-import { errorMessage, log } from "../lib/util.ts";
-import { failIfWorkspaceAlreadyLive } from "../lib/workspaceLiveness.ts";
+import { naturalIdFromCanonical } from "../lib/taskSource.ts";
+import { errorMessage, log, withConsoleOutputSuppressed } from "../lib/util.ts";
 import { workspaces } from "../lib/workspaces.ts";
 import { resolveLaunchDir, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
+import {
+  executeLifecycleMutation,
+  lifecycleCancellationSuffix,
+  type LifecycleCancellationContext,
+} from "./lifecycleCommand.ts";
+import {
+  LIFECYCLE_PROBLEM_CODES,
+  type LifecycleProblem,
+  type LifecycleResources,
+  type ResumeResult,
+} from "./lifecycleResult.ts";
 
 export interface ResumeWorkspaceOptions {
   task: string;
+  /** Source-qualified id supplied at the CLI boundary, when present. */
+  taskSourceId?: string;
   /**
    * Force a fresh conversation: cold-start the agent (the historic behavior),
    * ignoring the agent's `resumeArgs`. Defaults to false, which reopens the
    * agent's previous conversation when `resumeArgs` is configured.
    */
   fresh?: boolean;
+}
+
+export interface ResumeWorkspaceRunOptions {
+  signal?: AbortSignal;
+  board?: Board;
 }
 
 interface TaskDetails {
@@ -55,12 +71,17 @@ interface ResumeContext {
   resumeCount: number;
 }
 
-function parseArguments(argv: string[]): ResumeWorkspaceOptions {
+function parseArguments(argv: string[]): { options: ResumeWorkspaceOptions; json: boolean } {
   let fresh = false;
+  let json = false;
   const positionals: string[] = [];
   for (const argument of argv) {
     if (argument === "--new") {
       fresh = true;
+      continue;
+    }
+    if (argument === "--json") {
+      json = true;
       continue;
     }
     positionals.push(argument);
@@ -69,30 +90,67 @@ function parseArguments(argv: string[]): ResumeWorkspaceOptions {
   if (task === undefined || task.length === 0 || extras.length > 0 || task.startsWith("-")) {
     throw new Error("Usage: crew resume [--new] <task>");
   }
-  return { task: naturalIdFromCanonical(task).toLowerCase(), fresh };
+  return {
+    options: {
+      task: naturalIdFromCanonical(task).toLowerCase(),
+      taskSourceId: task,
+      fresh,
+    },
+    json,
+  };
 }
 
-async function fetchTaskDetails(task: string): Promise<TaskDetails | undefined> {
+async function resolveTaskDetails(
+  config: ResolvedConfig,
+  taskId: string,
+  board?: Board,
+): Promise<TaskDetails | undefined> {
+  const rawSources = sourcesFromConfig(config);
+  if (rawSources.length === 0) {
+    return undefined;
+  }
   try {
-    const issue = await getLinearClient().issue(task.toUpperCase());
+    const resolvedBoard =
+      board ?? createBoard(await buildSources(rawSources, { globalConfig: config }));
+    const issue = await resolvedBoard.resolveOne(taskId);
+    if (issue === undefined) {
+      return undefined;
+    }
     return {
       title: issue.title,
-      description: issue.description ?? "",
-      url: issue.url,
+      description: issue.description,
+      ...(issue.url === undefined ? {} : { url: issue.url }),
     };
   } catch (error) {
-    log(`Resume Linear detail lookup failed for ${task}: ${errorMessage(error)}`);
+    log(`Resume task detail lookup failed for ${taskId}: ${errorMessage(error)}`);
     return undefined;
   }
 }
 
-async function contextFromLinear(
+async function contextFromBoard(
   config: ResolvedConfig,
   task: string,
+  taskId: string,
   worktree: WorktreeEntry,
+  board?: Board,
 ): Promise<ResumeContext> {
-  const resolved = await fetchResolvedIssue({ client: getLinearClient(), config, task });
-  const completionTaskId = toCanonicalId("linear", task);
+  const rawSources = sourcesFromConfig(config);
+  if (rawSources.length === 0) {
+    throw new Error(
+      `Cannot resume ${task}: no run state recorded and no task source is configured.`,
+    );
+  }
+  const resolvedBoard =
+    board ?? createBoard(await buildSources(rawSources, { globalConfig: config }));
+  const resolved = await resolvedBoard.resolveOne(taskId);
+  if (resolved === undefined) {
+    throw new Error(`Task ${taskId} not found across configured sources.`);
+  }
+  if (resolved.repository === undefined || resolved.agent === undefined) {
+    throw new Error(
+      `Task ${taskId} resolved but isn't groundcrew-eligible (missing agent-* label or repository/agent).`,
+    );
+  }
   return {
     task,
     repository: resolved.repository,
@@ -100,11 +158,11 @@ async function contextFromLinear(
     worktree,
     title: resolved.title,
     description: resolved.description,
-    url: resolved.url,
-    completionTaskId,
+    ...(resolved.url === undefined ? {} : { url: resolved.url }),
+    completionTaskId: resolved.id,
     completionMarkDoneSupported: taskSupportsCompletionCommand({
-      rawSources: sourcesFromConfig(config),
-      taskId: completionTaskId,
+      rawSources,
+      taskId: resolved.id,
     }),
     resumeCount: 0,
   };
@@ -115,15 +173,11 @@ async function contextFromState(
   task: string,
   state: RunState,
   worktree: WorktreeEntry,
+  board?: Board,
 ): Promise<ResumeContext> {
-  // Skip the Linear lookup when Linear is disabled — otherwise the
-  // missing-API-key error logs noisily even though resume only needs it to
-  // enrich the prompt title/description (which falls back to the task id).
-  const details = isLinearEnabled(config) ? await fetchTaskDetails(task) : undefined;
   const completionTaskId = state.completionTaskId ?? task;
-  const url =
-    state.url ??
-    (taskUsesLinearSource({ config, taskId: completionTaskId }) ? details?.url : undefined);
+  const details = await resolveTaskDetails(config, completionTaskId, board);
+  const url = state.url ?? details?.url;
   return {
     task,
     repository: state.repository,
@@ -145,26 +199,12 @@ async function contextFromState(
   };
 }
 
-function taskUsesLinearSource(arguments_: { config: ResolvedConfig; taskId: string }): boolean {
-  const { config, taskId } = arguments_;
-  const rawSources = sourcesFromConfig(config);
-  const colonIndex = taskId.indexOf(":");
-  if (colonIndex === -1) {
-    const [singleSource] = rawSources;
-    return (
-      rawSources.length === 1 &&
-      singleSource !== undefined &&
-      summarizeSource(singleSource).kind === "linear"
-    );
-  }
-  const sourceName = taskId.slice(0, colonIndex);
-  return rawSources.some((rawSource) => {
-    const source = summarizeSource(rawSource);
-    return source.name === sourceName && source.kind === "linear";
-  });
-}
-
-async function buildResumeContext(config: ResolvedConfig, task: string): Promise<ResumeContext> {
+async function buildResumeContext(
+  config: ResolvedConfig,
+  options: ResumeWorkspaceOptions,
+  board?: Board,
+): Promise<ResumeContext | undefined> {
+  const { task } = options;
   const state = readRunState(config, task);
   const entries = worktrees.findByTask(config, task);
   const worktree =
@@ -172,18 +212,12 @@ async function buildResumeContext(config: ResolvedConfig, task: string): Promise
       ? entries[0]
       : (entries.find((entry) => entry.repository === state.repository) ?? entries[0]);
   if (worktree === undefined) {
-    throw new Error(`No worktree found for ${task}; cannot resume.`);
+    return undefined;
   }
   if (state !== undefined) {
-    return await contextFromState(config, task, state, worktree);
+    return await contextFromState(config, task, state, worktree, board);
   }
-  // The cold-resume path resolves repository + agent from Linear alone, so it
-  // can't proceed when Linear is disabled. Fail with a clear reason instead of
-  // the cryptic missing-API-key error getLinearClient() would otherwise raise.
-  if (!isLinearEnabled(config)) {
-    throw new Error(`Cannot resume ${task}: no run state recorded and Linear is disabled.`);
-  }
-  return await contextFromLinear(config, task, worktree);
+  return await contextFromBoard(config, task, options.taskSourceId ?? task, worktree, board);
 }
 
 function renderResumePrompt(context: ResumeContext): string {
@@ -232,10 +266,74 @@ function resolveResumeLaunch(input: {
 export async function resumeWorkspace(
   config: ResolvedConfig,
   options: ResumeWorkspaceOptions,
-): Promise<void> {
+  runOptions: ResumeWorkspaceRunOptions = {},
+): Promise<ResumeResult> {
+  return await withConsoleOutputSuppressed(
+    async () => await resumeWorkspaceOperation(config, options, runOptions),
+  );
+}
+
+// oxlint-disable-next-line eslint/complexity -- lifecycle outcomes are kept together as one decision table
+async function resumeWorkspaceOperation(
+  config: ResolvedConfig,
+  options: ResumeWorkspaceOptions,
+  runOptions: ResumeWorkspaceRunOptions,
+): Promise<ResumeResult> {
   const task = options.task.toLowerCase();
-  await failIfWorkspaceAlreadyLive(config, task, "resuming");
-  const context = await buildResumeContext(config, task);
+  const state = readRunState(config, task);
+  const entries = worktrees.findByTask(config, task);
+  const probe =
+    runOptions.signal === undefined
+      ? await workspaces.probe(config)
+      : await workspaces.probe(config, runOptions.signal);
+  if (probe.kind === "unavailable") {
+    const detail = probe.error === undefined ? "" : `: ${errorMessage(probe.error)}`;
+    return resumeClassifiedResult({
+      task,
+      state,
+      resources: resumeResourcesFromLocal({ state, entries }),
+      outcome: "conflict",
+      lifecycleState: state?.state ?? "unknown",
+      problems: [
+        {
+          code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+          message: `Could not verify whether the task workspace is already live${detail}.`,
+        },
+      ],
+    });
+  }
+  if (probe.names.has(task)) {
+    const hasMatchingContext = state !== undefined || entries.length > 0;
+    return resumeClassifiedResult({
+      task,
+      state,
+      resources: {
+        ...resumeResourcesFromLocal({ state, entries }),
+        workspace: { name: task },
+      },
+      outcome: hasMatchingContext ? "already-running" : "conflict",
+      lifecycleState: state?.state === "resumed" ? "resumed" : "running",
+      problems: hasMatchingContext
+        ? []
+        : [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.workspaceConflict,
+              message: "A live workspace exists without matching local task context.",
+            },
+          ],
+    });
+  }
+  const context = await buildResumeContext(config, options, runOptions.board);
+  if (context === undefined) {
+    return resumeClassifiedResult({
+      task,
+      state,
+      resources: resumeResourcesFromLocal({ state, entries }),
+      outcome: "not-found",
+      lifecycleState: "absent",
+      problems: [],
+    });
+  }
   const definition = config.agents.definitions[context.agent];
   if (definition === undefined) {
     throw new Error(`Unknown agent: ${context.agent}`);
@@ -253,6 +351,7 @@ export async function resumeWorkspace(
       agent: context.agent,
       definition: launchDefinition,
       purpose: "resumes",
+      ...(runOptions.signal === undefined ? {} : { signal: runOptions.signal }),
     });
   await ensureReady();
 
@@ -265,7 +364,6 @@ export async function resumeWorkspace(
   });
   const secretsFile = stageBuildSecrets(stagedPrompt.directory);
   let cleanupAgentLaunch: (() => void) | undefined;
-  let workspaceOpened = false;
   try {
     const taskSourceWritePaths =
       runner === "safehouse"
@@ -309,8 +407,25 @@ export async function resumeWorkspace(
       command: launchCmd,
       agent: context.agent,
       color: definition.color,
+      ...(runOptions.signal === undefined ? {} : { signal: runOptions.signal }),
     });
-    workspaceOpened = true;
+  } catch (error) {
+    cleanupAgentLaunchBestEffort({
+      cleanup: cleanupAgentLaunch,
+      context: `resume rollback for ${task}`,
+    });
+    try {
+      removeStagedPrompt(stagedPrompt.directory);
+    } catch (cleanupError) {
+      log(
+        `Staged prompt cleanup failed during resume rollback for ${task}: ${errorMessage(cleanupError)}`,
+      );
+    }
+    throw error;
+  }
+
+  let stateProblem: LifecycleProblem | undefined;
+  try {
     recordRunState({
       config,
       state: {
@@ -328,41 +443,224 @@ export async function resumeWorkspace(
       },
     });
   } catch (error) {
-    if (workspaceOpened) {
-      try {
-        const result = await workspaces.close(config, task);
-        if (result.kind === "unavailable") {
-          const detail =
-            result.error === undefined
-              ? "workspace backend unavailable"
-              : errorMessage(result.error);
-          log(
-            `Workspace close was not confirmed during resume rollback for ${task}: ${detail}. Close it manually in the configured workspace backend.`,
-          );
-        }
-      } catch (closeError) {
-        log(
-          `Workspace close failed during resume rollback for ${task}: ${errorMessage(closeError)}. Close it manually in the configured workspace backend.`,
-        );
-      }
-    }
-    cleanupAgentLaunchBestEffort({
-      cleanup: cleanupAgentLaunch,
-      context: `resume rollback for ${task}`,
-    });
-    try {
-      removeStagedPrompt(stagedPrompt.directory);
-    } catch (cleanupError) {
-      log(
-        `Staged prompt cleanup failed during resume rollback for ${task}: ${errorMessage(cleanupError)}`,
-      );
-    }
-    throw error;
+    stateProblem = {
+      code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+      message: `Workspace resumed but run state could not be updated: ${errorMessage(error)}`,
+    };
   }
-  log(`Resumed ${task} in ${context.worktree.dir} (${context.agent})`);
+  const cancelled = runOptions.signal?.aborted === true;
+  return {
+    action: "resume",
+    task: {
+      id: task,
+      canonicalId: context.completionTaskId,
+      ...(context.url === undefined ? {} : { url: context.url }),
+    },
+    outcome: stateProblem === undefined && !cancelled ? "resumed" : "partial",
+    state: "resumed",
+    resources: resourcesFromResumeContext(context),
+    problems: [
+      ...(cancelled
+        ? [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.cancelled,
+              message: "Resume was cancelled after the workspace opened.",
+            },
+          ]
+        : []),
+      ...(stateProblem === undefined ? [] : [stateProblem]),
+    ],
+  };
 }
 
-export async function resumeWorkspaceCli(argv: string[]): Promise<void> {
+export async function resumeWorkspaceCli(argv: string[]): Promise<ResumeResult> {
+  const parsed = parseArguments(argv);
   const config = await loadConfig();
-  await resumeWorkspace(config, parseArguments(argv));
+  return await executeLifecycleMutation({
+    config,
+    task: parsed.options.task,
+    json: parsed.json,
+    conflictResult: () => resumeLockConflictResult({ config, task: parsed.options.task }),
+    operation: async ({ signal }) => await resumeWorkspace(config, parsed.options, { signal }),
+    cancelledResult: async (context) =>
+      await cancelledResumeResult({ config, task: parsed.options.task, context }),
+  });
+}
+
+function resumeClassifiedResult(arguments_: {
+  task: string;
+  state: RunState | undefined;
+  resources: LifecycleResources;
+  outcome: ResumeResult["outcome"];
+  lifecycleState: ResumeResult["state"];
+  problems: LifecycleProblem[];
+}): ResumeResult {
+  return {
+    action: "resume",
+    task: resumeTaskIdentity(arguments_.task, arguments_.state),
+    outcome: arguments_.outcome,
+    state: arguments_.lifecycleState,
+    resources: arguments_.resources,
+    problems: arguments_.problems,
+  };
+}
+
+function resumeTaskIdentity(task: string, state: RunState | undefined): ResumeResult["task"] {
+  return {
+    id: task,
+    ...(state?.completionTaskId === undefined ? {} : { canonicalId: state.completionTaskId }),
+    ...(state?.url === undefined ? {} : { url: state.url }),
+  };
+}
+
+function resumeResourcesFromLocal(arguments_: {
+  state: RunState | undefined;
+  entries: readonly WorktreeEntry[];
+}): LifecycleResources {
+  const entry =
+    arguments_.state === undefined
+      ? arguments_.entries[0]
+      : (arguments_.entries.find(
+          (candidate) => candidate.repository === arguments_.state?.repository,
+        ) ?? arguments_.entries[0]);
+  const repository = arguments_.state?.repository ?? entry?.repository;
+  const branch = arguments_.state?.branchName ?? entry?.branchName;
+  const worktreeDir = arguments_.state?.worktreeDir ?? entry?.dir;
+  return {
+    ...(repository === undefined ? {} : { repository }),
+    ...(branch === undefined ? {} : { branch }),
+    ...(worktreeDir === undefined ? {} : { worktreeDir }),
+    ...(arguments_.state?.agent === undefined ? {} : { agent: arguments_.state.agent }),
+  };
+}
+
+function resourcesFromResumeContext(context: ResumeContext): LifecycleResources {
+  return {
+    repository: context.repository,
+    branch: context.worktree.branchName,
+    worktreeDir: context.worktree.dir,
+    workspace: { name: context.task },
+    agent: context.agent,
+  };
+}
+
+function resumeLockConflictResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+}): ResumeResult {
+  const state = readRunState(arguments_.config, arguments_.task);
+  return resumeClassifiedResult({
+    task: arguments_.task,
+    state,
+    resources: resumeResourcesFromLocal({
+      state,
+      entries: worktrees.findByTask(arguments_.config, arguments_.task),
+    }),
+    outcome: "conflict",
+    lifecycleState: state?.state ?? "unknown",
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.lifecycleLockHeld,
+        message: "Another lifecycle mutation owns this task.",
+      },
+    ],
+  });
+}
+
+function reconciledResumeRunState(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  state: RunState | undefined;
+  repository: string;
+  worktreeDir: string;
+  branchName: string;
+}): Parameters<typeof recordRunState>[0]["state"] {
+  return {
+    task: arguments_.task,
+    repository: arguments_.repository,
+    agent: arguments_.state?.agent ?? arguments_.config.agents.default,
+    worktreeDir: arguments_.worktreeDir,
+    branchName: arguments_.branchName,
+    workspaceName: arguments_.state?.workspaceName ?? arguments_.task,
+    state: "resumed",
+    resumeCount: (arguments_.state?.resumeCount ?? 0) + 1,
+    ...(arguments_.state?.completionTaskId === undefined
+      ? {}
+      : { completionTaskId: arguments_.state.completionTaskId }),
+    ...(arguments_.state?.url === undefined ? {} : { url: arguments_.state.url }),
+    ...(arguments_.state?.reason === undefined ? {} : { reason: arguments_.state.reason }),
+  };
+}
+
+function reconcileCancelledResumeState(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  state: RunState | undefined;
+  entries: readonly WorktreeEntry[];
+  isLive: boolean;
+}): LifecycleProblem | undefined {
+  if (!arguments_.isLive) {
+    return undefined;
+  }
+  const [entry] = arguments_.entries;
+  const repository = arguments_.state?.repository ?? entry?.repository;
+  const worktreeDir = arguments_.state?.worktreeDir ?? entry?.dir;
+  const branchName = arguments_.state?.branchName ?? entry?.branchName;
+  if (repository === undefined || worktreeDir === undefined || branchName === undefined) {
+    return undefined;
+  }
+  try {
+    recordRunState({
+      config: arguments_.config,
+      state: reconciledResumeRunState({
+        config: arguments_.config,
+        task: arguments_.task,
+        state: arguments_.state,
+        repository,
+        worktreeDir,
+        branchName,
+      }),
+    });
+    return undefined;
+  } catch (error) {
+    return {
+      code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+      message: `Live resumed workspace could not be reconciled to run state: ${errorMessage(error)}`,
+    };
+  }
+}
+
+async function cancelledResumeResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  context: LifecycleCancellationContext;
+}): Promise<ResumeResult> {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const entries = worktrees.findByTask(arguments_.config, arguments_.task);
+  const probe = await workspaces.probe(arguments_.config);
+  const isLive = probe.kind === "ok" && probe.names.has(arguments_.task);
+  const stateProblem = reconcileCancelledResumeState({
+    config: arguments_.config,
+    task: arguments_.task,
+    state,
+    entries,
+    isLive,
+  });
+  return resumeClassifiedResult({
+    task: arguments_.task,
+    state,
+    resources: {
+      ...resumeResourcesFromLocal({ state, entries }),
+      ...(isLive ? { workspace: { name: arguments_.task } } : {}),
+    },
+    outcome: "partial",
+    lifecycleState: isLive ? "resumed" : (state?.state ?? "unknown"),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.cancelled,
+        message: `Resume cancelled${lifecycleCancellationSuffix(arguments_.context)}.`,
+      },
+      ...(stateProblem === undefined ? [] : [stateProblem]),
+    ],
+  });
 }

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -2164,6 +2164,60 @@ describe(setupWorkspaceCli, () => {
     }
   });
 
+  it("contends on the resolved task lock when start was invoked with a unique prefix", async () => {
+    defaultBoard.resolveOne.mockResolvedValueOnce(
+      canonicalLinearIssue({
+        naturalId: "team-1",
+        repository: "repo-a",
+        agent: "claude",
+        url: "https://linear.app/team-1",
+      }),
+    );
+    const resolvedLock = requireAcquiredLock(
+      acquireLifecycleLock({ config: makeConfig(), task: "team-1" }),
+    );
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team", { json: true });
+
+      expect(defaultBoard.resolveOne).toHaveBeenCalledWith("team");
+      expect(actual).toMatchObject({
+        action: "start",
+        task: {
+          id: "team-1",
+          canonicalId: "linear:team-1",
+          url: "https://linear.app/team-1",
+        },
+        outcome: "conflict",
+        problems: [{ code: "lifecycle-lock-held" }],
+      });
+      expect(createMock).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+      resolvedLock.release();
+    }
+  });
+
+  it("releases the resolved task lock after a unique-prefix start completes", async () => {
+    const consoleLog = captureConsoleLog();
+
+    try {
+      await expect(setupWorkspaceCli("team", { json: true })).resolves.toMatchObject({
+        outcome: "started",
+        task: { id: "team-1" },
+      });
+
+      const next = requireAcquiredLock(
+        acquireLifecycleLock({ config: makeConfig(), task: "team-1" }),
+      );
+      next.release();
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
   it("returns already-running for the same live task", async () => {
     findByTaskMock.mockReturnValue([hostEntry()]);
     runCommandMock.mockImplementation((command, arguments_) => {

--- a/src/commands/setupWorkspace.test.ts
+++ b/src/commands/setupWorkspace.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable eslint/max-lines -- lifecycle variants share this command's existing setup harness */
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type * as nodeFs from "node:fs";
 import path from "node:path";
@@ -5,7 +6,7 @@ import { ensureClearance, type SafehouseCmuxIntegration } from "@clipboard-healt
 import type { RunCommandOptions } from "../lib/commandRunner.ts";
 import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
 import { detectHostCapabilities, type HostCapabilities } from "../lib/host.ts";
-import { recordRunState } from "../lib/runState.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { canonicalLinearIssue, canonicalShellIssue } from "../lib/testing/canonicalFixtures.ts";
 import { createBoard, type Board } from "../lib/board.ts";
 import type * as boardModule from "../lib/board.ts";
@@ -17,6 +18,7 @@ import { debug, log } from "../lib/util.ts";
 import { WorktreeAlreadyExistsError, type WorktreeEntry, worktrees } from "../lib/worktrees.ts";
 import { deleteEnvironmentVariable, setEnvironmentVariable } from "../testHelpers/env.ts";
 import { safehouseCmuxIntegrationFixture } from "../testHelpers/safehouseCmuxIntegration.ts";
+import { captureConsoleLog } from "../testHelpers/consoleCapture.ts";
 import { emptyTeardownResult } from "../testHelpers/teardownResult.ts";
 import {
   setupWorkspace,
@@ -24,6 +26,7 @@ import {
   type SetupWorkspaceOptions,
   type TaskDetails,
 } from "./setupWorkspace.ts";
+import { acquireLifecycleLock } from "./lifecycleCommand.ts";
 
 interface NodeFsMock extends Omit<
   typeof nodeFs,
@@ -83,7 +86,11 @@ vi.mock(import("../lib/commandRunner.ts"), async (importOriginal) => {
 });
 vi.mock(import("../lib/runState.ts"), async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, recordRunState: vi.fn<typeof recordRunState>() };
+  return {
+    ...actual,
+    readRunState: vi.fn<typeof readRunState>(),
+    recordRunState: vi.fn<typeof recordRunState>(),
+  };
 });
 vi.mock(import("../lib/util.ts"), async (importOriginal) => {
   const actual = await importOriginal<typeof utilModule>();
@@ -143,6 +150,7 @@ const detectHostMock = vi.mocked(detectHostCapabilities);
 const ensureClearanceMock = vi.mocked(ensureClearance);
 const logMock = vi.mocked(log);
 const debugMock = vi.mocked(debug);
+const readRunStateMock = vi.mocked(readRunState);
 const recordRunStateMock = vi.mocked(recordRunState);
 const createMock = vi.mocked(worktrees.create);
 const teardownMock = vi.mocked(worktrees.teardown);
@@ -184,6 +192,15 @@ function hostEntry(): WorktreeEntry {
   };
 }
 
+function requireAcquiredLock(
+  lock: ReturnType<typeof acquireLifecycleLock>,
+): Extract<ReturnType<typeof acquireLifecycleLock>, { kind: "acquired" }> {
+  if (lock.kind !== "acquired") {
+    throw new Error("test could not acquire lifecycle lock");
+  }
+  return lock;
+}
+
 function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): ResolvedConfig {
   return {
     sources: [],
@@ -217,7 +234,7 @@ function makeConfig(overrides: Partial<ResolvedConfig["agents"]> = {}): Resolved
       safehouse: { enable: [] },
       readOnlyDirs: [],
     },
-    logging: { file: "/tmp/groundcrew-test.log" },
+    logging: { file: "/tmp/groundcrew-setup-workspace-test.log" },
   };
 }
 
@@ -1311,35 +1328,40 @@ describe(setupWorkspace, () => {
     });
   });
 
-  it("logs the tmux access hint after launch so the user knows how to reach the workspace", async () => {
+  it("returns the tmux access hint after launch so the renderer can show it", async () => {
     mockTmuxHost();
     const config = makeConfig();
 
-    await setupWorkspace(config, {
+    const actual = await setupWorkspace(config, {
       task: "team-1",
       repository: "repo-a",
       agent: "claude",
       details: { title: "Test Title", description: "Body" },
     });
 
-    expect(debugMock).toHaveBeenCalledWith("  Attach:   tmux attach -t groundcrew:team-1");
+    expect(actual.resources.workspace?.accessCommand).toBe("tmux attach -t groundcrew:team-1");
   });
 
-  it("collapses the launch into a single success line naming agent and worktree", async () => {
+  it("returns the launch resources without printing final result text", async () => {
     mockTmuxHost();
     const config = makeConfig();
 
-    await setupWorkspace(config, {
+    const actual = await setupWorkspace(config, {
       task: "team-1",
       repository: "repo-a",
       agent: "claude",
       details: { title: "Test Title", description: "Body" },
     });
 
-    expect(logMock).toHaveBeenCalledWith('✓ "team-1" launched (claude)  worktree repo-a-team-1');
-    // The verbose-only detail lines must not reach the important (log) tier.
-    expect(logMock).not.toHaveBeenCalledWith(expect.stringMatching(/^ {2}(?:Worktree|Branch):/));
-    expect(logMock).not.toHaveBeenCalledWith("Opening workspace...");
+    expect(actual).toMatchObject({
+      outcome: "started",
+      resources: {
+        agent: "claude",
+        worktreeDir: "/work/repo-a-team-1",
+        branch: "dev-team-1",
+      },
+    });
+    expect(logMock).not.toHaveBeenCalledWith(expect.stringContaining("launched"));
   });
 
   it("omits the access hint when the backend has no external hint (cmux)", async () => {
@@ -1805,7 +1827,7 @@ describe(setupWorkspace, () => {
         agent: "claude",
         details: { title: "Test Title", description: "Body" },
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ outcome: "started" });
 
     expect(runCommandMock).not.toHaveBeenCalledWith(
       "cmux",
@@ -2063,7 +2085,214 @@ describe(setupWorkspaceCli, () => {
   });
 
   afterEach(() => {
+    process.exitCode = undefined;
     vi.resetAllMocks();
+  });
+
+  it("returns and emits a single structured start receipt in JSON mode", async () => {
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team-1", { json: true });
+
+      expect(actual).toMatchObject({
+        action: "start",
+        task: { id: "team-1", canonicalId: "linear:team-1" },
+        outcome: "started",
+        state: "running",
+        resources: {
+          repository: "repo-a",
+          branch: "dev-team-1",
+          worktreeDir: "/work/repo-a-team-1",
+          workspace: { name: "team-1" },
+        },
+        problems: [],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(JSON.parse(consoleLog.output())).toStrictEqual(actual);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reports task-source writeback failure as partial after local launch", async () => {
+    defaultBoard.markInProgress.mockRejectedValueOnce(new Error("source unavailable"));
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team-1", { json: true });
+
+      expect(actual).toMatchObject({
+        action: "start",
+        outcome: "partial",
+        state: "running",
+        problems: [
+          {
+            code: "task-status-update-failed",
+            message: expect.stringContaining("source unavailable"),
+          },
+        ],
+      });
+      expect(createMock).toHaveBeenCalledTimes(1);
+      expect(process.exitCode).toBe(1);
+      expect(consoleLog.calls).toHaveLength(1);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("returns a stable conflict receipt when another lifecycle command owns the task", async () => {
+    const lock = requireAcquiredLock(
+      acquireLifecycleLock({ config: makeConfig(), task: "team-1" }),
+    );
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team-1", { json: true });
+
+      expect(actual).toMatchObject({
+        action: "start",
+        outcome: "conflict",
+        problems: [{ code: "lifecycle-lock-held" }],
+      });
+      expect(createBoardMock).not.toHaveBeenCalled();
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+      lock.release();
+    }
+  });
+
+  it("returns already-running for the same live task", async () => {
+    findByTaskMock.mockReturnValue([hostEntry()]);
+    runCommandMock.mockImplementation((command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- mock routes the workspace inventory command
+      if (command === "cmux" && arguments_.includes("list-workspaces")) {
+        return JSON.stringify({
+          workspaces: [
+            {
+              title: "Task",
+              ref: "workspace:1",
+              description: "groundcrew:team-1",
+            },
+          ],
+        });
+      }
+      return JSON.stringify({ ref: "workspace:1" });
+    });
+
+    const actual = await setupWorkspaceCli("team-1", { json: true });
+
+    expect(actual).toMatchObject({ outcome: "already-running", state: "running" });
+    expect(createMock).not.toHaveBeenCalled();
+    expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict for a stale task worktree", async () => {
+    findByTaskMock.mockReturnValue([hostEntry()]);
+
+    const actual = await setupWorkspaceCli("team-1", { json: true });
+
+    expect(actual).toMatchObject({
+      outcome: "conflict",
+      problems: [{ code: "worktree-conflict" }],
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict for a live workspace without matching local context", async () => {
+    findByTaskMock.mockReturnValue([]);
+    runCommandMock.mockImplementation((command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- mock routes the workspace inventory command
+      if (command === "cmux" && arguments_.includes("list-workspaces")) {
+        return JSON.stringify({
+          workspaces: [{ title: "Task", ref: "workspace:1", description: "groundcrew:team-1" }],
+        });
+      }
+      return JSON.stringify({ ref: "workspace:1" });
+    });
+
+    const actual = await setupWorkspaceCli("team-1", { json: true });
+
+    expect(actual).toMatchObject({
+      outcome: "conflict",
+      state: "running",
+      problems: [{ code: "workspace-conflict" }],
+    });
+  });
+
+  it("uses persisted state as the best observed context for an already-live task", async () => {
+    const persisted: RunState = {
+      task: "team-1",
+      repository: "repo-a",
+      agent: "claude",
+      worktreeDir: "/persisted/team-1",
+      branchName: "persisted-branch",
+      workspaceName: "team-1",
+      state: "resumed",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      resumeCount: 2,
+    };
+    readRunStateMock.mockReturnValue(persisted);
+    findByTaskMock.mockReturnValue([hostEntry()]);
+    runCommandMock.mockImplementation((command, arguments_) => {
+      // oxlint-disable-next-line vitest/no-conditional-in-test -- mock routes the workspace inventory command
+      if (command === "cmux" && arguments_.includes("list-workspaces")) {
+        return JSON.stringify({
+          workspaces: [{ title: "Task", ref: "workspace:1", description: "groundcrew:team-1" }],
+        });
+      }
+      return JSON.stringify({ ref: "workspace:1" });
+    });
+
+    const actual = await setupWorkspaceCli("team-1", { json: true });
+
+    expect(actual).toMatchObject({
+      outcome: "already-running",
+      state: "resumed",
+      resources: {
+        repository: "repo-a",
+        branch: "persisted-branch",
+        worktreeDir: "/persisted/team-1",
+        workspace: { name: "team-1" },
+        agent: "claude",
+      },
+    });
+  });
+
+  it("falls back to the first worktree when persisted repository context has no match", async () => {
+    readRunStateMock.mockReturnValue({
+      task: "team-1",
+      repository: "repo-b",
+      agent: "claude",
+      worktreeDir: "/persisted/team-1",
+      branchName: "persisted-branch",
+      workspaceName: "team-1",
+      state: "interrupted",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      resumeCount: 0,
+    });
+    findByTaskMock.mockReturnValue([hostEntry()]);
+
+    await expect(setupWorkspaceCli("team-1", { json: true })).resolves.toMatchObject({
+      outcome: "conflict",
+      resources: { repository: "repo-b" },
+    });
+  });
+
+  it("returns conflict when existing workspace status cannot be verified", async () => {
+    mockCmuxFailure();
+
+    const actual = await setupWorkspaceCli("team-1", { json: true });
+
+    expect(actual).toMatchObject({
+      outcome: "conflict",
+      problems: [{ code: "workspace-status-unavailable" }],
+    });
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   it("resolves the task via Board and provisions the workspace", async () => {
@@ -2074,10 +2303,12 @@ describe(setupWorkspaceCli, () => {
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ repository: "repo-a", task: "team-1" }),
+      expect.any(AbortSignal),
     );
     expect(runCommandMock).toHaveBeenCalledWith(
       "cmux",
       expect.arrayContaining(["set-status", "agent", "claude"]),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
@@ -2127,13 +2358,12 @@ describe(setupWorkspaceCli, () => {
   });
 
   it("does not provision or mark In Progress in dry-run mode", async () => {
-    await setupWorkspaceCli("team-1", { dryRun: true });
+    const actual = await setupWorkspaceCli("team-1", { dryRun: true });
 
     expect(createMock).not.toHaveBeenCalled();
     expect(runCommandMock).not.toHaveBeenCalled();
     expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
-    const logged = logMock.mock.calls.map(([message]) => message).join("\n");
-    expect(logged).toContain("[dry-run] Would launch team-1 in repo-a (claude)");
+    expect(actual).toMatchObject({ outcome: "dry-run" });
   });
 
   it("reports skipped worktree preparation in dry-run mode", async () => {
@@ -2148,10 +2378,9 @@ describe(setupWorkspaceCli, () => {
       ),
     );
 
-    await setupWorkspaceCli("team-1", { dryRun: true });
+    const actual = await setupWorkspaceCli("team-1", { dryRun: true });
 
-    const logged = logMock.mock.calls.map(([message]) => message).join("\n");
-    expect(logged).toContain("prepareWorktree skipped");
+    expect(actual.resources.worktreePreparation).toBe("skip");
   });
 
   it("does not mark the task In Progress when workspace setup fails", async () => {
@@ -2160,6 +2389,53 @@ describe(setupWorkspaceCli, () => {
     await expect(setupWorkspaceCli("team-1")).rejects.toThrow(/worktree failed/);
 
     expect(defaultBoard.markInProgress).not.toHaveBeenCalled();
+  });
+
+  it("returns a partial receipt when cooperative cancellation interrupts provisioning", async () => {
+    createMock.mockImplementationOnce(async () => {
+      process.listeners("SIGTERM").at(-1)?.("SIGTERM");
+      throw new Error("Signal: SIGTERM");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team-1", { json: true });
+
+      expect(actual).toMatchObject({
+        action: "start",
+        outcome: "partial",
+        problems: [{ code: "cancelled", message: expect.stringContaining("SIGTERM") }],
+      });
+      expect(consoleLog.calls).toHaveLength(1);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      consoleLog.restore();
+    }
+  });
+
+  it("reports a live workspace observed during cancellation reconciliation", async () => {
+    runCommandMock.mockReturnValueOnce(JSON.stringify({ workspaces: [] })).mockReturnValue(
+      JSON.stringify({
+        workspaces: [{ title: "Task", ref: "workspace:1", description: "groundcrew:team-1" }],
+      }),
+    );
+    createMock.mockImplementationOnce(async () => {
+      process.listeners("SIGINT").at(-1)?.("SIGINT");
+      throw new Error("Signal: SIGINT");
+    });
+    const consoleLog = captureConsoleLog();
+
+    try {
+      const actual = await setupWorkspaceCli("team-1", { json: true });
+
+      expect(actual).toMatchObject({
+        outcome: "partial",
+        state: "running",
+        resources: { workspace: { name: "team-1" } },
+      });
+    } finally {
+      consoleLog.restore();
+    }
   });
 
   it("throws a clear error when the task is not found", async () => {
@@ -2183,7 +2459,7 @@ describe(setupWorkspaceCli, () => {
     buildSourcesMock.mockRejectedValueOnce(new Error("unknown source kind 'wat'"));
 
     await expect(setupWorkspaceCli("eng-1")).rejects.toThrow(
-      /Could not initialize task sources for 'crew setup eng-1': unknown source kind 'wat'/,
+      /Could not initialize task sources for 'crew start eng-1': unknown source kind 'wat'/,
     );
   });
 
@@ -2205,6 +2481,7 @@ describe(setupWorkspaceCli, () => {
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ task: "staff-508" }),
+      expect.any(AbortSignal),
     );
   });
 
@@ -2292,6 +2569,7 @@ describe(setupWorkspaceCli, () => {
     expect(createMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ task: "team-1" }),
+      expect.any(AbortSignal),
     );
   });
 });

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -26,9 +26,11 @@ import {
 } from "../lib/worktrees.ts";
 import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 import {
+  acquireLifecycleLock,
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
   loadLifecycleConfig,
+  probeWorkspaceForLifecycleReconciliation,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -510,7 +512,7 @@ export async function setupWorkspaceCli(
     json: options.json === true,
     conflictResult: () => startLockConflictResult({ config, task: localTask }),
     operation: async (context) =>
-      await startLifecycle({ config, taskArgument: task, options, context }),
+      await startLifecycle({ config, taskArgument: task, lockedTask: localTask, options, context }),
     cancelledResult: async (context) =>
       await cancelledStartResult({ config, task: localTask, context }),
   });
@@ -519,10 +521,11 @@ export async function setupWorkspaceCli(
 async function startLifecycle(arguments_: {
   config: ResolvedConfig;
   taskArgument: string;
+  lockedTask: string;
   options: { dryRun?: boolean };
   context: LifecycleCancellationContext;
 }): Promise<StartResult> {
-  const { config, taskArgument, options, context } = arguments_;
+  const { config, taskArgument, lockedTask, options, context } = arguments_;
   const rawSources = sourcesFromConfig(config);
   let sources;
   try {
@@ -550,79 +553,95 @@ async function startLifecycle(arguments_: {
   }
 
   const naturalId = naturalIdFromCanonical(resolved.id).toLowerCase();
-  log(`Resolved ${taskArgument}: repository=${resolved.repository}, agent=${resolved.agent}`);
-
-  if (options.dryRun === true) {
-    const predicted = worktrees.predictedEntry(config, resolved.repository, naturalId);
-    return {
-      action: "start",
-      task: lifecycleTaskIdentity({
-        task: naturalId,
-        canonicalId: resolved.id,
-        url: resolved.url,
-      }),
-      outcome: "dry-run",
-      state: observedState(readRunState(config, naturalId)),
-      resources: {
-        repository: resolved.repository,
-        branch: predicted.branchName,
-        worktreeDir: predicted.worktreeDir,
-        agent: resolved.agent,
-        ...(resolved.worktreePreparation === "skip" ? { worktreePreparation: "skip" } : {}),
-      },
-      problems: [],
-    };
-  }
-
-  const existing = await existingStartResult({
-    config,
-    task: naturalId,
-    canonicalId: resolved.id,
-    url: resolved.url,
-    repository: resolved.repository,
-    signal: context.signal,
-  });
-  if (existing !== undefined) {
-    return existing;
-  }
-
-  const result = await setupWorkspace(
-    config,
-    {
+  const resolvedLock =
+    naturalId === lockedTask ? undefined : acquireLifecycleLock({ config, task: naturalId });
+  if (resolvedLock?.kind === "conflict") {
+    return startLockConflictResult({
+      config,
       task: naturalId,
-      completionTaskId: resolved.id,
-      completionMarkDoneSupported: sourceSupportsMarkDone({
-        rawSources,
-        sourceName: resolved.source,
-      }),
-      repository: resolved.repository,
-      agent: resolved.agent,
-      ...(resolved.worktreePreparation === undefined
-        ? {}
-        : { worktreePreparation: resolved.worktreePreparation }),
-      details: {
-        title: resolved.title,
-        description: resolved.description,
-        ...(resolved.url === undefined ? {} : { url: resolved.url }),
-      },
-    },
-    { signal: context.signal },
-  );
+      canonicalId: resolved.id,
+      url: resolved.url,
+    });
+  }
   try {
-    await board.markInProgress(resolved);
-    return result;
-  } catch (error) {
-    return {
-      ...result,
-      outcome: "partial",
-      problems: [
-        ...result.problems,
-        {
-          code: LIFECYCLE_PROBLEM_CODES.taskStatusUpdateFailed,
-          message: `Task status update failed: ${errorMessage(error)}`,
+    log(`Resolved ${taskArgument}: repository=${resolved.repository}, agent=${resolved.agent}`);
+
+    if (options.dryRun === true) {
+      const predicted = worktrees.predictedEntry(config, resolved.repository, naturalId);
+      return {
+        action: "start",
+        task: lifecycleTaskIdentity({
+          task: naturalId,
+          canonicalId: resolved.id,
+          url: resolved.url,
+        }),
+        outcome: "dry-run",
+        state: observedState(readRunState(config, naturalId)),
+        resources: {
+          repository: resolved.repository,
+          branch: predicted.branchName,
+          worktreeDir: predicted.worktreeDir,
+          agent: resolved.agent,
+          ...(resolved.worktreePreparation === "skip" ? { worktreePreparation: "skip" } : {}),
         },
-      ],
-    };
+        problems: [],
+      };
+    }
+
+    const existing = await existingStartResult({
+      config,
+      task: naturalId,
+      canonicalId: resolved.id,
+      url: resolved.url,
+      repository: resolved.repository,
+      signal: context.signal,
+    });
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const result = await setupWorkspace(
+      config,
+      {
+        task: naturalId,
+        completionTaskId: resolved.id,
+        completionMarkDoneSupported: sourceSupportsMarkDone({
+          rawSources,
+          sourceName: resolved.source,
+        }),
+        repository: resolved.repository,
+        agent: resolved.agent,
+        ...(resolved.worktreePreparation === undefined
+          ? {}
+          : { worktreePreparation: resolved.worktreePreparation }),
+        details: {
+          title: resolved.title,
+          description: resolved.description,
+          ...(resolved.url === undefined ? {} : { url: resolved.url }),
+        },
+      },
+      { signal: context.signal },
+    );
+    try {
+      await board.markInProgress(resolved);
+      return result;
+    } catch (error) {
+      return {
+        ...result,
+        outcome: "partial",
+        problems: [
+          ...result.problems,
+          {
+            code: LIFECYCLE_PROBLEM_CODES.taskStatusUpdateFailed,
+            message: `Task status update failed: ${errorMessage(error)}`,
+          },
+        ],
+      };
+    }
+  } finally {
+    if (resolvedLock?.kind === "acquired") {
+      resolvedLock.release();
+    }
   }
 }
 
@@ -702,14 +721,16 @@ async function existingStartResult(arguments_: {
 function startLockConflictResult(arguments_: {
   config: ResolvedConfig;
   task: string;
+  canonicalId?: string;
+  url?: string | undefined;
 }): StartResult {
   const state = readRunState(arguments_.config, arguments_.task);
   return {
     action: "start",
     task: lifecycleTaskIdentity({
       task: arguments_.task,
-      canonicalId: state?.completionTaskId,
-      url: state?.url,
+      canonicalId: arguments_.canonicalId ?? state?.completionTaskId,
+      url: arguments_.url ?? state?.url,
     }),
     outcome: "conflict",
     state: observedState(state),
@@ -733,7 +754,7 @@ async function cancelledStartResult(arguments_: {
 }): Promise<StartResult> {
   const state = readRunState(arguments_.config, arguments_.task);
   const entries = worktrees.findByTask(arguments_.config, arguments_.task);
-  const probe = await workspaces.probe(arguments_.config);
+  const probe = await probeWorkspaceForLifecycleReconciliation(arguments_.config);
   return {
     action: "start",
     task: lifecycleTaskIdentity({

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -1,4 +1,4 @@
-import { loadConfig, type ResolvedConfig } from "../lib/config.ts";
+import type { ResolvedConfig } from "../lib/config.ts";
 import { composeAgentLaunch, openAgentWorkspace, prepareAgentLaunch } from "../lib/agentLaunch.ts";
 import { inferAgentCommandName, workerEnvironmentForTask } from "../lib/launchCommand.ts";
 import { type Board, createBoard } from "../lib/board.ts";
@@ -28,6 +28,7 @@ import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
 import {
   executeLifecycleMutation,
   lifecycleCancellationSuffix,
+  loadLifecycleConfig,
   type LifecycleCancellationContext,
 } from "./lifecycleCommand.ts";
 import {
@@ -501,7 +502,7 @@ export async function setupWorkspaceCli(
   task: string,
   options: { dryRun?: boolean; json?: boolean } = {},
 ): Promise<StartResult> {
-  const config = await loadConfig();
+  const config = await loadLifecycleConfig(options.json === true);
   const localTask = naturalIdFromCanonical(task).toLowerCase();
   return await executeLifecycleMutation({
     config,

--- a/src/commands/setupWorkspace.ts
+++ b/src/commands/setupWorkspace.ts
@@ -4,7 +4,7 @@ import { inferAgentCommandName, workerEnvironmentForTask } from "../lib/launchCo
 import { type Board, createBoard } from "../lib/board.ts";
 import { buildSources, sourcesFromConfig } from "../lib/buildSources.ts";
 import { resolveRepositoryPreparationCommands } from "../lib/repositoryHooks.ts";
-import { recordRunState } from "../lib/runState.ts";
+import { readRunState, recordRunState, type RunState } from "../lib/runState.ts";
 import { seedLaunchWorkspaceTrust } from "../lib/seedLaunchWorkspaceTrust.ts";
 import { sourceSupportsMarkDone } from "../lib/sourceCapabilities.ts";
 import {
@@ -16,7 +16,7 @@ import {
 } from "../lib/stagedLaunch.ts";
 import { taskSourceWritePathsForCompletion } from "../lib/taskSourceFilesystem.ts";
 import { naturalIdFromCanonical, type WorktreePreparation } from "../lib/taskSource.ts";
-import { debug, errorMessage, log, okMark } from "../lib/util.ts";
+import { debug, errorMessage, log, withConsoleOutputSuppressed } from "../lib/util.ts";
 import { type WorkspaceAccessHint, workspaces } from "../lib/workspaces.ts";
 import {
   resolveLaunchDir,
@@ -25,6 +25,17 @@ import {
   worktrees,
 } from "../lib/worktrees.ts";
 import { cleanupAgentLaunchBestEffort } from "./agentLaunchCleanup.ts";
+import {
+  executeLifecycleMutation,
+  lifecycleCancellationSuffix,
+  type LifecycleCancellationContext,
+} from "./lifecycleCommand.ts";
+import {
+  LIFECYCLE_PROBLEM_CODES,
+  type LifecycleProblem,
+  type LifecycleResources,
+  type StartResult,
+} from "./lifecycleResult.ts";
 
 export interface TaskDetails {
   title: string;
@@ -75,7 +86,17 @@ export async function setupWorkspace(
   config: ResolvedConfig,
   options: SetupWorkspaceOptions,
   runOptions: SetupWorkspaceRunOptions = {},
-): Promise<void> {
+): Promise<StartResult> {
+  return await withConsoleOutputSuppressed(
+    async () => await setupWorkspaceOperation(config, options, runOptions),
+  );
+}
+
+async function setupWorkspaceOperation(
+  config: ResolvedConfig,
+  options: SetupWorkspaceOptions,
+  runOptions: SetupWorkspaceRunOptions,
+): Promise<StartResult> {
   const { task, repository, agent } = options;
   const { signal } = runOptions;
   const definition = config.agents.definitions[agent];
@@ -124,11 +145,12 @@ export async function setupWorkspace(
   // the task strands forever.
   let promptDir: string | undefined;
   let cleanupAgentLaunch: (() => void) | undefined;
+  let accessHint: WorkspaceAccessHint | undefined;
   try {
     await assertLaunchReady(readinessPromise);
 
     const taskDetails = options.details;
-    const accessHint = await workspaces.accessHint(config, task, signal);
+    accessHint = await workspaces.accessHint(config, task, signal);
 
     const stagedPrompt = stagePrompt({
       config,
@@ -204,7 +226,7 @@ export async function setupWorkspace(
       color: definition.color,
       ...(signal === undefined ? {} : { signal }),
     });
-    recordRunStateBestEffort({
+    const stateProblem = recordRunStateBestEffort({
       config,
       task,
       repository,
@@ -218,12 +240,27 @@ export async function setupWorkspace(
       ...(taskDetails.url === undefined ? {} : { url: taskDetails.url }),
     });
 
-    log(`${okMark()} "${task}" launched (${agent})  worktree ${worktreeName}`);
-    debug(`  Worktree: ${launchDir}`);
-    debug(`  Branch:   ${branchName}`);
-    if (accessHint !== undefined) {
-      logAccessHint(accessHint);
-    }
+    return {
+      action: "start",
+      task: lifecycleTaskIdentity({
+        task,
+        canonicalId: completionTaskId,
+        url: taskDetails.url,
+      }),
+      outcome: stateProblem === undefined ? "started" : "partial",
+      state: "running",
+      resources: {
+        repository,
+        branch: branchName,
+        worktreeDir,
+        workspace: {
+          name: task,
+          ...(accessHint === undefined ? {} : { accessCommand: accessHint.command }),
+        },
+        agent,
+      },
+      problems: stateProblem === undefined ? [] : [stateProblem],
+    };
   } catch (error) {
     cleanupAgentLaunchBestEffort({ cleanup: cleanupAgentLaunch, context: "setup rollback" });
     await rollbackWorktree({ config, entry: created, promptDir });
@@ -387,7 +424,7 @@ function recordRunStateBestEffort(arguments_: {
   detail?: string;
   url?: string;
   completionTaskId: string;
-}): void {
+}): LifecycleProblem | undefined {
   try {
     recordRunState({
       config: arguments_.config,
@@ -405,8 +442,13 @@ function recordRunStateBestEffort(arguments_: {
         ...(arguments_.url === undefined ? {} : { url: arguments_.url }),
       },
     });
+    return undefined;
   } catch (error) {
     log(`Run state update failed for ${arguments_.task}: ${errorMessage(error)}`);
+    return {
+      code: LIFECYCLE_PROBLEM_CODES.stateWriteFailed,
+      message: `Run state update failed: ${errorMessage(error)}`,
+    };
   }
 }
 
@@ -457,9 +499,29 @@ async function rollbackWorktree(arguments_: {
 
 export async function setupWorkspaceCli(
   task: string,
-  options: { dryRun?: boolean } = {},
-): Promise<void> {
+  options: { dryRun?: boolean; json?: boolean } = {},
+): Promise<StartResult> {
   const config = await loadConfig();
+  const localTask = naturalIdFromCanonical(task).toLowerCase();
+  return await executeLifecycleMutation({
+    config,
+    task: localTask,
+    json: options.json === true,
+    conflictResult: () => startLockConflictResult({ config, task: localTask }),
+    operation: async (context) =>
+      await startLifecycle({ config, taskArgument: task, options, context }),
+    cancelledResult: async (context) =>
+      await cancelledStartResult({ config, task: localTask, context }),
+  });
+}
+
+async function startLifecycle(arguments_: {
+  config: ResolvedConfig;
+  taskArgument: string;
+  options: { dryRun?: boolean };
+  context: LifecycleCancellationContext;
+}): Promise<StartResult> {
+  const { config, taskArgument, options, context } = arguments_;
   const rawSources = sourcesFromConfig(config);
   let sources;
   try {
@@ -467,52 +529,276 @@ export async function setupWorkspaceCli(
   } catch (error) {
     /* v8 ignore next @preserve -- catch re-throw always receives an Error; String(error) is an unreachable fallback */
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Could not initialize task sources for 'crew setup ${task}': ${message}`, {
-      cause: error,
-    });
+    throw new Error(
+      `Could not initialize task sources for 'crew start ${taskArgument}': ${message}`,
+      {
+        cause: error,
+      },
+    );
   }
   const board: Board = createBoard(sources);
 
-  const resolved = await board.resolveOne(task);
+  const resolved = await board.resolveOne(taskArgument);
   if (resolved === undefined) {
-    throw new Error(`Task ${task} not found across configured sources.`);
+    throw new Error(`Task ${taskArgument} not found across configured sources.`);
   }
   if (resolved.repository === undefined || resolved.agent === undefined) {
     throw new Error(
-      `Task ${task} resolved but isn't groundcrew-eligible (missing agent-* label or repository/agent).`,
+      `Task ${taskArgument} resolved but isn't groundcrew-eligible (missing agent-* label or repository/agent).`,
     );
   }
 
-  log(`Resolved ${task}: repository=${resolved.repository}, agent=${resolved.agent}`);
+  const naturalId = naturalIdFromCanonical(resolved.id).toLowerCase();
+  log(`Resolved ${taskArgument}: repository=${resolved.repository}, agent=${resolved.agent}`);
 
   if (options.dryRun === true) {
-    const preparationSuffix =
-      resolved.worktreePreparation === "skip" ? "; prepareWorktree skipped" : "";
-    log(
-      `[dry-run] Would launch ${task} in ${resolved.repository} (${resolved.agent})${preparationSuffix}`,
-    );
-    return;
+    const predicted = worktrees.predictedEntry(config, resolved.repository, naturalId);
+    return {
+      action: "start",
+      task: lifecycleTaskIdentity({
+        task: naturalId,
+        canonicalId: resolved.id,
+        url: resolved.url,
+      }),
+      outcome: "dry-run",
+      state: observedState(readRunState(config, naturalId)),
+      resources: {
+        repository: resolved.repository,
+        branch: predicted.branchName,
+        worktreeDir: predicted.worktreeDir,
+        agent: resolved.agent,
+        ...(resolved.worktreePreparation === "skip" ? { worktreePreparation: "skip" } : {}),
+      },
+      problems: [],
+    };
   }
 
-  const naturalId = naturalIdFromCanonical(resolved.id);
-
-  await setupWorkspace(config, {
+  const existing = await existingStartResult({
+    config,
     task: naturalId,
-    completionTaskId: resolved.id,
-    completionMarkDoneSupported: sourceSupportsMarkDone({
-      rawSources,
-      sourceName: resolved.source,
-    }),
+    canonicalId: resolved.id,
+    url: resolved.url,
     repository: resolved.repository,
-    agent: resolved.agent,
-    ...(resolved.worktreePreparation === undefined
-      ? {}
-      : { worktreePreparation: resolved.worktreePreparation }),
-    details: {
-      title: resolved.title,
-      description: resolved.description,
-      ...(resolved.url === undefined ? {} : { url: resolved.url }),
-    },
+    signal: context.signal,
   });
-  await board.markInProgress(resolved);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const result = await setupWorkspace(
+    config,
+    {
+      task: naturalId,
+      completionTaskId: resolved.id,
+      completionMarkDoneSupported: sourceSupportsMarkDone({
+        rawSources,
+        sourceName: resolved.source,
+      }),
+      repository: resolved.repository,
+      agent: resolved.agent,
+      ...(resolved.worktreePreparation === undefined
+        ? {}
+        : { worktreePreparation: resolved.worktreePreparation }),
+      details: {
+        title: resolved.title,
+        description: resolved.description,
+        ...(resolved.url === undefined ? {} : { url: resolved.url }),
+      },
+    },
+    { signal: context.signal },
+  );
+  try {
+    await board.markInProgress(resolved);
+    return result;
+  } catch (error) {
+    return {
+      ...result,
+      outcome: "partial",
+      problems: [
+        ...result.problems,
+        {
+          code: LIFECYCLE_PROBLEM_CODES.taskStatusUpdateFailed,
+          message: `Task status update failed: ${errorMessage(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+async function existingStartResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  canonicalId: string;
+  url: string | undefined;
+  repository: string;
+  signal: AbortSignal;
+}): Promise<StartResult | undefined> {
+  const { config, task, canonicalId, url, repository, signal } = arguments_;
+  const state = readRunState(config, task);
+  const entries = worktrees.findByTask(config, task);
+  const probe = await workspaces.probe(config, signal);
+  const resources = startResourcesFromContext({ state, entries });
+  const identity = lifecycleTaskIdentity({ task, canonicalId, url: url ?? state?.url });
+  if (probe.kind === "unavailable") {
+    return {
+      action: "start",
+      task: identity,
+      outcome: "conflict",
+      state: observedState(state),
+      resources,
+      problems: [
+        {
+          code: LIFECYCLE_PROBLEM_CODES.workspaceStatusUnavailable,
+          message: "Could not verify whether the task workspace is already live.",
+        },
+      ],
+    };
+  }
+  if (probe.names.has(task)) {
+    const matchingContext =
+      state?.repository === repository || entries.some((entry) => entry.repository === repository);
+    return matchingContext
+      ? {
+          action: "start",
+          task: identity,
+          outcome: "already-running",
+          state: observedState(state, "running"),
+          resources: { ...resources, workspace: { name: task } },
+          problems: [],
+        }
+      : {
+          action: "start",
+          task: identity,
+          outcome: "conflict",
+          state: observedState(state, "running"),
+          resources: { ...resources, workspace: { name: task } },
+          problems: [
+            {
+              code: LIFECYCLE_PROBLEM_CODES.workspaceConflict,
+              message: "A live workspace exists without matching local task context.",
+            },
+          ],
+        };
+  }
+  if (state !== undefined || entries.length > 0) {
+    return {
+      action: "start",
+      task: identity,
+      outcome: "conflict",
+      state: observedState(state),
+      resources,
+      problems: [
+        {
+          code: LIFECYCLE_PROBLEM_CODES.worktreeConflict,
+          message: "Existing local state or a stale worktree must be reconciled before starting.",
+        },
+      ],
+    };
+  }
+  return undefined;
+}
+
+function startLockConflictResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+}): StartResult {
+  const state = readRunState(arguments_.config, arguments_.task);
+  return {
+    action: "start",
+    task: lifecycleTaskIdentity({
+      task: arguments_.task,
+      canonicalId: state?.completionTaskId,
+      url: state?.url,
+    }),
+    outcome: "conflict",
+    state: observedState(state),
+    resources: startResourcesFromContext({
+      state,
+      entries: worktrees.findByTask(arguments_.config, arguments_.task),
+    }),
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.lifecycleLockHeld,
+        message: "Another lifecycle mutation owns this task.",
+      },
+    ],
+  };
+}
+
+async function cancelledStartResult(arguments_: {
+  config: ResolvedConfig;
+  task: string;
+  context: LifecycleCancellationContext;
+}): Promise<StartResult> {
+  const state = readRunState(arguments_.config, arguments_.task);
+  const entries = worktrees.findByTask(arguments_.config, arguments_.task);
+  const probe = await workspaces.probe(arguments_.config);
+  return {
+    action: "start",
+    task: lifecycleTaskIdentity({
+      task: arguments_.task,
+      canonicalId: state?.completionTaskId,
+      url: state?.url,
+    }),
+    outcome: "partial",
+    state: observedState(
+      state,
+      probe.kind === "ok" && probe.names.has(arguments_.task) ? "running" : undefined,
+    ),
+    resources: {
+      ...startResourcesFromContext({ state, entries }),
+      ...(probe.kind === "ok" && probe.names.has(arguments_.task)
+        ? { workspace: { name: arguments_.task } }
+        : {}),
+    },
+    problems: [
+      {
+        code: LIFECYCLE_PROBLEM_CODES.cancelled,
+        message: `Start cancelled${lifecycleCancellationSuffix(arguments_.context)}.`,
+      },
+    ],
+  };
+}
+
+function lifecycleTaskIdentity(arguments_: {
+  task: string;
+  canonicalId?: string | undefined;
+  url?: string | undefined;
+}): StartResult["task"] {
+  return {
+    id: arguments_.task,
+    ...(arguments_.canonicalId === undefined ? {} : { canonicalId: arguments_.canonicalId }),
+    ...(arguments_.url === undefined ? {} : { url: arguments_.url }),
+  };
+}
+
+function startResourcesFromContext(arguments_: {
+  state: RunState | undefined;
+  entries: readonly WorktreeEntry[];
+}): LifecycleResources {
+  const entry =
+    arguments_.state === undefined
+      ? arguments_.entries[0]
+      : (arguments_.entries.find(
+          (candidate) => candidate.repository === arguments_.state?.repository,
+        ) ?? arguments_.entries[0]);
+  const repository = arguments_.state?.repository ?? entry?.repository;
+  const branch = arguments_.state?.branchName ?? entry?.branchName;
+  const worktreeDir = arguments_.state?.worktreeDir ?? entry?.dir;
+  return {
+    ...(repository === undefined ? {} : { repository }),
+    ...(branch === undefined ? {} : { branch }),
+    ...(worktreeDir === undefined ? {} : { worktreeDir }),
+    ...(arguments_.state?.workspaceName === undefined
+      ? {}
+      : { workspace: { name: arguments_.state.workspaceName } }),
+    ...(arguments_.state?.agent === undefined ? {} : { agent: arguments_.state.agent }),
+  };
+}
+
+function observedState(
+  state: RunState | undefined,
+  fallback?: StartResult["state"],
+): StartResult["state"] {
+  return state?.state ?? fallback ?? "absent";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,23 @@ export { orchestrate, type OrchestratorOptions } from "./commands/orchestrator.t
 export { resumeWorkspace, type ResumeWorkspaceOptions } from "./commands/resumeWorkspace.ts";
 export { setupWorkspace, type SetupWorkspaceOptions } from "./commands/setupWorkspace.ts";
 export { status, type StatusOptions } from "./commands/status.ts";
+export {
+  LIFECYCLE_PROBLEM_CODES,
+  lifecycleResultExitCode,
+  type CleanupResult,
+  type CleanupResources,
+  type CleanupWorkspaceResource,
+  type CleanupWorktreeResource,
+  type LifecycleProblem,
+  type LifecycleResources,
+  type LifecycleResult,
+  type LifecycleState,
+  type LifecycleTaskIdentity,
+  type LifecycleWorkspaceResource,
+  type ResumeResult,
+  type StartResult,
+  type StopResult,
+} from "./commands/lifecycleResult.ts";
 export type {
   Config,
   HookCommands,

--- a/src/lib/runStateCleanup.ts
+++ b/src/lib/runStateCleanup.ts
@@ -3,15 +3,23 @@ import { removeRunState } from "./runState.ts";
 import { debug, errorMessage } from "./util.ts";
 import type { WorktreeEntry } from "./worktrees.ts";
 
+export interface RunStateCleanupFailure {
+  task: string;
+  error: unknown;
+}
+
 export function recordCleanedUpRuns(
   config: ResolvedConfig,
   entries: readonly WorktreeEntry[],
-): void {
+): RunStateCleanupFailure[] {
+  const failures: RunStateCleanupFailure[] = [];
   for (const entry of entries) {
     try {
       removeRunState(config, entry.task);
     } catch (error) {
       debug(`Run state cleanup failed for ${entry.task}: ${errorMessage(error)}`);
+      failures.push({ task: entry.task, error });
     }
   }
+  return failures;
 }

--- a/src/lib/util.test.ts
+++ b/src/lib/util.test.ts
@@ -16,6 +16,7 @@ import {
   sleep,
   styleDim,
   styleWarning,
+  withConsoleOutputSuppressed,
   withLogOutputSuppressed,
 } from "./util.ts";
 
@@ -221,6 +222,32 @@ describe(withLogOutputSuppressed, () => {
     expect(consoleLog.output()).toMatch(/visible/);
     expect(consoleLog.output()).toMatch(/event=visible-event outcome=ok/);
     expect(consoleLog.output()).not.toMatch(/hidden/);
+    consoleLog.restore();
+  });
+});
+
+describe(withConsoleOutputSuppressed, () => {
+  afterEach(() => {
+    setVerbose(false);
+  });
+
+  it("suppresses every diagnostic tier on stdout and restores them afterwards", async () => {
+    const consoleLog = captureConsoleLog();
+    setVerbose(true);
+
+    await withConsoleOutputSuppressed(async () => {
+      log("hidden-log");
+      debug("hidden-debug");
+      logEvent("hidden-event", {});
+    });
+    log("visible-log");
+    debug("visible-debug");
+    logEvent("visible-event", {});
+
+    expect(consoleLog.output()).not.toContain("hidden");
+    expect(consoleLog.output()).toContain("visible-log");
+    expect(consoleLog.output()).toContain("visible-debug");
+    expect(consoleLog.output()).toContain("event=visible-event");
     consoleLog.restore();
   });
 });

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -80,6 +80,7 @@ export function styleDim(text: string): string {
 let logFilePath: string | undefined;
 let logRunStartByte = 0;
 let suppressedLogDepth = 0;
+let suppressedConsoleDepth = 0;
 
 export function setLogFile(filePath: string | undefined): void {
   logFilePath = filePath;
@@ -118,6 +119,16 @@ export async function withLogOutputSuppressed<T>(operation: () => Promise<T>): P
   }
 }
 
+/** Keep lifecycle JSON stdout clean while preserving diagnostics in the log file. */
+export async function withConsoleOutputSuppressed<T>(operation: () => Promise<T>): Promise<T> {
+  suppressedConsoleDepth += 1;
+  try {
+    return await operation();
+  } finally {
+    suppressedConsoleDepth -= 1;
+  }
+}
+
 function appendLogLine(line: string): void {
   if (logFilePath === undefined) {
     return;
@@ -152,7 +163,9 @@ export function log(message: string): void {
     return;
   }
   const { plain, timestamp } = timestamped(message);
-  writeOutput(`${styleDim(`[${timestamp}]`)} ${message}`);
+  if (suppressedConsoleDepth === 0) {
+    writeOutput(`${styleDim(`[${timestamp}]`)} ${message}`);
+  }
   appendLogLine(plain);
 }
 
@@ -166,7 +179,7 @@ export function debug(message: string): void {
     return;
   }
   const { plain } = timestamped(message);
-  if (verboseConsole) {
+  if (verboseConsole && suppressedConsoleDepth === 0) {
     writeOutput(styleDim(plain));
   }
   appendLogLine(plain);
@@ -195,7 +208,7 @@ export function logEvent(event: string, fields: Record<string, LogEventFieldValu
   }
   const line = parts.join(" ");
   // Structured telemetry is diagnostic: file always, console only under --verbose.
-  if (verboseConsole) {
+  if (verboseConsole && suppressedConsoleDepth === 0) {
     writeOutput(styleDim(line));
   }
   appendLogLine(line);
@@ -218,33 +231,6 @@ export function readTaskArgument(argv: string[], index: number, command: string)
     throw new Error(`crew ${command} --task: task id is required`);
   }
   return value;
-}
-
-export interface DryRunPositionals {
-  dryRun: boolean;
-  positionals: string[];
-}
-
-/**
- * Parses an argv that accepts an optional `--dry-run` flag plus free
- * positionals, rejecting any other dash-prefixed token. Shared by the
- * subcommands whose only flag is `--dry-run` so each parser stays DRY; pass the
- * command's `usage` string for the "Unknown option" error.
- */
-export function parseDryRunPositionals(argv: string[], usage: string): DryRunPositionals {
-  let dryRun = false;
-  const positionals: string[] = [];
-  for (const argument of argv) {
-    if (argument === "--dry-run") {
-      dryRun = true;
-      continue;
-    }
-    if (argument.startsWith("-")) {
-      throw new Error(`Unknown option: ${argument}\nUsage: ${usage}`);
-    }
-    positionals.push(argument);
-  }
-  return { dryRun, positionals };
 }
 
 interface SourceFilterArgs {

--- a/src/lib/workspaceLiveness.test.ts
+++ b/src/lib/workspaceLiveness.test.ts
@@ -1,0 +1,53 @@
+import type { ResolvedConfig } from "./config.ts";
+import { failIfWorkspaceAlreadyLive } from "./workspaceLiveness.ts";
+import { workspaces } from "./workspaces.ts";
+
+vi.mock(import("./workspaces.ts"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    workspaces: {
+      ...actual.workspaces,
+      probe: vi.fn<typeof actual.workspaces.probe>(),
+    },
+  };
+});
+
+const probeMock = vi.mocked(workspaces.probe);
+const config = {} as ResolvedConfig;
+
+describe(failIfWorkspaceAlreadyLive, () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("allows an absent workspace", async () => {
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set() });
+
+    await expect(failIfWorkspaceAlreadyLive(config, "team-1", "opening")).resolves.toBeUndefined();
+  });
+
+  it("rejects a live workspace", async () => {
+    probeMock.mockResolvedValue({ kind: "ok", names: new Set(["team-1"]) });
+
+    await expect(failIfWorkspaceAlreadyLive(config, "team-1", "resuming")).rejects.toThrow(
+      /already live.*resuming/,
+    );
+  });
+
+  it("rejects an unavailable workspace probe with its diagnostic", async () => {
+    probeMock.mockResolvedValue({ kind: "unavailable", error: new Error("backend down") });
+
+    await expect(failIfWorkspaceAlreadyLive(config, "team-1", "opening")).rejects.toThrow(
+      /already live: backend down.*opening/,
+    );
+  });
+
+  it("rejects an unavailable workspace probe without inventing a diagnostic", async () => {
+    probeMock.mockResolvedValue({ kind: "unavailable" });
+
+    await expect(failIfWorkspaceAlreadyLive(config, "team-1", "opening")).rejects.toThrow(
+      /already live\. Retry/,
+    );
+  });
+});

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1363,6 +1363,22 @@ describe(teardown, () => {
     });
   });
 
+  it("does not begin teardown when cancellation arrives with the workspace inventory", async () => {
+    const controller = new AbortController();
+    workspacesProbeMock.mockImplementation(async () => {
+      controller.abort();
+      return { kind: "ok", names: new Set<string>() };
+    });
+    const config = makeConfig({ projectDir });
+
+    const actual = await teardown(config, [hostEntry("team-1")], {
+      signal: controller.signal,
+    });
+
+    expect(actual).toMatchObject({ removed: [], failures: [], cancelled: true });
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
   it("only best-effort closes a task once when duplicate entries exist and probe is unavailable", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
     const config = makeConfig({
@@ -1390,7 +1406,7 @@ describe(teardown, () => {
     expect(result.removed).toHaveLength(2);
   });
 
-  it("records workspace_close failures and continues to remove the worktree", async () => {
+  it("records workspace_close failures without removing a worktree that may still be in use", async () => {
     workspacesProbeMock.mockResolvedValue({
       kind: "ok",
       names: new Set(["team-1"]),
@@ -1406,17 +1422,45 @@ describe(teardown, () => {
     expect(result.failures).toHaveLength(1);
     expect(result.failures[0]?.entry).toBe(entry);
     expect(result.failures[0]?.step).toBe("workspace_close");
-    expect(result.removed).toStrictEqual([entry]);
+    expect(result.removed).toStrictEqual([]);
+    expect(runCommandMock).not.toHaveBeenCalled();
   });
 
-  it("returns workspace_close progress after the shutdown signal fires", async () => {
+  it("does not begin removal when cancellation arrives after closing the workspace", async () => {
     const controller = new AbortController();
-    controller.abort();
     workspacesProbeMock.mockResolvedValue({
       kind: "ok",
       names: new Set(["team-1"]),
     });
-    workspacesCloseMock.mockRejectedValue(new Error("close interrupted"));
+    workspacesCloseMock.mockImplementation(async () => {
+      controller.abort();
+      return { kind: "closed" };
+    });
+    const config = makeConfig({ projectDir });
+
+    const actual = await teardown(config, [hostEntry("team-1")], {
+      signal: controller.signal,
+    });
+
+    expect(actual).toMatchObject({
+      closed: ["team-1"],
+      removed: [],
+      failures: [],
+      cancelled: true,
+    });
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("returns workspace_close progress after the shutdown signal fires", async () => {
+    const controller = new AbortController();
+    workspacesProbeMock.mockResolvedValue({
+      kind: "ok",
+      names: new Set(["team-1"]),
+    });
+    workspacesCloseMock.mockImplementation(async () => {
+      controller.abort();
+      throw new Error("close interrupted");
+    });
     const config = makeConfig({ projectDir });
 
     const actual = await teardown(config, [hostEntry("team-1")], {
@@ -1452,12 +1496,12 @@ describe(teardown, () => {
 
   it("returns worktree_remove progress after the shutdown signal fires", async () => {
     const controller = new AbortController();
-    controller.abort();
     workspacesProbeMock.mockResolvedValue({
       kind: "ok",
       names: new Set<string>(),
     });
     runCommandMock.mockImplementationOnce(() => {
+      controller.abort();
       throw new Error("remove interrupted");
     });
     const config = makeConfig({ projectDir });

--- a/src/lib/worktrees.test.ts
+++ b/src/lib/worktrees.test.ts
@@ -1334,6 +1334,35 @@ describe(teardown, () => {
     expect(result.removed).toHaveLength(2);
   });
 
+  it("propagates an unexpected exception thrown by the workspace probe", async () => {
+    workspacesProbeMock.mockRejectedValue(new Error("probe crashed"));
+    const config = makeConfig({ projectDir });
+
+    await expect(teardown(config, [hostEntry("team-1")])).rejects.toThrow(/probe crashed/);
+  });
+
+  it("classifies a workspace probe exception after cancellation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    workspacesProbeMock.mockRejectedValue(new Error("probe interrupted"));
+    const config = makeConfig({ projectDir });
+
+    const actual = await teardown(config, [hostEntry("team-1")], {
+      signal: controller.signal,
+    });
+
+    expect(actual).toMatchObject({
+      closed: [],
+      removed: [],
+      failures: [],
+      cancelled: true,
+      workspaceProbe: {
+        kind: "unavailable",
+        error: expect.objectContaining({ message: "probe interrupted" }),
+      },
+    });
+  });
+
   it("only best-effort closes a task once when duplicate entries exist and probe is unavailable", async () => {
     workspacesProbeMock.mockResolvedValue({ kind: "unavailable" });
     const config = makeConfig({
@@ -1380,7 +1409,7 @@ describe(teardown, () => {
     expect(result.removed).toStrictEqual([entry]);
   });
 
-  it("rethrows workspace_close failures after the shutdown signal fires", async () => {
+  it("returns workspace_close progress after the shutdown signal fires", async () => {
     const controller = new AbortController();
     controller.abort();
     workspacesProbeMock.mockResolvedValue({
@@ -1390,9 +1419,14 @@ describe(teardown, () => {
     workspacesCloseMock.mockRejectedValue(new Error("close interrupted"));
     const config = makeConfig({ projectDir });
 
-    await expect(
-      teardown(config, [hostEntry("team-1")], { signal: controller.signal }),
-    ).rejects.toThrow("close interrupted");
+    const actual = await teardown(config, [hostEntry("team-1")], {
+      signal: controller.signal,
+    });
+
+    expect(actual.cancelled).toBe(true);
+    expect(actual.failures).toMatchObject([
+      { step: "workspace_close", error: expect.objectContaining({ message: "close interrupted" }) },
+    ]);
   });
 
   it("records worktree_remove failures and continues to the next entry", async () => {
@@ -1416,7 +1450,7 @@ describe(teardown, () => {
     expect(result.removed).toStrictEqual([entries[1]]);
   });
 
-  it("rethrows worktree_remove failures after the shutdown signal fires", async () => {
+  it("returns worktree_remove progress after the shutdown signal fires", async () => {
     const controller = new AbortController();
     controller.abort();
     workspacesProbeMock.mockResolvedValue({
@@ -1428,9 +1462,17 @@ describe(teardown, () => {
     });
     const config = makeConfig({ projectDir });
 
-    await expect(
-      teardown(config, [hostEntry("team-1")], { signal: controller.signal }),
-    ).rejects.toThrow("remove interrupted");
+    const actual = await teardown(config, [hostEntry("team-1")], {
+      signal: controller.signal,
+    });
+
+    expect(actual.cancelled).toBe(true);
+    expect(actual.failures).toMatchObject([
+      {
+        step: "worktree_remove",
+        error: expect.objectContaining({ message: "remove interrupted" }),
+      },
+    ]);
   });
 
   it("passes force through to the underlying remove", async () => {

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -216,6 +216,10 @@ function signalProperty(signal?: AbortSignal): { signal: AbortSignal } | Record<
   return signal === undefined ? {} : { signal };
 }
 
+function signalIsAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 function parseWorktreeDirectoryName(
   directoryName: string,
   repositoryEntriesByLongestName: ReadonlyArray<readonly [string, string]>,
@@ -960,6 +964,10 @@ async function teardownEntry(arguments_: {
 }): Promise<void> {
   const { config, entry, force, signal, workspaceProbe, liveNames, closedTasks, result } =
     arguments_;
+  if (signalIsAborted(signal)) {
+    result.cancelled = true;
+    return;
+  }
   if (shouldCloseWorkspaceForTeardown(entry.task, workspaceProbe, liveNames, closedTasks)) {
     try {
       const closed = await closeWorkspaceForTeardown(config, entry.task, signal);
@@ -968,19 +976,23 @@ async function teardownEntry(arguments_: {
       }
     } catch (error) {
       result.failures.push({ entry, step: "workspace_close", error });
-      if (signal?.aborted === true) {
+      if (signalIsAborted(signal)) {
         result.cancelled = true;
-        return;
       }
+      return;
     }
     closedTasks.add(entry.task);
+  }
+  if (signalIsAborted(signal)) {
+    result.cancelled = true;
+    return;
   }
   try {
     await remove(config, entry, { force, ...signalProperty(signal) });
     result.removed.push(entry);
   } catch (error) {
     result.failures.push({ entry, step: "worktree_remove", error });
-    if (signal?.aborted === true) {
+    if (signalIsAborted(signal)) {
       result.cancelled = true;
     }
   }

--- a/src/lib/worktrees.ts
+++ b/src/lib/worktrees.ts
@@ -926,6 +926,8 @@ export interface TeardownResult {
   /** Per-entry failures; teardown continues past them. */
   failures: TeardownFailure[];
   workspaceProbe: WorkspaceProbe;
+  /** Present only when cooperative cancellation stopped the remaining teardown steps. */
+  cancelled?: true;
 }
 
 async function closeWorkspaceForTeardown(
@@ -946,6 +948,44 @@ function shouldCloseWorkspaceForTeardown(
   return !closedTasks.has(task) && (workspaceProbe.kind === "unavailable" || liveNames.has(task));
 }
 
+async function teardownEntry(arguments_: {
+  config: ResolvedConfig;
+  entry: WorktreeEntry;
+  force: boolean;
+  signal: AbortSignal | undefined;
+  workspaceProbe: WorkspaceProbe;
+  liveNames: ReadonlySet<string>;
+  closedTasks: Set<string>;
+  result: TeardownResult;
+}): Promise<void> {
+  const { config, entry, force, signal, workspaceProbe, liveNames, closedTasks, result } =
+    arguments_;
+  if (shouldCloseWorkspaceForTeardown(entry.task, workspaceProbe, liveNames, closedTasks)) {
+    try {
+      const closed = await closeWorkspaceForTeardown(config, entry.task, signal);
+      if (closed) {
+        result.closed.push(entry.task);
+      }
+    } catch (error) {
+      result.failures.push({ entry, step: "workspace_close", error });
+      if (signal?.aborted === true) {
+        result.cancelled = true;
+        return;
+      }
+    }
+    closedTasks.add(entry.task);
+  }
+  try {
+    await remove(config, entry, { force, ...signalProperty(signal) });
+    result.removed.push(entry);
+  } catch (error) {
+    result.failures.push({ entry, step: "worktree_remove", error });
+    if (signal?.aborted === true) {
+      result.cancelled = true;
+    }
+  }
+}
+
 // A flaky cmux/tmux must not abort the batch — otherwise every on-disk
 // worktree gets stranded. The probe verdict is captured on the result and
 // removal proceeds with no live-workspace knowledge (so no close attempts).
@@ -963,7 +1003,21 @@ async function teardown(
     };
   }
   const force = options?.force ?? false;
-  const workspaceProbe = await workspaces.probe(config, options?.signal);
+  let workspaceProbe: WorkspaceProbe;
+  try {
+    workspaceProbe = await workspaces.probe(config, options?.signal);
+  } catch (error) {
+    if (options?.signal?.aborted !== true) {
+      throw error;
+    }
+    return {
+      closed: [],
+      removed: [],
+      failures: [],
+      workspaceProbe: { kind: "unavailable", error },
+      cancelled: true,
+    };
+  }
   const liveNames = workspaceProbe.kind === "ok" ? workspaceProbe.names : new Set<string>();
   const closedTasks = new Set<string>();
   const result: TeardownResult = {
@@ -974,30 +1028,19 @@ async function teardown(
   };
 
   for (const entry of entries) {
-    if (shouldCloseWorkspaceForTeardown(entry.task, workspaceProbe, liveNames, closedTasks)) {
-      try {
-        // oxlint-disable-next-line no-await-in-loop -- teardown is intentionally sequential per task
-        const closed = await closeWorkspaceForTeardown(config, entry.task, options?.signal);
-        if (closed) {
-          result.closed.push(entry.task);
-        }
-      } catch (error) {
-        if (options?.signal?.aborted === true) {
-          throw error;
-        }
-        result.failures.push({ entry, step: "workspace_close", error });
-      }
-      closedTasks.add(entry.task);
-    }
-    try {
-      // oxlint-disable-next-line no-await-in-loop -- one worktree at a time avoids racing on git
-      await remove(config, entry, { force, ...signalProperty(options?.signal) });
-      result.removed.push(entry);
-    } catch (error) {
-      if (options?.signal?.aborted === true) {
-        throw error;
-      }
-      result.failures.push({ entry, step: "worktree_remove", error });
+    // oxlint-disable-next-line no-await-in-loop -- one worktree at a time avoids racing on git
+    await teardownEntry({
+      config,
+      entry,
+      force,
+      signal: options?.signal,
+      workspaceProbe,
+      liveNames,
+      closedTasks,
+      result,
+    });
+    if (result.cancelled === true) {
+      break;
     }
   }
 


### PR DESCRIPTION
## Why

Raycast and other automation need lifecycle mutations to return stable action receipts without progress text corrupting stdout. Previously Start, Stop, Resume, and Cleanup mixed final output with command execution and lacked a shared typed contract, reliable conflict serialization, and cooperative cancellation reconciliation. This change makes those commands safe to invoke programmatically while preserving human CLI behavior.

## Summary

- Add action-specific typed lifecycle results and one-document `--json` rendering for Start, Stop, Resume, and Cleanup.
- Define stable outcomes, problem codes, resources, exit semantics, SemVer compatibility, and mandatory post-mutation `status --json` refresh behavior.
- Serialize per-task mutations with crash-recoverable locks and thread cooperative SIGINT/SIGTERM cancellation through workspace and teardown operations.
- Make cold Resume task-source neutral, preserve Start writeback partials and Stop reasons, and retain complete Cleanup teardown/reconciliation results without force recommendations.
- Add focused coverage for JSON cleanliness, exit behavior, idempotence, locking, cancellation, source-neutral resolution, refusal, and partial completion.

## Validation

- `node --run verify`
- Focused lifecycle Vitest files run sequentially during implementation.
- `cb-review --effort low --report`: Ship gate pass; TEM-3893 requirements met.

## Notes

Closes tem-3893

Raycast automation must never pass, expose, or recommend `cleanup --force`.

<sub>🤖 <code>cb-ship:created v1 skill@1.0.3</code></sub>