### PR TITLE
Carry decisions across the per-task worktrees

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question - it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,21 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question - it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **a worktree per task, sandboxed by default** - Each dispatched task gets its own git worktree and runs sandboxed unless told otherwise.  _(README.md)_
+- **coverage ignores are annotated and preserved** - `/* v8 ignore next @preserve */` for genuinely unreachable statements or functions, and `/* v8 ignore else @preserve */` before an `if` when only the else branch is unreachable.  _(AGENTS.md, Project-specific rules)_
+- **run state is per worktree** - `src/lib/worktreeRunState.ts` scopes run state to the worktree that produced it.  _(src/lib/worktreeRunState.ts)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
*"One git worktree per task, sandboxed by default"* - `src/lib/worktrees.create.ts` and `worktreeRunState.ts` handle the isolation, and `worktreeRunState` is per-worktree by design. Nothing crosses between them, so the reason a task was done a particular way is lost to the next task that touches the same code.

**What's in the PR**

- `.knos/decisions.md` - a record shared by every worktree of the repo, keyed on `git rev-parse --git-common-dir` rather than `--show-toplevel`; the latter returns the worktree root, which is exactly what makes per-worktree state per-worktree. Seeded from this repo's own rules, each line citing its source.
- `.mcp.json` - one server, three tools, stdio.

It does not touch `worktreeRunState`. Run state should stay per-worktree; decisions should not.

**Disclosure:** I wrote Knos. It is a local MCP server - three tools, no ports, no network, no account, no model download. The record is seeded from your own docs rather than mine so it is checkable rather than promotional. Close it if a third-party entry isn't wanted; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)