### PR TITLE
fix: preserve safehouse features when opening workspaces (TG-4571)

### DIFF
--- a/src/commands/openWorkspace.test.ts
+++ b/src/commands/openWorkspace.test.ts
@@ -433,6 +433,26 @@ describe(openWorkspace, () => {
     });
   });
 
+  it("passes configured safehouse features to the agent launch", async () => {
+    const configWithSafehouseFeatures: ResolvedConfig = {
+      ...config,
+      local: {
+        ...config.local,
+        safehouse: { enable: ["agent-browser", "docker"] },
+      },
+    };
+    const composeAgentLaunchMock = vi.spyOn(agentLaunch, "composeAgentLaunch");
+
+    await openWorkspace(configWithSafehouseFeatures, {
+      input: { kind: "pr", pr: "42" },
+      repository: "acme/widgets",
+    });
+
+    expect(composeAgentLaunchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ safehouseEnableFeatures: ["agent-browser", "docker"] }),
+    );
+  });
+
   it("resolves a PR URL to a unique bare known repository", async () => {
     const configWithBareRepository = makeConfigWithRepositories(["widgets"]);
     worktreeOpenMock.mockResolvedValue({

--- a/src/commands/openWorkspace.ts
+++ b/src/commands/openWorkspace.ts
@@ -289,6 +289,7 @@ export async function openWorkspace(
       sandboxName,
       workspaceKind,
       readOnlyDirs: config.local.readOnlyDirs,
+      safehouseEnableFeatures: config.local.safehouse.enable,
       omitPromptArgument,
     });
     cleanupAgentLaunch = launch.cleanup;


### PR DESCRIPTION
## Why

`crew open` omitted the Safehouse feature profiles configured in `local.safehouse.enable`, silently launching review and follow-up agents with fewer capabilities than `crew start` and `crew resume`. This restores consistent sandbox composition for operators who depend on configured browser, credential, or container access.

## Summary

- Pass configured Safehouse enable features through the `openWorkspace` agent launch input.
- Add regression coverage that verifies `crew open` preserves configured feature profiles.

## Validation

- `npx vitest run src/commands/openWorkspace.test.ts --testNamePattern "passes configured safehouse features"`
- `npx vitest run src/commands/openWorkspace.test.ts`
- `node --run verify` (91 test files, 2,190 tests, 100% coverage; all repository checks passed)
- Pre-push `node --run verify`

## Notes

- [TG-4571](https://linear.app/clipboardhealth/issue/TG-4571)
- Closes tg-4571

Agent session: `codex resume 01a0825d-6d2d-73a2-ad9d-679c63526e6c` · Model: `gpt-5-6-sol`

<sub>🤖 <code>cb-ship:created v1 skill@1.0.5</code></sub>
