### PR TITLE
chore(deps): bump @clipboard-health/clearance to 1.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.50.7",
       "license": "MIT",
       "dependencies": {
-        "@clipboard-health/clearance": "1.6.6",
+        "@clipboard-health/clearance": "1.8.3",
         "@linear/sdk": "90.0.0",
         "agent-trust": "1.0.0",
         "cosmiconfig": "10.0.0",
@@ -1809,9 +1809,9 @@
       "license": "MIT"
     },
     "node_modules/@clipboard-health/clearance": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.6.6.tgz",
-      "integrity": "sha512-ivIlc9AseWX2NhBCHtCZle7lPFqoGT6u/NIdWZ1zAvknVvztGk4gHmeoJ0LD4woabsH85CxVee4gAUwT/wnOGQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@clipboard-health/clearance/-/clearance-1.8.3.tgz",
+      "integrity": "sha512-X/a/lPIRIpnH1VhFWzC9AC+PGN+xnBRkG3rMB8kVRImTXLk4EKqK6cD1AeF3QhebQK+XEqnhZNVh/R3NRF2Wmw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "verify": "node scripts/verifyAll.mts"
   },
   "dependencies": {
-    "@clipboard-health/clearance": "1.6.6",
+    "@clipboard-health/clearance": "1.8.3",
     "@linear/sdk": "90.0.0",
     "agent-trust": "1.0.0",
     "cosmiconfig": "10.0.0",


### PR DESCRIPTION
## Why

`crew` printed this on every safehouse Claude launch under cmux:

```
groundcrew: cmux wrapper references unreviewed env vars: CMUX_AGENT_RESTORE_LAUNCH, CMUX_AGENT_RESUME_LAUNCH, CMUX_CLAUDE_TEAMS_CMUX_BIN, CMUX_CLAUDE_TEAMS_WRAPPER_LAUNCH
groundcrew: update SAFEHOUSE_CMUX_ENV_PASS or SAFEHOUSE_CMUX_WRAPPER_LOCAL_ENV_NAMES after reviewing them.
```

Those four names were reviewed in ClipboardHealth/core-utils#862 and released as clearance 1.8.3. The pin here was exact at `1.6.6`, so the fix could not arrive without this bump.

## What

`@clipboard-health/clearance` `1.6.6` → `1.8.3`. No source changes — groundcrew consumes only `ensureClearance`, `resolveSafehouseCmuxIntegration`, `safehouseCmuxIntegrationWarningLines`, the `SafehouseCmuxIntegration` type, and the shipped `safehouse/` wrapper paths, and the intervening releases are additive to those shapes:

- #862 — reviewed the four cmux launch markers (the warning above)
- #831 — allow Safehouse to run cmux agent hooks (TG-4209)
- #804 — marked the cmux settings-merge wrapper env names as reviewed

## Verification

- `node --run verify` fully green: build, lint, test (all suites), format, knip, cpd, architecture, markdown, syncpack.
- Ran `resolveSafehouseCmuxIntegration` from the newly installed 1.8.3 against the live cmux Claude wrapper with the real process env: `unreviewedEnvNames` is empty and `safehouseCmuxIntegrationWarningLines` returns nothing, i.e. the warning is gone at the source.